### PR TITLE
Build billing period view with tiered cost breakdown

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -1,0 +1,107 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type {
+  BillingLineItem,
+  BillingPeriod,
+  Microgrid,
+  RateSchedule,
+  Tenant,
+} from "@/lib/types/database";
+import { BillingTable } from "@/components/BillingTable";
+
+export default async function BillingPeriodDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; periodId: string }>;
+}) {
+  const { id, periodId } = await params;
+  const supabase = await createClient();
+
+  const [
+    { data: period, error: periodError },
+    { data: lineItems, error: lineItemsError },
+    { data: tenants, error: tenantsError },
+    { data: schedule, error: scheduleError },
+    { data: microgrid, error: microgridError },
+  ] = await Promise.all([
+    supabase
+      .from("billing_periods")
+      .select("*")
+      .eq("id", periodId)
+      .eq("microgrid_id", id)
+      .single()
+      .then((res) => ({ ...res, data: res.data as BillingPeriod | null })),
+    supabase
+      .from("billing_line_items")
+      .select("*")
+      .eq("billing_period_id", periodId)
+      .returns<BillingLineItem[]>(),
+    supabase
+      .from("tenants")
+      .select("*")
+      .eq("microgrid_id", id)
+      .order("name")
+      .returns<Tenant[]>(),
+    supabase
+      .from("rate_schedules")
+      .select("*")
+      .eq("microgrid_id", id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+      .then((res) => ({ ...res, data: res.data as RateSchedule | null })),
+    supabase
+      .from("microgrids")
+      .select("id, name, currency")
+      .eq("id", id)
+      .single()
+      .then((res) => ({ ...res, data: res.data as Microgrid | null })),
+  ]);
+
+  if (periodError || !period) {
+    notFound();
+  }
+
+  if (microgridError || !microgrid) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Error loading microgrid: {microgridError?.message ?? "Not found"}
+      </div>
+    );
+  }
+
+  if (tenantsError) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Error loading tenants: {tenantsError.message}
+      </div>
+    );
+  }
+
+  if (lineItemsError) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Error loading line items: {lineItemsError.message}
+      </div>
+    );
+  }
+
+  if (scheduleError) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Error loading rate schedule: {scheduleError.message}
+      </div>
+    );
+  }
+
+  return (
+    <BillingTable
+      microgridId={id}
+      period={period}
+      lineItems={lineItems ?? []}
+      tenants={tenants ?? []}
+      tiers={schedule?.tiers ?? []}
+      currency={microgrid.currency}
+    />
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
@@ -1,7 +1,29 @@
-export default function BillingPage() {
-  return (
-    <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
-      Billing periods coming soon.
-    </div>
-  );
+import { createClient } from "@/lib/supabase/server";
+import type { BillingPeriod } from "@/lib/types/database";
+import { BillingPeriodList } from "@/components/BillingPeriodList";
+
+export default async function BillingPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: periods, error } = await supabase
+    .from("billing_periods")
+    .select("*")
+    .eq("microgrid_id", id)
+    .order("start_date", { ascending: false })
+    .returns<BillingPeriod[]>();
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Error loading billing periods: {error.message}
+      </div>
+    );
+  }
+
+  return <BillingPeriodList microgridId={id} periods={periods ?? []} />;
 }

--- a/src/app/api/billing/generate/route.ts
+++ b/src/app/api/billing/generate/route.ts
@@ -1,0 +1,250 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import { calculateTieredCost } from "@/lib/billing/calculations";
+import type {
+  BillingPeriod,
+  Meter,
+  RateSchedule,
+  Tenant,
+} from "@/lib/types/database";
+import type { MeterConfig } from "@/lib/adapters/types";
+
+type GenerateRequestBody = {
+  billingPeriodId: string;
+};
+
+type GenerateError = {
+  tenantId: string;
+  tenantName: string;
+  error: string;
+};
+
+export async function POST(request: NextRequest) {
+  let body: GenerateRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.billingPeriodId) {
+    return NextResponse.json(
+      { error: "billingPeriodId is required" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // 1. Fetch billing period
+  const { data: period, error: periodError } = await supabase
+    .from("billing_periods")
+    .select("*")
+    .eq("id", body.billingPeriodId)
+    .single();
+
+  if (periodError || !period) {
+    return NextResponse.json(
+      { error: "Billing period not found" },
+      { status: 404 }
+    );
+  }
+
+  const billingPeriod = period as BillingPeriod;
+
+  if (billingPeriod.status === "closed") {
+    return NextResponse.json(
+      { error: "Cannot generate line items for a closed billing period" },
+      { status: 400 }
+    );
+  }
+
+  // 2. Fetch rate schedule
+  const { data: schedule, error: scheduleError } = await supabase
+    .from("rate_schedules")
+    .select("*")
+    .eq("microgrid_id", billingPeriod.microgrid_id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (scheduleError || !schedule) {
+    return NextResponse.json(
+      { error: "No rate schedule found for this microgrid" },
+      { status: 400 }
+    );
+  }
+
+  const rateSchedule = schedule as RateSchedule;
+
+  // 3. Fetch tenants
+  const { data: tenants, error: tenantsError } = await supabase
+    .from("tenants")
+    .select("*")
+    .eq("microgrid_id", billingPeriod.microgrid_id)
+    .order("name");
+
+  if (tenantsError) {
+    return NextResponse.json(
+      { error: `Error fetching tenants: ${tenantsError.message}` },
+      { status: 500 }
+    );
+  }
+
+  const tenantList = (tenants ?? []) as Tenant[];
+
+  // 4. Fetch meters
+  const { data: meters, error: metersError } = await supabase
+    .from("meters")
+    .select("*")
+    .eq("microgrid_id", billingPeriod.microgrid_id);
+
+  if (metersError) {
+    return NextResponse.json(
+      { error: `Error fetching meters: ${metersError.message}` },
+      { status: 500 }
+    );
+  }
+
+  const meterList = (meters ?? []) as Meter[];
+  const meterMap = new Map(meterList.map((m) => [m.id, m]));
+
+  // 5. Build MeterConfig array — skip tenants without meters
+  const errors: GenerateError[] = [];
+  const meterConfigs: MeterConfig[] = [];
+  const tenantMeterMap = new Map<string, string>(); // meterId -> tenantId
+
+  for (const tenant of tenantList) {
+    if (!tenant.meter_id) {
+      errors.push({
+        tenantId: tenant.id,
+        tenantName: tenant.name,
+        error: "No meter assigned",
+      });
+      continue;
+    }
+
+    const meter = meterMap.get(tenant.meter_id);
+    if (!meter) {
+      errors.push({
+        tenantId: tenant.id,
+        tenantName: tenant.name,
+        error: "Assigned meter not found",
+      });
+      continue;
+    }
+
+    meterConfigs.push({
+      id: meter.id,
+      dataSourceType: meter.data_source_type,
+      dataSourceConfig: meter.data_source_config,
+    });
+    tenantMeterMap.set(meter.id, tenant.id);
+  }
+
+  if (meterConfigs.length === 0 && tenantList.length > 0) {
+    // No meters to query, but we still delete old line items
+    await supabase
+      .from("billing_line_items")
+      .delete()
+      .eq("billing_period_id", body.billingPeriodId);
+
+    return NextResponse.json({ lineItems: 0, errors });
+  }
+
+  // 6. Call OpenEMS for readings
+  try {
+    const client = getOpenEmsClient();
+    const readings = await client.getReadings(
+      meterConfigs,
+      billingPeriod.start_date,
+      billingPeriod.end_date
+    );
+
+    // 7. Build meterId -> usageKwh map
+    const usageMap = new Map<string, number | null>();
+    for (const reading of readings) {
+      usageMap.set(reading.meterId, reading.usageKwh);
+    }
+
+    // 8. Calculate tier breakdown per tenant and build line items
+    const lineItemRows: {
+      billing_period_id: string;
+      tenant_id: string;
+      meter_id: string;
+      usage_kwh: number;
+      tier_breakdown: { label: string; kwh: number; amount: number }[];
+      total_amount: number;
+    }[] = [];
+
+    for (const tenant of tenantList) {
+      if (!tenant.meter_id) continue; // already in errors
+
+      const usageKwh = usageMap.get(tenant.meter_id);
+      if (usageKwh === null || usageKwh === undefined) {
+        errors.push({
+          tenantId: tenant.id,
+          tenantName: tenant.name,
+          error: "No meter reading data available",
+        });
+        continue;
+      }
+
+      const calc = calculateTieredCost(
+        usageKwh,
+        rateSchedule.tiers,
+        rateSchedule.service_charge,
+        rateSchedule.tax_rate
+      );
+
+      lineItemRows.push({
+        billing_period_id: body.billingPeriodId,
+        tenant_id: tenant.id,
+        meter_id: tenant.meter_id,
+        usage_kwh: usageKwh,
+        tier_breakdown: calc.tierBreakdown,
+        total_amount: calc.totalAmount,
+      });
+    }
+
+    // 9. Delete existing line items
+    await supabase
+      .from("billing_line_items")
+      .delete()
+      .eq("billing_period_id", body.billingPeriodId);
+
+    // 10. Insert new line items
+    if (lineItemRows.length > 0) {
+      const { error: insertError } = await supabase
+        .from("billing_line_items")
+        .insert(lineItemRows);
+
+      if (insertError) {
+        return NextResponse.json(
+          { error: `Failed to insert line items: ${insertError.message}` },
+          { status: 500 }
+        );
+      }
+    }
+
+    return NextResponse.json({
+      lineItems: lineItemRows.length,
+      errors,
+    });
+  } catch (err) {
+    if (err instanceof OpenEmsError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: err.statusCode }
+      );
+    }
+    return NextResponse.json(
+      { error: "Unexpected error generating billing data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import type { BillingPeriod } from "@/lib/types/database";
+
+function getDefaultDates() {
+  const now = new Date();
+  const year = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear();
+  const month = now.getMonth() === 0 ? 11 : now.getMonth() - 1; // previous month (0-indexed)
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+
+  return {
+    start: firstDay.toISOString().split("T")[0],
+    end: lastDay.toISOString().split("T")[0],
+  };
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function BillingPeriodList({
+  microgridId,
+  periods,
+}: {
+  microgridId: string;
+  periods: BillingPeriod[];
+}) {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const defaults = getDefaultDates();
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [startDate, setStartDate] = useState(defaults.start);
+  const [endDate, setEndDate] = useState(defaults.end);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!startDate || !endDate) {
+      setError("Start and end dates are required");
+      return;
+    }
+
+    if (startDate >= endDate) {
+      setError("Start date must be before end date");
+      return;
+    }
+
+    setCreating(true);
+
+    const { data: newPeriod, error: insertError } = await supabase
+      .from("billing_periods")
+      .insert({
+        microgrid_id: microgridId,
+        start_date: startDate,
+        end_date: endDate,
+        status: "draft",
+      })
+      .select("id")
+      .single();
+
+    if (insertError) {
+      setError(insertError.message);
+      setCreating(false);
+      return;
+    }
+
+    setCreating(false);
+    router.push(`/microgrids/${microgridId}/billing/${newPeriod.id}`);
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Billing Periods</h2>
+        <button
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+        >
+          {showCreateForm ? "Cancel" : "New Period"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {showCreateForm && (
+        <form
+          onSubmit={handleCreate}
+          className="mb-4 space-y-3 rounded-md border border-gray-200 bg-gray-50 p-4"
+        >
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                Start Date
+              </label>
+              <input
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                End Date
+              </label>
+              <input
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                required
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={creating}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {creating ? "Creating..." : "Create Period"}
+          </button>
+        </form>
+      )}
+
+      {periods.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No billing periods yet. Create a new period to get started.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="pb-2 pr-4 font-medium text-gray-700">
+                  Date Range
+                </th>
+                <th className="pb-2 pr-4 font-medium text-gray-700">Status</th>
+                <th className="pb-2 font-medium text-gray-700">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {periods.map((period) => (
+                <tr key={period.id} className="border-b border-gray-100">
+                  <td className="py-3 pr-4 text-gray-900">
+                    {formatDate(period.start_date)} &ndash;{" "}
+                    {formatDate(period.end_date)}
+                  </td>
+                  <td className="py-3 pr-4">
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                        period.status === "closed"
+                          ? "bg-green-100 text-green-800"
+                          : "bg-yellow-100 text-yellow-800"
+                      }`}
+                    >
+                      {period.status}
+                    </span>
+                  </td>
+                  <td className="py-3">
+                    <Link
+                      href={`/microgrids/${microgridId}/billing/${period.id}`}
+                      className="rounded-md px-2 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                    >
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { CopyButton } from "@/components/CopyButton";
+import type {
+  BillingLineItem,
+  BillingPeriod,
+  Tenant,
+  TierConfig,
+} from "@/lib/types/database";
+
+function formatAmount(value: number): string {
+  return new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatKwh(value: number): string {
+  return new Intl.NumberFormat("en", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function BillingTable({
+  microgridId,
+  period,
+  lineItems,
+  tenants,
+  tiers,
+  currency,
+}: {
+  microgridId: string;
+  period: BillingPeriod;
+  lineItems: BillingLineItem[];
+  tenants: Tenant[];
+  tiers: TierConfig[];
+  currency: string;
+}) {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const [generating, setGenerating] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [generateErrors, setGenerateErrors] = useState<
+    { tenantName: string; error: string }[]
+  >([]);
+
+  const isDraft = period.status === "draft";
+
+  // Build tenantId -> lineItem map
+  const lineItemMap = new Map<string, BillingLineItem>();
+  for (const item of lineItems) {
+    lineItemMap.set(item.tenant_id, item);
+  }
+
+  // Grand totals
+  let grandTotalKwh = 0;
+  let grandTotal = 0;
+  const grandTierKwh: number[] = tiers.map(() => 0);
+  const grandTierAmount: number[] = tiers.map(() => 0);
+
+  for (const item of lineItems) {
+    grandTotalKwh += item.usage_kwh;
+    grandTotal += item.total_amount;
+
+    for (let i = 0; i < item.tier_breakdown.length && i < tiers.length; i++) {
+      grandTierKwh[i] += item.tier_breakdown[i].kwh;
+      grandTierAmount[i] += item.tier_breakdown[i].amount;
+    }
+  }
+
+  async function handleGenerate() {
+    setError(null);
+    setGenerateErrors([]);
+    setGenerating(true);
+
+    try {
+      const res = await fetch("/api/billing/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ billingPeriodId: period.id }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "Failed to generate billing data");
+        setGenerating(false);
+        return;
+      }
+
+      if (data.errors && data.errors.length > 0) {
+        setGenerateErrors(
+          data.errors.map((e: { tenantName: string; error: string }) => ({
+            tenantName: e.tenantName,
+            error: e.error,
+          }))
+        );
+      }
+
+      setGenerating(false);
+      router.refresh();
+    } catch {
+      setError("Network error while generating billing data");
+      setGenerating(false);
+    }
+  }
+
+  async function handleClose() {
+    if (
+      !confirm(
+        "Are you sure you want to close this billing period? This action cannot be undone."
+      )
+    ) {
+      return;
+    }
+
+    setError(null);
+    setClosing(true);
+
+    const { error: updateError } = await supabase
+      .from("billing_periods")
+      .update({
+        status: "closed",
+        closed_at: new Date().toISOString(),
+      })
+      .eq("id", period.id);
+
+    if (updateError) {
+      setError(updateError.message);
+      setClosing(false);
+      return;
+    }
+
+    setClosing(false);
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {formatDate(period.start_date)} &ndash;{" "}
+              {formatDate(period.end_date)}
+            </h2>
+            <span
+              className={`mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                period.status === "closed"
+                  ? "bg-green-100 text-green-800"
+                  : "bg-yellow-100 text-yellow-800"
+              }`}
+            >
+              {period.status}
+            </span>
+          </div>
+
+          {isDraft && (
+            <div className="flex gap-2">
+              <button
+                onClick={handleGenerate}
+                disabled={generating || closing}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {generating
+                  ? "Generating..."
+                  : lineItems.length > 0
+                    ? "Refresh Readings"
+                    : "Generate"}
+              </button>
+              <button
+                onClick={handleClose}
+                disabled={generating || closing || lineItems.length === 0}
+                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {closing ? "Closing..." : "Close Period"}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Errors */}
+      {error && (
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Generate warnings */}
+      {generateErrors.length > 0 && (
+        <div className="rounded-md bg-yellow-50 p-3 text-sm text-yellow-700">
+          <p className="font-medium">
+            Some tenants could not be billed:
+          </p>
+          <ul className="mt-1 list-inside list-disc">
+            {generateErrors.map((e, i) => (
+              <li key={i}>
+                {e.tenantName}: {e.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Billing Table */}
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        {lineItems.length === 0 && tenants.length > 0 ? (
+          <p className="text-sm text-gray-500">
+            No billing data yet.{" "}
+            {isDraft
+              ? 'Click "Generate" to fetch meter readings and calculate costs.'
+              : ""}
+          </p>
+        ) : tenants.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No tenants configured for this microgrid.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-200">
+                  <th className="pb-2 pr-4 font-medium text-gray-700">
+                    Tenant
+                  </th>
+                  <th className="pb-2 pr-4 text-right font-medium text-gray-700">
+                    Usage (kWh)
+                  </th>
+                  {tiers.map((tier, i) => (
+                    <React.Fragment key={`tier-hdr-${i}`}>
+                      <th className="pb-2 pr-2 text-right font-medium text-gray-700">
+                        {tier.label} kWh
+                      </th>
+                      <th className="pb-2 pr-2 text-right font-medium text-gray-700">
+                        {tier.label} ({currency})
+                      </th>
+                    </React.Fragment>
+                  ))}
+                  <th className="pb-2 text-right font-medium text-gray-700">
+                    Total ({currency})
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {tenants.map((tenant) => {
+                  const item = lineItemMap.get(tenant.id);
+
+                  if (!item) {
+                    return (
+                      <tr
+                        key={tenant.id}
+                        className="border-b border-gray-100"
+                      >
+                        <td className="py-3 pr-4 text-gray-900">
+                          {tenant.name}
+                        </td>
+                        <td
+                          className="py-3 pr-4 text-right text-gray-400"
+                          colSpan={tiers.length * 2 + 2}
+                        >
+                          {tenant.meter_id ? "No data" : "No meter"}
+                        </td>
+                      </tr>
+                    );
+                  }
+
+                  return (
+                    <tr
+                      key={tenant.id}
+                      className="border-b border-gray-100"
+                    >
+                      <td className="py-3 pr-4 text-gray-900">
+                        {tenant.name}
+                      </td>
+                      <td className="whitespace-nowrap py-3 pr-4 text-right text-gray-900">
+                        {formatKwh(item.usage_kwh)}
+                        <CopyButton value={item.usage_kwh} />
+                      </td>
+                      {tiers.map((_, i) => {
+                        const tierData = item.tier_breakdown[i];
+                        const kwh = tierData?.kwh ?? 0;
+                        const amount = tierData?.amount ?? 0;
+                        return (
+                          <React.Fragment key={`tier-${i}`}>
+                            <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
+                              {formatKwh(kwh)}
+                              <CopyButton value={kwh} />
+                            </td>
+                            <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
+                              {formatAmount(amount)}
+                              <CopyButton value={amount} />
+                            </td>
+                          </React.Fragment>
+                        );
+                      })}
+                      <td className="whitespace-nowrap py-3 text-right font-medium text-gray-900">
+                        {formatAmount(item.total_amount)}
+                        <CopyButton value={item.total_amount} />
+                      </td>
+                    </tr>
+                  );
+                })}
+
+                {/* Grand total row */}
+                {lineItems.length > 0 && (
+                  <tr className="border-t-2 border-gray-300 font-medium">
+                    <td className="py-3 pr-4 text-gray-900">Total</td>
+                    <td className="whitespace-nowrap py-3 pr-4 text-right text-gray-900">
+                      {formatKwh(grandTotalKwh)}
+                      <CopyButton value={grandTotalKwh} />
+                    </td>
+                    {tiers.map((_, i) => (
+                      <React.Fragment key={`grand-tier-${i}`}>
+                        <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
+                          {formatKwh(grandTierKwh[i])}
+                          <CopyButton value={grandTierKwh[i]} />
+                        </td>
+                        <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
+                          {formatAmount(grandTierAmount[i])}
+                          <CopyButton value={grandTierAmount[i]} />
+                        </td>
+                      </React.Fragment>
+                    ))}
+                    <td className="whitespace-nowrap py-3 text-right text-gray-900">
+                      {formatAmount(grandTotal)}
+                      <CopyButton value={grandTotal} />
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyButton({ value }: { value: number }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(String(value));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="ml-1 inline-flex items-center text-xs text-gray-400 hover:text-gray-600"
+      title="Copy value"
+    >
+      {copied ? (
+        <span className="text-green-600">Copied</span>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="h-3.5 w-3.5"
+        >
+          <path
+            fillRule="evenodd"
+            d="M15.988 3.012A2.25 2.25 0 0118 5.25v6.5A2.25 2.25 0 0115.75 14H13.5v-3.25a3.25 3.25 0 00-3.25-3.25H7V5.25A2.25 2.25 0 019.25 3h4.488a2.25 2.25 0 011.25.012zM4 8.25A2.25 2.25 0 016.25 6h3.5A2.25 2.25 0 0112 8.25v6.5A2.25 2.25 0 019.75 17h-3.5A2.25 2.25 0 014 14.75v-6.5z"
+            clipRule="evenodd"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/lib/billing/__tests__/calculations.test.ts
+++ b/src/lib/billing/__tests__/calculations.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { calculateTieredCost } from "../calculations";
+import type { TierConfig } from "@/lib/types/database";
+
+// Seed tiers matching the real-world Uganda pricing structure
+const seedTiers: TierConfig[] = [
+  { label: "Tier 1", min_kwh: 1, max_kwh: 15, rate_per_kwh: 250 },
+  { label: "Tier 2", min_kwh: 16, max_kwh: 80, rate_per_kwh: 756.2 },
+  { label: "Tier 3", min_kwh: 81, max_kwh: 150, rate_per_kwh: 412 },
+  { label: "Tier 4", min_kwh: 151, max_kwh: null, rate_per_kwh: 756.2 },
+];
+
+const SERVICE_CHARGE = 5320;
+const TAX_RATE = 0.18;
+
+describe("calculateTieredCost", () => {
+  it("should handle usage spanning all 4 tiers (200 kWh)", () => {
+    const result = calculateTieredCost(200, seedTiers, SERVICE_CHARGE, TAX_RATE);
+
+    // Tier 1: 15 kWh (capacity: 15-1+1=15), Tier 2: 65 kWh (80-16+1=65),
+    // Tier 3: 70 kWh (150-81+1=70), Tier 4: 50 kWh (remaining)
+    expect(result.tierBreakdown).toHaveLength(4);
+    expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 15, amount: 15 * 250 });
+    expect(result.tierBreakdown[1]).toEqual({ label: "Tier 2", kwh: 65, amount: 65 * 756.2 });
+    expect(result.tierBreakdown[2]).toEqual({ label: "Tier 3", kwh: 70, amount: 70 * 412 });
+    expect(result.tierBreakdown[3]).toEqual({ label: "Tier 4", kwh: 50, amount: 50 * 756.2 });
+
+    const expectedSubtotal = 15 * 250 + 65 * 756.2 + 70 * 412 + 50 * 756.2;
+    expect(result.subtotal).toBeCloseTo(expectedSubtotal);
+    expect(result.serviceCharge).toBe(SERVICE_CHARGE);
+    expect(result.netAmount).toBeCloseTo(expectedSubtotal + SERVICE_CHARGE);
+    expect(result.taxAmount).toBeCloseTo((expectedSubtotal + SERVICE_CHARGE) * TAX_RATE);
+    expect(result.totalAmount).toBeCloseTo(
+      (expectedSubtotal + SERVICE_CHARGE) * (1 + TAX_RATE)
+    );
+  });
+
+  it("should handle usage fitting in first tier only (10 kWh)", () => {
+    const result = calculateTieredCost(10, seedTiers, SERVICE_CHARGE, TAX_RATE);
+
+    expect(result.tierBreakdown).toHaveLength(1);
+    expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 10, amount: 10 * 250 });
+
+    const expectedSubtotal = 10 * 250;
+    expect(result.subtotal).toBeCloseTo(expectedSubtotal);
+    expect(result.netAmount).toBeCloseTo(expectedSubtotal + SERVICE_CHARGE);
+  });
+
+  it("should handle usage exactly on tier boundary (15 kWh)", () => {
+    const result = calculateTieredCost(15, seedTiers, SERVICE_CHARGE, TAX_RATE);
+
+    expect(result.tierBreakdown).toHaveLength(1);
+    expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 15, amount: 15 * 250 });
+  });
+
+  it("should apply service charge and tax even with zero usage", () => {
+    const result = calculateTieredCost(0, seedTiers, SERVICE_CHARGE, TAX_RATE);
+
+    expect(result.tierBreakdown).toHaveLength(0);
+    expect(result.subtotal).toBe(0);
+    expect(result.serviceCharge).toBe(SERVICE_CHARGE);
+    expect(result.netAmount).toBe(SERVICE_CHARGE);
+    expect(result.taxAmount).toBeCloseTo(SERVICE_CHARGE * TAX_RATE);
+    expect(result.totalAmount).toBeCloseTo(SERVICE_CHARGE * (1 + TAX_RATE));
+  });
+
+  it("should handle fractional kWh (15.5 kWh)", () => {
+    const result = calculateTieredCost(15.5, seedTiers, SERVICE_CHARGE, TAX_RATE);
+
+    // Tier 1 capacity = 15, so 15 kWh in tier 1, 0.5 kWh in tier 2
+    expect(result.tierBreakdown).toHaveLength(2);
+    expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 15, amount: 15 * 250 });
+    expect(result.tierBreakdown[1]).toEqual({ label: "Tier 2", kwh: 0.5, amount: 0.5 * 756.2 });
+  });
+
+  it("should handle a single unbounded tier", () => {
+    const singleTier: TierConfig[] = [
+      { label: "Flat Rate", min_kwh: 1, max_kwh: null, rate_per_kwh: 500 },
+    ];
+    const result = calculateTieredCost(100, singleTier, 1000, 0.1);
+
+    expect(result.tierBreakdown).toHaveLength(1);
+    expect(result.tierBreakdown[0]).toEqual({ label: "Flat Rate", kwh: 100, amount: 50000 });
+    expect(result.subtotal).toBe(50000);
+    expect(result.netAmount).toBe(51000);
+    expect(result.taxAmount).toBeCloseTo(5100);
+    expect(result.totalAmount).toBeCloseTo(56100);
+  });
+
+  it("should handle empty tiers array", () => {
+    const result = calculateTieredCost(100, [], SERVICE_CHARGE, TAX_RATE);
+
+    expect(result.tierBreakdown).toHaveLength(0);
+    expect(result.subtotal).toBe(0);
+    expect(result.netAmount).toBe(SERVICE_CHARGE);
+    expect(result.totalAmount).toBeCloseTo(SERVICE_CHARGE * (1 + TAX_RATE));
+  });
+
+  it("should handle 6 tiers (N-tier support)", () => {
+    const sixTiers: TierConfig[] = [
+      { label: "Tier 1", min_kwh: 1, max_kwh: 10, rate_per_kwh: 100 },
+      { label: "Tier 2", min_kwh: 11, max_kwh: 20, rate_per_kwh: 200 },
+      { label: "Tier 3", min_kwh: 21, max_kwh: 30, rate_per_kwh: 300 },
+      { label: "Tier 4", min_kwh: 31, max_kwh: 40, rate_per_kwh: 400 },
+      { label: "Tier 5", min_kwh: 41, max_kwh: 50, rate_per_kwh: 500 },
+      { label: "Tier 6", min_kwh: 51, max_kwh: null, rate_per_kwh: 600 },
+    ];
+
+    const result = calculateTieredCost(55, sixTiers, 0, 0);
+
+    expect(result.tierBreakdown).toHaveLength(6);
+    expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 10, amount: 1000 });
+    expect(result.tierBreakdown[1]).toEqual({ label: "Tier 2", kwh: 10, amount: 2000 });
+    expect(result.tierBreakdown[2]).toEqual({ label: "Tier 3", kwh: 10, amount: 3000 });
+    expect(result.tierBreakdown[3]).toEqual({ label: "Tier 4", kwh: 10, amount: 4000 });
+    expect(result.tierBreakdown[4]).toEqual({ label: "Tier 5", kwh: 10, amount: 5000 });
+    expect(result.tierBreakdown[5]).toEqual({ label: "Tier 6", kwh: 5, amount: 3000 });
+
+    expect(result.subtotal).toBe(18000);
+    expect(result.totalAmount).toBe(18000);
+  });
+
+  it("should handle large usage (10000 kWh)", () => {
+    const result = calculateTieredCost(10000, seedTiers, SERVICE_CHARGE, TAX_RATE);
+
+    // Tier 1: 15, Tier 2: 65, Tier 3: 70, Tier 4: 9850
+    expect(result.tierBreakdown).toHaveLength(4);
+    expect(result.tierBreakdown[0].kwh).toBe(15);
+    expect(result.tierBreakdown[1].kwh).toBe(65);
+    expect(result.tierBreakdown[2].kwh).toBe(70);
+    expect(result.tierBreakdown[3].kwh).toBe(9850);
+
+    const expectedSubtotal =
+      15 * 250 + 65 * 756.2 + 70 * 412 + 9850 * 756.2;
+    expect(result.subtotal).toBeCloseTo(expectedSubtotal);
+    expect(result.totalAmount).toBeCloseTo(
+      (expectedSubtotal + SERVICE_CHARGE) * (1 + TAX_RATE)
+    );
+  });
+});

--- a/src/lib/billing/calculations.ts
+++ b/src/lib/billing/calculations.ts
@@ -1,0 +1,64 @@
+import type { TierConfig, TierBreakdown } from "@/lib/types/database";
+
+export type BillingCalculation = {
+  tierBreakdown: TierBreakdown[];
+  subtotal: number; // sum of tier amounts
+  serviceCharge: number; // pass-through
+  netAmount: number; // subtotal + serviceCharge
+  taxAmount: number; // netAmount * taxRate
+  totalAmount: number; // netAmount + taxAmount
+};
+
+export function calculateTieredCost(
+  usageKwh: number,
+  tiers: TierConfig[],
+  serviceCharge: number,
+  taxRate: number
+): BillingCalculation {
+  if (usageKwh <= 0 || tiers.length === 0) {
+    const netAmount = serviceCharge;
+    const taxAmount = netAmount * taxRate;
+    return {
+      tierBreakdown: [],
+      subtotal: 0,
+      serviceCharge,
+      netAmount,
+      taxAmount,
+      totalAmount: netAmount + taxAmount,
+    };
+  }
+
+  let remaining = usageKwh;
+  const tierBreakdown: TierBreakdown[] = [];
+
+  for (const tier of tiers) {
+    if (remaining <= 0) break;
+
+    const tierCapacity =
+      tier.max_kwh !== null ? tier.max_kwh - tier.min_kwh + 1 : Infinity;
+    const kwhInTier = Math.min(remaining, tierCapacity);
+    const amount = kwhInTier * tier.rate_per_kwh;
+
+    tierBreakdown.push({
+      label: tier.label,
+      kwh: kwhInTier,
+      amount,
+    });
+
+    remaining -= kwhInTier;
+  }
+
+  const subtotal = tierBreakdown.reduce((sum, t) => sum + t.amount, 0);
+  const netAmount = subtotal + serviceCharge;
+  const taxAmount = netAmount * taxRate;
+  const totalAmount = netAmount + taxAmount;
+
+  return {
+    tierBreakdown,
+    subtotal,
+    serviceCharge,
+    netAmount,
+    taxAmount,
+    totalAmount,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #3. Adds the core billing screen — the primary value of the app. Replaces the entrepreneur's manual spreadsheet workflow.

- **Billing period management** at `/microgrids/[id]/billing` — create periods with date picker (defaults to previous month), list with status badges
- **Line item generation** via `POST /api/billing/generate` — fetches OpenEMS meter readings, calculates N-tier progressive costs, writes billing_line_items to Supabase
- **Billing table** at `/microgrids/[id]/billing/[periodId]` — dynamic columns per tier (kWh + amount interleaved), grand total row, copy-to-clipboard on every numeric cell
- **Draft/Closed workflow** — draft periods can be regenerated ("Refresh Readings"), closed periods are read-only
- **Tier calculation** — pure function supporting N tiers with progressive allocation, service charge, and tax rate. 9 unit tests.

### Files created (8)
| File | Purpose |
|------|---------|
| `src/lib/billing/calculations.ts` | Pure tier calculation: N-tier progressive allocation |
| `src/lib/billing/__tests__/calculations.test.ts` | 9 unit tests covering edge cases |
| `src/app/api/billing/generate/route.ts` | Server API: fetch readings → calculate → write line items |
| `src/components/CopyButton.tsx` | Clipboard button with "Copied" feedback |
| `src/components/BillingPeriodList.tsx` | Create/list billing periods |
| `src/components/BillingTable.tsx` | Core billing table with dynamic tier columns |
| `src/app/(dashboard)/microgrids/[id]/billing/page.tsx` | Replaced placeholder with period list |
| `src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx` | Period detail with parallel data fetching |

## Test plan

- [ ] Navigate to Kisakye → Billing tab → see empty period list
- [ ] Click "New Period" → dates default to previous month → Create
- [ ] Click "Generate" → line items appear for tenants with assigned meters
- [ ] Verify tier columns match the rate schedule (4 tiers for Kisakye)
- [ ] Click any copy button → value copied to clipboard (verify paste)
- [ ] Click "Refresh Readings" → line items regenerate
- [ ] Click "Close Period" → confirm → status changes to "closed", buttons disappear
- [ ] Navigate back to billing list → see closed period with green badge
- [ ] Tenants without meters show "No meter" in the table
- [ ] `npm run build` passes
- [ ] `npx vitest run` → 26/26 tests pass (9 billing + 17 OpenEMS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)