### PR TITLE
Add meter discovery from OpenEMS (#11)

### DIFF
--- a/src/app/api/openems/discover/route.ts
+++ b/src/app/api/openems/discover/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import type {
+  DiscoveredMeter,
+  EdgeDiscoveryResult,
+  MeterType,
+} from "@/lib/openems/types";
+
+const METER_NATURE_ID = "io.openems.edge.meter.api.ElectricityMeter";
+
+function classifyMeterType(factoryId: string): MeterType {
+  if (/GridMeter|\.Grid\./i.test(factoryId)) return "GRID";
+  if (/ProductionMeter|\.Production\./i.test(factoryId)) return "PRODUCTION";
+  if (/NRCMeter|\.Nrc\.|ConsumptionMeter/i.test(factoryId))
+    return "CONSUMPTION";
+  return "UNKNOWN";
+}
+
+export async function GET(request: NextRequest) {
+  const edgeIdsParam = request.nextUrl.searchParams.get("edgeIds");
+
+  if (!edgeIdsParam) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: edgeIds" },
+      { status: 400 }
+    );
+  }
+
+  const edgeIds = edgeIdsParam
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+
+  if (edgeIds.length === 0) {
+    return NextResponse.json(
+      { error: "edgeIds parameter must contain at least one edge ID" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const client = getOpenEmsClient();
+
+    // Get online/offline status for all edges
+    const statuses = await client.getEdgesStatus(edgeIds);
+    const statusMap = new Map(statuses.map((s) => [s.edgeId, s.online]));
+
+    // Fetch config for each edge in parallel, handling individual failures
+    const edges: EdgeDiscoveryResult[] = await Promise.all(
+      edgeIds.map(async (edgeId) => {
+        const online = statusMap.get(edgeId) ?? false;
+
+        try {
+          const config = await client.getEdgeConfig(edgeId);
+          const meters: DiscoveredMeter[] = [];
+
+          for (const [componentId, component] of Object.entries(
+            config.components
+          )) {
+            const factory = config.factories[component.factoryId];
+            if (!factory) continue;
+
+            if (factory.natureIds.includes(METER_NATURE_ID)) {
+              meters.push({
+                componentId,
+                alias: component.alias,
+                meterType: classifyMeterType(component.factoryId),
+                channelAddress: `${componentId}/ActiveConsumptionEnergy`,
+              });
+            }
+          }
+
+          return { edgeId, online, meters };
+        } catch {
+          // If edge config fails (e.g. edge is offline), return empty meters
+          return { edgeId, online: false, meters: [] };
+        }
+      })
+    );
+
+    return NextResponse.json({ edges });
+  } catch (err) {
+    if (err instanceof OpenEmsError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: err.statusCode }
+      );
+    }
+    return NextResponse.json(
+      { error: "Unexpected error discovering meters" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/MeterManager.tsx
+++ b/src/components/MeterManager.tsx
@@ -4,7 +4,32 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { Meter, Tenant } from "@/lib/types/database";
-import type { OpenEmsDataSourceConfig } from "@/lib/openems/types";
+import type {
+  DiscoveredMeter,
+  EdgeDiscoveryResult,
+  MeterType,
+  OpenEmsDataSourceConfig,
+} from "@/lib/openems/types";
+
+const METER_TYPE_BADGES: Record<MeterType, { label: string; classes: string }> =
+  {
+    GRID: {
+      label: "Grid",
+      classes: "bg-blue-100 text-blue-800",
+    },
+    PRODUCTION: {
+      label: "Production",
+      classes: "bg-green-100 text-green-800",
+    },
+    CONSUMPTION: {
+      label: "Consumption",
+      classes: "bg-orange-100 text-orange-800",
+    },
+    UNKNOWN: {
+      label: "Unknown",
+      classes: "bg-gray-100 text-gray-800",
+    },
+  };
 
 export function MeterManager({
   microgridId,
@@ -19,11 +44,43 @@ export function MeterManager({
   const supabase = createClient();
 
   const [showForm, setShowForm] = useState(false);
+  const [showDiscovery, setShowDiscovery] = useState(false);
   const [name, setName] = useState("");
   const [edgeId, setEdgeId] = useState("");
   const [channelAddress, setChannelAddress] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Discovery state
+  const [discoveryResults, setDiscoveryResults] = useState<
+    EdgeDiscoveryResult[]
+  >([]);
+  const [discoveryLoading, setDiscoveryLoading] = useState(false);
+  const [discoveryError, setDiscoveryError] = useState<string | null>(null);
+  const [addingMeter, setAddingMeter] = useState<string | null>(null);
+  // Optimistic tracking of meters added during this session (before router.refresh() completes)
+  const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
+
+  // Build set of already-added meter keys for dedup (prop-based + optimistic)
+  const existingKeys = new Set([
+    ...meters
+      .filter((m) => m.data_source_type === "openems")
+      .map((m) => {
+        const config = m.data_source_config as OpenEmsDataSourceConfig;
+        return `${config.edgeId}:${config.channelAddress.split("/")[0]}`;
+      }),
+    ...addedKeys,
+  ]);
+
+  // Derive edge IDs from existing meters, defaulting to "edge0" if none configured
+  function getDiscoverEdgeIds(): string {
+    const edgeIds = new Set(
+      meters
+        .filter((m) => m.data_source_type === "openems")
+        .map((m) => (m.data_source_config as OpenEmsDataSourceConfig).edgeId)
+    );
+    return edgeIds.size > 0 ? Array.from(edgeIds).join(",") : "edge0";
+  }
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault();
@@ -40,7 +97,10 @@ export function MeterManager({
       microgrid_id: microgridId,
       name: name.trim(),
       data_source_type: "openems",
-      data_source_config: { edgeId: edgeId.trim(), channelAddress: channelAddress.trim() },
+      data_source_config: {
+        edgeId: edgeId.trim(),
+        channelAddress: channelAddress.trim(),
+      },
     });
 
     if (insertError) {
@@ -79,21 +139,219 @@ export function MeterManager({
     router.refresh();
   }
 
+  async function handleDiscover() {
+    setShowDiscovery(true);
+    setShowForm(false);
+    setDiscoveryError(null);
+    setDiscoveryLoading(true);
+
+    try {
+      const res = await fetch(`/api/openems/discover?edgeIds=${encodeURIComponent(getDiscoverEdgeIds())}`);
+      const data = await res.json();
+
+      if (!res.ok) {
+        setDiscoveryError(data.error || "Failed to discover meters");
+        setDiscoveryResults([]);
+        return;
+      }
+
+      setDiscoveryResults(data.edges ?? []);
+    } catch {
+      setDiscoveryError(
+        "Could not reach the server. Check your network connection."
+      );
+      setDiscoveryResults([]);
+    } finally {
+      setDiscoveryLoading(false);
+    }
+  }
+
+  async function handleAddDiscovered(
+    discoveredEdgeId: string,
+    meter: DiscoveredMeter
+  ) {
+    setAddingMeter(meter.componentId);
+    setError(null);
+
+    const { error: insertError } = await supabase.from("meters").insert({
+      microgrid_id: microgridId,
+      name: meter.alias,
+      data_source_type: "openems",
+      data_source_config: {
+        edgeId: discoveredEdgeId,
+        channelAddress: meter.channelAddress,
+      },
+    });
+
+    if (insertError) {
+      setError(insertError.message);
+      setAddingMeter(null);
+      return;
+    }
+
+    // Optimistically mark as added so UI updates immediately (no race with router.refresh)
+    setAddedKeys((prev) => new Set([...prev, `${discoveredEdgeId}:${meter.componentId}`]));
+    setAddingMeter(null);
+    router.refresh();
+  }
+
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-900">Meters</h2>
-        <button
-          onClick={() => setShowForm(!showForm)}
-          className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
-        >
-          {showForm ? "Cancel" : "Add Meter"}
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={handleDiscover}
+            className="rounded-md bg-green-600 px-3 py-1.5 text-sm text-white hover:bg-green-700"
+          >
+            Discover Meters
+          </button>
+          <button
+            onClick={() => {
+              setShowForm(!showForm);
+              setShowDiscovery(false);
+            }}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+          >
+            {showForm ? "Cancel" : "Add Meter"}
+          </button>
+        </div>
       </div>
 
       {error && (
         <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
           {error}
+        </div>
+      )}
+
+      {showDiscovery && (
+        <div className="mb-4 rounded-md border border-gray-200 bg-gray-50 p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-gray-900">
+              Discovered Meters
+            </h3>
+            <button
+              onClick={() => setShowDiscovery(false)}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              Close
+            </button>
+          </div>
+
+          {discoveryLoading && (
+            <p className="text-sm text-gray-500">
+              Scanning OpenEMS for meters...
+            </p>
+          )}
+
+          {discoveryError && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+              {discoveryError}
+            </div>
+          )}
+
+          {!discoveryLoading &&
+            !discoveryError &&
+            discoveryResults.length === 0 && (
+              <p className="text-sm text-gray-500">No edges found.</p>
+            )}
+
+          {!discoveryLoading &&
+            !discoveryError &&
+            discoveryResults.map((edge) => (
+              <div key={edge.edgeId} className="mb-3 last:mb-0">
+                <div className="mb-2 flex items-center gap-2">
+                  <span
+                    className={`inline-block h-2.5 w-2.5 rounded-full ${
+                      edge.online ? "bg-green-500" : "bg-red-500"
+                    }`}
+                    title={edge.online ? "Online" : "Offline"}
+                  />
+                  <span className="text-sm font-medium text-gray-700">
+                    {edge.edgeId}
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    {edge.online ? "Online" : "Offline"}
+                  </span>
+                </div>
+
+                {edge.meters.length === 0 ? (
+                  <p className="ml-5 text-sm text-gray-400">
+                    No meters found on this edge.
+                  </p>
+                ) : (
+                  <div className="ml-5 space-y-2">
+                    {edge.meters.map((meter) => {
+                      const alreadyAdded = existingKeys.has(
+                        `${edge.edgeId}:${meter.componentId}`
+                      );
+                      const badge = METER_TYPE_BADGES[meter.meterType];
+
+                      return (
+                        <div
+                          key={meter.componentId}
+                          className={`flex items-center justify-between rounded-md border px-3 py-2 ${
+                            alreadyAdded
+                              ? "border-gray-100 bg-gray-100"
+                              : "border-gray-200 bg-white"
+                          }`}
+                        >
+                          <div className="flex items-center gap-3">
+                            <div>
+                              <p
+                                className={`text-sm font-medium ${
+                                  alreadyAdded
+                                    ? "text-gray-400"
+                                    : "text-gray-900"
+                                }`}
+                              >
+                                {meter.alias}
+                              </p>
+                              <p
+                                className={`text-xs ${
+                                  alreadyAdded
+                                    ? "text-gray-300"
+                                    : "text-gray-500"
+                                }`}
+                              >
+                                {meter.componentId}
+                              </p>
+                            </div>
+                            <span
+                              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                alreadyAdded
+                                  ? "bg-gray-100 text-gray-400"
+                                  : badge.classes
+                              }`}
+                            >
+                              {badge.label}
+                            </span>
+                          </div>
+
+                          {alreadyAdded ? (
+                            <span className="text-xs italic text-gray-400">
+                              Already added
+                            </span>
+                          ) : (
+                            <button
+                              onClick={() =>
+                                handleAddDiscovered(edge.edgeId, meter)
+                              }
+                              disabled={addingMeter === meter.componentId}
+                              className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              {addingMeter === meter.componentId
+                                ? "Adding..."
+                                : "Add"}
+                            </button>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            ))}
         </div>
       )}
 

--- a/src/lib/openems/client.ts
+++ b/src/lib/openems/client.ts
@@ -2,6 +2,7 @@ import type { MeterConfig, MeterDataAdapter, MeterReading } from "@/lib/adapters
 import { OpenEmsError } from "./errors";
 import type {
   ChannelValue,
+  EdgeConfig,
   EdgeStatus,
   JsonRpcResponse,
   MeterEnergyResult,
@@ -87,6 +88,25 @@ export class OpenEmsClient implements MeterDataAdapter {
       edgeId,
       online: status.online,
     }));
+  }
+
+  /**
+   * Get the full configuration of an edge (components + factories).
+   */
+  async getEdgeConfig(edgeId: string): Promise<EdgeConfig> {
+    const result = await this.rpc<{
+      payload: JsonRpcResponse<EdgeConfig>;
+    }>("edgeRpc", {
+      edgeId,
+      payload: {
+        jsonrpc: "2.0",
+        id: crypto.randomUUID(),
+        method: "getEdgeConfig",
+        params: {},
+      },
+    });
+
+    return result.payload.result;
   }
 
   /**

--- a/src/lib/openems/types.ts
+++ b/src/lib/openems/types.ts
@@ -54,3 +54,37 @@ export type ChannelValue = {
   channelAddress: string;
   value: number | null;
 };
+
+/** Edge configuration from getEdgeConfig */
+export type EdgeConfig = {
+  components: Record<string, EdgeComponent>;
+  factories: Record<string, EdgeFactory>;
+};
+
+export type EdgeComponent = {
+  alias: string;
+  factoryId: string;
+  properties: Record<string, unknown>;
+};
+
+export type EdgeFactory = {
+  natureIds: string[];
+};
+
+/** Meter type classification */
+export type MeterType = "GRID" | "PRODUCTION" | "CONSUMPTION" | "UNKNOWN";
+
+/** A discovered meter from OpenEMS */
+export type DiscoveredMeter = {
+  componentId: string;
+  alias: string;
+  meterType: MeterType;
+  channelAddress: string;
+};
+
+/** Discovery result per edge */
+export type EdgeDiscoveryResult = {
+  edgeId: string;
+  online: boolean;
+  meters: DiscoveredMeter[];
+};


### PR DESCRIPTION
## Summary
- Add `getEdgeConfig()` method to OpenEMS client for retrieving edge components and factories
- New `/api/openems/discover` endpoint that identifies meters by `ElectricityMeter` nature ID and classifies type (Grid/Production/Consumption) from factory ID
- "Discover Meters" button in MeterManager with one-click add, online/offline status indicators, meter type badges, and "Already added" dedup
- Edge IDs derived dynamically from existing meters (falls back to `edge0`)
- Optimistic UI tracking prevents duplicate insertion race condition

## Test plan
- [x] `npm run build` passes with no type errors
- [x] All 26 tests pass (9 billing + 17 OpenEMS client)
- [ ] Manual: click "Discover Meters" on tenants page, verify meters from edge0 appear
- [ ] Manual: click "Add" on a discovered meter, verify it appears in meters list and shows "Already added"
- [ ] Manual: verify "Add Meter" manual form still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)