### PR TITLE
Add delete billing period (#13)

### DIFF
--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -42,22 +42,25 @@ export function BillingPeriodList({
   const [startDate, setStartDate] = useState(defaults.start);
   const [endDate, setEndDate] = useState(defaults.end);
   const [creating, setCreating] = useState(false);
+  const [deletingPeriodId, setDeletingPeriodId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function handleDeletePeriod(period: BillingPeriod) {
     if (
       !confirm(
-        `Delete billing period ${formatDate(period.start_date)} – ${formatDate(period.end_date)}? This will also delete all line items.`
+        `Delete billing period ${formatDate(period.start_date)} – ${formatDate(period.end_date)}? This will also delete all line items. This cannot be undone.`
       )
     )
       return;
     setError(null);
+    setDeletingPeriodId(period.id);
     const { error: deleteError } = await supabase
       .from("billing_periods")
       .delete()
       .eq("id", period.id);
     if (deleteError) {
       setError(deleteError.message);
+      setDeletingPeriodId(null);
       return;
     }
     router.refresh();
@@ -203,9 +206,10 @@ export function BillingPeriodList({
                     {period.status === "draft" && (
                       <button
                         onClick={() => handleDeletePeriod(period)}
-                        className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700"
+                        disabled={deletingPeriodId === period.id}
+                        className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        Delete
+                        {deletingPeriodId === period.id ? "Deleting..." : "Delete"}
                       </button>
                     )}
                   </td>

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -50,6 +50,7 @@ export function BillingTable({
 
   const [generating, setGenerating] = useState(false);
   const [closing, setClosing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [generateErrors, setGenerateErrors] = useState<
     { tenantName: string; error: string }[]
@@ -124,12 +125,14 @@ export function BillingTable({
     )
       return;
     setError(null);
+    setDeleting(true);
     const { error: deleteError } = await supabase
       .from("billing_periods")
       .delete()
       .eq("id", period.id);
     if (deleteError) {
       setError(deleteError.message);
+      setDeleting(false);
       return;
     }
     router.push(`/microgrids/${microgridId}/billing`);
@@ -190,7 +193,7 @@ export function BillingTable({
             <div className="flex gap-2">
               <button
                 onClick={handleGenerate}
-                disabled={generating || closing}
+                disabled={generating || closing || deleting}
                 className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {generating
@@ -201,17 +204,17 @@ export function BillingTable({
               </button>
               <button
                 onClick={handleClose}
-                disabled={generating || closing || lineItems.length === 0}
+                disabled={generating || closing || deleting || lineItems.length === 0}
                 className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {closing ? "Closing..." : "Close Period"}
               </button>
               <button
                 onClick={handleDelete}
-                disabled={generating || closing}
+                disabled={generating || closing || deleting}
                 className="rounded-md border border-red-300 bg-white px-4 py-2 text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                Delete
+                {deleting ? "Deleting..." : "Delete"}
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add "Delete" button to draft billing periods in both list view and detail view
- List view: delete refreshes the list in place
- Detail view: delete redirects back to the billing tab
- Uses `ON DELETE CASCADE` — single delete call removes period + all line items
- Only draft periods can be deleted; closed periods have no delete button

## Test plan
- [x] `npm run build` passes with no type errors
- [x] All 26 tests pass
- [ ] Manual: create a draft period, click Delete in list view — period disappears
- [ ] Manual: create a draft period, open it, click Delete — redirects to billing list
- [ ] Manual: close a period — verify no Delete button shown
- [ ] Manual: confirm dialog appears before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)