### PR TITLE
Allow deletion of closed billing periods

### DIFF
--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -46,12 +46,12 @@ export function BillingPeriodList({
   const [error, setError] = useState<string | null>(null);
 
   async function handleDeletePeriod(period: BillingPeriod) {
-    if (
-      !confirm(
-        `Delete billing period ${formatDate(period.start_date)} – ${formatDate(period.end_date)}? This will also delete all line items. This cannot be undone.`
-      )
-    )
-      return;
+    const dateRange = `${formatDate(period.start_date)} – ${formatDate(period.end_date)}`;
+    const message =
+      period.status === "closed"
+        ? `Permanently delete this closed billing period (${dateRange}) and all its finalized bills? This cannot be undone.`
+        : `Delete this draft billing period (${dateRange}) and any generated bills? This cannot be undone.`;
+    if (!confirm(message)) return;
     setError(null);
     setDeletingPeriodId(period.id);
     const { error: deleteError } = await supabase
@@ -203,15 +203,13 @@ export function BillingPeriodList({
                     >
                       View
                     </Link>
-                    {period.status === "draft" && (
-                      <button
-                        onClick={() => handleDeletePeriod(period)}
-                        disabled={deletingPeriodId === period.id}
-                        className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {deletingPeriodId === period.id ? "Deleting..." : "Delete"}
-                      </button>
-                    )}
+                    <button
+                      onClick={() => handleDeletePeriod(period)}
+                      disabled={deletingPeriodId === period.id}
+                      className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {deletingPeriodId === period.id ? "Deleting..." : "Delete"}
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -118,12 +118,12 @@ export function BillingTable({
   }
 
   async function handleDelete() {
-    if (
-      !confirm(
-        "Delete this billing period? This will also delete all line items. This cannot be undone."
-      )
-    )
-      return;
+    const dateRange = `${formatDate(period.start_date)} – ${formatDate(period.end_date)}`;
+    const message =
+      period.status === "closed"
+        ? `Permanently delete this closed billing period (${dateRange}) and all its finalized bills? This cannot be undone.`
+        : `Delete this draft billing period (${dateRange}) and any generated bills? This cannot be undone.`;
+    if (!confirm(message)) return;
     setError(null);
     setDeleting(true);
     const { error: deleteError } = await supabase
@@ -189,35 +189,37 @@ export function BillingTable({
             </span>
           </div>
 
-          {isDraft && (
-            <div className="flex gap-2">
-              <button
-                onClick={handleGenerate}
-                disabled={generating || closing || deleting}
-                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {generating
-                  ? "Generating..."
-                  : lineItems.length > 0
-                    ? "Refresh Readings"
-                    : "Generate"}
-              </button>
-              <button
-                onClick={handleClose}
-                disabled={generating || closing || deleting || lineItems.length === 0}
-                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {closing ? "Closing..." : "Close Period"}
-              </button>
-              <button
-                onClick={handleDelete}
-                disabled={generating || closing || deleting}
-                className="rounded-md border border-red-300 bg-white px-4 py-2 text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {deleting ? "Deleting..." : "Delete"}
-              </button>
-            </div>
-          )}
+          <div className="flex gap-2">
+            {isDraft && (
+              <>
+                <button
+                  onClick={handleGenerate}
+                  disabled={generating || closing || deleting}
+                  className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {generating
+                    ? "Generating..."
+                    : lineItems.length > 0
+                      ? "Refresh Readings"
+                      : "Generate"}
+                </button>
+                <button
+                  onClick={handleClose}
+                  disabled={generating || closing || deleting || lineItems.length === 0}
+                  className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {closing ? "Closing..." : "Close Period"}
+                </button>
+              </>
+            )}
+            <button
+              onClick={handleDelete}
+              disabled={generating || closing || deleting}
+              className="rounded-md border border-red-300 bg-white px-4 py-2 text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Remove draft-only guard on Delete buttons in BillingPeriodList and BillingTable
- Enhance confirmation messages with date ranges and stronger warnings for closed periods
- Keep Generate and Close Period buttons draft-only (no regression)

Closes #21

## Test plan
- [ ] Open billing list → verify Delete button appears on both draft and closed periods
- [ ] Delete a closed period → confirm warning mentions "finalized bills" and shows date range
- [ ] Delete a draft period → confirm warning says "draft" and shows date range
- [ ] Verify Generate and Close Period buttons only appear on draft periods
- [ ] After deleting from detail view, verify redirect to billing list

🤖 Generated with [Claude Code](https://claude.com/claude-code)