### PR TITLE
Add local dev setup with Supabase CLI

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,6 @@
+# Populated by ./setup.sh (local or cloud mode)
+# Run ./setup.sh --help or see docs/setup.md for details
+
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# supabase CLI temp
+# supabase CLI
 supabase/.temp/
+.supabase/
+supabase/.branches/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Metering & Billing Engine (MBE)
+
+Multi-tenant billing engine for microgrid energy management. Tracks energy consumption per tenant, applies time-of-use rate schedules, and generates billing summaries for microgrid entrepreneurs.
+
+**Stack:** Next.js (App Router) + Supabase (Postgres, Auth, RLS) + OpenEMS (meter data via B2B REST API)
+
+## Getting Started
+
+See [docs/setup.md](docs/setup.md) for prerequisites and setup instructions.
+
+```bash
+./setup.sh      # bootstrap local Supabase + .env.local
+npm run dev     # start dev server at http://localhost:3000
+```
+
+## Related
+
+- [energy-iot/docker-openems](https://github.com/energy-iot/docker-openems) -- OpenEMS energy platform (Edge + Backend + UI)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -83,6 +83,7 @@ Usage:
 | `--anon-key=KEY` | Supabase anon/publishable key (cloud mode only) |
 | `--service-role-key=KEY` | Supabase service role key (cloud mode only) |
 | `--force` | Overwrite `.env.local` if it already exists |
+| `--help`, `-h` | Show usage information and exit |
 
 ### What the script does
 
@@ -149,7 +150,7 @@ The MBE connects to OpenEMS via the B2B REST API at `http://localhost:8075`. Thi
 |---------|----------|
 | `Docker daemon is not running` | Start Docker Desktop, then re-run `./setup.sh` |
 | `supabase: command not found` | Install: `brew install supabase/tap/supabase` |
-| `function gen_salt(unknown) does not exist` | The seed.sql may need `extensions.crypt()` prefix -- file an issue |
+| `function gen_salt(unknown) does not exist` | Verify seed.sql uses `extensions.crypt()` / `extensions.gen_salt()`. Run `supabase db reset` to re-apply. |
 | `.env.local already exists` | Use `./setup.sh --force` to overwrite |
 | Login fails with "Invalid credentials" | Run `supabase db reset` to re-seed the admin user |
 | `Failed to reach OpenEMS at localhost:8075` | Start the docker-openems stack first (see Full-Stack Setup) |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,172 @@
+# MBE Local Development Setup
+
+## Prerequisites
+
+### Required (all modes)
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | 18+ | [nodejs.org](https://nodejs.org/) or `brew install node` |
+| npm | 9+ | Bundled with Node.js |
+
+### Required for local mode only
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Docker Desktop | 4.0+ | [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/) |
+| Supabase CLI | 2.75+ | `brew install supabase/tap/supabase` or [docs](https://supabase.com/docs/guides/cli/getting-started) |
+
+> Cloud mode (`--cloud`) does not require Docker or the Supabase CLI.
+
+### Optional (for full-stack testing with OpenEMS)
+
+| Tool | Repo | Purpose |
+|------|------|---------|
+| docker-openems | [energy-iot/docker-openems](https://github.com/energy-iot/docker-openems) | OpenEMS energy platform (Edge + Backend + UI). Run its `./setup.sh --edges 1` first. Required for meter readings and billing generation. |
+
+## Quick Start
+
+### Option A: Local development (recommended)
+
+Runs a local Supabase instance in Docker. Full isolation -- no cloud dependency.
+
+```bash
+git clone https://github.com/energy-iot/metering-billing-engine.git
+cd metering-billing-engine
+./setup.sh
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and log in:
+- **Email:** `admin@eiot.energy`
+- **Password:** `admin123`
+
+### Option B: Cloud Supabase
+
+Connects to an existing hosted Supabase project. No Docker required.
+
+```bash
+git clone https://github.com/energy-iot/metering-billing-engine.git
+cd metering-billing-engine
+
+# Interactive (prompts for credentials):
+./setup.sh --cloud
+
+# Non-interactive (CI / scripted):
+./setup.sh --cloud \
+  --url=https://your-project.supabase.co \
+  --anon-key=your-anon-key \
+  --service-role-key=your-service-role-key
+
+npm run dev
+```
+
+## Setup Script Reference
+
+```
+Usage:
+  ./setup.sh                     Local mode (default)
+  ./setup.sh --local             Explicit local mode
+  ./setup.sh --cloud             Cloud mode, interactive prompts
+  ./setup.sh --cloud --url=URL --anon-key=KEY --service-role-key=KEY
+                                 Cloud mode, non-interactive
+  ./setup.sh --force             Overwrite existing .env.local
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--local` | Use local Supabase via CLI (default if no mode specified) |
+| `--cloud` | Use a hosted Supabase instance |
+| `--url=URL` | Supabase project URL (cloud mode only) |
+| `--anon-key=KEY` | Supabase anon/publishable key (cloud mode only) |
+| `--service-role-key=KEY` | Supabase service role key (cloud mode only) |
+| `--force` | Overwrite `.env.local` if it already exists |
+
+### What the script does
+
+**Local mode:**
+1. Checks prerequisites (Node.js, npm, Docker, Supabase CLI)
+2. Starts local Supabase containers (`supabase start`)
+3. Applies database migrations and seeds a dev admin user (`supabase db reset`)
+4. Generates `.env.local` with local Supabase URLs and keys
+5. Installs npm dependencies
+
+**Cloud mode:**
+1. Checks prerequisites (Node.js, npm)
+2. Collects Supabase credentials (from flags or interactive prompts)
+3. Generates `.env.local` with cloud Supabase URLs and keys
+4. Installs npm dependencies
+
+Both modes append OpenEMS B2B defaults to `.env.local`:
+```
+OPENEMS_B2B_URL=http://localhost:8075
+OPENEMS_B2B_USERNAME=admin
+OPENEMS_B2B_PASSWORD=Icui4cyou
+```
+
+## Local Supabase Services
+
+After `./setup.sh` in local mode, these services are running:
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| API (PostgREST) | http://127.0.0.1:54321 | REST API used by the app |
+| Studio | http://127.0.0.1:54323 | Database admin UI |
+| Inbucket | http://127.0.0.1:54324 | Email testing (catches auth emails) |
+| Database | postgresql://postgres:postgres@127.0.0.1:54322/postgres | Direct psql access |
+
+### Useful commands
+
+```bash
+supabase status         # Show running services and keys
+supabase db reset       # Re-apply migrations + seed (destructive)
+supabase stop           # Stop all local Supabase containers
+supabase start          # Restart containers
+```
+
+## Full-Stack Setup (with OpenEMS)
+
+To test meter readings and billing generation, you need the OpenEMS stack running alongside MBE.
+
+```bash
+# Terminal 1: Start OpenEMS
+cd ~/Projects/energy-iot/docker-openems
+./setup.sh --edges 1
+
+# Terminal 2: Start MBE
+cd ~/Projects/energy-iot/metering-billing-engine
+./setup.sh
+npm run dev
+```
+
+The MBE connects to OpenEMS via the B2B REST API at `http://localhost:8075`. This is configured automatically by the setup script.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `Docker daemon is not running` | Start Docker Desktop, then re-run `./setup.sh` |
+| `supabase: command not found` | Install: `brew install supabase/tap/supabase` |
+| `function gen_salt(unknown) does not exist` | The seed.sql may need `extensions.crypt()` prefix -- file an issue |
+| `.env.local already exists` | Use `./setup.sh --force` to overwrite |
+| Login fails with "Invalid credentials" | Run `supabase db reset` to re-seed the admin user |
+| `Failed to reach OpenEMS at localhost:8075` | Start the docker-openems stack first (see Full-Stack Setup) |
+| Billing generation shows "No meter reading data" | Ensure OpenEMS edge simulations are running and meters are assigned to tenants |
+
+## Architecture
+
+```
+Browser (localhost:3000)
+   |
+   +-- Next.js App (App Router)
+   |     +-- Supabase Auth (login, session, RLS)
+   |     +-- Supabase Postgres (orgs, microgrids, tenants, billing)
+   |     +-- OpenEMS B2B REST API (meter readings)
+   |
+   +-- Local Supabase (localhost:54321)  <-- setup.sh --local
+   |   or Cloud Supabase (*.supabase.co)  <-- setup.sh --cloud
+   |
+   +-- OpenEMS Backend (localhost:8075)  <-- docker-openems
+```

--- a/setup.sh
+++ b/setup.sh
@@ -126,21 +126,43 @@ if [ "$MODE" = "local" ]; then
   supabase start
 
   # Step 2: Apply migrations + seed
-  log "Applying migrations and seeding database..."
-  supabase db reset --yes
+  if [ -f .env.local ] && [ "$FORCE" = false ]; then
+    # Re-run scenario — skip db reset to preserve data
+    log "Supabase already configured. Skipping db reset (use --force to reset database)."
+  else
+    log "Applying migrations and seed data..."
+    supabase db reset --yes
+  fi
 
   # Step 3: Generate .env.local
   if check_existing_env; then
     log "Generating .env.local from local Supabase..."
 
-    # Extract env vars from supabase status
-    eval "$(supabase status -o env \
+    supabase status -o env \
       --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
       --override-name anon_key=NEXT_PUBLIC_SUPABASE_ANON_KEY \
       --override-name service_role_key=SUPABASE_SERVICE_ROLE_KEY \
-      | grep -E '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|SUPABASE_SERVICE_ROLE_KEY)=')"
+      | grep -E '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|SUPABASE_SERVICE_ROLE_KEY)=' \
+      > .env.local
 
-    generate_env_local "$NEXT_PUBLIC_SUPABASE_URL" "$NEXT_PUBLIC_SUPABASE_ANON_KEY" "$SUPABASE_SERVICE_ROLE_KEY"
+    # Validate we got all three values
+    if ! grep -q '^NEXT_PUBLIC_SUPABASE_URL=' .env.local || \
+       ! grep -q '^NEXT_PUBLIC_SUPABASE_ANON_KEY=' .env.local || \
+       ! grep -q '^SUPABASE_SERVICE_ROLE_KEY=' .env.local; then
+      err "Failed to extract Supabase credentials from 'supabase status'"
+      rm -f .env.local
+      exit 1
+    fi
+
+    # Append OpenEMS defaults
+    cat >> .env.local <<'ENVEOF'
+
+# OpenEMS B2B REST API
+OPENEMS_B2B_URL=http://localhost:8075
+OPENEMS_B2B_USERNAME=admin
+OPENEMS_B2B_PASSWORD=Icui4cyou
+ENVEOF
+
     log ".env.local created (local mode)"
   fi
 
@@ -167,7 +189,6 @@ if [ "$MODE" = "local" ]; then
 elif [ "$MODE" = "cloud" ]; then
   # Step 1: Collect credentials
   HAS_FLAGS=false
-  HAS_PROMPTS=false
 
   if [ -n "$CLOUD_URL" ] || [ -n "$CLOUD_ANON_KEY" ] || [ -n "$CLOUD_SERVICE_ROLE_KEY" ]; then
     HAS_FLAGS=true

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# setup.sh — One-command bootstrap for the Metering & Billing Engine.
+# Supports local Supabase (via CLI + Docker) or cloud Supabase instances.
+#
+# Usage:
+#   ./setup.sh                     # local mode (default)
+#   ./setup.sh --local             # explicit local mode
+#   ./setup.sh --cloud             # cloud mode, interactive prompts
+#   ./setup.sh --cloud --url=URL --anon-key=KEY --service-role-key=KEY
+#                                  # cloud mode, non-interactive
+#   ./setup.sh --force             # overwrite existing .env.local
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[setup]${NC} $*"; }
+warn() { echo -e "${YELLOW}[setup]${NC} $*"; }
+err()  { echo -e "${RED}[setup]${NC} $*" >&2; }
+
+# ── Flag parsing ─────────────────────────────────────────────────────
+MODE="local"
+FORCE=false
+CLOUD_URL=""
+CLOUD_ANON_KEY=""
+CLOUD_SERVICE_ROLE_KEY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local)  MODE="local"; shift ;;
+    --cloud)  MODE="cloud"; shift ;;
+    --force)  FORCE=true; shift ;;
+    --url=*)  CLOUD_URL="${1#--url=}"; shift ;;
+    --anon-key=*)  CLOUD_ANON_KEY="${1#--anon-key=}"; shift ;;
+    --service-role-key=*)  CLOUD_SERVICE_ROLE_KEY="${1#--service-role-key=}"; shift ;;
+    --help|-h)
+      echo "Usage:"
+      echo "  ./setup.sh                     Local mode (default)"
+      echo "  ./setup.sh --local             Explicit local mode"
+      echo "  ./setup.sh --cloud             Cloud mode, interactive prompts"
+      echo "  ./setup.sh --cloud --url=URL --anon-key=KEY --service-role-key=KEY"
+      echo "                                 Cloud mode, non-interactive"
+      echo "  ./setup.sh --force             Overwrite existing .env.local"
+      echo ""
+      echo "See docs/setup.md for full documentation."
+      exit 0
+      ;;
+    *)  err "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# ── Prerequisite checks ─────────────────────────────────────────────
+check_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "$1 is required but not installed."
+    [ -n "${2:-}" ] && err "  Install: $2"
+    exit 1
+  fi
+}
+
+log "Mode: ${MODE}"
+log ""
+
+# Common prerequisites
+check_command "node" "https://nodejs.org/ or brew install node"
+check_command "npm" "bundled with Node.js"
+
+if [ "$MODE" = "local" ]; then
+  check_command "docker" "https://www.docker.com/products/docker-desktop/"
+
+  # Check Docker daemon is running
+  if ! docker info >/dev/null 2>&1; then
+    err "Docker daemon is not running. Start Docker Desktop and try again."
+    exit 1
+  fi
+
+  check_command "supabase" "brew install supabase/tap/supabase"
+fi
+
+log "Prerequisites OK"
+log ""
+
+# ── Helper: generate .env.local ──────────────────────────────────────
+generate_env_local() {
+  local supabase_url="$1"
+  local anon_key="$2"
+  local service_role_key="$3"
+
+  cat > .env.local <<ENVEOF
+NEXT_PUBLIC_SUPABASE_URL=${supabase_url}
+NEXT_PUBLIC_SUPABASE_ANON_KEY=${anon_key}
+SUPABASE_SERVICE_ROLE_KEY=${service_role_key}
+
+# OpenEMS B2B REST API
+OPENEMS_B2B_URL=http://localhost:8075
+OPENEMS_B2B_USERNAME=admin
+OPENEMS_B2B_PASSWORD=Icui4cyou
+ENVEOF
+}
+
+# ── Helper: check existing .env.local ────────────────────────────────
+check_existing_env() {
+  if [ -f .env.local ] && [ "$FORCE" = false ]; then
+    local existing_url
+    existing_url=$(grep '^NEXT_PUBLIC_SUPABASE_URL=' .env.local | cut -d= -f2- || echo "")
+    if echo "$existing_url" | grep -qE '(localhost|127\.0\.0\.1)'; then
+      warn ".env.local already exists (pointing at local Supabase)"
+    else
+      warn ".env.local already exists (pointing at ${existing_url})"
+    fi
+    warn "Use --force to overwrite"
+    return 1
+  fi
+  return 0
+}
+
+# ── Local mode ───────────────────────────────────────────────────────
+if [ "$MODE" = "local" ]; then
+  # Step 1: Start local Supabase
+  log "Starting local Supabase..."
+  supabase start
+
+  # Step 2: Apply migrations + seed
+  log "Applying migrations and seeding database..."
+  supabase db reset --yes
+
+  # Step 3: Generate .env.local
+  if check_existing_env; then
+    log "Generating .env.local from local Supabase..."
+
+    # Extract env vars from supabase status
+    eval "$(supabase status -o env \
+      --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
+      --override-name anon_key=NEXT_PUBLIC_SUPABASE_ANON_KEY \
+      --override-name service_role_key=SUPABASE_SERVICE_ROLE_KEY \
+      | grep -E '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|SUPABASE_SERVICE_ROLE_KEY)=')"
+
+    generate_env_local "$NEXT_PUBLIC_SUPABASE_URL" "$NEXT_PUBLIC_SUPABASE_ANON_KEY" "$SUPABASE_SERVICE_ROLE_KEY"
+    log ".env.local created (local mode)"
+  fi
+
+  # Step 4: Install dependencies
+  log "Installing npm dependencies..."
+  npm install
+
+  # Step 5: Summary
+  log ""
+  log "=== Setup Complete (local mode) ==="
+  log ""
+  log "  App:         http://localhost:3000"
+  log "  Studio:      http://127.0.0.1:54323"
+  log "  Inbucket:    http://127.0.0.1:54324"
+  log "  Database:    postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+  log ""
+  log "  Login:       admin@eiot.energy / admin123"
+  log ""
+  log "Next steps:"
+  log "  npm run dev"
+  log ""
+
+# ── Cloud mode ───────────────────────────────────────────────────────
+elif [ "$MODE" = "cloud" ]; then
+  # Step 1: Collect credentials
+  HAS_FLAGS=false
+  HAS_PROMPTS=false
+
+  if [ -n "$CLOUD_URL" ] || [ -n "$CLOUD_ANON_KEY" ] || [ -n "$CLOUD_SERVICE_ROLE_KEY" ]; then
+    HAS_FLAGS=true
+  fi
+
+  if [ "$HAS_FLAGS" = true ]; then
+    # Non-interactive: all three must be provided
+    if [ -z "$CLOUD_URL" ] || [ -z "$CLOUD_ANON_KEY" ] || [ -z "$CLOUD_SERVICE_ROLE_KEY" ]; then
+      err "Provide all three flags (--url, --anon-key, --service-role-key) or none for interactive mode."
+      exit 1
+    fi
+  else
+    # Interactive: prompt for all three
+    log "Enter your Supabase project credentials:"
+    echo ""
+    read -rp "  Supabase URL: " CLOUD_URL
+    read -rp "  Anon key: " CLOUD_ANON_KEY
+    read -rp "  Service role key: " CLOUD_SERVICE_ROLE_KEY
+    echo ""
+  fi
+
+  # Validate
+  if [ -z "$CLOUD_URL" ] || [ -z "$CLOUD_ANON_KEY" ] || [ -z "$CLOUD_SERVICE_ROLE_KEY" ]; then
+    err "All three Supabase credentials are required."
+    exit 1
+  fi
+
+  if ! echo "$CLOUD_URL" | grep -qE '^https://'; then
+    warn "Supabase URL should start with https:// (got: ${CLOUD_URL})"
+  fi
+
+  # Step 2: Generate .env.local
+  if check_existing_env; then
+    log "Generating .env.local (cloud mode)..."
+    generate_env_local "$CLOUD_URL" "$CLOUD_ANON_KEY" "$CLOUD_SERVICE_ROLE_KEY"
+    log ".env.local created (cloud mode)"
+  fi
+
+  # Step 3: Install dependencies
+  log "Installing npm dependencies..."
+  npm install
+
+  # Step 4: Summary
+  log ""
+  log "=== Setup Complete (cloud mode) ==="
+  log ""
+  log "  App:         http://localhost:3000"
+  log "  Supabase:    ${CLOUD_URL}"
+  log ""
+  log "Next steps:"
+  log "  npm run dev"
+  log ""
+fi

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,388 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "metering-billing-engine"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,39 @@
+-- seed.sql — local dev only, runs after migrations on `supabase db reset`
+
+CREATE OR REPLACE FUNCTION seed_create_user(
+  user_email text,
+  user_password text,
+  user_id uuid DEFAULT 'a1111111-1111-1111-1111-111111111111'::uuid
+) RETURNS uuid AS $$
+DECLARE
+  encrypted_pw text;
+BEGIN
+  encrypted_pw := extensions.crypt(user_password, extensions.gen_salt('bf'));
+  INSERT INTO auth.users (
+    instance_id, id, aud, role, email, encrypted_password,
+    email_confirmed_at, last_sign_in_at,
+    raw_app_meta_data, raw_user_meta_data,
+    created_at, updated_at,
+    confirmation_token, email_change, email_change_token_new, recovery_token
+  ) VALUES (
+    '00000000-0000-0000-0000-000000000000', user_id, 'authenticated', 'authenticated',
+    user_email, encrypted_pw, now(), now(),
+    '{"provider":"email","providers":["email"]}', '{}',
+    now(), now(), '', '', '', ''
+  );
+  INSERT INTO auth.identities (
+    id, user_id, provider_id, identity_data, provider,
+    last_sign_in_at, created_at, updated_at
+  ) VALUES (
+    user_id, user_id, user_id::text,
+    jsonb_build_object('sub', user_id::text, 'email', user_email),
+    'email', now(), now(), now()
+  );
+  RETURN user_id;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT seed_create_user('admin@eiot.energy', 'admin123');
+INSERT INTO user_roles (user_id, role)
+VALUES ('a1111111-1111-1111-1111-111111111111', 'system_admin');
+DROP FUNCTION seed_create_user;


### PR DESCRIPTION
## Summary

Closes #27.

Adds a dual-mode `setup.sh` that bootstraps MBE for either local or cloud Supabase with a single command.

### New files
- **`setup.sh`** — `./setup.sh` (local Supabase via CLI) or `./setup.sh --cloud` (hosted Supabase). Checks prereqs, generates `.env.local`, runs `npm install`. Supports `--force` to overwrite, `--url=`/`--anon-key=`/`--service-role-key=` flags for CI.
- **`supabase/config.toml`** — Supabase CLI project config (API 54321, DB 54322, Studio 54323)
- **`supabase/seed.sql`** — Seeds dev admin user `admin@eiot.energy` / `admin123` with `system_admin` role. Uses `extensions.crypt()`/`extensions.gen_salt()` for GoTrue compatibility.
- **`docs/setup.md`** — Full setup guide: prerequisites, quick start (both modes), script reference, troubleshooting, architecture diagram

### Modified files
- **`README.md`** — Replaced Next.js boilerplate with project overview + link to docs/setup.md
- **`.gitignore`** — Added `.supabase/`, `supabase/.branches/`
- **`.env.local.example`** — Added setup.sh reference comment

### Review fixes applied
- Removed `eval` on `supabase status` output (security risk) — now pipes directly to `.env.local`
- Added validation that all 3 Supabase env vars were extracted
- Guarded `supabase db reset` on re-runs to prevent data loss (skips unless `--force`)

## Test plan

- [ ] Fresh clone → `./setup.sh` → `npm run dev` → login with `admin@eiot.energy` / `admin123`
- [ ] `./setup.sh --cloud --url=https://test.supabase.co --anon-key=xxx --service-role-key=yyy` → generates .env.local
- [ ] `./setup.sh --cloud` (no flags) → prompts for credentials interactively
- [ ] Re-run `./setup.sh` → skips .env.local and db reset (preserves data)
- [ ] `./setup.sh --force` → overwrites .env.local and resets database
- [ ] `bash -n setup.sh` passes (syntax valid)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)