### PR TITLE
Add Docker mode for zero-install local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+.git/
+.env*
+supabase/.temp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,134 @@
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./docker/init-roles.sql:/docker-entrypoint-initdb.d/01-init-roles.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  gotrue:
+    image: supabase/gotrue:v2.187.0
+    depends_on:
+      postgres: { condition: service_healthy }
+    environment:
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      GOTRUE_API_HOST: "0.0.0.0"
+      GOTRUE_API_PORT: "9999"
+      GOTRUE_SITE_URL: http://localhost:3000
+      API_EXTERNAL_URL: http://localhost:54321
+      GOTRUE_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
+      GOTRUE_JWT_EXP: "3600"
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
+      GOTRUE_MAILER_AUTOCONFIRM: "true"
+      GOTRUE_DISABLE_SIGNUP: "false"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:9999/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  postgrest:
+    image: postgrest/postgrest:v12.2.3
+    depends_on:
+      postgres: { condition: service_healthy }
+    environment:
+      PGRST_DB_URI: postgres://postgres:postgres@postgres:5432/postgres
+      PGRST_DB_SCHEMAS: public
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_DB_EXTRA_SEARCH_PATH: public,extensions
+      PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+    # No health check — postgrest image is minimal Nix build with no shell/curl/wget
+
+  kong:
+    image: kong:3.5
+    depends_on:
+      gotrue: { condition: service_healthy }
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /etc/kong/kong.yml
+      KONG_LOG_LEVEL: info
+    volumes:
+      - ./docker/kong.yml:/etc/kong/kong.yml:ro
+    ports:
+      - "54321:8000"
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mbe-migrate:
+    image: postgres:15-alpine
+    depends_on:
+      gotrue: { condition: service_healthy }
+    volumes:
+      - ./supabase/migrations:/migrations:ro
+      - ./supabase/seed.sql:/seed.sql:ro
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: postgres
+    command: |
+      sh -c '
+      echo "Waiting for auth schema..."
+      until psql -c "SELECT 1 FROM auth.users LIMIT 0" 2>/dev/null; do sleep 1; done
+
+      if psql -c "SELECT 1 FROM organizations LIMIT 0" 2>/dev/null; then
+        echo "Migrations already applied, skipping."
+        exit 0
+      fi
+
+      echo "Granting auth schema access..."
+      psql -c "GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;"
+      psql -c "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA auth TO anon, authenticated, service_role;"
+
+      echo "Applying migrations..."
+      for f in /migrations/*.sql; do echo "  $$(basename $$f)"; psql -f "$$f"; done
+      echo "Applying seed..."
+      psql -f /seed.sql
+      echo "Done."
+      '
+    restart: "no"
+
+  mbe-app:
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+    depends_on:
+      kong: { condition: service_healthy }
+      mbe-migrate: { condition: service_completed_successfully }
+    environment:
+      NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+      SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+      SUPABASE_INTERNAL_URL: http://kong:8000
+      OPENEMS_B2B_URL: http://host.docker.internal:8075
+      OPENEMS_B2B_USERNAME: admin
+      OPENEMS_B2B_PASSWORD: Icui4cyou
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:3000/"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:

--- a/docker/init-roles.sql
+++ b/docker/init-roles.sql
@@ -1,0 +1,15 @@
+-- docker/init-roles.sql
+CREATE ROLE anon NOLOGIN;
+CREATE ROLE authenticated NOLOGIN;
+CREATE ROLE service_role NOLOGIN BYPASSRLS;
+CREATE ROLE authenticator NOLOGIN;
+GRANT anon, authenticated, service_role TO authenticator;
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
+
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA extensions;

--- a/docker/kong.yml
+++ b/docker/kong.yml
@@ -1,0 +1,20 @@
+_format_version: "3.0"
+services:
+  - name: auth
+    url: http://gotrue:9999
+    routes:
+      - name: auth-route
+        paths: ["/auth/v1/"]
+        strip_path: true
+  - name: rest
+    url: http://postgrest:3000
+    routes:
+      - name: rest-route
+        paths: ["/rest/v1/"]
+        strip_path: true
+plugins:
+  - name: cors
+    config:
+      origins: ["http://localhost:3000"]
+      methods: [GET, POST, PUT, PATCH, DELETE, OPTIONS]
+      headers: [Authorization, Content-Type, apikey, x-client-info]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,34 +1,70 @@
 # MBE Local Development Setup
 
-## Prerequisites
+## Which path should I use?
 
-### Required (all modes)
+| I want to... | Use |
+|--------------|-----|
+| Run and test the app (no dev tools needed) | **Docker path** (`./setup.sh --docker`) |
+| Write code with hot reload and Supabase Studio | **Dev path** (`./setup.sh`) |
 
-| Tool | Version | Install |
-|------|---------|---------|
-| Node.js | 18+ | [nodejs.org](https://nodejs.org/) or `brew install node` |
-| npm | 9+ | Bundled with Node.js |
+## Docker path (contributor / tester)
 
-### Required for local mode only
+Run the entire stack in Docker. No Node.js, npm, or Supabase CLI required.
+
+### Prerequisites
 
 | Tool | Version | Install |
 |------|---------|---------|
 | Docker Desktop | 4.0+ | [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/) |
+
+### Quick Start
+
+```bash
+git clone https://github.com/energy-iot/metering-billing-engine.git
+cd metering-billing-engine
+./setup.sh --docker
+```
+
+Open [http://localhost:3000](http://localhost:3000) and log in:
+- **Email:** `admin@eiot.energy`
+- **Password:** `admin123`
+
+### Data persistence
+
+| Command | Data preserved? |
+|---------|----------------|
+| `docker compose stop` / `start` | Yes |
+| `docker compose down` | Yes (volume kept) |
+| `docker compose down -v` | **No** (fresh start) |
+| `docker compose up --build` | Yes (images rebuilt, data kept) |
+
+### Reset to fresh state
+
+```bash
+./setup.sh --docker --force
+# or manually:
+docker compose down -v && docker compose up --build -d
+```
+
+### Limitations
+
+- No hot reload -- runs `next start` (production build). Use the dev path for active development.
+- No Supabase Studio -- use the dev path if you need the database admin UI.
+
+## Dev path (developer)
+
+Runs local Supabase via CLI with hot reload and full dev tooling.
+
+### Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | 20+ | [nodejs.org](https://nodejs.org/) or `brew install node` |
+| npm | 9+ | Bundled with Node.js |
+| Docker Desktop | 4.0+ | [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/) |
 | Supabase CLI | 2.75+ | `brew install supabase/tap/supabase` or [docs](https://supabase.com/docs/guides/cli/getting-started) |
 
-> Cloud mode (`--cloud`) does not require Docker or the Supabase CLI.
-
-### Optional (for full-stack testing with OpenEMS)
-
-| Tool | Repo | Purpose |
-|------|------|---------|
-| docker-openems | [energy-iot/docker-openems](https://github.com/energy-iot/docker-openems) | OpenEMS energy platform (Edge + Backend + UI). Run its `./setup.sh --edges 1` first. Required for meter readings and billing generation. |
-
-## Quick Start
-
-### Option A: Local development (recommended)
-
-Runs a local Supabase instance in Docker. Full isolation -- no cloud dependency.
+### Quick Start — Local Supabase (recommended)
 
 ```bash
 git clone https://github.com/energy-iot/metering-billing-engine.git
@@ -41,7 +77,7 @@ Open [http://localhost:3000](http://localhost:3000) and log in:
 - **Email:** `admin@eiot.energy`
 - **Password:** `admin123`
 
-### Option B: Cloud Supabase
+### Quick Start — Cloud Supabase
 
 Connects to an existing hosted Supabase project. No Docker required.
 
@@ -67,6 +103,7 @@ npm run dev
 Usage:
   ./setup.sh                     Local mode (default)
   ./setup.sh --local             Explicit local mode
+  ./setup.sh --docker            Docker mode, full stack in Docker
   ./setup.sh --cloud             Cloud mode, interactive prompts
   ./setup.sh --cloud --url=URL --anon-key=KEY --service-role-key=KEY
                                  Cloud mode, non-interactive
@@ -78,14 +115,21 @@ Usage:
 | Flag | Description |
 |------|-------------|
 | `--local` | Use local Supabase via CLI (default if no mode specified) |
+| `--docker` | Run the full stack in Docker (no dev tools needed) |
 | `--cloud` | Use a hosted Supabase instance |
 | `--url=URL` | Supabase project URL (cloud mode only) |
 | `--anon-key=KEY` | Supabase anon/publishable key (cloud mode only) |
 | `--service-role-key=KEY` | Supabase service role key (cloud mode only) |
-| `--force` | Overwrite `.env.local` if it already exists |
+| `--force` | Overwrite `.env.local` if it already exists. In docker mode: `docker compose down -v` first. |
 | `--help`, `-h` | Show usage information and exit |
 
 ### What the script does
+
+**Docker mode:**
+1. Checks prerequisites (Docker, docker compose)
+2. Builds and starts 6 containers (Postgres, GoTrue, PostgREST, Kong, migrations, Next.js app)
+3. Waits for the app to be ready
+4. Prints summary with URLs and credentials
 
 **Local mode:**
 1. Checks prerequisites (Node.js, npm, Docker, Supabase CLI)
@@ -100,7 +144,7 @@ Usage:
 3. Generates `.env.local` with cloud Supabase URLs and keys
 4. Installs npm dependencies
 
-Both modes append OpenEMS B2B defaults to `.env.local`:
+Local and cloud modes append OpenEMS B2B defaults to `.env.local`:
 ```
 OPENEMS_B2B_URL=http://localhost:8075
 OPENEMS_B2B_USERNAME=admin
@@ -138,11 +182,12 @@ cd ~/Projects/energy-iot/docker-openems
 
 # Terminal 2: Start MBE
 cd ~/Projects/energy-iot/metering-billing-engine
-./setup.sh
-npm run dev
+./setup.sh            # or ./setup.sh --docker
 ```
 
-The MBE connects to OpenEMS via the B2B REST API at `http://localhost:8075`. This is configured automatically by the setup script.
+If using `--docker` mode, OpenEMS on the host is reachable via `host.docker.internal:8075` (configured automatically).
+
+If using local/dev mode, run `npm run dev` after setup.
 
 ## Troubleshooting
 
@@ -152,9 +197,11 @@ The MBE connects to OpenEMS via the B2B REST API at `http://localhost:8075`. Thi
 | `supabase: command not found` | Install: `brew install supabase/tap/supabase` |
 | `function gen_salt(unknown) does not exist` | Verify seed.sql uses `extensions.crypt()` / `extensions.gen_salt()`. Run `supabase db reset` to re-apply. |
 | `.env.local already exists` | Use `./setup.sh --force` to overwrite |
-| Login fails with "Invalid credentials" | Run `supabase db reset` to re-seed the admin user |
+| Login fails with "Invalid credentials" | Run `supabase db reset` (local mode) or `./setup.sh --docker --force` (docker mode) to re-seed the admin user |
 | `Failed to reach OpenEMS at localhost:8075` | Start the docker-openems stack first (see Full-Stack Setup) |
 | Billing generation shows "No meter reading data" | Ensure OpenEMS edge simulations are running and meters are assigned to tenants |
+| Docker mode: app not starting | Check `docker compose logs mbe-app` for errors |
+| Docker mode: migration failures | Check `docker compose logs mbe-migrate` for errors. Try `./setup.sh --docker --force` for a fresh start. |
 
 ## Architecture
 
@@ -167,6 +214,7 @@ Browser (localhost:3000)
    |     +-- OpenEMS B2B REST API (meter readings)
    |
    +-- Local Supabase (localhost:54321)  <-- setup.sh --local
+   |   or Docker Supabase (localhost:54321)  <-- setup.sh --docker
    |   or Cloud Supabase (*.supabase.co)  <-- setup.sh --cloud
    |
    +-- OpenEMS Backend (localhost:8075)  <-- docker-openems

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   ./setup.sh                     # local mode (default)
 #   ./setup.sh --local             # explicit local mode
+#   ./setup.sh --docker            # docker mode, full stack in Docker
 #   ./setup.sh --cloud             # cloud mode, interactive prompts
 #   ./setup.sh --cloud --url=URL --anon-key=KEY --service-role-key=KEY
 #                                  # cloud mode, non-interactive
@@ -33,6 +34,7 @@ CLOUD_SERVICE_ROLE_KEY=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)  MODE="local"; shift ;;
+    --docker) MODE="docker"; shift ;;
     --cloud)  MODE="cloud"; shift ;;
     --force)  FORCE=true; shift ;;
     --url=*)  CLOUD_URL="${1#--url=}"; shift ;;
@@ -42,6 +44,7 @@ while [ $# -gt 0 ]; do
       echo "Usage:"
       echo "  ./setup.sh                     Local mode (default)"
       echo "  ./setup.sh --local             Explicit local mode"
+      echo "  ./setup.sh --docker            Docker mode, full stack in Docker"
       echo "  ./setup.sh --cloud             Cloud mode, interactive prompts"
       echo "  ./setup.sh --cloud --url=URL --anon-key=KEY --service-role-key=KEY"
       echo "                                 Cloud mode, non-interactive"
@@ -66,20 +69,36 @@ check_command() {
 log "Mode: ${MODE}"
 log ""
 
-# Common prerequisites
-check_command "node" "https://nodejs.org/ or brew install node"
-check_command "npm" "bundled with Node.js"
-
-if [ "$MODE" = "local" ]; then
+if [ "$MODE" = "docker" ]; then
+  # Docker mode: only needs docker + docker compose
   check_command "docker" "https://www.docker.com/products/docker-desktop/"
 
-  # Check Docker daemon is running
   if ! docker info >/dev/null 2>&1; then
     err "Docker daemon is not running. Start Docker Desktop and try again."
     exit 1
   fi
 
-  check_command "supabase" "brew install supabase/tap/supabase"
+  if ! docker compose version >/dev/null 2>&1; then
+    err "docker compose is required but not available."
+    err "  Install Docker Desktop 4.0+ which includes docker compose."
+    exit 1
+  fi
+else
+  # Local/cloud modes: need node + npm
+  check_command "node" "https://nodejs.org/ or brew install node"
+  check_command "npm" "bundled with Node.js"
+
+  if [ "$MODE" = "local" ]; then
+    check_command "docker" "https://www.docker.com/products/docker-desktop/"
+
+    # Check Docker daemon is running
+    if ! docker info >/dev/null 2>&1; then
+      err "Docker daemon is not running. Start Docker Desktop and try again."
+      exit 1
+    fi
+
+    check_command "supabase" "brew install supabase/tap/supabase"
+  fi
 fi
 
 log "Prerequisites OK"
@@ -119,8 +138,46 @@ check_existing_env() {
   return 0
 }
 
+# ── Docker mode ──────────────────────────────────────────────────────
+if [ "$MODE" = "docker" ]; then
+  if [ "$FORCE" = true ]; then
+    log "Force mode: tearing down existing containers and volumes..."
+    docker compose down -v
+  fi
+
+  log "Building and starting Docker stack..."
+  docker compose up --build -d
+
+  log "Waiting for app to be ready..."
+  RETRIES=0
+  MAX_RETRIES=60
+  until curl -sf http://localhost:3000/ >/dev/null 2>&1; do
+    RETRIES=$((RETRIES + 1))
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+      err "App did not become ready within ${MAX_RETRIES} seconds."
+      err "Check logs with: docker compose logs"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  log ""
+  log "=== Setup Complete (docker mode) ==="
+  log ""
+  log "  App:         http://localhost:3000"
+  log "  Supabase:    http://localhost:54321"
+  log ""
+  log "  Login:       admin@eiot.energy / admin123"
+  log ""
+  log "Useful commands:"
+  log "  docker compose logs -f         Follow logs"
+  log "  docker compose stop            Stop (preserves data)"
+  log "  docker compose down            Stop + remove containers (preserves data)"
+  log "  docker compose down -v         Stop + remove everything (fresh start)"
+  log ""
+
 # ── Local mode ───────────────────────────────────────────────────────
-if [ "$MODE" = "local" ]; then
+elif [ "$MODE" = "local" ]; then
   # Step 1: Start local Supabase
   log "Starting local Supabase..."
   supabase start

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -5,7 +5,7 @@ export async function createClient() {
   const cookieStore = await cookies();
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,7 @@ export async function middleware(request: NextRequest) {
   });
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {


### PR DESCRIPTION
## Summary

Closes #30.

Adds a `--docker` mode to `setup.sh` that runs the entire MBE stack (Next.js + Supabase) in Docker containers. Contributors only need Docker installed — no Node.js, npm, or Supabase CLI.

### New files
- **`Dockerfile`** — Multi-stage Next.js build (node:20-alpine, standalone output)
- **`.dockerignore`** — Keeps build context small
- **`docker-compose.yml`** — 6 services: postgres, gotrue, postgrest, kong, mbe-migrate (init), mbe-app
- **`docker/init-roles.sql`** — Phase 1 DB init: Postgres roles + extensions
- **`docker/kong.yml`** — API gateway routing (/auth/v1 → GoTrue, /rest/v1 → PostgREST)

### Modified files
- **`next.config.ts`** — Added `output: "standalone"` for Docker builds
- **`src/lib/supabase/server.ts`** — `SUPABASE_INTERNAL_URL` fallback for Docker networking
- **`src/middleware.ts`** — Same `SUPABASE_INTERNAL_URL` fallback
- **`setup.sh`** — Added `--docker` mode with mode-aware prereq checks
- **`docs/setup.md`** — Two-path docs (Docker path vs Dev path) with decision guide

### Architecture
```
./setup.sh --docker
├── postgres       (DB + roles/extensions)
├── gotrue         (Auth — auto-migrates auth schema)
├── postgrest      (REST API with RLS)
├── kong           (API gateway at localhost:54321)
├── mbe-migrate    (applies migrations + seed after GoTrue, then exits)
└── mbe-app        (Next.js at localhost:3000)
```

### Key design decisions (from 5 rounds of refinement)
- **Two-phase DB init**: GoTrue must create `auth.users`/`auth.uid()` before app migrations reference them
- **No PostgREST health check**: Minimal Nix image has no shell/curl
- **Browser/server URL split**: Build arg `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321` (browser), runtime `SUPABASE_INTERNAL_URL=http://kong:8000` (server)
- **Kong required**: Supabase JS client derives `/auth/v1/*` and `/rest/v1/*` from a single base URL
- **Idempotent migrations**: mbe-migrate checks if `organizations` table exists before re-applying

## Test plan

- [ ] `./setup.sh --docker` on a machine with only Docker → containers start, app at localhost:3000
- [ ] Login with `admin@eiot.energy` / `admin123` → see Kisakye microgrid
- [ ] `./setup.sh --docker --force` → fresh rebuild with data reset
- [ ] `docker compose down` then `docker compose up -d` → data persists
- [ ] `./setup.sh --local` still works (no regression)
- [ ] `npm run dev` still works (standalone output doesn't affect dev mode)
- [ ] `bash -n setup.sh` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)