### PR TITLE
Add SigV4 auth strategy to OpenEMS adapter

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,6 +6,18 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # OpenEMS B2B REST API
+# OPENEMS_B2B_URL accepts two forms:
+#   - Local / direct:  http://host:port  (Basic auth appends /jsonrpc automatically)
+#   - Lambda proxy:    https://<id>.lambda-url.<region>.on.aws/  (SigV4 auth — Lambda handler routes to /jsonrpc internally)
 OPENEMS_B2B_URL=http://localhost:8075
+
+# Basic auth credentials — used when OPENEMS_AWS_* vars are NOT set (local Docker / direct B2B endpoint)
 OPENEMS_B2B_USERNAME=admin
 OPENEMS_B2B_PASSWORD=Icui4cyou
+
+# SigV4 credentials — used when set, takes precedence over Basic auth (Vercel / Lambda Function URL)
+# Requires an IAM identity with lambda:InvokeFunctionUrl + lambda:InvokeFunction on the Lambda proxy function.
+# Leave unset for local development (setup.sh does not write these).
+OPENEMS_AWS_ACCESS_KEY_ID=
+OPENEMS_AWS_SECRET_ACCESS_KEY=
+OPENEMS_AWS_REGION=us-east-1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.0",
+        "aws4": "^1.13.0",
         "next": "16.1.7",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -3515,6 +3516,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.11.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.0",
+    "aws4": "^1.13.0",
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/src/lib/openems/__tests__/auth.test.ts
+++ b/src/lib/openems/__tests__/auth.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import { BasicAuth, SigV4Auth } from "../auth";
+
+// Deterministic test credentials (canonical AWS example values)
+const TEST_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+const TEST_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+const TEST_REGION = "us-east-1";
+
+const TEST_LAMBDA_URL =
+  "https://abcdefghij.lambda-url.us-east-1.on.aws/";
+const TEST_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: "test-uuid-1234",
+  method: "getEdgesStatus",
+  params: { edgeIds: ["edge0"] },
+});
+
+// Expected date format: YYYYMMDD
+const TODAY_YYYYMMDD = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+
+describe("BasicAuth", () => {
+  const auth = new BasicAuth("admin", "testpass");
+
+  it("resolveUrl appends /jsonrpc to baseUrl", () => {
+    expect(auth.resolveUrl("http://localhost:8075")).toBe(
+      "http://localhost:8075/jsonrpc"
+    );
+  });
+
+  it("resolveUrl works with trailing slash", () => {
+    // Preserves exactly what the caller passes
+    expect(auth.resolveUrl("http://localhost:8075/")).toBe(
+      "http://localhost:8075//jsonrpc"
+    );
+  });
+
+  it("apply returns Authorization Basic header and Content-Type", async () => {
+    const headers = await auth.apply({
+      url: "http://localhost:8075/jsonrpc",
+      method: "POST",
+      body: "{}",
+    });
+
+    const expectedAuth = `Basic ${Buffer.from("admin:testpass").toString("base64")}`;
+    expect(headers).toEqual(
+      expect.objectContaining({
+        Authorization: expectedAuth,
+        "Content-Type": "application/json",
+      })
+    );
+  });
+
+  it("apply returns a plain object (not a Headers instance)", async () => {
+    const headers = await auth.apply({
+      url: "http://localhost:8075/jsonrpc",
+      method: "POST",
+      body: "{}",
+    });
+    expect(headers).not.toBeInstanceOf(Headers);
+    expect(typeof headers).toBe("object");
+    // All values must be strings
+    for (const v of Object.values(headers)) {
+      expect(typeof v).toBe("string");
+    }
+  });
+
+  it("encodes special characters in credentials", async () => {
+    const specialAuth = new BasicAuth("user@domain.com", "p@ss:w0rd!");
+    const headers = await specialAuth.apply({
+      url: "http://localhost:8075/jsonrpc",
+      method: "POST",
+      body: "{}",
+    });
+    const expectedAuth = `Basic ${Buffer.from("user@domain.com:p@ss:w0rd!").toString("base64")}`;
+    expect(headers.Authorization).toBe(expectedAuth);
+  });
+});
+
+describe("SigV4Auth", () => {
+  const auth = new SigV4Auth({
+    accessKeyId: TEST_ACCESS_KEY_ID,
+    secretAccessKey: TEST_SECRET_ACCESS_KEY,
+    region: TEST_REGION,
+  });
+
+  it("resolveUrl returns baseUrl unchanged (no /jsonrpc appended)", () => {
+    expect(auth.resolveUrl(TEST_LAMBDA_URL)).toBe(TEST_LAMBDA_URL);
+  });
+
+  it("apply returns a plain object (not a Headers instance)", async () => {
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    expect(headers).not.toBeInstanceOf(Headers);
+    expect(typeof headers).toBe("object");
+    for (const v of Object.values(headers)) {
+      expect(typeof v).toBe("string");
+    }
+  });
+
+  it("Authorization header starts with AWS4-HMAC-SHA256 ", async () => {
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    expect(headers.Authorization).toBeDefined();
+    expect(headers.Authorization).toMatch(/^AWS4-HMAC-SHA256 /);
+  });
+
+  it("Authorization header contains Credential with keyId, date, region, and service", async () => {
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    // Must contain: Credential=<accessKeyId>/<YYYYMMDD>/us-east-1/lambda/aws4_request
+    expect(headers.Authorization).toContain(
+      `Credential=${TEST_ACCESS_KEY_ID}/${TODAY_YYYYMMDD}/us-east-1/lambda/aws4_request`
+    );
+  });
+
+  it("Authorization header contains SignedHeaders segment", async () => {
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    expect(headers.Authorization).toContain("SignedHeaders=");
+  });
+
+  it("Authorization header contains Signature segment", async () => {
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    expect(headers.Authorization).toContain("Signature=");
+  });
+
+  it("Host header is present and matches the Lambda URL host", async () => {
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    // aws4 sets the Host header; it must match the URL host
+    const expectedHost = new URL(TEST_LAMBDA_URL).host;
+    expect(headers.Host ?? headers.host).toBe(expectedHost);
+  });
+
+  it("produces different signatures for different bodies (body is hashed)", async () => {
+    const body1 = JSON.stringify({ jsonrpc: "2.0", id: "a", method: "m", params: {} });
+    const body2 = JSON.stringify({ jsonrpc: "2.0", id: "b", method: "m", params: {} });
+
+    const headers1 = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: body1,
+    });
+    const headers2 = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: body2,
+    });
+
+    // Different bodies must produce different signatures
+    expect(headers1.Authorization).not.toBe(headers2.Authorization);
+  });
+
+  it("produces consistent signatures for the same input", async () => {
+    // Since SigV4 includes a timestamp, signatures made within the same minute
+    // should produce the same X-Amz-Date. We just verify both calls produce
+    // the same signature when inputs are identical.
+    const headers1 = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    const headers2 = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+
+    // Both should have the same X-Amz-Date (within the same second of test execution)
+    // and therefore the same Authorization if timestamp matches.
+    // The key property we assert: same inputs produce structurally identical headers.
+    expect(Object.keys(headers1).sort()).toEqual(Object.keys(headers2).sort());
+  });
+
+  it("does not include Authorization header value in any thrown error details", async () => {
+    // Calling apply() should not leak credentials — this is a smoke test that
+    // apply() returns without embedding header values in thrown errors.
+    const headers = await auth.apply({
+      url: TEST_LAMBDA_URL,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    // The Authorization header should be present but not equal to the access key
+    expect(headers.Authorization).not.toBe(TEST_ACCESS_KEY_ID);
+    expect(headers.Authorization).not.toBe(TEST_SECRET_ACCESS_KEY);
+  });
+
+  it("works with a different region (region must appear in Credential scope)", async () => {
+    const euAuth = new SigV4Auth({
+      accessKeyId: TEST_ACCESS_KEY_ID,
+      secretAccessKey: TEST_SECRET_ACCESS_KEY,
+      region: "eu-west-1",
+    });
+    const euUrl = "https://xyz.lambda-url.eu-west-1.on.aws/";
+    const headers = await euAuth.apply({
+      url: euUrl,
+      method: "POST",
+      body: TEST_BODY,
+    });
+    expect(headers.Authorization).toContain(
+      `Credential=${TEST_ACCESS_KEY_ID}/${TODAY_YYYYMMDD}/eu-west-1/lambda/aws4_request`
+    );
+  });
+});

--- a/src/lib/openems/__tests__/client.test.ts
+++ b/src/lib/openems/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { OpenEmsClient } from "../client";
+import { BasicAuth } from "../auth";
 import { OpenEmsError } from "../errors";
 import type { MeterConfig } from "@/lib/adapters/types";
 
@@ -30,7 +31,10 @@ describe("OpenEmsClient", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    client = new OpenEmsClient("http://localhost:8075", "admin", "testpass");
+    client = new OpenEmsClient(
+      "http://localhost:8075",
+      new BasicAuth("admin", "testpass")
+    );
     fetchSpy = vi.spyOn(globalThis, "fetch");
   });
 
@@ -478,6 +482,21 @@ describe("OpenEmsClient", () => {
       ).rejects.toMatchObject({
         code: "OPENEMS_AUTH_FAILED",
         statusCode: 401,
+      });
+    });
+
+    it("throws OPENEMS_AUTH_FAILED on 403 response (SigV4 permission failure)", async () => {
+      fetchSpy.mockResolvedValue(mockResponse({}, 403));
+
+      await expect(
+        client.getEdgesStatus(["edge0"])
+      ).rejects.toThrow(OpenEmsError);
+
+      await expect(
+        client.getEdgesStatus(["edge0"])
+      ).rejects.toMatchObject({
+        code: "OPENEMS_AUTH_FAILED",
+        statusCode: 403,
       });
     });
 

--- a/src/lib/openems/__tests__/factory.test.ts
+++ b/src/lib/openems/__tests__/factory.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getOpenEmsClient } from "../index";
+import { OpenEmsClient } from "../client";
+import { BasicAuth, SigV4Auth } from "../auth";
+import { OpenEmsError } from "../errors";
+
+// Helper: cast the returned client to access the private `auth` field for assertions.
+// We do NOT add test-only exports to production code.
+function getAuth(client: OpenEmsClient): unknown {
+  return (client as unknown as { auth: unknown }).auth;
+}
+
+describe("getOpenEmsClient() factory dispatch", () => {
+  beforeEach(() => {
+    // Clear all relevant env vars before each test
+    vi.stubEnv("OPENEMS_B2B_URL", undefined as unknown as string);
+    vi.stubEnv("OPENEMS_B2B_USERNAME", undefined as unknown as string);
+    vi.stubEnv("OPENEMS_B2B_PASSWORD", undefined as unknown as string);
+    vi.stubEnv("OPENEMS_AWS_ACCESS_KEY_ID", undefined as unknown as string);
+    vi.stubEnv("OPENEMS_AWS_SECRET_ACCESS_KEY", undefined as unknown as string);
+    vi.stubEnv("OPENEMS_AWS_REGION", undefined as unknown as string);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("Branch A — SigV4 when AWS credentials are present", () => {
+    it("returns a SigV4Auth-backed client when AWS creds are set", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "https://abc.lambda-url.us-east-1.on.aws/");
+      vi.stubEnv("OPENEMS_AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+      vi.stubEnv("OPENEMS_AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+      const client = getOpenEmsClient();
+
+      expect(client).toBeInstanceOf(OpenEmsClient);
+      expect(getAuth(client)).toBeInstanceOf(SigV4Auth);
+    });
+
+    it("uses us-east-1 as default region when OPENEMS_AWS_REGION is not set", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "https://abc.lambda-url.us-east-1.on.aws/");
+      vi.stubEnv("OPENEMS_AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+      vi.stubEnv("OPENEMS_AWS_SECRET_ACCESS_KEY", "secret");
+      // OPENEMS_AWS_REGION intentionally NOT set
+
+      const client = getOpenEmsClient();
+      expect(getAuth(client)).toBeInstanceOf(SigV4Auth);
+    });
+
+    it("prefers SigV4 over Basic even when Basic env vars are also present", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "https://abc.lambda-url.us-east-1.on.aws/");
+      vi.stubEnv("OPENEMS_AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+      vi.stubEnv("OPENEMS_AWS_SECRET_ACCESS_KEY", "secret");
+      vi.stubEnv("OPENEMS_B2B_USERNAME", "admin");
+      vi.stubEnv("OPENEMS_B2B_PASSWORD", "password");
+
+      const client = getOpenEmsClient();
+      expect(getAuth(client)).toBeInstanceOf(SigV4Auth);
+    });
+  });
+
+  describe("Branch B — Basic auth fallback when only Basic env vars are present", () => {
+    it("returns a BasicAuth-backed client when only Basic env vars are set", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "http://localhost:8075");
+      vi.stubEnv("OPENEMS_B2B_USERNAME", "admin");
+      vi.stubEnv("OPENEMS_B2B_PASSWORD", "Icui4cyou");
+
+      const client = getOpenEmsClient();
+
+      expect(client).toBeInstanceOf(OpenEmsClient);
+      expect(getAuth(client)).toBeInstanceOf(BasicAuth);
+    });
+
+    it("does not use SigV4 when AWS creds are absent", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "http://localhost:8075");
+      vi.stubEnv("OPENEMS_B2B_USERNAME", "admin");
+      vi.stubEnv("OPENEMS_B2B_PASSWORD", "password");
+      // AWS keys intentionally NOT set
+
+      const client = getOpenEmsClient();
+      expect(getAuth(client)).toBeInstanceOf(BasicAuth);
+      expect(getAuth(client)).not.toBeInstanceOf(SigV4Auth);
+    });
+  });
+
+  describe("Branch C — throws OPENEMS_INVALID_CONFIG when neither auth set is available", () => {
+    it("throws when OPENEMS_B2B_URL is missing entirely", () => {
+      // No env vars set at all
+      expect(() => getOpenEmsClient()).toThrow(OpenEmsError);
+      expect(() => getOpenEmsClient()).toThrow(
+        expect.objectContaining({
+          code: "OPENEMS_INVALID_CONFIG",
+          statusCode: 503,
+        })
+      );
+    });
+
+    it("throws when URL is set but neither auth strategy has credentials", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "http://localhost:8075");
+      // No username/password, no AWS creds
+
+      expect(() => getOpenEmsClient()).toThrow(OpenEmsError);
+      expect(() => getOpenEmsClient()).toThrow(
+        expect.objectContaining({
+          code: "OPENEMS_INVALID_CONFIG",
+          statusCode: 503,
+        })
+      );
+    });
+
+    it("throws when only access key is set (missing secret key)", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "http://localhost:8075");
+      vi.stubEnv("OPENEMS_AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+      // No secret key, no Basic creds
+
+      expect(() => getOpenEmsClient()).toThrow(OpenEmsError);
+      expect(() => getOpenEmsClient()).toThrow(
+        expect.objectContaining({
+          code: "OPENEMS_INVALID_CONFIG",
+          statusCode: 503,
+        })
+      );
+    });
+
+    it("throws when only username is set (missing password)", () => {
+      vi.stubEnv("OPENEMS_B2B_URL", "http://localhost:8075");
+      vi.stubEnv("OPENEMS_B2B_USERNAME", "admin");
+      // No password, no AWS creds
+
+      expect(() => getOpenEmsClient()).toThrow(OpenEmsError);
+      expect(() => getOpenEmsClient()).toThrow(
+        expect.objectContaining({
+          code: "OPENEMS_INVALID_CONFIG",
+          statusCode: 503,
+        })
+      );
+    });
+  });
+});

--- a/src/lib/openems/auth.ts
+++ b/src/lib/openems/auth.ts
@@ -1,0 +1,92 @@
+import aws4 from "aws4";
+
+export interface OpenEmsAuth {
+  /** Resolve the full request URL given the configured baseUrl. */
+  resolveUrl(baseUrl: string): string;
+  /**
+   * Return signed/authenticated request headers as a plain object.
+   * Must return Record<string, string> (not Headers) so test assertions
+   * using expect.objectContaining() work correctly.
+   */
+  apply(request: {
+    url: string;
+    method: string;
+    body: string;
+  }): Promise<Record<string, string>>;
+}
+
+export class BasicAuth implements OpenEmsAuth {
+  constructor(
+    private readonly username: string,
+    private readonly password: string
+  ) {}
+
+  resolveUrl(baseUrl: string): string {
+    return `${baseUrl}/jsonrpc`;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async apply(_request: {
+    url: string;
+    method: string;
+    body: string;
+  }): Promise<Record<string, string>> {
+    return {
+      Authorization: `Basic ${Buffer.from(`${this.username}:${this.password}`).toString("base64")}`,
+      "Content-Type": "application/json",
+    };
+  }
+}
+
+export class SigV4Auth implements OpenEmsAuth {
+  constructor(
+    private readonly creds: {
+      accessKeyId: string;
+      secretAccessKey: string;
+      region: string;
+    }
+  ) {}
+
+  resolveUrl(baseUrl: string): string {
+    // Lambda handler routes to /jsonrpc internally — sign the root URL
+    return baseUrl;
+  }
+
+  async apply(req: {
+    url: string;
+    method: string;
+    body: string;
+  }): Promise<Record<string, string>> {
+    const url = new URL(req.url);
+
+    // NOTE: aws4.sign mutates the options object. Build a fresh one each call.
+    const opts = aws4.sign(
+      {
+        host: url.host,
+        path: url.pathname + (url.search || ""),
+        method: req.method,
+        headers: { "Content-Type": "application/json" },
+        body: req.body,
+        service: "lambda",
+        region: this.creds.region,
+      },
+      {
+        accessKeyId: this.creds.accessKeyId,
+        secretAccessKey: this.creds.secretAccessKey,
+      }
+    );
+
+    // aws4 returns headers as Record<string, string | string[]>; normalize to string values.
+    // Pass through ALL headers returned by aws4.sign (Host, X-Amz-Date, Authorization, etc.)
+    // so the signature matches what the server verifies.
+    const rawHeaders = (opts.headers ?? {}) as Record<
+      string,
+      string | string[] | undefined
+    >;
+    return Object.fromEntries(
+      Object.entries(rawHeaders)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => [k, Array.isArray(v) ? v.join(",") : String(v)])
+    );
+  }
+}

--- a/src/lib/openems/client.ts
+++ b/src/lib/openems/client.ts
@@ -1,5 +1,6 @@
 import type { MeterConfig, MeterDataAdapter, MeterReading } from "@/lib/adapters/types";
 import { OpenEmsError } from "./errors";
+import type { OpenEmsAuth } from "./auth";
 import type {
   ChannelValue,
   EdgeConfig,
@@ -10,15 +11,10 @@ import type {
 } from "./types";
 
 export class OpenEmsClient implements MeterDataAdapter {
-  private readonly authHeader: string;
-
   constructor(
     private readonly baseUrl: string,
-    username: string,
-    password: string
-  ) {
-    this.authHeader = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
-  }
+    private readonly auth: OpenEmsAuth
+  ) {}
 
   /**
    * Send a JSON-RPC request to the OpenEMS B2B REST endpoint.
@@ -27,23 +23,22 @@ export class OpenEmsClient implements MeterDataAdapter {
     method: string,
     params: Record<string, unknown>
   ): Promise<T> {
-    const body = {
+    // INVARIANT: the same `body` string MUST be passed to both `auth.apply`
+    // (which hashes it for the SigV4 signature) AND `fetch` (which transmits it).
+    // Any byte-level divergence breaks the signature and returns 403.
+    const body = JSON.stringify({
       jsonrpc: "2.0" as const,
       id: crypto.randomUUID(),
       method,
       params,
-    };
+    });
+
+    const url = this.auth.resolveUrl(this.baseUrl);
+    const headers = await this.auth.apply({ url, method: "POST", body });
 
     let response: Response;
     try {
-      response = await fetch(`${this.baseUrl}/jsonrpc`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: this.authHeader,
-        },
-        body: JSON.stringify(body),
-      });
+      response = await fetch(url, { method: "POST", headers, body });
     } catch (err) {
       throw new OpenEmsError(
         `Failed to reach OpenEMS at ${this.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
@@ -53,11 +48,11 @@ export class OpenEmsClient implements MeterDataAdapter {
       );
     }
 
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       throw new OpenEmsError(
         "OpenEMS B2B authentication failed",
         "OPENEMS_AUTH_FAILED",
-        401
+        response.status
       );
     }
 

--- a/src/lib/openems/index.ts
+++ b/src/lib/openems/index.ts
@@ -1,22 +1,47 @@
 import { OpenEmsError } from "./errors";
 import { OpenEmsClient } from "./client";
+import { BasicAuth, SigV4Auth } from "./auth";
 
 export function getOpenEmsClient(): OpenEmsClient {
   const url = process.env.OPENEMS_B2B_URL;
-  const username = process.env.OPENEMS_B2B_USERNAME;
-  const password = process.env.OPENEMS_B2B_PASSWORD;
-
-  if (!url || !username || !password) {
+  if (!url) {
     throw new OpenEmsError(
-      "OpenEMS B2B REST credentials not configured",
+      "OPENEMS_B2B_URL not set",
       "OPENEMS_INVALID_CONFIG",
       503
     );
   }
 
-  return new OpenEmsClient(url, username, password);
+  // SigV4-first: if AWS credentials are present, use Lambda Function URL auth
+  const accessKeyId = process.env.OPENEMS_AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.OPENEMS_AWS_SECRET_ACCESS_KEY;
+  if (accessKeyId && secretAccessKey) {
+    return new OpenEmsClient(
+      url,
+      new SigV4Auth({
+        accessKeyId,
+        secretAccessKey,
+        region: process.env.OPENEMS_AWS_REGION ?? "us-east-1",
+      })
+    );
+  }
+
+  // Basic fallback: local Docker / direct OpenEMS B2B endpoint
+  const username = process.env.OPENEMS_B2B_USERNAME;
+  const password = process.env.OPENEMS_B2B_PASSWORD;
+  if (username && password) {
+    return new OpenEmsClient(url, new BasicAuth(username, password));
+  }
+
+  throw new OpenEmsError(
+    "OpenEMS auth not configured (need either AWS creds for SigV4 or B2B user/password for Basic)",
+    "OPENEMS_INVALID_CONFIG",
+    503
+  );
 }
 
 export { OpenEmsClient } from "./client";
+export { BasicAuth, SigV4Auth } from "./auth";
+export type { OpenEmsAuth } from "./auth";
 export * from "./types";
 export * from "./errors";

--- a/src/types/aws4.d.ts
+++ b/src/types/aws4.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal type declaration for the aws4 package.
+ * aws4 v1.13.x does not ship bundled TypeScript types.
+ * @types/aws4 is intentionally NOT used per project constraints.
+ */
+declare module "aws4" {
+  export interface Credentials {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+  }
+
+  export interface Request {
+    host?: string;
+    hostname?: string;
+    path?: string;
+    method?: string;
+    headers?: Record<string, string | string[]>;
+    body?: string;
+    service?: string;
+    region?: string;
+    signQuery?: boolean;
+  }
+
+  export function sign(request: Request, credentials?: Credentials): Request;
+}


### PR DESCRIPTION
## Summary
- Adds `SigV4Auth` strategy so MBE on Vercel can authenticate to the OpenEMS Lambda Function URL via IAM SigV4.
- Refactors `OpenEmsClient` to an auth-agnostic 2-arg constructor: `(baseUrl, auth: OpenEmsAuth)`. Existing `BasicAuth` path preserved with zero behavior change.
- Factory `getOpenEmsClient()` auto-selects: SigV4 when `OPENEMS_AWS_ACCESS_KEY_ID` + `OPENEMS_AWS_SECRET_ACCESS_KEY` are set, otherwise Basic. Local-dev flow needs no AWS account.
- Error mapping extended to 403 (Lambda Function URL failure mode) in addition to 401, with `response.status` passed through to `OpenEmsError`.

Closes #36.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new errors (5 pre-existing `no-html-link-for-pages` errors on `main`, unrelated)
- [x] `npm test -- src/lib/openems` — 43/43 passing
  - Existing 18 Basic-auth tests in `client.test.ts` unchanged in behavior
  - New 16 tests in `auth.test.ts` (BasicAuth + SigV4 signing format, Credential scope with region + service, Host pass-through, body-signature consistency)
  - New 9 tests in `factory.test.ts` covering all 3 dispatch branches
  - New 403 test asserting `{ code: "OPENEMS_AUTH_FAILED", statusCode: 403 }`
- [x] Local-dev path: without `OPENEMS_AWS_*` env vars, `aws4.sign` is never invoked; Basic flow identical to today.
- [ ] End-to-end validation against real Lambda Function URL — deferred to Vercel env-var configuration (separate follow-up per `mbe-docs/docs/mbe-environments.md`).

## Notes for reviewer
- `aws4` v1.13.2 does not ship `.d.ts` files despite claims in some docs — added a minimal `src/types/aws4.d.ts` rather than pulling `@types/aws4`.
- Out-of-scope per ticket: `setup.sh`, `docker-compose.yml`, `docs/setup.md`, the 5 API route callers of `getOpenEmsClient()`, and `MeterDataAdapter` interface all intentionally untouched.
- Follow-up (not blocking): `BasicAuth.resolveUrl` currently produces `//jsonrpc` if the user sets `OPENEMS_B2B_URL` with a trailing slash. No known production cases; worth a one-line trim in a future pass.

Ticket refined twice before implementation (both rounds' notes in issue #36). Agent review: zero blockers, five cosmetic nits.