### PR TITLE
Fix tw-animate-css plugin resolution in Turbopack build (#42)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,7 +106,7 @@
 }
 
 @import "tailwindcss";
-@plugin "tw-animate-css";
+@import "tw-animate-css";
 
 body {
   background: var(--background);


### PR DESCRIPTION
## Summary

- Replaces `@plugin "tw-animate-css"` with `@import "tw-animate-css"` in `src/app/globals.css` (line 109)
- `tw-animate-css@1.4.0` exports only a `"style"` condition; `@plugin` requires `["node","require"]` → resolution failure. `@import` correctly uses the style export.
- Unblocks all Vercel Production and Preview deployments from `main`.

Fixes #42.

## Verification

All commands run from the worktree (`metering-billing-engine-hotfix-42`). `.env.local` copied from main worktree — no shims needed.

```
npx tsc --noEmit    → clean (no output)
npm run lint        → 5 pre-existing errors in dashboard layout files (no-html-link-for-pages), zero new errors
npm test            → 63/63 passing (6 test files)
npm run build       → ✓ Compiled successfully in 8.9s, all 14 routes generated
```

Animate-in CSS custom properties (`--tw-enter-*`, `--tw-exit-*`) are present in the built CSS chunk (`.next/static/chunks/f14ba1e879b9242e.css`), confirming `@import "tw-animate-css"` emits the expected variables for Radix state animations.

## Lesson

`npm run build` is now a non-negotiable AC item for any PR touching `globals.css` or CSS pipeline config. Vitest does not exercise Turbopack's CSS resolution — only a full build catches `@plugin` vs `@import` mismatches.