### PR TITLE
Migrate MBE pages to design system (T3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,22 @@ src/
 - **Adapter pattern** — MBE doesn't import OpenEMS-specific types in billing logic. `MeterDataAdapter` interface in `src/lib/adapters/types.ts`
 - **DCO sign-off** on docker-openems commits (`git commit -s`)
 
+## Design System
+
+Token reference: `../mbe-docs/design/v2-paste/README.md`
+
+Five rules every contributor must follow:
+
+1. **Status chips:** Use `<Chip>` not raw `<span>` for status indicators. Use `<StatusChip kind="…" status="…">` to map domain enums (billingPeriod, meterType, edge, household) — this keeps tone-to-status mapping in one file (`src/components/ui/status-chip.tsx`). Add new domain enums by extending `MAPS` in that file, not inline.
+
+2. **Format primitives:** Use `<Currency>`, `<Kwh>`, and `<LocalDate>` — never `Intl.NumberFormat` or `toLocaleDateString` directly. Locale comes from `Accept-Language` (detected at the app root); currency comes from microgrid context (wired in `microgrids/[id]/layout.tsx` via `<LocaleProvider currency={microgrid.currency}>`). In-table currency cells use `bareNumber` prop so Aaron's URA paste workflow gets `4,216,800` not `UGX 4,216,800`; show currency code only in column headers.
+
+3. **Token classes only:** No `bg-blue-*`, `text-gray-*`, or any hardcoded Tailwind color scale classes in `src/app/(dashboard)` or `src/components`. Use semantic tokens: `bg-card`, `bg-muted`, `text-foreground`, `text-muted-foreground`, `border-border`, `bg-primary`, `text-primary-foreground`, `bg-destructive-muted`, `text-destructive-fg`, `bg-warning-muted`, `text-warning-fg`, `bg-success-muted`, `text-success-fg`, etc.
+
+4. **Copy table:** Use `<CopyTable>` for billing data tables (built-in per-cell copy + keyboard nav). Grand-total footer rows go BELOW the CopyTable as a `<div>` — CopyTable doesn't support footer rows. Retain `<CopyButton>` only for footer cells.
+
+5. **Destructive actions:** Use `<ConfirmDialog tone="destructive">` for delete flows (Delete Period, Delete Meter, Delete Tenant). Use `<ClosePeriodDialog>` for billing-period close (irreversible, needs multi-channel confirm). Use `<ConfirmDialog tone="neutral">` for non-destructive warnings (e.g. remove-last-tier). Never use `confirm()` — it blocks the main thread and can't be tested.
+
 ## Local Dev Setup
 
 See `docs/setup.md` for three modes:

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { LogoutButton } from "./logout-button";
 
@@ -19,24 +20,24 @@ export default async function DashboardLayout({
   return (
     <div className="flex min-h-screen">
       {/* Sidebar */}
-      <aside className="flex w-64 flex-col border-r border-gray-200 bg-gray-50">
-        <div className="border-b border-gray-200 px-6 py-4">
-          <h2 className="text-lg font-semibold text-gray-900">MBE</h2>
+      <aside className="flex w-64 flex-col border-r border-border bg-muted">
+        <div className="border-b border-border px-6 py-4">
+          <h2 className="text-lg font-semibold text-foreground">MBE</h2>
         </div>
         <nav className="flex-1 space-y-1 px-3 py-4">
-          <a
+          <Link
             href="/"
-            className="flex items-center rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-900"
+            className="flex items-center rounded-md bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
           >
             Dashboard
-          </a>
-          <a
+          </Link>
+          <Link
             href="/microgrids"
-            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
           >
             Microgrids
-          </a>
-          <span className="flex items-center rounded-md px-3 py-2 text-sm text-gray-400 cursor-not-allowed">
+          </Link>
+          <span className="flex items-center rounded-md px-3 py-2 text-sm text-muted-foreground cursor-not-allowed">
             Settings (coming soon)
           </span>
         </nav>
@@ -45,10 +46,10 @@ export default async function DashboardLayout({
       {/* Main content */}
       <div className="flex flex-1 flex-col">
         {/* Top bar */}
-        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3">
+        <header className="flex items-center justify-between border-b border-border bg-card px-6 py-3">
           <div />
           <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-600">{user.email}</span>
+            <span className="text-sm text-muted-foreground">{user.email}</span>
             <LogoutButton />
           </div>
         </header>

--- a/src/app/(dashboard)/logout-button.tsx
+++ b/src/app/(dashboard)/logout-button.tsx
@@ -16,7 +16,7 @@ export function LogoutButton() {
   return (
     <button
       onClick={handleLogout}
-      className="rounded-md px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+      className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
     >
       Logout
     </button>

--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -64,7 +64,7 @@ export default async function BillingPeriodDetailPage({
 
   if (microgridError || !microgrid) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading microgrid: {microgridError?.message ?? "Not found"}
       </div>
     );
@@ -72,7 +72,7 @@ export default async function BillingPeriodDetailPage({
 
   if (tenantsError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading tenants: {tenantsError.message}
       </div>
     );
@@ -80,7 +80,7 @@ export default async function BillingPeriodDetailPage({
 
   if (lineItemsError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading line items: {lineItemsError.message}
       </div>
     );
@@ -88,7 +88,7 @@ export default async function BillingPeriodDetailPage({
 
   if (scheduleError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading rate schedule: {scheduleError.message}
       </div>
     );

--- a/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
@@ -20,7 +20,7 @@ export default async function BillingPage({
 
   if (error) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading billing periods: {error.message}
       </div>
     );

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -2,6 +2,8 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/database";
 import { TabNav } from "./tab-nav";
+import { HierarchyNav, type HierarchyLevel } from "@/components/ui/hierarchy-nav";
+import { LocaleProvider } from "@/components/format/locale-context";
 
 export default async function MicrogridLayout({
   children,
@@ -25,24 +27,66 @@ export default async function MicrogridLayout({
 
   const microgrid = data as Microgrid;
 
+  // Query org count and microgrid count for HierarchyNav
+  const { data: orgs } = await supabase
+    .from("organizations")
+    .select("id, name");
+
+  const { data: siblings } = await supabase
+    .from("microgrids")
+    .select("id, name")
+    .eq("org_id", microgrid.org_id);
+
+  const orgCount = orgs?.length ?? 1;
+  const microgridCount = siblings?.length ?? 1;
+
+  // Find the current org name
+  const currentOrg = orgs?.find((o) =>
+    siblings?.some((s) => s.id === id)
+      ? o.id === microgrid.org_id
+      : false
+  ) ?? orgs?.[0];
+
+  const levels: HierarchyLevel[] = [
+    {
+      kind: "Organization",
+      label: currentOrg?.name ?? "Organization",
+      count: orgCount,
+      href: "/",
+      active: false,
+      siblings: orgCount > 1
+        ? orgs?.map((o) => ({ label: o.name, href: "/" }))
+        : undefined,
+    },
+    {
+      kind: "Microgrid",
+      label: microgrid.name,
+      count: microgridCount,
+      href: `/microgrids/${id}/tenants`,
+      active: true,
+      siblings: microgridCount > 1
+        ? siblings
+            ?.filter((s) => s.id !== id)
+            .map((s) => ({ label: s.name, href: `/microgrids/${s.id}/tenants` }))
+        : undefined,
+    },
+  ];
+
   return (
-    <div>
-      <div className="mb-6">
-        <a
-          href="/microgrids"
-          className="text-sm text-gray-500 hover:text-gray-700"
-        >
-          &larr; Back to Microgrids
-        </a>
-        <h1 className="mt-2 text-2xl font-semibold text-gray-900">
-          {microgrid.name}
-        </h1>
-        {microgrid.location && (
-          <p className="mt-1 text-sm text-gray-500">{microgrid.location}</p>
-        )}
+    <LocaleProvider currency={microgrid.currency}>
+      <div>
+        <div className="mb-6">
+          <HierarchyNav levels={levels} />
+          <h1 className="mt-3 text-2xl font-semibold text-foreground">
+            {microgrid.name}
+          </h1>
+          {microgrid.location && (
+            <p className="mt-1 text-sm text-muted-foreground">{microgrid.location}</p>
+          )}
+        </div>
+        <TabNav microgridId={id} />
+        <div className="mt-6">{children}</div>
       </div>
-      <TabNav microgridId={id} />
-      <div className="mt-6">{children}</div>
-    </div>
+    </LocaleProvider>
   );
 }

--- a/src/app/(dashboard)/microgrids/[id]/rates/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/rates/page.tsx
@@ -29,7 +29,7 @@ export default async function RatesPage({
 
   if (microgridError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading microgrid: {microgridError.message}
       </div>
     );
@@ -37,7 +37,7 @@ export default async function RatesPage({
 
   if (scheduleError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading rate schedule: {scheduleError.message}
       </div>
     );

--- a/src/app/(dashboard)/microgrids/[id]/tab-nav.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/tab-nav.tsx
@@ -12,7 +12,7 @@ export function TabNav({ microgridId }: { microgridId: string }) {
   const pathname = usePathname();
 
   return (
-    <nav className="flex space-x-1 border-b border-gray-200">
+    <nav className="flex space-x-1 border-b border-border">
       {tabs.map((tab) => {
         const href = `/microgrids/${microgridId}/${tab.segment}`;
         const isActive = pathname.startsWith(href);
@@ -23,8 +23,8 @@ export function TabNav({ microgridId }: { microgridId: string }) {
             href={href}
             className={`border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
               isActive
-                ? "border-blue-500 text-blue-600"
-                : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
             }`}
           >
             {tab.label}

--- a/src/app/(dashboard)/microgrids/[id]/tenants/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/tenants/page.tsx
@@ -29,7 +29,7 @@ export default async function TenantsPage({
 
   if (tenantsError || metersError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading data: {tenantsError?.message ?? metersError?.message}
       </div>
     );

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -15,7 +15,7 @@ export default async function MicrogridsPage() {
 
   if (error) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading microgrids: {error.message}
       </div>
     );
@@ -24,10 +24,10 @@ export default async function MicrogridsPage() {
   if (!microgrids || microgrids.length === 0) {
     return (
       <div>
-        <h1 className="mb-6 text-2xl font-semibold text-gray-900">
+        <h1 className="mb-6 text-2xl font-semibold text-foreground">
           Microgrids
         </h1>
-        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+        <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
           No microgrids found. Microgrids are configured by your system
           administrator.
         </div>
@@ -50,23 +50,23 @@ export default async function MicrogridsPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-semibold text-gray-900">Microgrids</h1>
+      <h1 className="mb-6 text-2xl font-semibold text-foreground">Microgrids</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {microgridsWithCounts.map((mg) => (
           <a
             key={mg.id}
             href={`/microgrids/${mg.id}`}
-            className="block rounded-lg border border-gray-200 bg-white p-6 transition-colors hover:border-gray-300 hover:bg-gray-50"
+            className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted"
           >
-            <h2 className="font-medium text-gray-900">{mg.name}</h2>
+            <h2 className="font-medium text-foreground">{mg.name}</h2>
             {mg.location && (
-              <p className="mt-1 text-sm text-gray-500">{mg.location}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{mg.location}</p>
             )}
             <div className="mt-3 flex items-center justify-between text-sm">
-              <span className="text-gray-600">
+              <span className="text-muted-foreground">
                 {mg.tenant_count} tenant{mg.tenant_count !== 1 ? "s" : ""}
               </span>
-              <span className="text-gray-400">{mg.currency}</span>
+              <span className="text-muted-foreground">{mg.currency}</span>
             </div>
           </a>
         ))}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -19,7 +19,7 @@ export default async function DashboardPage() {
 
   if (orgError) {
     return (
-      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
         Error loading organizations: {orgError.message}
       </div>
     );
@@ -28,10 +28,10 @@ export default async function DashboardPage() {
   if (!organizations || organizations.length === 0) {
     return (
       <div>
-        <h1 className="mb-6 text-2xl font-semibold text-gray-900">
+        <h1 className="mb-6 text-2xl font-semibold text-foreground">
           Dashboard
         </h1>
-        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+        <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
           No organizations found. You may need to run the database migrations
           and seed data, or your account may not have the required permissions.
         </div>
@@ -41,7 +41,7 @@ export default async function DashboardPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-semibold text-gray-900">Dashboard</h1>
+      <h1 className="mb-6 text-2xl font-semibold text-foreground">Dashboard</h1>
       <div className="space-y-6">
         {organizations.map((org) => (
           <OrgCard key={org.id} org={org} />
@@ -77,26 +77,26 @@ async function OrgCard({ org }: { org: Organization }) {
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6">
-      <h2 className="mb-4 text-lg font-semibold text-gray-900">{org.name}</h2>
+    <div className="rounded-lg border border-border bg-card p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">{org.name}</h2>
       {microgridsWithCounts.length === 0 ? (
-        <p className="text-sm text-gray-500">No microgrids configured.</p>
+        <p className="text-sm text-muted-foreground">No microgrids configured.</p>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {microgridsWithCounts.map((mg) => (
             <div
               key={mg.id}
-              className="rounded-md border border-gray-100 bg-gray-50 p-4"
+              className="rounded-md border border-border bg-muted p-4"
             >
-              <h3 className="font-medium text-gray-900">{mg.name}</h3>
+              <h3 className="font-medium text-foreground">{mg.name}</h3>
               {mg.location && (
-                <p className="mt-1 text-sm text-gray-500">{mg.location}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{mg.location}</p>
               )}
               <div className="mt-3 flex items-center justify-between text-sm">
-                <span className="text-gray-600">
+                <span className="text-muted-foreground">
                   {mg.tenant_count} tenant{mg.tenant_count !== 1 ? "s" : ""}
                 </span>
-                <span className="text-gray-400">{mg.currency}</span>
+                <span className="text-muted-foreground">{mg.currency}</span>
               </div>
             </div>
           ))}

--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -5,6 +5,11 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import type { BillingPeriod } from "@/lib/types/database";
+import { StatusChip } from "@/components/ui/status-chip";
+import { Currency } from "@/components/format/currency";
+import { Kwh } from "@/components/format/kwh";
+import { LocalDate } from "@/components/format/local-date";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 function getDefaultDates() {
   const now = new Date();
@@ -17,25 +22,6 @@ function getDefaultDates() {
     start: firstDay.toISOString().split("T")[0],
     end: lastDay.toISOString().split("T")[0],
   };
-}
-
-function formatDate(dateStr: string) {
-  return new Date(dateStr + "T00:00:00").toLocaleDateString("en", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-function formatKwh(value: number): string {
-  return new Intl.NumberFormat("en", {
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  }).format(value);
-}
-
-function formatAmount(value: number): string {
-  return new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(value);
 }
 
 export function BillingPeriodList({
@@ -57,28 +43,25 @@ export function BillingPeriodList({
   const [startDate, setStartDate] = useState(defaults.start);
   const [endDate, setEndDate] = useState(defaults.end);
   const [creating, setCreating] = useState(false);
-  const [deletingPeriodId, setDeletingPeriodId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleDeletePeriod(period: BillingPeriod) {
-    const dateRange = period.start_date === period.end_date
-      ? formatDate(period.start_date)
-      : `${formatDate(period.start_date)} – ${formatDate(period.end_date)}`;
-    const message =
-      period.status === "closed"
-        ? `Permanently delete this closed billing period (${dateRange}) and all its finalized bills? This cannot be undone.`
-        : `Delete this draft billing period (${dateRange}) and any generated bills? This cannot be undone.`;
-    if (!confirm(message)) return;
-    setError(null);
-    setDeletingPeriodId(period.id);
+  // ConfirmDialog state for delete
+  const [deletingPeriod, setDeletingPeriod] = useState<BillingPeriod | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  function openDeleteDialog(period: BillingPeriod) {
+    setDeletingPeriod(period);
+    setDeleteDialogOpen(true);
+  }
+
+  async function handleDeletePeriod() {
+    if (!deletingPeriod) return;
     const { error: deleteError } = await supabase
       .from("billing_periods")
       .delete()
-      .eq("id", period.id);
+      .eq("id", deletingPeriod.id);
     if (deleteError) {
-      setError(deleteError.message);
-      setDeletingPeriodId(null);
-      return;
+      throw new Error(deleteError.message);
     }
     router.refresh();
   }
@@ -121,19 +104,36 @@ export function BillingPeriodList({
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6">
+    <div className="rounded-lg border border-border bg-card p-6">
+      {/* Delete Period ConfirmDialog */}
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        title="Delete period?"
+        description={
+          deletingPeriod
+            ? deletingPeriod.status === "closed"
+              ? "This permanently removes the closed billing period and all its finalized bills. This cannot be undone."
+              : "This removes the draft billing period and any generated bills. This cannot be undone."
+            : "This action cannot be undone."
+        }
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={handleDeletePeriod}
+      />
+
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-gray-900">Billing Periods</h2>
+        <h2 className="text-lg font-semibold text-foreground">Billing Periods</h2>
         <button
           onClick={() => setShowCreateForm(!showCreateForm)}
-          className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+          className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
         >
           {showCreateForm ? "Cancel" : "New Period"}
         </button>
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div className="mb-4 rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
           {error}
         </div>
       )}
@@ -141,11 +141,11 @@ export function BillingPeriodList({
       {showCreateForm && (
         <form
           onSubmit={handleCreate}
-          className="mb-4 space-y-3 rounded-md border border-gray-200 bg-gray-50 p-4"
+          className="mb-4 space-y-3 rounded-md border border-border bg-muted p-4"
         >
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium text-foreground">
                 Start Date
               </label>
               <input
@@ -153,11 +153,11 @@ export function BillingPeriodList({
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
                 required
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium text-foreground">
                 End Date
               </label>
               <input
@@ -165,14 +165,14 @@ export function BillingPeriodList({
                 value={endDate}
                 onChange={(e) => setEndDate(e.target.value)}
                 required
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               />
             </div>
           </div>
           <button
             type="submit"
             disabled={creating}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {creating ? "Creating..." : "Create Period"}
           </button>
@@ -180,65 +180,66 @@ export function BillingPeriodList({
       )}
 
       {periods.length === 0 ? (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-muted-foreground">
           No billing periods yet. Create a new period to get started.
         </p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead>
-              <tr className="border-b border-gray-200">
-                <th className="pb-2 pr-4 font-medium text-gray-700">
+              <tr className="border-b border-border">
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">
                   Date Range
                 </th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">Status</th>
-                <th className="pb-2 pr-4 text-right font-medium text-gray-700">Total kWh</th>
-                <th className="pb-2 pr-4 text-right font-medium text-gray-700">Total ({currency})</th>
-                <th className="pb-2 font-medium text-gray-700">Actions</th>
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">Status</th>
+                <th className="pb-2 pr-4 text-right font-medium text-muted-foreground">Total kWh</th>
+                <th className="pb-2 pr-4 text-right font-medium text-muted-foreground">Total ({currency})</th>
+                <th className="pb-2 font-medium text-muted-foreground">Actions</th>
               </tr>
             </thead>
             <tbody>
               {periods.map((period) => (
-                <tr key={period.id} className="border-b border-gray-100">
-                  <td className="py-3 pr-4 text-gray-900">
-                    {period.start_date === period.end_date
-                      ? formatDate(period.start_date)
-                      : <>{formatDate(period.start_date)} &ndash; {formatDate(period.end_date)}</>}
+                <tr key={period.id} className="border-b border-border">
+                  <td className="py-3 pr-4 text-foreground">
+                    {period.start_date === period.end_date ? (
+                      <LocalDate value={period.start_date + "T00:00:00"} />
+                    ) : (
+                      <>
+                        <LocalDate value={period.start_date + "T00:00:00"} />
+                        {" – "}
+                        <LocalDate value={period.end_date + "T00:00:00"} />
+                      </>
+                    )}
                   </td>
                   <td className="py-3 pr-4">
-                    <span
-                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-                        period.status === "closed"
-                          ? "bg-green-100 text-green-800"
-                          : "bg-yellow-100 text-yellow-800"
-                      }`}
-                    >
-                      {period.status}
-                    </span>
+                    <StatusChip kind="billingPeriod" status={period.status} />
                   </td>
-                  <td className="py-3 pr-4 text-right text-gray-900">
-                    {summaries[period.id]
-                      ? formatKwh(summaries[period.id].totalKwh)
-                      : "0"}
+                  <td className="py-3 pr-4 text-right text-foreground">
+                    {summaries[period.id] ? (
+                      <Kwh value={summaries[period.id].totalKwh} bareNumber />
+                    ) : (
+                      "0"
+                    )}
                   </td>
-                  <td className="py-3 pr-4 text-right text-gray-900">
-                    {summaries[period.id]
-                      ? formatAmount(summaries[period.id].totalAmount)
-                      : "N/A"}
+                  <td className="py-3 pr-4 text-right text-foreground">
+                    {summaries[period.id] ? (
+                      <Currency value={summaries[period.id].totalAmount} bareNumber />
+                    ) : (
+                      "N/A"
+                    )}
                   </td>
                   <td className="py-3">
                     <Link
                       href={`/microgrids/${microgridId}/billing/${period.id}`}
-                      className="rounded-md px-2 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                      className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"
                     >
                       View
                     </Link>
                     <button
-                      onClick={() => handleDeletePeriod(period)}
-                      disabled={deletingPeriodId === period.id}
-                      className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => openDeleteDialog(period)}
+                      className="rounded-md px-2 py-1 text-sm text-destructive hover:bg-destructive-muted disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                      {deletingPeriodId === period.id ? "Deleting..." : "Delete"}
+                      Delete
                     </button>
                   </td>
                 </tr>

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -4,31 +4,19 @@ import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { CopyButton } from "@/components/CopyButton";
+import { Currency } from "@/components/format/currency";
+import { Kwh } from "@/components/format/kwh";
+import { LocalDate } from "@/components/format/local-date";
+import { StatusChip } from "@/components/ui/status-chip";
+import { CopyTable, type ColumnDef } from "@/components/ui/copy-table";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ClosePeriodDialog, type ClosePeriodSummaryRow } from "@/components/ui/close-period-dialog";
 import type {
   BillingLineItem,
   BillingPeriod,
   Tenant,
   TierConfig,
 } from "@/lib/types/database";
-
-function formatAmount(value: number): string {
-  return new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(value);
-}
-
-function formatKwh(value: number): string {
-  return new Intl.NumberFormat("en", {
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  }).format(value);
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr + "T00:00:00").toLocaleDateString("en", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 export function BillingTable({
   microgridId,
@@ -55,6 +43,10 @@ export function BillingTable({
   const [generateErrors, setGenerateErrors] = useState<
     { tenantName: string; error: string }[]
   >([]);
+
+  // Dialog state
+  const [closePeriodOpen, setClosePeriodOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const isDraft = period.status === "draft";
 
@@ -118,14 +110,6 @@ export function BillingTable({
   }
 
   async function handleDelete() {
-    const dateRange = period.start_date === period.end_date
-      ? formatDate(period.start_date)
-      : `${formatDate(period.start_date)} – ${formatDate(period.end_date)}`;
-    const message =
-      period.status === "closed"
-        ? `Permanently delete this closed billing period (${dateRange}) and all its finalized bills? This cannot be undone.`
-        : `Delete this draft billing period (${dateRange}) and any generated bills? This cannot be undone.`;
-    if (!confirm(message)) return;
     setError(null);
     setDeleting(true);
     const { error: deleteError } = await supabase
@@ -133,22 +117,13 @@ export function BillingTable({
       .delete()
       .eq("id", period.id);
     if (deleteError) {
-      setError(deleteError.message);
       setDeleting(false);
-      return;
+      throw new Error(deleteError.message);
     }
     router.push(`/microgrids/${microgridId}/billing`);
   }
 
   async function handleClose() {
-    if (
-      !confirm(
-        "Are you sure you want to close this billing period? This action cannot be undone."
-      )
-    ) {
-      return;
-    }
-
     setError(null);
     setClosing(true);
 
@@ -161,34 +136,132 @@ export function BillingTable({
       .eq("id", period.id);
 
     if (updateError) {
-      setError(updateError.message);
       setClosing(false);
-      return;
+      throw new Error(updateError.message);
     }
 
     setClosing(false);
     router.refresh();
   }
 
+  // Build period label for ClosePeriodDialog
+  const periodLabel =
+    period.start_date === period.end_date
+      ? period.start_date
+      : `${period.start_date} – ${period.end_date}`;
+
+  // Build summary rows for ClosePeriodDialog
+  const closePeriodSummaryRows: ClosePeriodSummaryRow[] = [
+    {
+      label: "Tenants",
+      value: String(lineItems.length),
+    },
+    {
+      label: `Total (${currency})`,
+      value: <Currency value={grandTotal} bareNumber />,
+    },
+    {
+      label: "Total (kWh)",
+      value: <Kwh value={grandTotalKwh} bareNumber />,
+    },
+  ];
+
+  // CopyTable columns built from tiers
+  // Format helpers (plain string, for CopyTable column defs)
+  const kwhFormat = (v: number | string | null) =>
+    v == null ? "—" : new Intl.NumberFormat("en", { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(Number(v));
+  const amountFormat = (v: number | string | null) =>
+    v == null ? "—" : new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(Number(v));
+
+  const columns: ColumnDef<Tenant>[] = [
+    {
+      kind: "row-header",
+      header: "Tenant",
+      accessor: (t) => t.name,
+    },
+    {
+      kind: "value",
+      header: "Begin (kWh)",
+      accessor: (t) => lineItemMap.get(t.id)?.start_kwh ?? null,
+      format: (v) => (v == null ? "—" : kwhFormat(v)),
+    },
+    {
+      kind: "value",
+      header: "End (kWh)",
+      accessor: (t) => lineItemMap.get(t.id)?.end_kwh ?? null,
+      format: (v) => (v == null ? "—" : kwhFormat(v)),
+    },
+    {
+      kind: "value",
+      header: "Usage (kWh)",
+      accessor: (t) => lineItemMap.get(t.id)?.usage_kwh ?? null,
+      format: (v) => (v == null ? "—" : kwhFormat(v)),
+    },
+    ...tiers.flatMap((tier, i): ColumnDef<Tenant>[] => [
+      {
+        kind: "value",
+        header: `${tier.label} kWh`,
+        accessor: (t) => lineItemMap.get(t.id)?.tier_breakdown[i]?.kwh ?? null,
+        format: (v) => (v == null ? "—" : kwhFormat(v)),
+      },
+      {
+        kind: "value",
+        header: `${tier.label} (${currency})`,
+        accessor: (t) => lineItemMap.get(t.id)?.tier_breakdown[i]?.amount ?? null,
+        format: (v) => (v == null ? "—" : amountFormat(v)),
+      },
+    ]),
+    {
+      kind: "value",
+      header: `Total (${currency})`,
+      accessor: (t) => lineItemMap.get(t.id)?.total_amount ?? null,
+      format: (v) => (v == null ? "—" : amountFormat(v)),
+    },
+  ];
+
+  // Tenants with line items for the CopyTable (only tenants that have data)
+  const tenantsWithItems = tenants.filter((t) => lineItemMap.has(t.id));
+
   return (
     <div className="space-y-4">
+      {/* Delete Period Dialog */}
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        title="Delete period?"
+        description="This permanently removes the period and all its line items."
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={handleDelete}
+      />
+
+      {/* Close Period Dialog */}
+      <ClosePeriodDialog
+        open={closePeriodOpen}
+        onOpenChange={setClosePeriodOpen}
+        periodLabel={periodLabel}
+        summaryRows={closePeriodSummaryRows}
+        grandTotal={grandTotal}
+        onConfirm={handleClose}
+      />
+
       {/* Header */}
-      <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <div className="rounded-lg border border-border bg-card p-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">
-              {period.start_date === period.end_date
-                ? formatDate(period.start_date)
-                : <>{formatDate(period.start_date)} &ndash; {formatDate(period.end_date)}</>}
+            <h2 className="text-lg font-semibold text-foreground">
+              {period.start_date === period.end_date ? (
+                <LocalDate value={period.start_date + "T00:00:00"} />
+              ) : (
+                <>
+                  <LocalDate value={period.start_date + "T00:00:00"} />
+                  {" – "}
+                  <LocalDate value={period.end_date + "T00:00:00"} />
+                </>
+              )}
             </h2>
-            <span
-              className={`mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-                period.status === "closed"
-                  ? "bg-green-100 text-green-800"
-                  : "bg-yellow-100 text-yellow-800"
-              }`}
-            >
-              {period.status}
+            <span className="mt-1 inline-block">
+              <StatusChip kind="billingPeriod" status={period.status} />
             </span>
           </div>
 
@@ -198,7 +271,7 @@ export function BillingTable({
                 <button
                   onClick={handleGenerate}
                   disabled={generating || closing || deleting}
-                  className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {generating
                     ? "Generating..."
@@ -207,18 +280,18 @@ export function BillingTable({
                       : "Generate"}
                 </button>
                 <button
-                  onClick={handleClose}
+                  onClick={() => setClosePeriodOpen(true)}
                   disabled={generating || closing || deleting || lineItems.length === 0}
-                  className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md border border-border bg-card px-4 py-2 text-sm text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {closing ? "Closing..." : "Close Period"}
                 </button>
               </>
             )}
             <button
-              onClick={handleDelete}
+              onClick={() => setDeleteDialogOpen(true)}
               disabled={generating || closing || deleting}
-              className="rounded-md border border-red-300 bg-white px-4 py-2 text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-md border border-destructive bg-card px-4 py-2 text-sm text-destructive hover:bg-destructive-muted disabled:cursor-not-allowed disabled:opacity-50"
             >
               {deleting ? "Deleting..." : "Delete"}
             </button>
@@ -228,14 +301,14 @@ export function BillingTable({
 
       {/* Errors */}
       {error && (
-        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div className="rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
           {error}
         </div>
       )}
 
       {/* Generate warnings */}
       {generateErrors.length > 0 && (
-        <div className="rounded-md bg-yellow-50 p-3 text-sm text-yellow-700">
+        <div className="rounded-md bg-warning-muted p-3 text-sm text-warning-fg">
           <p className="font-medium">
             Some tenants could not be billed:
           </p>
@@ -250,160 +323,64 @@ export function BillingTable({
       )}
 
       {/* Billing Table */}
-      <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <div className="rounded-lg border border-border bg-card p-6">
         {lineItems.length === 0 && tenants.length > 0 ? (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-foreground">
             No billing data yet.{" "}
             {isDraft
               ? 'Click "Generate" to fetch meter readings and calculate costs.'
               : ""}
           </p>
         ) : tenants.length === 0 ? (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-foreground">
             No tenants configured for this microgrid.
           </p>
+        ) : tenantsWithItems.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No billing data yet.{" "}
+            {isDraft
+              ? 'Click "Generate" to fetch meter readings and calculate costs.'
+              : ""}
+          </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead>
-                <tr className="border-b border-gray-200">
-                  <th className="pb-2 pr-4 font-medium text-gray-700">
-                    Tenant
-                  </th>
-                  <th className="pb-2 pr-4 text-right font-medium text-gray-700">
-                    Begin (kWh)
-                  </th>
-                  <th className="pb-2 pr-4 text-right font-medium text-gray-700">
-                    End (kWh)
-                  </th>
-                  <th className="pb-2 pr-4 text-right font-medium text-gray-700">
-                    Usage (kWh)
-                  </th>
-                  {tiers.map((tier, i) => (
-                    <React.Fragment key={`tier-hdr-${i}`}>
-                      <th className="pb-2 pr-2 text-right font-medium text-gray-700">
-                        {tier.label} kWh
-                      </th>
-                      <th className="pb-2 pr-2 text-right font-medium text-gray-700">
-                        {tier.label} ({currency})
-                      </th>
-                    </React.Fragment>
-                  ))}
-                  <th className="pb-2 text-right font-medium text-gray-700">
-                    Total ({currency})
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {tenants.map((tenant) => {
-                  const item = lineItemMap.get(tenant.id);
+          <div className="space-y-4">
+            <CopyTable
+              rows={tenantsWithItems}
+              columns={columns}
+              caption={`Billing table for period ${periodLabel} — ${tenantsWithItems.length} tenant${tenantsWithItems.length !== 1 ? "s" : ""}`}
+              ariaLabel={`Billing data for ${periodLabel}`}
+            />
 
-                  if (!item) {
-                    return (
-                      <tr
-                        key={tenant.id}
-                        className="border-b border-gray-100"
-                      >
-                        <td className="py-3 pr-4 text-gray-900">
-                          {tenant.name}
-                        </td>
-                        <td
-                          className="py-3 pr-4 text-right text-gray-400"
-                          colSpan={tiers.length * 2 + 4}
-                        >
-                          {tenant.meter_id ? "No data" : "No meter"}
-                        </td>
-                      </tr>
-                    );
-                  }
-
-                  return (
-                    <tr
-                      key={tenant.id}
-                      className="border-b border-gray-100"
-                    >
-                      <td className="py-3 pr-4 text-gray-900">
-                        {tenant.name}
-                      </td>
-                      <td className="whitespace-nowrap py-3 pr-4 text-right text-gray-900">
-                        {item.start_kwh !== null && item.start_kwh !== undefined ? (
-                          <>
-                            {formatKwh(item.start_kwh)}
-                            <CopyButton value={item.start_kwh} />
-                          </>
-                        ) : (
-                          <span className="text-gray-400">&mdash;</span>
-                        )}
-                      </td>
-                      <td className="whitespace-nowrap py-3 pr-4 text-right text-gray-900">
-                        {item.end_kwh !== null && item.end_kwh !== undefined ? (
-                          <>
-                            {formatKwh(item.end_kwh)}
-                            <CopyButton value={item.end_kwh} />
-                          </>
-                        ) : (
-                          <span className="text-gray-400">&mdash;</span>
-                        )}
-                      </td>
-                      <td className="whitespace-nowrap py-3 pr-4 text-right text-gray-900">
-                        {formatKwh(item.usage_kwh)}
-                        <CopyButton value={item.usage_kwh} />
-                      </td>
-                      {tiers.map((_, i) => {
-                        const tierData = item.tier_breakdown[i];
-                        const kwh = tierData?.kwh ?? 0;
-                        const amount = tierData?.amount ?? 0;
-                        return (
-                          <React.Fragment key={`tier-${i}`}>
-                            <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
-                              {formatKwh(kwh)}
-                              <CopyButton value={kwh} />
-                            </td>
-                            <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
-                              {formatAmount(amount)}
-                              <CopyButton value={amount} />
-                            </td>
-                          </React.Fragment>
-                        );
-                      })}
-                      <td className="whitespace-nowrap py-3 text-right font-medium text-gray-900">
-                        {formatAmount(item.total_amount)}
-                        <CopyButton value={item.total_amount} />
-                      </td>
-                    </tr>
-                  );
-                })}
-
-                {/* Grand total row */}
-                {lineItems.length > 0 && (
-                  <tr className="border-t-2 border-gray-300 font-medium">
-                    <td className="py-3 pr-4 text-gray-900">Total</td>
-                    <td className="py-3 pr-4"></td>
-                    <td className="py-3 pr-4"></td>
-                    <td className="whitespace-nowrap py-3 pr-4 text-right text-gray-900">
-                      {formatKwh(grandTotalKwh)}
-                      <CopyButton value={grandTotalKwh} />
-                    </td>
-                    {tiers.map((_, i) => (
-                      <React.Fragment key={`grand-tier-${i}`}>
-                        <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
-                          {formatKwh(grandTierKwh[i])}
-                          <CopyButton value={grandTierKwh[i]} />
-                        </td>
-                        <td className="whitespace-nowrap py-3 pr-2 text-right text-gray-900">
-                          {formatAmount(grandTierAmount[i])}
-                          <CopyButton value={grandTierAmount[i]} />
-                        </td>
-                      </React.Fragment>
-                    ))}
-                    <td className="whitespace-nowrap py-3 text-right text-gray-900">
-                      {formatAmount(grandTotal)}
-                      <CopyButton value={grandTotal} />
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
+            {/* Grand-total footer — rendered BELOW the CopyTable */}
+            {lineItems.length > 0 && (
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-t-2 border-border pt-3 text-sm font-medium text-foreground">
+                <span className="w-32 text-foreground">Total</span>
+                <span className="whitespace-nowrap">
+                  <span className="text-xs text-muted-foreground mr-1">kWh</span>
+                  <Kwh value={grandTotalKwh} bareNumber />
+                  <CopyButton value={grandTotalKwh} />
+                </span>
+                {tiers.map((_, i) => (
+                  <React.Fragment key={`grand-tier-${i}`}>
+                    <span className="whitespace-nowrap">
+                      <span className="text-xs text-muted-foreground mr-1">{tiers[i].label} kWh</span>
+                      <Kwh value={grandTierKwh[i]} bareNumber />
+                      <CopyButton value={grandTierKwh[i]} />
+                    </span>
+                    <span className="whitespace-nowrap">
+                      <span className="text-xs text-muted-foreground mr-1">{tiers[i].label} ({currency})</span>
+                      <Currency value={grandTierAmount[i]} bareNumber />
+                      <CopyButton value={grandTierAmount[i]} />
+                    </span>
+                  </React.Fragment>
+                ))}
+                <span className="whitespace-nowrap">
+                  <span className="text-xs text-muted-foreground mr-1">Total ({currency})</span>
+                  <Currency value={grandTotal} bareNumber />
+                  <CopyButton value={grandTotal} />
+                </span>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -14,11 +14,11 @@ export function CopyButton({ value }: { value: number }) {
   return (
     <button
       onClick={handleCopy}
-      className="ml-1 inline-flex items-center text-xs text-gray-400 hover:text-gray-600"
+      className="ml-1 inline-flex items-center text-xs text-muted-foreground hover:text-foreground"
       title="Copy value"
     >
       {copied ? (
-        <span className="text-green-600">Copied</span>
+        <span className="text-success-fg">Copied</span>
       ) : (
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/MeterManager.tsx
+++ b/src/components/MeterManager.tsx
@@ -11,26 +11,8 @@ import type {
   OpenEmsDataSourceConfig,
 } from "@/lib/openems/types";
 import { METER_TYPE_INFO } from "@/lib/openems/meter-descriptions";
-
-const METER_TYPE_BADGES: Record<MeterType, { label: string; classes: string }> =
-  {
-    GRID: {
-      label: "Grid",
-      classes: "bg-blue-100 text-blue-800",
-    },
-    PRODUCTION: {
-      label: "Production",
-      classes: "bg-green-100 text-green-800",
-    },
-    CONSUMPTION: {
-      label: "Consumption",
-      classes: "bg-orange-100 text-orange-800",
-    },
-    UNKNOWN: {
-      label: "Unknown",
-      classes: "bg-gray-100 text-gray-800",
-    },
-  };
+import { StatusChip } from "@/components/ui/status-chip";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 export function MeterManager({
   microgridId,
@@ -69,6 +51,10 @@ export function MeterManager({
   // Refresh types state
   const [refreshing, setRefreshing] = useState(false);
   const [refreshResult, setRefreshResult] = useState<string | null>(null);
+
+  // Delete dialog state
+  const [meterToDelete, setMeterToDelete] = useState<Meter | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   // Build set of already-added meter keys for dedup (prop-based + optimistic)
   const existingKeys = new Set([
@@ -126,28 +112,35 @@ export function MeterManager({
     router.refresh();
   }
 
-  async function handleDelete(meter: Meter) {
-    const assignedTenants = tenants.filter((t) => t.meter_id === meter.id);
-    const tenantNames = assignedTenants.map((t) => t.name).join(", ");
-    const message =
-      assignedTenants.length > 0
-        ? `This meter is assigned to: ${tenantNames}. Deleting it will unassign their meter.\n\nContinue?`
-        : `Delete "${meter.name}"?`;
+  function openDeleteDialog(meter: Meter) {
+    setMeterToDelete(meter);
+    setDeleteDialogOpen(true);
+  }
 
-    if (!confirm(message)) return;
-
+  async function handleDelete() {
+    if (!meterToDelete) return;
     const { error: deleteError } = await supabase
       .from("meters")
       .delete()
-      .eq("id", meter.id);
+      .eq("id", meterToDelete.id);
 
     if (deleteError) {
-      setError(deleteError.message);
-      return;
+      throw new Error(deleteError.message);
     }
 
     router.refresh();
   }
+
+  // Build delete dialog description
+  const deleteDescription = meterToDelete
+    ? (() => {
+        const assignedTenants = tenants.filter((t) => t.meter_id === meterToDelete.id);
+        const tenantNames = assignedTenants.map((t) => t.name).join(", ");
+        return assignedTenants.length > 0
+          ? `This meter is assigned to: ${tenantNames}. Deleting it will unassign their meter.`
+          : `Delete "${meterToDelete.name}"?`;
+      })()
+    : undefined;
 
   async function handleDiscover() {
     setShowDiscovery(true);
@@ -277,23 +270,34 @@ export function MeterManager({
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6">
+    <div className="rounded-lg border border-border bg-card p-6">
+      {/* Delete Meter ConfirmDialog */}
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        title="Delete meter?"
+        description={deleteDescription}
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={handleDelete}
+      />
+
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-gray-900">Meters</h2>
+        <h2 className="text-lg font-semibold text-foreground">Meters</h2>
         <div className="flex items-center gap-2">
           {refreshResult && (
-            <span className="text-xs text-green-600">{refreshResult}</span>
+            <span className="text-xs text-success-fg">{refreshResult}</span>
           )}
           <button
             onClick={handleRefreshTypes}
             disabled={refreshing}
-            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
             {refreshing ? "Refreshing..." : "Refresh Types"}
           </button>
           <button
             onClick={handleDiscover}
-            className="rounded-md bg-green-600 px-3 py-1.5 text-sm text-white hover:bg-green-700"
+            className="rounded-md bg-success px-3 py-1.5 text-sm text-success-foreground hover:opacity-90"
           >
             Discover Meters
           </button>
@@ -302,7 +306,7 @@ export function MeterManager({
               setShowForm(!showForm);
               setShowDiscovery(false);
             }}
-            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
           >
             {showForm ? "Cancel" : "Add Meter"}
           </button>
@@ -310,33 +314,33 @@ export function MeterManager({
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div className="mb-4 rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
           {error}
         </div>
       )}
 
       {showDiscovery && (
-        <div className="mb-4 rounded-md border border-gray-200 bg-gray-50 p-4">
+        <div className="mb-4 rounded-md border border-border bg-muted p-4">
           <div className="mb-3 flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-gray-900">
+            <h3 className="text-sm font-semibold text-foreground">
               Discovered Meters
             </h3>
             <button
               onClick={() => setShowDiscovery(false)}
-              className="text-sm text-gray-500 hover:text-gray-700"
+              className="text-sm text-muted-foreground hover:text-foreground"
             >
               Close
             </button>
           </div>
 
           {discoveryLoading && (
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               Scanning OpenEMS for meters...
             </p>
           )}
 
           {discoveryError && (
-            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            <div className="rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
               {discoveryError}
             </div>
           )}
@@ -344,7 +348,7 @@ export function MeterManager({
           {!discoveryLoading &&
             !discoveryError &&
             discoveryResults.length === 0 && (
-              <p className="text-sm text-gray-500">No edges found.</p>
+              <p className="text-sm text-muted-foreground">No edges found.</p>
             )}
 
           {!discoveryLoading &&
@@ -354,20 +358,20 @@ export function MeterManager({
                 <div className="mb-2 flex items-center gap-2">
                   <span
                     className={`inline-block h-2.5 w-2.5 rounded-full ${
-                      edge.online ? "bg-green-500" : "bg-red-500"
+                      edge.online ? "bg-success" : "bg-destructive"
                     }`}
                     title={edge.online ? "Online" : "Offline"}
                   />
-                  <span className="text-sm font-medium text-gray-700">
+                  <span className="text-sm font-medium text-foreground">
                     {edge.edgeId}
                   </span>
-                  <span className="text-xs text-gray-400">
+                  <span className="text-xs text-muted-foreground">
                     {edge.online ? "Online" : "Offline"}
                   </span>
                 </div>
 
                 {edge.meters.length === 0 ? (
-                  <p className="ml-5 text-sm text-gray-400">
+                  <p className="ml-5 text-sm text-muted-foreground">
                     No meters found on this edge.
                   </p>
                 ) : (
@@ -376,7 +380,6 @@ export function MeterManager({
                       const alreadyAdded = existingKeys.has(
                         `${edge.edgeId}:${meter.componentId}`
                       );
-                      const badge = METER_TYPE_BADGES[meter.meterType];
 
                       const typeInfo = METER_TYPE_INFO[meter.meterType];
 
@@ -385,8 +388,8 @@ export function MeterManager({
                           key={meter.componentId}
                           className={`rounded-md border px-3 py-2 ${
                             alreadyAdded
-                              ? "border-gray-100 bg-gray-100"
-                              : "border-gray-200 bg-white"
+                              ? "border-border bg-muted"
+                              : "border-border bg-card"
                           }`}
                         >
                           <div className="flex items-center justify-between">
@@ -395,8 +398,8 @@ export function MeterManager({
                                 <p
                                   className={`text-sm font-medium ${
                                     alreadyAdded
-                                      ? "text-gray-400"
-                                      : "text-gray-900"
+                                      ? "text-muted-foreground"
+                                      : "text-foreground"
                                   }`}
                                 >
                                   {meter.alias}
@@ -404,26 +407,22 @@ export function MeterManager({
                                 <p
                                   className={`text-xs ${
                                     alreadyAdded
-                                      ? "text-gray-300"
-                                      : "text-gray-500"
+                                      ? "text-muted-foreground"
+                                      : "text-muted-foreground"
                                   }`}
                                 >
                                   {meter.componentId}
                                 </p>
                               </div>
-                              <span
-                                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                                  alreadyAdded
-                                    ? "bg-gray-100 text-gray-400"
-                                    : badge.classes
-                                }`}
-                              >
-                                {badge.label}
-                              </span>
+                              {alreadyAdded ? (
+                                <StatusChip kind="meterType" status={meter.meterType} state="disabled" />
+                              ) : (
+                                <StatusChip kind="meterType" status={meter.meterType} />
+                              )}
                             </div>
 
                             {alreadyAdded ? (
-                              <span className="text-xs italic text-gray-400">
+                              <span className="text-xs italic text-muted-foreground">
                                 Already added
                               </span>
                             ) : namingMeterId === meter.componentId ? (
@@ -436,20 +435,20 @@ export function MeterManager({
                                     if (e.key === "Enter") handleAddDiscovered(edge.edgeId, meter);
                                     if (e.key === "Escape") setNamingMeterId(null);
                                   }}
-                                  className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                                  className="rounded-md border border-border px-2 py-1 text-sm"
                                   autoFocus
                                   placeholder="Enter meter name"
                                 />
                                 <button
                                   onClick={() => handleAddDiscovered(edge.edgeId, meter)}
                                   disabled={!namingValue.trim() || addingMeter === meter.componentId}
-                                  className="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                                  className="rounded-md bg-primary px-3 py-1 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
                                 >
                                   {addingMeter === meter.componentId ? "Saving..." : "Save"}
                                 </button>
                                 <button
                                   onClick={() => setNamingMeterId(null)}
-                                  className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-600 hover:bg-gray-50"
+                                  className="rounded-md border border-border px-3 py-1 text-sm text-foreground hover:bg-muted"
                                 >
                                   Cancel
                                 </button>
@@ -460,16 +459,16 @@ export function MeterManager({
                                   setNamingMeterId(meter.componentId);
                                   setNamingValue(meter.alias || meter.componentId);
                                 }}
-                                className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700"
+                                className="rounded-md bg-primary px-3 py-1 text-xs text-primary-foreground hover:opacity-90"
                               >
                                 Add
                               </button>
                             )}
                           </div>
                           {typeInfo && !alreadyAdded && (
-                            <div className="mt-1.5 ml-0 text-xs text-gray-500">
+                            <div className="mt-1.5 ml-0 text-xs text-muted-foreground">
                               <p>{typeInfo.shortDesc}</p>
-                              <p className="mt-0.5 italic text-gray-400">
+                              <p className="mt-0.5 italic text-muted-foreground">
                                 {typeInfo.billingHint}
                               </p>
                             </div>
@@ -487,10 +486,10 @@ export function MeterManager({
       {showForm && (
         <form
           onSubmit={handleAdd}
-          className="mb-4 space-y-3 rounded-md border border-gray-200 bg-gray-50 p-4"
+          className="mb-4 space-y-3 rounded-md border border-border bg-muted p-4"
         >
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Name
             </label>
             <input
@@ -498,23 +497,23 @@ export function MeterManager({
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               placeholder="e.g. Unit 1 Meter"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Data Source
             </label>
             <input
               type="text"
               value="openems"
               disabled
-              className="mt-1 block w-full rounded-md border border-gray-200 bg-gray-100 px-3 py-2 text-gray-500"
+              className="mt-1 block w-full rounded-md border border-border bg-muted px-3 py-2 text-muted-foreground"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Edge ID
             </label>
             <input
@@ -522,12 +521,12 @@ export function MeterManager({
               value={edgeId}
               onChange={(e) => setEdgeId(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               placeholder="e.g. edge0"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Channel Address
             </label>
             <input
@@ -535,14 +534,14 @@ export function MeterManager({
               value={channelAddress}
               onChange={(e) => setChannelAddress(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               placeholder="e.g. meter0/ActiveConsumptionEnergy"
             />
           </div>
           <button
             type="submit"
             disabled={saving}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? "Adding..." : "Add Meter"}
           </button>
@@ -550,47 +549,40 @@ export function MeterManager({
       )}
 
       {meters.length === 0 ? (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-muted-foreground">
           No meters configured. Add a meter to start assigning tenants.
         </p>
       ) : (
         <div className="space-y-2">
           {meters.map((meter) => {
             const config = meter.data_source_config as OpenEmsDataSourceConfig;
-            const typeBadge = meter.meter_type
-              ? METER_TYPE_BADGES[meter.meter_type as MeterType]
-              : null;
             const typeInfo = meter.meter_type
               ? METER_TYPE_INFO[meter.meter_type]
               : null;
             return (
               <div
                 key={meter.id}
-                className="flex items-center justify-between rounded-md border border-gray-100 bg-gray-50 px-4 py-3"
+                className="flex items-center justify-between rounded-md border border-border bg-muted px-4 py-3"
               >
                 <div>
                   <div className="flex items-center gap-2">
-                    <p className="font-medium text-gray-900">{meter.name}</p>
-                    {typeBadge && (
-                      <span
-                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${typeBadge.classes}`}
-                      >
-                        {typeBadge.label}
-                      </span>
+                    <p className="font-medium text-foreground">{meter.name}</p>
+                    {meter.meter_type && (
+                      <StatusChip kind="meterType" status={meter.meter_type} />
                     )}
                   </div>
-                  <p className="text-sm text-gray-500">
+                  <p className="text-sm text-muted-foreground">
                     {config.edgeId} / {config.channelAddress}
                   </p>
                   {typeInfo && (
-                    <p className="mt-0.5 text-xs text-gray-400">
+                    <p className="mt-0.5 text-xs text-muted-foreground">
                       {typeInfo.shortDesc}
                     </p>
                   )}
                 </div>
                 <button
-                  onClick={() => handleDelete(meter)}
-                  className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700"
+                  onClick={() => openDeleteDialog(meter)}
+                  className="rounded-md px-2 py-1 text-sm text-destructive hover:bg-destructive-muted"
                 >
                   Delete
                 </button>

--- a/src/components/TenantTable.tsx
+++ b/src/components/TenantTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { Meter, Tenant } from "@/lib/types/database";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 export function TenantTable({
   microgridId,
@@ -32,6 +33,10 @@ export function TenantTable({
   const [editPhone, setEditPhone] = useState("");
   const [editEmail, setEditEmail] = useState("");
   const [editSaving, setEditSaving] = useState(false);
+
+  // Delete dialog state
+  const [tenantToDelete, setTenantToDelete] = useState<Tenant | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   // Compute which meters are shared (assigned to multiple tenants)
   const meterAssignmentCounts = new Map<string, number>();
@@ -129,17 +134,20 @@ export function TenantTable({
     router.refresh();
   }
 
-  async function handleDelete(tenant: Tenant) {
-    if (!confirm(`Are you sure you want to delete "${tenant.name}"?`)) return;
+  function openDeleteDialog(tenant: Tenant) {
+    setTenantToDelete(tenant);
+    setDeleteDialogOpen(true);
+  }
 
+  async function handleDelete() {
+    if (!tenantToDelete) return;
     const { error: deleteError } = await supabase
       .from("tenants")
       .delete()
-      .eq("id", tenant.id);
+      .eq("id", tenantToDelete.id);
 
     if (deleteError) {
-      setError(deleteError.message);
-      return;
+      throw new Error(deleteError.message);
     }
 
     router.refresh();
@@ -162,19 +170,34 @@ export function TenantTable({
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6">
+    <div className="rounded-lg border border-border bg-card p-6">
+      {/* Delete Tenant ConfirmDialog */}
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        title="Delete tenant?"
+        description={
+          tenantToDelete
+            ? `Are you sure you want to delete "${tenantToDelete.name}"?`
+            : undefined
+        }
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={handleDelete}
+      />
+
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-gray-900">Tenants</h2>
+        <h2 className="text-lg font-semibold text-foreground">Tenants</h2>
         <button
           onClick={() => setShowAddForm(!showAddForm)}
-          className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+          className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
         >
           {showAddForm ? "Cancel" : "Add Tenant"}
         </button>
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div className="mb-4 rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
           {error}
         </div>
       )}
@@ -182,10 +205,10 @@ export function TenantTable({
       {showAddForm && (
         <form
           onSubmit={handleAdd}
-          className="mb-4 space-y-3 rounded-md border border-gray-200 bg-gray-50 p-4"
+          className="mb-4 space-y-3 rounded-md border border-border bg-muted p-4"
         >
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Name
             </label>
             <input
@@ -193,38 +216,38 @@ export function TenantTable({
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               placeholder="Tenant name"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Phone
             </label>
             <input
               type="text"
               value={newPhone}
               onChange={(e) => setNewPhone(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               placeholder="Optional"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-foreground">
               Email
             </label>
             <input
               type="email"
               value={newEmail}
               onChange={(e) => setNewEmail(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
               placeholder="Optional"
             />
           </div>
           <button
             type="submit"
             disabled={addSaving}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {addSaving ? "Adding..." : "Add Tenant"}
           </button>
@@ -232,26 +255,26 @@ export function TenantTable({
       )}
 
       {tenants.length === 0 ? (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-muted-foreground">
           No tenants yet. Add a tenant to get started.
         </p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead>
-              <tr className="border-b border-gray-200">
-                <th className="pb-2 pr-4 font-medium text-gray-700">Name</th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">Phone</th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">Email</th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">
+              <tr className="border-b border-border">
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">Name</th>
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">Phone</th>
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">Email</th>
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">
                   Assigned Meter
                 </th>
-                <th className="pb-2 font-medium text-gray-700">Actions</th>
+                <th className="pb-2 font-medium text-muted-foreground">Actions</th>
               </tr>
             </thead>
             <tbody>
               {tenants.map((tenant) => (
-                <tr key={tenant.id} className="border-b border-gray-100">
+                <tr key={tenant.id} className="border-b border-border">
                   {editingId === tenant.id ? (
                     <>
                       <td className="py-3 pr-4">
@@ -260,7 +283,7 @@ export function TenantTable({
                           value={editName}
                           onChange={(e) => setEditName(e.target.value)}
                           required
-                          className="w-full rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                         />
                       </td>
                       <td className="py-3 pr-4">
@@ -268,7 +291,7 @@ export function TenantTable({
                           type="text"
                           value={editPhone}
                           onChange={(e) => setEditPhone(e.target.value)}
-                          className="w-full rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                         />
                       </td>
                       <td className="py-3 pr-4">
@@ -276,11 +299,11 @@ export function TenantTable({
                           type="email"
                           value={editEmail}
                           onChange={(e) => setEditEmail(e.target.value)}
-                          className="w-full rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                         />
                       </td>
                       <td className="py-3 pr-4">
-                        <span className="text-gray-500">
+                        <span className="text-muted-foreground">
                           {getMeterName(tenant.meter_id)}
                         </span>
                       </td>
@@ -289,13 +312,13 @@ export function TenantTable({
                           <button
                             onClick={() => handleEditSave(tenant.id)}
                             disabled={editSaving}
-                            className="rounded-md px-2 py-1 text-sm text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+                            className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent disabled:opacity-50"
                           >
                             {editSaving ? "Saving..." : "Save"}
                           </button>
                           <button
                             onClick={cancelEdit}
-                            className="rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100"
+                            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted"
                           >
                             Cancel
                           </button>
@@ -304,13 +327,13 @@ export function TenantTable({
                     </>
                   ) : (
                     <>
-                      <td className="py-3 pr-4 text-gray-900">
+                      <td className="py-3 pr-4 text-foreground">
                         {tenant.name}
                       </td>
-                      <td className="py-3 pr-4 text-gray-600">
+                      <td className="py-3 pr-4 text-muted-foreground">
                         {tenant.phone ?? "-"}
                       </td>
-                      <td className="py-3 pr-4 text-gray-600">
+                      <td className="py-3 pr-4 text-muted-foreground">
                         {tenant.email ?? "-"}
                       </td>
                       <td className="py-3 pr-4">
@@ -320,7 +343,7 @@ export function TenantTable({
                             onChange={(e) =>
                               handleMeterChange(tenant.id, e.target.value)
                             }
-                            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            className="rounded-md border border-border px-2 py-1 text-sm text-foreground focus:outline-none"
                           >
                             <option value="">Unassigned</option>
                             {meters.map((meter) => (
@@ -329,11 +352,11 @@ export function TenantTable({
                               </option>
                             ))}
                           </select>
-                          <p className="mt-1 text-xs text-gray-400">
+                          <p className="mt-1 text-xs text-muted-foreground">
                             Assign a CONSUMPTION meter to bill this tenant for their electricity usage.
                           </p>
                           {isSharedMeter(tenant.meter_id) && (
-                            <p className="mt-1 text-xs text-yellow-600">
+                            <p className="mt-1 text-xs text-warning-fg">
                               Shared with another tenant
                             </p>
                           )}
@@ -343,13 +366,13 @@ export function TenantTable({
                         <div className="flex gap-2">
                           <button
                             onClick={() => startEdit(tenant)}
-                            className="rounded-md px-2 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                            className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"
                           >
                             Edit
                           </button>
                           <button
-                            onClick={() => handleDelete(tenant)}
-                            className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50"
+                            onClick={() => openDeleteDialog(tenant)}
+                            className="rounded-md px-2 py-1 text-sm text-destructive hover:bg-destructive-muted"
                           >
                             Delete
                           </button>

--- a/src/components/TierEditor.tsx
+++ b/src/components/TierEditor.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { RateSchedule, TierConfig } from "@/lib/types/database";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 export function TierEditor({
   microgridId,
@@ -29,6 +30,10 @@ export function TierEditor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+
+  // Last-tier warning dialog state
+  const [lastTierDialogOpen, setLastTierDialogOpen] = useState(false);
+  const [pendingRemoveIndex, setPendingRemoveIndex] = useState<number | null>(null);
 
   function updateTier(index: number, updates: Partial<TierConfig>) {
     setTiers((prev) =>
@@ -70,11 +75,21 @@ export function TierEditor({
 
   function removeTier(index: number) {
     if (tiers.length === 1) {
-      if (!confirm("Removing the last tier will leave an empty schedule. Continue?")) {
-        return;
-      }
+      setPendingRemoveIndex(index);
+      setLastTierDialogOpen(true);
+      return;
     }
+    doRemoveTier(index);
+  }
 
+  async function handleLastTierConfirm() {
+    if (pendingRemoveIndex !== null) {
+      doRemoveTier(pendingRemoveIndex);
+      setPendingRemoveIndex(null);
+    }
+  }
+
+  function doRemoveTier(index: number) {
     setTiers((prev) => {
       const updated = prev.filter((_, i) => i !== index);
       // Ensure the new last tier has max_kwh = null
@@ -183,56 +198,67 @@ export function TierEditor({
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6">
+    <div className="rounded-lg border border-border bg-card p-6">
+      {/* Last-tier warning ConfirmDialog */}
+      <ConfirmDialog
+        open={lastTierDialogOpen}
+        onOpenChange={setLastTierDialogOpen}
+        title="Remove last tier?"
+        description="Removing the last tier will leave an empty schedule. Continue?"
+        confirmLabel="Remove"
+        tone="neutral"
+        onConfirm={handleLastTierConfirm}
+      />
+
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-gray-900">Rate Schedule</h2>
+        <h2 className="text-lg font-semibold text-foreground">Rate Schedule</h2>
         <button
           onClick={addTier}
-          className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+          className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
         >
           Add Tier
         </button>
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+        <div className="mb-4 rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
           {error}
         </div>
       )}
 
       {success && (
-        <div className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-700">
+        <div className="mb-4 rounded-md bg-success-muted p-3 text-sm text-success-fg">
           {success}
         </div>
       )}
 
       {tiers.length === 0 ? (
-        <p className="mb-6 text-sm text-gray-500">
+        <p className="mb-6 text-sm text-muted-foreground">
           No tiers configured. Add a tier to define the rate schedule.
         </p>
       ) : (
         <div className="mb-6 overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead>
-              <tr className="border-b border-gray-200">
-                <th className="pb-2 pr-4 font-medium text-gray-700">Label</th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">
+              <tr className="border-b border-border">
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">Label</th>
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">
                   Min kWh
                 </th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">
                   Max kWh
                 </th>
-                <th className="pb-2 pr-4 font-medium text-gray-700">
+                <th className="pb-2 pr-4 font-medium text-muted-foreground">
                   Rate per kWh ({currency})
                 </th>
-                <th className="pb-2 font-medium text-gray-700">Actions</th>
+                <th className="pb-2 font-medium text-muted-foreground">Actions</th>
               </tr>
             </thead>
             <tbody>
               {tiers.map((tier, index) => {
                 const isLastTier = index === tiers.length - 1;
                 return (
-                  <tr key={index} className="border-b border-gray-100">
+                  <tr key={index} className="border-b border-border">
                     <td className="py-3 pr-4">
                       <input
                         type="text"
@@ -240,7 +266,7 @@ export function TierEditor({
                         onChange={(e) =>
                           updateTier(index, { label: e.target.value })
                         }
-                        className="w-full rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                       />
                     </td>
                     <td className="py-3 pr-4">
@@ -253,12 +279,12 @@ export function TierEditor({
                           })
                         }
                         min={1}
-                        className="w-24 rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        className="w-24 rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                       />
                     </td>
                     <td className="py-3 pr-4">
                       {isLastTier ? (
-                        <span className="inline-block w-24 px-2 py-1 text-gray-500">
+                        <span className="inline-block w-24 px-2 py-1 text-muted-foreground">
                           &infin;
                         </span>
                       ) : (
@@ -273,7 +299,7 @@ export function TierEditor({
                             })
                           }
                           min={tier.min_kwh + 1}
-                          className="w-24 rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          className="w-24 rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                         />
                       )}
                     </td>
@@ -288,13 +314,13 @@ export function TierEditor({
                         }
                         min={0}
                         step="any"
-                        className="w-28 rounded-md border border-gray-300 px-2 py-1 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        className="w-28 rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
                       />
                     </td>
                     <td className="py-3">
                       <button
                         onClick={() => removeTier(index)}
-                        className="rounded-md px-2 py-1 text-sm text-red-600 hover:bg-red-50 hover:text-red-700"
+                        className="rounded-md px-2 py-1 text-sm text-destructive hover:bg-destructive-muted"
                       >
                         Remove
                       </button>
@@ -309,7 +335,7 @@ export function TierEditor({
 
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
-          <label className="block text-sm font-medium text-gray-700">
+          <label className="block text-sm font-medium text-foreground">
             Service Charge ({currency})
           </label>
           <input
@@ -318,11 +344,11 @@ export function TierEditor({
             onChange={(e) => setServiceCharge(parseFloat(e.target.value) || 0)}
             min={0}
             step="any"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700">
+          <label className="block text-sm font-medium text-foreground">
             Tax Rate (%)
           </label>
           <input
@@ -334,7 +360,7 @@ export function TierEditor({
             min={0}
             max={100}
             step="any"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
           />
         </div>
       </div>
@@ -342,7 +368,7 @@ export function TierEditor({
       <button
         onClick={handleSave}
         disabled={saving}
-        className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {saving ? "Saving..." : "Save Rate Schedule"}
       </button>

--- a/src/components/__tests__/billing-table.test.tsx
+++ b/src/components/__tests__/billing-table.test.tsx
@@ -1,0 +1,187 @@
+// BillingTable integration test (jsdom, component environment)
+//
+// Strategy:
+//   - Mount BillingTable with a minimal fixture (one period, two tiers, three tenants,
+//     three line items) wrapped in <LocaleProvider locale="en-UG" currency="UGX">.
+//   - Assert rendered markup only; does NOT fire mutation handlers (Close / Delete /
+//     Generate) — those handlers instantiate a Supabase client and router, both mocked.
+//   - Assertions:
+//     (a) bg-warning-muted in StatusChip for a draft period
+//     (b) <caption> text from CopyTable
+//     (c) <Currency bareNumber> cells do not contain "UGX"
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { BillingTable } from "../BillingTable";
+import { LocaleProvider } from "../format/locale-context";
+import type {
+  BillingLineItem,
+  BillingPeriod,
+  Tenant,
+  TierConfig,
+} from "@/lib/types/database";
+
+// Mock next/navigation (BillingTable calls useRouter inside)
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+// Mock Supabase client (BillingTable calls createClient() on render)
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: () => ({
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }),
+  }),
+}));
+
+// Mock clipboard API (CopyButton uses navigator.clipboard)
+Object.defineProperty(navigator, "clipboard", {
+  value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  writable: true,
+});
+
+// ─── Fixture data ───────────────────────────────────────────────────────────
+
+const tiers: TierConfig[] = [
+  { label: "Tier 1", min_kwh: 1, max_kwh: 50, rate_per_kwh: 500 },
+  { label: "Tier 2", min_kwh: 51, max_kwh: null, rate_per_kwh: 800 },
+];
+
+const period: BillingPeriod = {
+  id: "period-1",
+  microgrid_id: "mg-1",
+  start_date: "2026-03-01",
+  end_date: "2026-03-31",
+  status: "draft",
+  created_at: "2026-03-01T00:00:00Z",
+  closed_at: null,
+};
+
+const tenants: Tenant[] = [
+  { id: "t-1", microgrid_id: "mg-1", name: "Alice", phone: null, email: null, meter_id: "m-1", created_at: "2026-01-01T00:00:00Z" },
+  { id: "t-2", microgrid_id: "mg-1", name: "Bob", phone: null, email: null, meter_id: "m-2", created_at: "2026-01-01T00:00:00Z" },
+  { id: "t-3", microgrid_id: "mg-1", name: "Carol", phone: null, email: null, meter_id: "m-3", created_at: "2026-01-01T00:00:00Z" },
+];
+
+const lineItems: BillingLineItem[] = [
+  {
+    id: "li-1",
+    billing_period_id: "period-1",
+    tenant_id: "t-1",
+    meter_id: "m-1",
+    usage_kwh: 80,
+    start_kwh: 200,
+    end_kwh: 280,
+    tier_breakdown: [
+      { label: "Tier 1", kwh: 50, amount: 25000 },
+      { label: "Tier 2", kwh: 30, amount: 24000 },
+    ],
+    total_amount: 49000,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "li-2",
+    billing_period_id: "period-1",
+    tenant_id: "t-2",
+    meter_id: "m-2",
+    usage_kwh: 45,
+    start_kwh: 100,
+    end_kwh: 145,
+    tier_breakdown: [
+      { label: "Tier 1", kwh: 45, amount: 22500 },
+      { label: "Tier 2", kwh: 0, amount: 0 },
+    ],
+    total_amount: 22500,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "li-3",
+    billing_period_id: "period-1",
+    tenant_id: "t-3",
+    meter_id: "m-3",
+    usage_kwh: 110,
+    start_kwh: 50,
+    end_kwh: 160,
+    tier_breakdown: [
+      { label: "Tier 1", kwh: 50, amount: 25000 },
+      { label: "Tier 2", kwh: 60, amount: 48000 },
+    ],
+    total_amount: 73000,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <LocaleProvider locale="en-UG" currency="UGX">
+      {children}
+    </LocaleProvider>
+  );
+}
+
+describe("BillingTable", () => {
+  it("(a) draft period status chip contains bg-warning-muted", () => {
+    const { container } = render(
+      <Wrapper>
+        <BillingTable
+          microgridId="mg-1"
+          period={period}
+          lineItems={lineItems}
+          tenants={tenants}
+          tiers={tiers}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+
+    // StatusChip for billingPeriod.draft maps to tone="warn" → Chip gets bg-warning-muted class
+    const chip = container.querySelector(".bg-warning-muted");
+    expect(chip).not.toBeNull();
+  });
+
+  it("(b) CopyTable renders a <caption> element with period info", () => {
+    const { container } = render(
+      <Wrapper>
+        <BillingTable
+          microgridId="mg-1"
+          period={period}
+          lineItems={lineItems}
+          tenants={tenants}
+          tiers={tiers}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+
+    // CopyTable always renders a <caption> (sr-only) describing the table
+    const caption = container.querySelector("caption");
+    expect(caption).not.toBeNull();
+    // Caption should mention the period
+    expect(caption?.textContent).toContain("Billing table for period");
+  });
+
+  it("(c) Currency bareNumber cells do not contain 'UGX'", () => {
+    const { container } = render(
+      <Wrapper>
+        <BillingTable
+          microgridId="mg-1"
+          period={period}
+          lineItems={lineItems}
+          tenants={tenants}
+          tiers={tiers}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+
+    // CopyTable cells render plain formatted numbers via format functions (no currency symbol)
+    // The grand-total footer uses <Currency bareNumber> which also omits "UGX"
+    // Find all table data cells and verify none contain the currency code
+    const tds = Array.from(container.querySelectorAll("td"));
+    const tdTexts = tds.map((td) => td.textContent ?? "");
+    const hasUgxInCell = tdTexts.some((t) => t.includes("UGX"));
+    expect(hasUgxInCell).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The visible payoff for T1 + T2. Every existing MBE page now consumes the token system, format primitives, and shadcn-shaped UI primitives.

- **Token migration:** zero hardcoded `bg-blue-*` / `text-gray-*` / `bg-yellow-100` etc. across `src/app/(dashboard)` and `src/components`. Grep-verified.
- **Format primitives:** `BillingTable` + `BillingPeriodList` now use `<Currency bareNumber />`, `<Kwh bareNumber />`, `<LocalDate />`. In-table currency cells are bare numbers (Aaron's URA paste workflow preserved); currency code only in column headers.
- **CopyTable swap:** `BillingTable`'s hand-rolled `<table>` → `<CopyTable>` with programmatic `ColumnDef[]` from tiers. Grand-total row renders as a footer `<div>` below with per-cell `<CopyButton>`. In-table `<CopyButton>` removed (CopyTable has built-in per-cell copy).
- **StatusChip swap:** period status (BillingTable, BillingPeriodList) + meter type (MeterManager) all use `<StatusChip>`. `meter.meter_type` passed uppercase directly.
- **All 6 `confirm()` calls migrated:** `grep -rn "confirm(" src/app src/components` → zero matches.
  - Close Period → `<ClosePeriodDialog>` (heavy ceremony)
  - Delete Period × 2, Delete Meter, Delete Tenant, Last-tier warning → `<ConfirmDialog>` (tenant name interpolation + `tone="neutral"` for the last-tier case)
- **LocaleProvider currency wiring:** microgrid layout wraps children with `<LocaleProvider currency={microgrid.currency}>`, server-side. Column `currency` prop preserved for header strings.
- **HierarchyNav:** microgrid layout's "← Back" link replaced with two-level HierarchyNav (Organization + Microgrid, counts queried server-side).
- **Sidebar + tab nav tokenized:** labels verbatim (entity refactor does the Households rename). Tab-active: `border-primary text-primary`.
- **CLAUDE.md Design System section:** 5-rule reference added under Key Conventions.
- **New test:** `src/components/__tests__/billing-table.test.tsx` mounts BillingTable in `<LocaleProvider>`, asserts StatusChip markup, CopyTable caption, bareNumber cells.

Closes #40.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (including 2 pre-existing `no-html-link-for-pages` errors bonus-fixed via `<a>`→`<Link>` migration in the sidebar)
- [x] `npm test` — 72/72 passing
- [x] `npm run build` — clean (Turbopack CSS pipeline exercised)
- [x] Token grep returns zero matches in target directories
- [x] `confirm(` grep returns zero matches
- [ ] Visual eyeball on Vercel Preview before merge

## Notes / follow-ups (not blocking)
- Two inline `Intl.NumberFormat("en", …)` remain in `BillingTable.tsx:171-174` for CopyTable's string-returning `format` callbacks. Hardcoded `"en"` works for Aaron's `en-UG` (both produce `4,216,800` grouping) but isn't design-system-clean. **Follow-up ticket will add `formatCurrency` / `formatKwh` string helpers to the format module** and refactor these sites.
- PeriodPicker component (installed in T2) is not yet wired into `BillingPeriodList` as a period-switcher — list table preserves the UX per AC. **Follow-up ticket** can add PeriodPicker if PM wants the switcher UX.
- Form primitives (Input/Select/Checkbox/Switch) are still default browser controls — native on tokenized container. Acknowledged UX gap; addresses via follow-up after shadcn `add input select` install.