### PR TITLE
Wire PeriodPicker into BillingPeriodList (#47)

### DIFF
--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -10,6 +10,20 @@ import { Currency } from "@/components/format/currency";
 import { Kwh } from "@/components/format/kwh";
 import { LocalDate } from "@/components/format/local-date";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { PeriodPicker, type PeriodOption } from "@/components/ui/period-picker";
+
+function toPeriodOption(
+  period: BillingPeriod,
+  summaries: Record<string, { totalKwh: number; totalAmount: number } | undefined>,
+): PeriodOption {
+  return {
+    id: period.id,
+    startDate: period.start_date,
+    endDate: period.end_date,
+    status: period.status,
+    totalAmount: summaries[period.id]?.totalAmount ?? 0,
+  };
+}
 
 function getDefaultDates() {
   const now = new Date();
@@ -32,7 +46,7 @@ export function BillingPeriodList({
 }: {
   microgridId: string;
   periods: BillingPeriod[];
-  summaries: Record<string, { totalKwh: number; totalAmount: number }>;
+  summaries: Record<string, { totalKwh: number; totalAmount: number } | undefined>;
   currency: string;
 }) {
   const router = useRouter();
@@ -124,12 +138,14 @@ export function BillingPeriodList({
 
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Billing Periods</h2>
-        <button
-          onClick={() => setShowCreateForm(!showCreateForm)}
-          className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
-        >
-          {showCreateForm ? "Cancel" : "New Period"}
-        </button>
+        {/* PeriodPicker replaces the standalone "New Period" button.
+            currentId is undefined — the index page has no "current" period to highlight. */}
+        <PeriodPicker
+          periods={periods.map((p) => toPeriodOption(p, summaries))}
+          currentId={undefined}
+          onSelect={(option) => router.push(`/microgrids/${microgridId}/billing/${option.id}`)}
+          onNewPeriod={() => setShowCreateForm(true)}
+        />
       </div>
 
       {error && (
@@ -216,14 +232,14 @@ export function BillingPeriodList({
                   </td>
                   <td className="py-3 pr-4 text-right text-foreground">
                     {summaries[period.id] ? (
-                      <Kwh value={summaries[period.id].totalKwh} bareNumber />
+                      <Kwh value={summaries[period.id]!.totalKwh} bareNumber />
                     ) : (
                       "0"
                     )}
                   </td>
                   <td className="py-3 pr-4 text-right text-foreground">
                     {summaries[period.id] ? (
-                      <Currency value={summaries[period.id].totalAmount} bareNumber />
+                      <Currency value={summaries[period.id]!.totalAmount} bareNumber />
                     ) : (
                       "N/A"
                     )}

--- a/src/components/__tests__/billing-period-list.test.tsx
+++ b/src/components/__tests__/billing-period-list.test.tsx
@@ -1,0 +1,130 @@
+// BillingPeriodList unit tests
+//
+// Strategy:
+//   - Mount BillingPeriodList with fixture periods wrapped in
+//     <LocaleProvider locale="en-UG" currency="UGX">.
+//   - Assert:
+//     (a) PeriodPicker trigger button is rendered (aria-haspopup="listbox").
+//     (b) Selecting an option calls router.push with the correct URL.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LocaleProvider } from "../format/locale-context";
+import type { BillingPeriod } from "@/lib/types/database";
+
+// Mock next/navigation BEFORE any component imports that use it
+const pushSpy = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushSpy, refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/microgrids/mg-1/billing",
+}));
+
+// Mock Supabase client (BillingPeriodList calls createClient() on render)
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: () => ({
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      insert: () => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: { id: "new-period" }, error: null }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+// Import after mocks are set up
+import { BillingPeriodList } from "../BillingPeriodList";
+
+// ─── Fixture data ────────────────────────────────────────────────────────────
+
+const MICROGRID_ID = "mg-fixture-1";
+
+const PERIOD_1: BillingPeriod = {
+  id: "period-a",
+  microgrid_id: MICROGRID_ID,
+  start_date: "2026-02-01",
+  end_date: "2026-02-28",
+  status: "closed",
+  created_at: "2026-02-01T00:00:00Z",
+  closed_at: "2026-03-01T00:00:00Z",
+};
+
+const PERIOD_2: BillingPeriod = {
+  id: "period-b",
+  microgrid_id: MICROGRID_ID,
+  start_date: "2026-03-01",
+  end_date: "2026-03-31",
+  status: "draft",
+  created_at: "2026-03-01T00:00:00Z",
+  closed_at: null,
+};
+
+const SUMMARIES = {
+  "period-a": { totalKwh: 120, totalAmount: 60000 },
+  "period-b": { totalKwh: 45, totalAmount: 22500 },
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <LocaleProvider locale="en-UG" currency="UGX">
+      {children}
+    </LocaleProvider>
+  );
+}
+
+describe("BillingPeriodList", () => {
+  beforeEach(() => {
+    pushSpy.mockClear();
+  });
+
+  it("(a) renders the PeriodPicker trigger button with aria-haspopup='listbox'", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[PERIOD_1, PERIOD_2]}
+          summaries={SUMMARIES}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+
+    const trigger = document.querySelector("button[aria-haspopup='listbox']");
+    expect(trigger).not.toBeNull();
+  });
+
+  it("(b) selecting the second option calls router.push with the correct URL", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[PERIOD_1, PERIOD_2]}
+          summaries={SUMMARIES}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+
+    // Open the picker by clicking the trigger
+    const trigger = document.querySelector(
+      "button[aria-haspopup='listbox']",
+    ) as HTMLButtonElement;
+    fireEvent.click(trigger);
+
+    // All period options are role="option" buttons inside the panel
+    const options = screen.getAllByRole("option");
+    // The picker renders periods in the same order as passed (server returns DESC by start_date)
+    // PERIOD_1 is index 0, PERIOD_2 is index 1
+    expect(options.length).toBeGreaterThanOrEqual(2);
+
+    // Click the second option (PERIOD_2)
+    fireEvent.click(options[1]);
+
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    expect(pushSpy).toHaveBeenCalledWith(
+      `/microgrids/${MICROGRID_ID}/billing/${PERIOD_2.id}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Wire `<PeriodPicker>` (installed in T2) into `BillingPeriodList.tsx` above the existing list table — additive, not a replacement.
- Add `toPeriodOption(period, summaries)` mapping function (snake_case DB rows → camelCase `PeriodOption`, `totalAmount` with `?? 0` fallback).
- `onSelect` → `router.push('/microgrids/{id}/billing/{periodId}')` via `useRouter()` from `next/navigation`.
- `onNewPeriod` → `setShowCreateForm(true)`; standalone "New Period" header toggle button removed (picker's built-in button replaces it; form body unchanged).
- `currentId={undefined}` — index page has no "current" period.

Closes #47.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 74/74 passing (2 new tests in `billing-period-list.test.tsx`)
- [x] `npm run build` — PASS
- [ ] Eyeball on Vercel Preview: dropdown opens, keyboard-navigates (↑/↓, Enter), selection navigates to detail page; "+ New period" inside picker reveals the existing inline create form

## Notes for reviewer
- `summaries` prop type widened from `Record<string, {...}>` to `Record<string, {...} | undefined>` to match `toPeriodOption`'s signature. Callsite at `billing/page.tsx` remains type-compatible (concrete satisfies wider). Non-null `!` assertions added inside truthy-guarded branches where TS needed help — cannot fire at runtime.
- Detail-page wiring (the real UX switcher win on `billing/[periodId]`) is intentionally scoped out; future follow-up.