### PR TITLE
Add string-returning format helpers (#46)

### DIFF
--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -5,8 +5,11 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { CopyButton } from "@/components/CopyButton";
 import { Currency } from "@/components/format/currency";
+import { formatCurrency } from "@/components/format/currency";
 import { Kwh } from "@/components/format/kwh";
+import { formatKwh } from "@/components/format/kwh";
 import { LocalDate } from "@/components/format/local-date";
+import { useLocale } from "@/components/format/locale-context";
 import { StatusChip } from "@/components/ui/status-chip";
 import { CopyTable, type ColumnDef } from "@/components/ui/copy-table";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -35,6 +38,7 @@ export function BillingTable({
 }) {
   const router = useRouter();
   const supabase = createClient();
+  const { locale, currency: localeCurrency } = useLocale();
 
   const [generating, setGenerating] = useState(false);
   const [closing, setClosing] = useState(false);
@@ -169,9 +173,9 @@ export function BillingTable({
   // CopyTable columns built from tiers
   // Format helpers (plain string, for CopyTable column defs)
   const kwhFormat = (v: number | string | null) =>
-    v == null ? "—" : new Intl.NumberFormat("en", { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(Number(v));
+    formatKwh(v == null ? null : Number(v), locale, { bareNumber: true });
   const amountFormat = (v: number | string | null) =>
-    v == null ? "—" : new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(Number(v));
+    formatCurrency(v == null ? null : Number(v), locale, localeCurrency, { bareNumber: true });
 
   const columns: ColumnDef<Tenant>[] = [
     {

--- a/src/components/format/__tests__/format.test.tsx
+++ b/src/components/format/__tests__/format.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { LocaleProvider } from "../locale-context";
 import { Currency } from "../currency";
+import { formatCurrency } from "../currency";
 import { Kwh } from "../kwh";
+import { formatKwh } from "../kwh";
 import { LocalDate } from "../local-date";
 
 function Wrapper({ children }: { children: React.ReactNode }) {
@@ -58,5 +60,52 @@ describe("LocalDate", () => {
     const text = container.textContent ?? "";
     expect(text.includes("Mar")).toBe(true);
     expect(text.includes("2026")).toBe(true);
+  });
+});
+
+describe("formatKwh", () => {
+  it("returns em-dash for null", () => {
+    expect(formatKwh(null, "en")).toBe("—");
+  });
+
+  it("default digits=1 renders one decimal place", () => {
+    expect(formatKwh(47.3, "en")).toBe("47.3");
+  });
+
+  it("digits: 0 renders integer", () => {
+    expect(formatKwh(47.321, "en", { digits: 0 })).toBe("47");
+  });
+
+  it("digits: 3 renders three decimal places", () => {
+    expect(formatKwh(47.321, "en", { digits: 3 })).toBe("47.321");
+  });
+
+  it("bareNumber does not change number formatting", () => {
+    expect(formatKwh(47.3, "en", { bareNumber: true })).toBe("47.3");
+    expect(formatKwh(47.3, "en", { bareNumber: false })).toBe("47.3");
+  });
+});
+
+describe("formatCurrency", () => {
+  it("returns em-dash for null", () => {
+    expect(formatCurrency(null, "en", "UGX")).toBe("—");
+  });
+
+  it("bareNumber: true renders decimal with 0 fraction digits and no UGX", () => {
+    const result = formatCurrency(4216800, "en", "UGX", { bareNumber: true });
+    expect(result.includes("4,216,800")).toBe(true);
+    expect(result.includes("UGX")).toBe(false);
+  });
+
+  it("bareNumber: false with locale en renders ISO code and number (NBSP-tolerant)", () => {
+    const result = formatCurrency(4216800, "en", "UGX", { bareNumber: false });
+    expect(result.includes("UGX")).toBe(true);
+    expect(result.includes("4,216,800")).toBe(true);
+  });
+
+  it("maxFractionDigits: 2 with bareNumber: false renders two decimal places", () => {
+    const result = formatCurrency(4216800, "en", "UGX", { bareNumber: false, maxFractionDigits: 2, minFractionDigits: 2 });
+    expect(result.includes("UGX")).toBe(true);
+    expect(result.includes("4,216,800.00")).toBe(true);
   });
 });

--- a/src/components/format/currency.tsx
+++ b/src/components/format/currency.tsx
@@ -12,6 +12,10 @@
 //     formatter options; does NOT post-process the string. Use for URA
 //     paste workflows where the cell value is digits only.
 //   - className is composable via cn() so callers can override sizing/tone.
+//
+// String helper:
+//   - `formatCurrency(value, locale, currency, opts?)` — pure function,
+//     no React context. Reuses the same getNF() cache. Returns "—" for null.
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
@@ -26,6 +30,29 @@ function getNF(locale: string, opts: Intl.NumberFormatOptions): Intl.NumberForma
     cache.set(key, nf);
   }
   return nf;
+}
+
+/** Pure string formatter — no React context. Pass locale/currency from useLocale(). */
+export function formatCurrency(
+  value: number | null,
+  locale: string,
+  currency: string,
+  opts: {
+    bareNumber?: boolean;
+    maxFractionDigits?: number;
+    minFractionDigits?: number;
+  } = {},
+): string {
+  if (value == null) return "—";
+  let nfOpts: Intl.NumberFormatOptions;
+  if (opts.bareNumber) {
+    nfOpts = { style: "decimal", maximumFractionDigits: 0, minimumFractionDigits: 0 };
+  } else {
+    nfOpts = { style: "currency", currency };
+    if (opts.maxFractionDigits !== undefined) nfOpts.maximumFractionDigits = opts.maxFractionDigits;
+    if (opts.minFractionDigits !== undefined) nfOpts.minimumFractionDigits = opts.minFractionDigits;
+  }
+  return getNF(locale, nfOpts).format(value);
 }
 
 export interface CurrencyProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -56,18 +83,9 @@ export function Currency({
   const lc = locale ?? ctx.locale;
   const cc = currency ?? ctx.currency;
 
-  let opts: Intl.NumberFormatOptions;
-  if (bareNumber) {
-    opts = { style: "decimal", maximumFractionDigits: 0, minimumFractionDigits: 0 };
-  } else {
-    opts = { style: "currency", currency: cc };
-    if (maxFractionDigits !== undefined) opts.maximumFractionDigits = maxFractionDigits;
-    if (minFractionDigits !== undefined) opts.minimumFractionDigits = minFractionDigits;
-  }
-
   return (
     <span className={cn("font-mono tabular-nums", className)} {...props}>
-      {getNF(lc, opts).format(value)}
+      {formatCurrency(value, lc, cc, { bareNumber, maxFractionDigits, minFractionDigits })}
     </span>
   );
 }

--- a/src/components/format/kwh.tsx
+++ b/src/components/format/kwh.tsx
@@ -6,6 +6,12 @@
 //   - Default digits = 1 (one decimal place — matches Aaron's URA filing
 //     convention). Pass digits={3} for sub-Watt diagnostics.
 //   - className composable via cn().
+//
+// String helper:
+//   - `formatKwh(value, locale, opts?)` — pure function, no React context.
+//     Reuses the same getNF() cache. Returns "—" for null.
+//   - bareNumber only affects the JSX wrapper's " kWh" suffix — the string
+//     helper itself never emits " kWh".
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
@@ -23,6 +29,17 @@ function getNF(locale: string, digits: number): Intl.NumberFormat {
     cache.set(key, nf);
   }
   return nf;
+}
+
+/** Pure string formatter — no React context. Pass locale from useLocale(). */
+export function formatKwh(
+  value: number | null,
+  locale: string,
+  opts: { bareNumber?: boolean; digits?: number } = {},
+): string {
+  if (value == null) return "—";
+  const digits = opts.digits ?? 1;
+  return getNF(locale, digits).format(value);
 }
 
 export interface KwhProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -45,7 +62,7 @@ export function Kwh({
   const lc = locale ?? ctx.locale;
   return (
     <span className={cn("font-mono tabular-nums", className)} {...props}>
-      {getNF(lc, digits).format(value)}
+      {formatKwh(value, lc, { digits })}
       {!bareNumber && " kWh"}
     </span>
   );


### PR DESCRIPTION
## Summary
- Export `formatKwh(value, locale, opts?)` from `src/components/format/kwh.tsx` and `formatCurrency(value, locale, currency, opts?)` from `src/components/format/currency.tsx` — pure string helpers that return `"—"` for null and reuse the existing `getNF()` memoization cache (no per-call `Intl.NumberFormat` allocation on the hot table-render path).
- Refactor `<Kwh>` and `<Currency>` JSX components to delegate to their string helpers — single source of truth for formatting logic.
- Replace the two inline `Intl.NumberFormat("en", …)` formatters in `BillingTable.tsx:171-174` with calls to the new helpers. `BillingTable` now calls `useLocale()` once at the top and passes `locale`/`currency` into each format callback.

`grep -rn "Intl.NumberFormat\|toLocaleDateString" src/components/ | grep -v "src/components/format/"` returns zero matches.

Closes #46.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 83/83 passing
  - 5 new `formatKwh` unit tests (null→em-dash; default digits=1 renders 47.3; digits=0 renders 47; digits=3 renders 47.321; bareNumber doesn't change number formatting)
  - 4 new `formatCurrency` unit tests (null→em-dash; bareNumber=true renders 4,216,800 without UGX; bareNumber=false with `en` renders UGX+4,216,800 via NBSP-tolerant two-separate-includes; maxFractionDigits+minFractionDigits=2 renders 4,216,800.00)
  - Pre-existing 4 format-component tests + 3 billing-table tests continue to pass unchanged
- [x] `npm run build` — PASS (Turbopack CSS pipeline exercised)
- [x] Grep check — zero `Intl.NumberFormat` / `toLocaleDateString` call sites outside `src/components/format/`

## Notes for reviewer
- Test for the `maxFractionDigits` override uses BOTH `maxFractionDigits: 2` and `minFractionDigits: 2` — Intl requires both to force trailing zeros (UGX default `minimumFractionDigits` is 0). Still exercises the `maxFractionDigits` option path.
- Defaults preserved: `formatKwh` defaults `digits = 1` (matches `<Kwh>`); `formatCurrency` defaults to Intl-picked fraction digits unless overridden or `bareNumber=true` (which forces 0/0 decimal).
- No `helpers.ts` module — helpers colocated in the component files per ticket spec.
- `<LocalDate>` not touched (no current call site needs a string date formatter).