### PR TITLE
Add sidebar Communities entry + listing page (D1, #52)

### DIFF
--- a/src/app/(dashboard)/communities/page.test.tsx
+++ b/src/app/(dashboard)/communities/page.test.tsx
@@ -1,0 +1,121 @@
+// Communities page server-component test (node environment).
+//
+// Strategy:
+//   - Mock @/lib/supabase/server to control what the Supabase client returns.
+//   - Call CommunitiesPage() directly (it is an async server component).
+//   - Render the returned JSX with react-dom/server renderToStaticMarkup.
+//   - Assert:
+//     (a) Row renders with community name, city/country, and microgrid count.
+//     (b) Empty state renders when the query returns zero rows.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+// ─── Supabase mock ───────────────────────────────────────────────────────────
+
+type MockBuilder = {
+  select: (...args: unknown[]) => MockBuilder;
+  order: (...args: unknown[]) => MockBuilder;
+  returns: <T>() => Promise<{ data: T | null; error: null }>;
+  _data: unknown;
+};
+
+function makeMockBuilder(data: unknown): MockBuilder {
+  const builder: MockBuilder = {
+    _data: data,
+    select() {
+      return builder;
+    },
+    order() {
+      return builder;
+    },
+    returns<T>() {
+      return Promise.resolve({ data: builder._data as T, error: null });
+    },
+  };
+  return builder;
+}
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: mockFrom,
+  }),
+}));
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const COMMUNITY_WITH_DATA = {
+  id: "comm-1",
+  name: "Kisakye",
+  address_city: "Kampala",
+  address_country: "Uganda",
+  microgrids: [{ count: 3 }],
+};
+
+const COMMUNITY_NO_LOCATION = {
+  id: "comm-2",
+  name: "Test Community",
+  address_city: null,
+  address_country: null,
+  microgrids: [{ count: 1 }],
+};
+
+// ─── Import page (after mocks) ────────────────────────────────────────────────
+
+import CommunitiesPage from "./page";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("CommunitiesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a row with name, city/country, and microgrid count", async () => {
+    mockFrom.mockReturnValue(makeMockBuilder([COMMUNITY_WITH_DATA]));
+
+    const jsx = await CommunitiesPage();
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("Kisakye");
+    expect(html).toContain("Kampala, Uganda");
+    expect(html).toContain("3 microgrids");
+    // Link should point to /microgrids?community=<id>
+    expect(html).toContain("/microgrids?community=comm-1");
+  });
+
+  it("renders multiple rows when multiple communities are returned", async () => {
+    mockFrom.mockReturnValue(
+      makeMockBuilder([COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION])
+    );
+
+    const jsx = await CommunitiesPage();
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("Kisakye");
+    expect(html).toContain("Test Community");
+    expect(html).toContain("1 microgrid");
+  });
+
+  it("renders empty state when query returns zero rows", async () => {
+    mockFrom.mockReturnValue(makeMockBuilder([]));
+
+    const jsx = await CommunitiesPage();
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No communities found");
+    expect(html).not.toContain("Kisakye");
+  });
+
+  it("renders empty state when query returns null", async () => {
+    mockFrom.mockReturnValue(makeMockBuilder(null));
+
+    const jsx = await CommunitiesPage();
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No communities found");
+  });
+});

--- a/src/app/(dashboard)/communities/page.tsx
+++ b/src/app/(dashboard)/communities/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+
+type CommunityRow = {
+  id: string;
+  name: string;
+  address_city: string | null;
+  address_country: string | null;
+  microgrids: { count: number }[];
+};
+
+export default async function CommunitiesPage() {
+  const supabase = await createClient();
+
+  const { data: communities, error } = await supabase
+    .from("communities")
+    .select("id, name, address_city, address_country, microgrids(count)")
+    .order("name")
+    .returns<CommunityRow[]>();
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
+        Error loading communities: {error.message}
+      </div>
+    );
+  }
+
+  if (!communities || communities.length === 0) {
+    return (
+      <div>
+        <h1 className="mb-6 text-2xl font-semibold text-foreground">
+          Communities
+        </h1>
+        <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
+          No communities found. Communities are configured by your system
+          administrator.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-semibold text-foreground">
+        Communities
+      </h1>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {communities.map((community) => {
+          const locationParts = [
+            community.address_city,
+            community.address_country,
+          ].filter(Boolean);
+          const locationLabel =
+            locationParts.length > 0 ? locationParts.join(", ") : null;
+
+          const microgridCount =
+            community.microgrids.length > 0
+              ? (community.microgrids[0].count ?? 0)
+              : 0;
+
+          return (
+            <Link
+              key={community.id}
+              href={`/microgrids?community=${community.id}`}
+              className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted"
+            >
+              <h2 className="font-medium text-foreground">{community.name}</h2>
+              {locationLabel && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {locationLabel}
+                </p>
+              )}
+              <div className="mt-3 text-sm text-muted-foreground">
+                {microgridCount} microgrid{microgridCount !== 1 ? "s" : ""}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -32,6 +32,12 @@ export default async function DashboardLayout({
             Dashboard
           </Link>
           <Link
+            href="/communities"
+            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            Communities
+          </Link>
+          <Link
             href="/microgrids"
             className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
           >

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -5,13 +5,43 @@ type MicrogridWithHouseholdCount = Microgrid & {
   household_count: number;
 };
 
-export default async function MicrogridsPage() {
+export default async function MicrogridsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ community?: string }>;
+}) {
+  const { community: communityId } = await searchParams;
   const supabase = await createClient();
 
-  const { data: microgrids, error } = await supabase
-    .from("microgrids")
-    .select("*")
-    .returns<Microgrid[]>();
+  // When a community filter is present, look up the community name for the heading.
+  let communityName: string | null = null;
+  let communityNotFound = false;
+
+  if (communityId) {
+    const { data: community } = await supabase
+      .from("communities")
+      .select("name")
+      .eq("id", communityId)
+      .maybeSingle();
+
+    if (community) {
+      communityName = community.name;
+    } else {
+      communityNotFound = true;
+    }
+  }
+
+  // Build the microgrids query, optionally filtered by community.
+  let query = supabase.from("microgrids").select("*");
+  if (communityId) {
+    query = query.eq("community_id", communityId);
+  }
+
+  const { data: microgrids, error } = await query.returns<Microgrid[]>();
+
+  const heading = communityName
+    ? `${communityName} · Microgrids`
+    : "Microgrids";
 
   if (error) {
     return (
@@ -21,11 +51,24 @@ export default async function MicrogridsPage() {
     );
   }
 
-  if (!microgrids || microgrids.length === 0) {
+  if (communityNotFound) {
     return (
       <div>
         <h1 className="mb-6 text-2xl font-semibold text-foreground">
           Microgrids
+        </h1>
+        <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
+          Community not found or not accessible.
+        </div>
+      </div>
+    );
+  }
+
+  if (!microgrids || microgrids.length === 0) {
+    return (
+      <div>
+        <h1 className="mb-6 text-2xl font-semibold text-foreground">
+          {heading}
         </h1>
         <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
           No microgrids found. Microgrids are configured by your system
@@ -50,7 +93,7 @@ export default async function MicrogridsPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-semibold text-foreground">Microgrids</h1>
+      <h1 className="mb-6 text-2xl font-semibold text-foreground">{heading}</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {microgridsWithCounts.map((mg) => {
           const locationParts = [mg.address_city, mg.address_country].filter(Boolean);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,15 @@ export default defineConfig({
           fileParallelism: false,
         },
       },
+      {
+        extends: true,
+        test: {
+          name: "app",
+          // Server-component tests (node environment) co-located with page files.
+          include: ["src/app/**/*.test.{ts,tsx}"],
+          environment: "node",
+        },
+      },
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- **Sidebar**: Communities entry added between Dashboard and Microgrids. Settings placeholder preserved (disabled `<span>`). Token classes only.
- **`/communities`** new route (server component): queries `from('communities').select('id, name, address_city, address_country, microgrids(count)').order('name')` scoped by RLS; renders row per community with name + city/country + microgrid count; each row links to `/microgrids?community=<id>`.
- **`/microgrids?community=<id>`** extended to filter microgrids by community and show a `{community.name} · Microgrids` heading via a second `maybeSingle()` query. Falls back to plain "Microgrids" heading when the param is absent or invalid.
- **RLS-invalid community_id** → empty state with message "Community not found or not accessible." (not `notFound()`).
- **Vitest test** for `communities/page.tsx` covering row render + empty state.

Closes #52.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 158/158 pass (4 new `communities/page.test.tsx` tests in the new `app` Vitest project)
- [x] `npm run build` — PASS; `/communities` route listed in output

## Notes for reviewer
- Added a new `app` project to `vitest.config.ts` (environment: `node`, glob `src/app/**/*.test.{ts,tsx}`) to pick up co-located server-component tests. Non-overlapping with existing `components`/`lib`/`rls` projects.
- **Out of scope** (explicitly deferred): HierarchyNav placement (D4 #55 owns), `Tenants`→`Households` route rename (D2 #53 owns), active-link highlighting fix (future — would require a client subcomponent).
- Pre-existing `hover:border-border` no-op in microgrids card pattern preserved for consistency.
- Household count N+1 on `microgrids/page.tsx` is pre-existing (not introduced here).