### PR TITLE
Add household detail page with linked devices (#54)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
@@ -1,0 +1,306 @@
+// Household detail page — server component test (D3 / #54).
+//
+// Strategy:
+//   - Mock @/lib/supabase/server so all three queries return fixture rows.
+//   - Call HouseholdDetailPage() directly (async server component) and serialize
+//     the returned JSX to HTML.
+//   - Cover 4 scenarios: populated, empty devices, empty billing, RLS-404.
+//   - Assert chip-highlight assertion for primary_consumption_meter row.
+//
+// Environment: node (same pattern as D2 page tests).
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// vi.hoisted() runs before vi.mock() hoisting — lets us capture the mock reference.
+const { notFoundMock } = vi.hoisted(() => {
+  const notFoundMock = vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  });
+  return { notFoundMock };
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+}));
+vi.mock("next/link", () => ({
+  // Render as plain anchor for static markup serialization.
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => {
+    return React.createElement("a", { href, className }, children);
+  },
+}));
+
+// ── Supabase mock ────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const HOUSEHOLD_BASE = {
+  id: "hh-1",
+  display_name: "Block A, Unit 1",
+  primary_phone: "+256 772 414 001",
+  primary_email: "aisha.m@example.org",
+  address_line1: "Plot 14, Kisakye Ln",
+  address_line2: "Block A",
+  unit_label: "Unit 1",
+  status: "active",
+};
+
+const DEVICE_ROW = {
+  id: "dev-1",
+  name: "Chint Meter 01",
+  device_type: "consumption_meter",
+  edges: { id: "edge-1", name: "Metering Pi" },
+};
+
+const BILLING_PERIOD = {
+  id: "bp-1",
+  start_date: "2026-03-01",
+  end_date: "2026-03-31",
+  status: "closed",
+};
+
+// ── Query builder helpers ─────────────────────────────────────────────────────
+
+/**
+ * Builds a mock Supabase query chain for the households table.
+ * Supports `.select().eq().eq().single()` pattern.
+ */
+function buildHouseholdQuery(data: unknown, error: unknown = null) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    single: () => Promise.resolve({ data, error }),
+  };
+  return chain;
+}
+
+/**
+ * Builds a mock Supabase query chain for household_users COUNT.
+ * Supports `.select("*", { count, head }).eq()` pattern.
+ */
+function buildCountQuery(count: number) {
+  const chain = {
+    select: () => chain,
+    eq: () => Promise.resolve({ count, error: null }),
+  };
+  return chain;
+}
+
+/**
+ * Builds a mock Supabase query chain for billing_line_items.
+ * Supports `.select().eq().eq().order().limit().returns()` pattern.
+ */
+function buildLineItemsQuery(data: unknown) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    returns: () => Promise.resolve({ data, error: null }),
+  };
+  return chain;
+}
+
+// ── Import page (after mocks) ─────────────────────────────────────────────────
+
+import HouseholdDetailPage from "./page";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("HouseholdDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // (a) Populated: 1 primary_consumption_meter device + 1 closed billing period
+  it("renders all sections for a populated household", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "households") {
+        return buildHouseholdQuery({
+          ...HOUSEHOLD_BASE,
+          household_devices: [
+            { role: "primary_consumption_meter", devices: DEVICE_ROW },
+          ],
+        });
+      }
+      if (table === "household_users") {
+        return buildCountQuery(2);
+      }
+      if (table === "billing_line_items") {
+        return buildLineItemsQuery([
+          {
+            usage_kwh: 45.3,
+            total_amount: 12500,
+            billing_periods: BILLING_PERIOD,
+          },
+        ]);
+      }
+      return buildCountQuery(0);
+    });
+
+    const jsx = await HouseholdDetailPage({
+      params: Promise.resolve({ id: "mg-1", householdId: "hh-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Household basics
+    expect(html).toContain("Block A, Unit 1");
+    expect(html).toContain("+256 772 414 001");
+    expect(html).toContain("aisha.m@example.org");
+    expect(html).toContain("Plot 14, Kisakye Ln");
+    expect(html).toContain("Block A");
+    expect(html).toContain("Unit 1");
+
+    // Portal users
+    expect(html).toContain("2 portal users linked");
+
+    // Linked device name + edge link
+    expect(html).toContain("Chint Meter 01");
+    expect(html).toContain("Metering Pi");
+    expect(html).toContain("/microgrids/mg-1/setup/edges/edge-1/");
+
+    // Role chip for primary_consumption_meter — uses warn tone = bg-warning-muted text-warning-fg
+    expect(html).toContain("Primary meter");
+    // Primary row has bg-warning-muted highlight on the row
+    expect(html).toContain("bg-warning-muted");
+
+    // Billing history
+    expect(html).toContain("2026-03-01");
+    expect(html).toContain("2026-03-31");
+  });
+
+  // (b) Empty devices: 0 household_devices
+  it("renders empty devices state when no devices are linked", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "households") {
+        return buildHouseholdQuery({
+          ...HOUSEHOLD_BASE,
+          household_devices: [],
+        });
+      }
+      if (table === "household_users") {
+        return buildCountQuery(0);
+      }
+      if (table === "billing_line_items") {
+        return buildLineItemsQuery([]);
+      }
+      return buildCountQuery(0);
+    });
+
+    const jsx = await HouseholdDetailPage({
+      params: Promise.resolve({ id: "mg-1", householdId: "hh-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No devices linked to this household yet");
+    // Billing empty state should still appear (0 line items)
+    expect(html).toContain("No billing history");
+  });
+
+  // (c) Empty billing: 0 closed billing periods
+  it("renders empty billing state when no closed periods exist", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "households") {
+        return buildHouseholdQuery({
+          ...HOUSEHOLD_BASE,
+          household_devices: [
+            { role: "primary_consumption_meter", devices: DEVICE_ROW },
+          ],
+        });
+      }
+      if (table === "household_users") {
+        return buildCountQuery(1);
+      }
+      if (table === "billing_line_items") {
+        return buildLineItemsQuery([]);
+      }
+      return buildCountQuery(0);
+    });
+
+    const jsx = await HouseholdDetailPage({
+      params: Promise.resolve({ id: "mg-1", householdId: "hh-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No billing history");
+    // Device section should still render
+    expect(html).toContain("Chint Meter 01");
+  });
+
+  // (d) RLS-404: non-NFE user gets notFound()
+  it("calls notFound() when household query returns an error (RLS deny / not found)", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "households") {
+        return buildHouseholdQuery(null, {
+          message: "Row not found",
+          code: "PGRST116",
+        });
+      }
+      return buildCountQuery(0);
+    });
+
+    await expect(
+      HouseholdDetailPage({
+        params: Promise.resolve({ id: "mg-1", householdId: "hh-unknown" }),
+      }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFoundMock).toHaveBeenCalledOnce();
+  });
+
+  // Chip highlight assertion: primary_consumption_meter row has warn-tone classes
+  it("highlights primary_consumption_meter row with warning background", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "households") {
+        return buildHouseholdQuery({
+          ...HOUSEHOLD_BASE,
+          household_devices: [
+            { role: "primary_consumption_meter", devices: DEVICE_ROW },
+            {
+              role: "secondary_meter",
+              devices: {
+                id: "dev-2",
+                name: "Secondary",
+                device_type: "consumption_meter",
+                edges: { id: "edge-1", name: "Metering Pi" },
+              },
+            },
+          ],
+        });
+      }
+      if (table === "household_users") {
+        return buildCountQuery(0);
+      }
+      if (table === "billing_line_items") {
+        return buildLineItemsQuery([]);
+      }
+      return buildCountQuery(0);
+    });
+
+    const jsx = await HouseholdDetailPage({
+      params: Promise.resolve({ id: "mg-1", householdId: "hh-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Primary row highlighted
+    expect(html).toContain("bg-warning-muted");
+    // Role chip label for primary
+    expect(html).toContain("Primary meter");
+    // Role chip label for secondary
+    expect(html).toContain("Secondary meter");
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
@@ -1,0 +1,322 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { StatusChip } from "@/components/ui/status-chip";
+import { Currency } from "@/components/format/currency";
+import { Kwh } from "@/components/format/kwh";
+
+// Setup > Households > [householdId] — Household detail page (D3 / #54).
+//
+// Renders: household basics, portal users count, linked devices table,
+// billing history (last 3 closed periods).
+//
+// Single stacked layout — no sub-tabs (confirmed design decision).
+// HierarchyNav is out-of-scope (D4 / #55 owns placement).
+// Editing household fields is deferred to a future ticket.
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type DeviceRow = {
+  id: string;
+  name: string;
+  device_type: string;
+  edges: { id: string; name: string } | null;
+};
+
+type HouseholdDeviceRow = {
+  role: string;
+  devices: DeviceRow | null;
+};
+
+type HouseholdRow = {
+  id: string;
+  display_name: string | null;
+  primary_phone: string | null;
+  primary_email: string | null;
+  address_line1: string | null;
+  address_line2: string | null;
+  unit_label: string | null;
+  status: string;
+  household_devices: HouseholdDeviceRow[];
+};
+
+type BillingLineItemRow = {
+  usage_kwh: number | null;
+  total_amount: number | null;
+  billing_periods: {
+    id: string;
+    start_date: string;
+    end_date: string;
+    status: string;
+  };
+};
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function HouseholdDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; householdId: string }>;
+}) {
+  const { id: microgridId, householdId } = await params;
+  const supabase = await createClient();
+
+  // Query 1 — household basics + linked devices (single round-trip).
+  const { data: household, error: householdError } = await supabase
+    .from("households")
+    .select(
+      `id, display_name, primary_phone, primary_email,
+       address_line1, address_line2, unit_label, status,
+       household_devices(role, devices(id, name, device_type, edges(id, name)))`,
+    )
+    .eq("id", householdId)
+    .eq("microgrid_id", microgridId)
+    .single<HouseholdRow>();
+
+  if (householdError || !household) {
+    notFound();
+  }
+
+  // Query 2 — portal users count.
+  const { count: portalUserCount } = await supabase
+    .from("household_users")
+    .select("*", { count: "exact", head: true })
+    .eq("household_id", householdId);
+
+  // Query 3 — last 3 closed billing periods' line items for this household.
+  const { data: lineItems } = await supabase
+    .from("billing_line_items")
+    .select(
+      `usage_kwh, total_amount,
+       billing_periods!inner(id, start_date, end_date, status)`,
+    )
+    .eq("household_id", householdId)
+    .eq("billing_periods.status", "closed")
+    .order("billing_periods(end_date)", { ascending: false })
+    .limit(3)
+    .returns<BillingLineItemRow[]>();
+
+  const devices = household.household_devices ?? [];
+  const closedLineItems = (lineItems ?? []).filter(
+    (li) => li.billing_periods?.status === "closed",
+  );
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      {/* Back nav */}
+      <div>
+        <Link
+          href={`/microgrids/${microgridId}/setup/households`}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          ← Back to households
+        </Link>
+        <div className="mt-2 flex items-center gap-3">
+          <h3 className="text-lg font-semibold text-foreground">
+            {household.display_name ?? "Unnamed household"}
+          </h3>
+          <StatusChip kind="household" status={household.status} />
+        </div>
+      </div>
+
+      {/* ── Section 1: Household basics ─────────────────────────────────────── */}
+      <section aria-labelledby="basics-heading">
+        <h4
+          id="basics-heading"
+          className="mb-3 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Household basics
+        </h4>
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <dl className="divide-y divide-border">
+            <BasicRow label="Display name" value={household.display_name} />
+            <BasicRow label="Phone" value={household.primary_phone} />
+            <BasicRow label="Email" value={household.primary_email} />
+            <BasicRow label="Address line 1" value={household.address_line1} />
+            <BasicRow label="Address line 2" value={household.address_line2} />
+            <BasicRow label="Unit label" value={household.unit_label} />
+          </dl>
+        </div>
+      </section>
+
+      {/* ── Section 2: Portal users ─────────────────────────────────────────── */}
+      <section aria-labelledby="portal-users-heading">
+        <h4
+          id="portal-users-heading"
+          className="mb-3 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Portal users
+        </h4>
+        <div className="rounded-lg border border-border bg-card px-4 py-3 text-sm text-foreground">
+          {portalUserCount ?? 0} portal user{(portalUserCount ?? 0) === 1 ? "" : "s"} linked
+        </div>
+      </section>
+
+      {/* ── Section 3: Linked devices ───────────────────────────────────────── */}
+      <section aria-labelledby="devices-heading">
+        <h4
+          id="devices-heading"
+          className="mb-3 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Linked devices
+        </h4>
+        {devices.length === 0 ? (
+          <p className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+            No devices linked to this household yet
+          </p>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-border bg-card">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-muted">
+                <tr>
+                  <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Device
+                  </th>
+                  <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Type
+                  </th>
+                  <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Role
+                  </th>
+                  <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Edge
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {devices.map((hd, idx) => {
+                  const device = hd.devices;
+                  const isPrimary = hd.role === "primary_consumption_meter";
+                  return (
+                    <tr
+                      key={device?.id ?? idx}
+                      className={`border-t border-border${isPrimary ? " bg-warning-muted/30" : ""}`}
+                    >
+                      <td className="px-4 py-3 font-medium text-foreground">
+                        {device?.name ?? "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        {device?.device_type ? (
+                          <StatusChip
+                            kind="deviceType"
+                            status={device.device_type}
+                          />
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusChip
+                          kind="householdDeviceRole"
+                          status={hd.role}
+                        />
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {device?.edges ? (
+                          <Link
+                            href={`/microgrids/${microgridId}/setup/edges/${device.edges.id}/`}
+                            className="text-foreground underline underline-offset-2 hover:text-muted-foreground"
+                          >
+                            {device.edges.name}
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* ── Section 4: Billing history ──────────────────────────────────────── */}
+      <section aria-labelledby="billing-heading">
+        <h4
+          id="billing-heading"
+          className="mb-3 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Billing history (last 3 closed periods)
+        </h4>
+        {closedLineItems.length === 0 ? (
+          <p className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+            No billing history
+          </p>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-border bg-card">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-muted">
+                <tr>
+                  <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Period
+                  </th>
+                  <th className="px-4 py-2 text-right text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Usage (kWh)
+                  </th>
+                  <th className="px-4 py-2 text-right text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Amount
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {closedLineItems.map((li, idx) => {
+                  const bp = li.billing_periods;
+                  return (
+                    <tr key={bp?.id ?? idx} className="border-t border-border">
+                      <td className="px-4 py-3 text-foreground">
+                        {bp ? (
+                          <span>
+                            {bp.start_date} — {bp.end_date}
+                          </span>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {li.usage_kwh != null ? (
+                          <Kwh value={li.usage_kwh} />
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {li.total_amount != null ? (
+                          <Currency value={li.total_amount} />
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function BasicRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  return (
+    <div className="flex items-baseline gap-4 px-4 py-3">
+      <dt className="w-36 shrink-0 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="text-sm text-foreground">{value ?? "—"}</dd>
+    </div>
+  );
+}

--- a/src/components/HouseholdTable.tsx
+++ b/src/components/HouseholdTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { Device, Household } from "@/lib/types/domain";
@@ -387,6 +388,12 @@ export function HouseholdTable({
                       </td>
                       <td className="py-3">
                         <div className="flex gap-2">
+                          <Link
+                            href={`/microgrids/${microgridId}/setup/households/${household.id}`}
+                            className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"
+                          >
+                            View
+                          </Link>
                           <button
                             onClick={() => startEdit(household)}
                             className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -17,6 +17,7 @@ type Kind =
   | "edgeSource"
   | "deviceType"
   | "household"
+  | "householdDeviceRole"
   | "meterType";
 
 type StatusMap = Record<string, { label: string; tone: ChipProps["tone"]; dot?: boolean }>;
@@ -64,6 +65,22 @@ const MAPS: Record<Kind, StatusMap> = {
     inverter:          { label: "Inverter",          tone: "brand" },
     ev_charger:        { label: "EV charger",        tone: "brand" },
     other:             { label: "Other",             tone: "neutral" },
+  },
+  // Household device role — mirrors `household_device_role` enum in AB schema.
+  // Tone rationale:
+  //   primary_consumption_meter → warn (the billable metering device; draws attention)
+  //   secondary_meter           → neutral (supplementary measurement, non-primary)
+  //   battery                   → success (storage asset)
+  //   solar                     → success (generation asset)
+  //   ev_charger                → brand (controllable load)
+  //   other                     → neutral (catchall)
+  householdDeviceRole: {
+    primary_consumption_meter: { label: "Primary meter", tone: "warn" },
+    secondary_meter:           { label: "Secondary meter", tone: "neutral" },
+    battery:                   { label: "Battery",         tone: "success" },
+    solar:                     { label: "Solar",           tone: "success" },
+    ev_charger:                { label: "EV charger",      tone: "brand" },
+    other:                     { label: "Other",           tone: "neutral" },
   },
   meterType: {
     // Lowercase keys (original)


### PR DESCRIPTION
## Summary
New server component at `src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx` with the full household detail surface. Single-stacked layout (no sub-tabs): basics / portal users / linked devices / billing history.

### Sections
- **Basics** — 6 AB columns rendered with em-dash fallback: `display_name`, `primary_phone`, `primary_email`, `address_line1`, `address_line2`, `unit_label`.
- **Portal users** — read-only count: `{N} portal users linked` from `household_users`.
- **Linked devices** — table with device name, `<StatusChip kind="deviceType">`, `<StatusChip kind="householdDeviceRole">` (primary_consumption_meter row highlighted per MAPS), and edge name as a link to `/microgrids/[id]/setup/edges/[edgeId]/`.
- **Billing history** — last 3 closed periods via `billing_periods!inner(status='closed') ORDER BY end_date DESC LIMIT 3`. Rendered with `<Currency>` + `formatCurrency()` and `<Kwh>` + `formatKwh()` — no inline `Intl.NumberFormat`, no hardcoded `$`/`kWh`.
- **RLS-404** via `user_can_access_microgrid` + `notFound()`.

### Supporting changes
- `src/components/ui/status-chip.tsx` — extended `Kind` union + `MAPS` with new `householdDeviceRole` kind (6 values: `primary_consumption_meter`, `secondary_meter`, `battery`, `solar`, `ev_charger`, `other`). Deterministic addition per round-3 refinement.
- `src/components/HouseholdTable.tsx` — added "View" link per household row pointing at `/microgrids/{microgridId}/setup/households/{householdId}`.

Closes #54.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 183/183 passing (5 new scenarios: populated / empty devices / empty billing / RLS-404 / chip-highlight)
- [x] `npm run build` — PASS; new route registered as dynamic

## Notes
- Billing history filter has a client-side `.filter(...)` as belt-and-suspenders after the server-side `billing_periods!inner` + `.eq("billing_periods.status", "closed")`. Server filter works; client filter is pure defensive code. Not redundant enough to block; harmless.
- Billing period date range rendered as raw ISO (`start_date — end_date`); `<LocalDate>` substitution is a future cosmetic follow-up (not called out in AC).
- Edge href has a trailing slash `/microgrids/[id]/setup/edges/[edgeId]/` to match the ticket text verbatim — Next.js normalizes either way, but inconsistent with other edge links in the app. Harmless.
- HierarchyNav not rendered — D4 #55 owns all placement.

## Out-of-scope (explicit, deferred)
- Editing household fields — deferred (future ticket).
- Wizard-form for add-household — D2 #53 ships a basic modal; rich wizard is deferred.
- HierarchyNav placement — D4 #55 owns.