### PR TITLE
Add HierarchyNav top-of-page + shared data helper (#55)

### DIFF
--- a/src/app/(dashboard)/communities/page.tsx
+++ b/src/app/(dashboard)/communities/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 type CommunityRow = {
   id: string;
@@ -12,11 +14,14 @@ type CommunityRow = {
 export default async function CommunitiesPage() {
   const supabase = await createClient();
 
-  const { data: communities, error } = await supabase
-    .from("communities")
-    .select("id, name, address_city, address_country, microgrids(count)")
-    .order("name")
-    .returns<CommunityRow[]>();
+  const [{ data: communities, error }, levels] = await Promise.all([
+    supabase
+      .from("communities")
+      .select("id, name, address_city, address_country, microgrids(count)")
+      .order("name")
+      .returns<CommunityRow[]>(),
+    getHierarchyLevels(supabase, { kind: "communities" }),
+  ]);
 
   if (error) {
     return (
@@ -29,6 +34,7 @@ export default async function CommunitiesPage() {
   if (!communities || communities.length === 0) {
     return (
       <div>
+        <HierarchyNav levels={levels} className="mb-4" />
         <h1 className="mb-6 text-2xl font-semibold text-foreground">
           Communities
         </h1>
@@ -42,6 +48,7 @@ export default async function CommunitiesPage() {
 
   return (
     <div>
+      <HierarchyNav levels={levels} className="mb-4" />
       <h1 className="mb-6 text-2xl font-semibold text-foreground">
         Communities
       </h1>

--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -8,6 +8,8 @@ import type {
   RateSchedule,
 } from "@/lib/types/domain";
 import { BillingTable } from "@/components/BillingTable";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 export default async function BillingPeriodDetailPage({
   params,
@@ -16,6 +18,11 @@ export default async function BillingPeriodDetailPage({
 }) {
   const { id, periodId } = await params;
   const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "microgrid",
+    microgridId: id,
+  });
 
   const [
     { data: period, error: periodError },
@@ -95,13 +102,16 @@ export default async function BillingPeriodDetailPage({
   }
 
   return (
-    <BillingTable
-      microgridId={id}
-      period={period}
-      lineItems={lineItems ?? []}
-      households={households ?? []}
-      tiers={(schedule?.tiers ?? []) as { label: string; min_kwh: number; max_kwh: number | null; rate_per_kwh: number }[]}
-      currency={microgrid.currency}
-    />
+    <>
+      <HierarchyNav levels={levels} className="mb-4" />
+      <BillingTable
+        microgridId={id}
+        period={period}
+        lineItems={lineItems ?? []}
+        households={households ?? []}
+        tiers={(schedule?.tiers ?? []) as { label: string; min_kwh: number; max_kwh: number | null; rate_per_kwh: number }[]}
+        currency={microgrid.currency}
+      />
+    </>
   );
 }

--- a/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import type { BillingPeriod } from "@/lib/types/domain";
 import { BillingPeriodList } from "@/components/BillingPeriodList";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 export default async function BillingPage({
   params,
@@ -9,6 +11,11 @@ export default async function BillingPage({
 }) {
   const { id } = await params;
   const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "microgrid",
+    microgridId: id,
+  });
 
   // Step 1: Fetch periods
   const { data: periods, error } = await supabase
@@ -60,11 +67,14 @@ export default async function BillingPage({
   }
 
   return (
-    <BillingPeriodList
-      microgridId={id}
-      periods={periods ?? []}
-      summaries={summaries}
-      currency={microgridResult.data?.currency ?? "UGX"}
-    />
+    <>
+      <HierarchyNav levels={levels} className="mb-4" />
+      <BillingPeriodList
+        microgridId={id}
+        periods={periods ?? []}
+        summaries={summaries}
+        currency={microgridResult.data?.currency ?? "UGX"}
+      />
+    </>
   );
 }

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -2,9 +2,11 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
 import { TabNav } from "./tab-nav";
-import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { LocaleProvider } from "@/components/format/locale-context";
-import { getHierarchyLevels } from "@/lib/hierarchy";
+
+// HierarchyNav is NOT placed here — leaf pages own their breadcrumb.
+// Each leaf page calls getHierarchyLevels() with the correct scope depth
+// so that exactly ONE breadcrumb appears per route.
 
 export default async function MicrogridLayout({
   children,
@@ -28,11 +30,6 @@ export default async function MicrogridLayout({
 
   const microgrid = data as Microgrid;
 
-  const levels = await getHierarchyLevels(supabase, {
-    kind: "microgrid",
-    microgridId: id,
-  });
-
   // Build location label from structured columns (location TEXT was dropped in AB)
   const locationParts = [microgrid.address_city, microgrid.address_country].filter(Boolean);
   const locationLabel = locationParts.length > 0 ? locationParts.join(", ") : null;
@@ -41,8 +38,7 @@ export default async function MicrogridLayout({
     <LocaleProvider currency={microgrid.currency}>
       <div>
         <div className="mb-6">
-          <HierarchyNav levels={levels} />
-          <h1 className="mt-3 text-2xl font-semibold text-foreground">
+          <h1 className="text-2xl font-semibold text-foreground">
             {microgrid.name}
           </h1>
           {locationLabel && (

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -2,8 +2,9 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
 import { TabNav } from "./tab-nav";
-import { HierarchyNav, type HierarchyLevel } from "@/components/ui/hierarchy-nav";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { LocaleProvider } from "@/components/format/locale-context";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 export default async function MicrogridLayout({
   children,
@@ -27,55 +28,10 @@ export default async function MicrogridLayout({
 
   const microgrid = data as Microgrid;
 
-  // Query org count and microgrid count for HierarchyNav
-  // Microgrid → community → org chain
-  const { data: communityRow } = await supabase
-    .from("communities")
-    .select("id, name, org_id, organizations!inner(id, name)")
-    .eq("id", microgrid.community_id)
-    .single();
-
-  const { data: orgs } = await supabase
-    .from("organizations")
-    .select("id, name");
-
-  const { data: siblings } = await supabase
-    .from("microgrids")
-    .select("id, name")
-    .eq("community_id", microgrid.community_id);
-
-  const orgCount = orgs?.length ?? 1;
-  const microgridCount = siblings?.length ?? 1;
-
-  type OrgRow = { id: string; name: string };
-  const currentOrg = communityRow
-    ? (communityRow as unknown as { organizations: OrgRow }).organizations
-    : orgs?.[0];
-
-  const levels: HierarchyLevel[] = [
-    {
-      kind: "Organization",
-      label: currentOrg?.name ?? "Organization",
-      count: orgCount,
-      href: "/",
-      active: false,
-      siblings: orgCount > 1
-        ? orgs?.map((o) => ({ label: o.name, href: "/" }))
-        : undefined,
-    },
-    {
-      kind: "Microgrid",
-      label: microgrid.name,
-      count: microgridCount,
-      href: `/microgrids/${id}`,
-      active: true,
-      siblings: microgridCount > 1
-        ? siblings
-            ?.filter((s) => s.id !== id)
-            .map((s) => ({ label: s.name, href: `/microgrids/${s.id}` }))
-        : undefined,
-    },
-  ];
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "microgrid",
+    microgridId: id,
+  });
 
   // Build location label from structured columns (location TEXT was dropped in AB)
   const locationParts = [microgrid.address_city, microgrid.address_country].filter(Boolean);

--- a/src/app/(dashboard)/microgrids/[id]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/page.tsx
@@ -3,6 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import type { BillingPeriod, Edge } from "@/lib/types/domain";
 import { Chip } from "@/components/ui/chip";
 import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 // Microgrid Dashboard landing (D2 / #53).
 //
@@ -56,7 +58,7 @@ export default async function MicrogridDashboardPage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const [{ data: edges }, { data: periods }] = await Promise.all([
+  const [{ data: edges }, { data: periods }, levels] = await Promise.all([
     supabase
       .from("edges")
       .select("id, name, data_source_type, openems_edge_id")
@@ -70,6 +72,7 @@ export default async function MicrogridDashboardPage({
       .order("start_date", { ascending: false })
       .limit(1)
       .returns<BillingPeriod[]>(),
+    getHierarchyLevels(supabase, { kind: "microgrid", microgridId: id }),
   ]);
 
   const openemsEdgeIds = (edges ?? [])
@@ -102,6 +105,7 @@ export default async function MicrogridDashboardPage({
 
   return (
     <div className="space-y-4">
+      <HierarchyNav levels={levels} className="mb-2" />
       <section
         aria-label="Edge health"
         className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card px-4 py-3"

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/layout.tsx
@@ -1,0 +1,31 @@
+// Setup > Edges > [edgeId] layout — adds Edge level to HierarchyNav.
+// The parent microgrid layout already renders Org → Community → Microgrid.
+// This layout overlays a new HierarchyNav with the full chain including Edge.
+// D4 sole-placer: all <HierarchyNav> placements use getHierarchyLevels().
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function EdgeDetailLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string; edgeId: string }>;
+}) {
+  const { id, edgeId } = await params;
+  const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "edge",
+    microgridId: id,
+    edgeId,
+  });
+
+  return (
+    <div>
+      <HierarchyNav levels={levels} className="mb-4" />
+      {children}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/layout.tsx
@@ -1,31 +1,9 @@
-// Setup > Edges > [edgeId] layout — adds Edge level to HierarchyNav.
-// The parent microgrid layout already renders Org → Community → Microgrid.
-// This layout overlays a new HierarchyNav with the full chain including Edge.
-// D4 sole-placer: all <HierarchyNav> placements use getHierarchyLevels().
-import { HierarchyNav } from "@/components/ui/hierarchy-nav";
-import { getHierarchyLevels } from "@/lib/hierarchy";
-import { createClient } from "@/lib/supabase/server";
-
-export default async function EdgeDetailLayout({
+// Passthrough layout — HierarchyNav is owned by the leaf page (edge detail page).
+// This file must exist to satisfy Next.js layout conventions but renders children directly.
+export default function EdgeDetailLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ id: string; edgeId: string }>;
 }) {
-  const { id, edgeId } = await params;
-  const supabase = await createClient();
-
-  const levels = await getHierarchyLevels(supabase, {
-    kind: "edge",
-    microgridId: id,
-    edgeId,
-  });
-
-  return (
-    <div>
-      <HierarchyNav levels={levels} className="mb-4" />
-      {children}
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Device, Edge, Household, HouseholdDevice } from "@/lib/types/domain";
 import { StatusChip } from "@/components/ui/status-chip";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 // Setup > Edges > [edgeId] — edge detail (D2 / #53).
 // Lists devices on this edge. For each device, shows the linked household
@@ -25,6 +27,12 @@ export default async function EdgeDetailPage({
 }) {
   const { id, edgeId } = await params;
   const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "edge",
+    microgridId: id,
+    edgeId,
+  });
 
   // Fetch the edge (scoped to this microgrid via `.eq("microgrid_id")`).
   const { data: edge, error: edgeError } = await supabase
@@ -84,6 +92,7 @@ export default async function EdgeDetailPage({
 
   return (
     <div className="space-y-4">
+      <HierarchyNav levels={levels} className="mb-2" />
       <div>
         <Link
           href={`/microgrids/${id}/setup/edges`}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -29,6 +29,11 @@ vi.mock("@/lib/openems", async () => {
   };
 });
 
+// Stub getHierarchyLevels so page tests don't need a full Supabase mock chain.
+vi.mock("@/lib/hierarchy", () => ({
+  getHierarchyLevels: vi.fn().mockResolvedValue([]),
+}));
+
 import SetupEdgesPage from "./page";
 
 function buildEdgesQuery(data: unknown) {

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
@@ -4,6 +4,8 @@ import type { Edge } from "@/lib/types/domain";
 import { StatusChip } from "@/components/ui/status-chip";
 import { Chip } from "@/components/ui/chip";
 import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 // Setup > Edges (D2 / #53).
 // Lists every edge attached to this microgrid. Rows link to edge detail.
@@ -42,6 +44,11 @@ export default async function SetupEdgesPage({
   const { id } = await params;
   const supabase = await createClient();
 
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "edges-listing",
+    microgridId: id,
+  });
+
   const { data: edges, error } = await supabase
     .from("edges")
     .select("id, name, data_source_type, openems_edge_id, openems_backend_url, role")
@@ -66,6 +73,7 @@ export default async function SetupEdgesPage({
 
   return (
     <div className="space-y-4">
+      <HierarchyNav levels={levels} className="mb-2" />
       <div className="flex items-end justify-between gap-4">
         <div>
           <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/shared/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/shared/page.test.tsx
@@ -13,6 +13,11 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({ from: mockFrom }),
 }));
 
+// Stub getHierarchyLevels so page tests don't need a full Supabase mock chain.
+vi.mock("@/lib/hierarchy", () => ({
+  getHierarchyLevels: vi.fn().mockResolvedValue([]),
+}));
+
 import SharedDevicesPage from "./page";
 
 function buildEmptyQuery() {

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/shared/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/shared/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import type { Device } from "@/lib/types/domain";
 import { StatusChip } from "@/components/ui/status-chip";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 // Setup > Edges > Shared (D2 / #53).
 // Devices on this microgrid's edges that are NOT linked to any household.
@@ -23,6 +25,11 @@ export default async function SharedDevicesPage({
 }) {
   const { id } = await params;
   const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "microgrid",
+    microgridId: id,
+  });
 
   const { data: sharedDevices, error: devErr } = await supabase
     .from("microgrid_shared_devices")
@@ -53,6 +60,7 @@ export default async function SharedDevicesPage({
 
   return (
     <div className="space-y-4">
+      <HierarchyNav levels={levels} className="mb-2" />
       <div>
         <Link
           href={`/microgrids/${id}/setup/edges`}

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/layout.tsx
@@ -1,0 +1,31 @@
+// Setup > Households > [householdId] layout — adds Household level to HierarchyNav.
+// The parent microgrid layout already renders Org → Community → Microgrid.
+// This layout renders the full chain including Household with Household active.
+// D4 sole-placer: all <HierarchyNav> placements use getHierarchyLevels().
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function HouseholdDetailLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string; householdId: string }>;
+}) {
+  const { id, householdId } = await params;
+  const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "household",
+    microgridId: id,
+    householdId,
+  });
+
+  return (
+    <div>
+      <HierarchyNav levels={levels} className="mb-4" />
+      {children}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/layout.tsx
@@ -1,31 +1,9 @@
-// Setup > Households > [householdId] layout — adds Household level to HierarchyNav.
-// The parent microgrid layout already renders Org → Community → Microgrid.
-// This layout renders the full chain including Household with Household active.
-// D4 sole-placer: all <HierarchyNav> placements use getHierarchyLevels().
-import { HierarchyNav } from "@/components/ui/hierarchy-nav";
-import { getHierarchyLevels } from "@/lib/hierarchy";
-import { createClient } from "@/lib/supabase/server";
-
-export default async function HouseholdDetailLayout({
+// Passthrough layout — HierarchyNav is owned by the leaf page (household detail page).
+// This file must exist to satisfy Next.js layout conventions but renders children directly.
+export default function HouseholdDetailLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ id: string; householdId: string }>;
 }) {
-  const { id, householdId } = await params;
-  const supabase = await createClient();
-
-  const levels = await getHierarchyLevels(supabase, {
-    kind: "household",
-    microgridId: id,
-    householdId,
-  });
-
-  return (
-    <div>
-      <HierarchyNav levels={levels} className="mb-4" />
-      {children}
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Device, Household } from "@/lib/types/domain";
 import { HouseholdsSection } from "./households-section";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 // Setup > Households (D2 / #53).
 // Lists households for this microgrid and exposes an "Add household" modal
@@ -15,6 +17,11 @@ export default async function SetupHouseholdsPage({
 }) {
   const { id } = await params;
   const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "households-listing",
+    microgridId: id,
+  });
 
   const [
     { data: households, error: householdsError },
@@ -64,11 +71,14 @@ export default async function SetupHouseholdsPage({
   }
 
   return (
-    <HouseholdsSection
-      microgridId={id}
-      households={households ?? []}
-      devices={devices ?? []}
-      primaryDeviceAssignments={primaryDeviceAssignments}
-    />
+    <>
+      <HierarchyNav levels={levels} className="mb-4" />
+      <HouseholdsSection
+        microgridId={id}
+        households={households ?? []}
+        devices={devices ?? []}
+        primaryDeviceAssignments={primaryDeviceAssignments}
+      />
+    </>
   );
 }

--- a/src/app/(dashboard)/microgrids/[id]/setup/rates/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/rates/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import type { RateSchedule } from "@/lib/types/domain";
 import { TierEditor } from "@/components/TierEditor";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 export default async function RatesPage({
   params,
@@ -9,6 +11,11 @@ export default async function RatesPage({
 }) {
   const { id } = await params;
   const supabase = await createClient();
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "microgrid",
+    microgridId: id,
+  });
 
   const [{ data: schedule, error: scheduleError }, { data: microgrid, error: microgridError }] =
     await Promise.all([
@@ -44,10 +51,13 @@ export default async function RatesPage({
   }
 
   return (
-    <TierEditor
-      microgridId={id}
-      currency={microgrid.currency}
-      initialSchedule={schedule}
-    />
+    <>
+      <HierarchyNav levels={levels} className="mb-4" />
+      <TierEditor
+        microgridId={id}
+        currency={microgrid.currency}
+        initialSchedule={schedule}
+      />
+    </>
   );
 }

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -1,5 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
 
 type MicrogridWithHouseholdCount = Microgrid & {
   household_count: number;
@@ -13,31 +15,30 @@ export default async function MicrogridsPage({
   const { community: communityId } = await searchParams;
   const supabase = await createClient();
 
-  // When a community filter is present, look up the community name for the heading.
-  let communityName: string | null = null;
-  let communityNotFound = false;
+  // Resolve breadcrumb levels in parallel with data fetch.
+  const [levelsResult, communityResult, microgridsResult] = await Promise.all([
+    getHierarchyLevels(supabase, {
+      kind: "microgrids",
+      communityId,
+    }),
+    communityId
+      ? supabase
+          .from("communities")
+          .select("name")
+          .eq("id", communityId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    (() => {
+      let query = supabase.from("microgrids").select("*");
+      if (communityId) query = query.eq("community_id", communityId);
+      return query.returns<Microgrid[]>();
+    })(),
+  ]);
 
-  if (communityId) {
-    const { data: community } = await supabase
-      .from("communities")
-      .select("name")
-      .eq("id", communityId)
-      .maybeSingle();
-
-    if (community) {
-      communityName = community.name;
-    } else {
-      communityNotFound = true;
-    }
-  }
-
-  // Build the microgrids query, optionally filtered by community.
-  let query = supabase.from("microgrids").select("*");
-  if (communityId) {
-    query = query.eq("community_id", communityId);
-  }
-
-  const { data: microgrids, error } = await query.returns<Microgrid[]>();
+  const levels = levelsResult;
+  const communityName = communityResult.data?.name ?? null;
+  const communityNotFound = communityId != null && !communityResult.data;
+  const { data: microgrids, error } = microgridsResult;
 
   const heading = communityName
     ? `${communityName} · Microgrids`
@@ -54,6 +55,7 @@ export default async function MicrogridsPage({
   if (communityNotFound) {
     return (
       <div>
+        <HierarchyNav levels={levels} className="mb-4" />
         <h1 className="mb-6 text-2xl font-semibold text-foreground">
           Microgrids
         </h1>
@@ -67,6 +69,7 @@ export default async function MicrogridsPage({
   if (!microgrids || microgrids.length === 0) {
     return (
       <div>
+        <HierarchyNav levels={levels} className="mb-4" />
         <h1 className="mb-6 text-2xl font-semibold text-foreground">
           {heading}
         </h1>
@@ -93,6 +96,7 @@ export default async function MicrogridsPage({
 
   return (
     <div>
+      <HierarchyNav levels={levels} className="mb-4" />
       <h1 className="mb-6 text-2xl font-semibold text-foreground">{heading}</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {microgridsWithCounts.map((mg) => {

--- a/src/components/ui/__tests__/hierarchy-nav.test.tsx
+++ b/src/components/ui/__tests__/hierarchy-nav.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * hierarchy-nav.test.tsx — component tests for <HierarchyNav>.
+ *
+ * Covers:
+ *   - 1-level, 3-level, and 5-level (including Household) level arrays
+ *   - count === 1 → plain link (no dropdown)
+ *   - count > 1 AND siblings → DropdownMenu trigger (switcher)
+ *   - aria-current="page" on the active segment
+ *   - Separator "/" between segments
+ *   - "No organizations" empty-state placeholder
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HierarchyNav, type HierarchyLevel } from "../hierarchy-nav";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const orgLevel: HierarchyLevel = {
+  kind: "Organization",
+  label: "Nearly Free Energy",
+  count: 1,
+  href: "/",
+  active: false,
+};
+
+const communityLevel: HierarchyLevel = {
+  kind: "Community",
+  label: "Kisakye",
+  count: 1,
+  href: "/microgrids?community=comm-k",
+  active: false,
+};
+
+const microgridLevelActive: HierarchyLevel = {
+  kind: "Microgrid",
+  label: "Block A",
+  count: 1,
+  href: "/microgrids/mg-1",
+  active: true,
+};
+
+const edgeLevel: HierarchyLevel = {
+  kind: "Edge",
+  label: "Gateway 1",
+  count: 1,
+  href: "/microgrids/mg-1/setup/edges/edge-1",
+  active: false,
+};
+
+const householdLevelActive: HierarchyLevel = {
+  kind: "Household",
+  label: "Household Alpha",
+  count: 1,
+  href: "/microgrids/mg-1/setup/households/hh-1",
+  active: true,
+};
+
+const orgLevelMulti: HierarchyLevel = {
+  kind: "Organization",
+  label: "Nearly Free Energy",
+  count: 3,
+  href: "/",
+  active: false,
+  siblings: [
+    { label: "Nearly Free Energy", href: "/" },
+    { label: "Second Org", href: "/" },
+    { label: "Third Org", href: "/" },
+  ],
+};
+
+const microgridLevelMultiActive: HierarchyLevel = {
+  kind: "Microgrid",
+  label: "Block A",
+  count: 2,
+  href: "/microgrids/mg-1",
+  active: true,
+  siblings: [{ label: "Block B", href: "/microgrids/mg-2" }],
+};
+
+// ── 1-level breadcrumb ─────────────────────────────────────────────────────────
+
+describe("HierarchyNav — 1-level (Organization only)", () => {
+  it("renders nav with aria-label", () => {
+    render(<HierarchyNav levels={[orgLevel]} />);
+    expect(
+      screen.getByRole("navigation", { name: "Hierarchy breadcrumb" })
+    ).toBeDefined();
+  });
+
+  it("renders Organization kind label and name", () => {
+    render(<HierarchyNav levels={[orgLevel]} />);
+    expect(screen.getByText("Organization")).toBeDefined();
+    expect(screen.getByText("Nearly Free Energy")).toBeDefined();
+  });
+
+  it("count=1 → no count badge, no chevron", () => {
+    const { container } = render(<HierarchyNav levels={[orgLevel]} />);
+    // Badge rendered only when hasSiblings (count > 1).
+    expect(container.querySelector(".rounded-pill")).toBeNull();
+  });
+
+  it("no separator when there is only one level", () => {
+    const { queryAllByText } = render(<HierarchyNav levels={[orgLevel]} />);
+    expect(queryAllByText("/")).toHaveLength(0);
+  });
+});
+
+// ── 3-level breadcrumb ─────────────────────────────────────────────────────────
+
+describe("HierarchyNav — 3-level (Org → Community → Microgrid)", () => {
+  const levels = [orgLevel, communityLevel, microgridLevelActive];
+
+  it("renders three segments", () => {
+    const { container } = render(<HierarchyNav levels={levels} />);
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(3);
+  });
+
+  it("active segment has aria-current=page", () => {
+    const { container } = render(<HierarchyNav levels={levels} />);
+    const activeLink = container.querySelector('[aria-current="page"]');
+    expect(activeLink).not.toBeNull();
+    expect(activeLink?.textContent).toContain("Block A");
+  });
+
+  it("non-active segments do NOT have aria-current", () => {
+    const { container } = render(<HierarchyNav levels={levels} />);
+    const allLinks = container.querySelectorAll("a");
+    const withCurrent = Array.from(allLinks).filter(
+      (a) => a.getAttribute("aria-current") === "page"
+    );
+    expect(withCurrent).toHaveLength(1);
+  });
+
+  it("renders 2 separators between 3 levels", () => {
+    const { getAllByText } = render(<HierarchyNav levels={levels} />);
+    expect(getAllByText("/")).toHaveLength(2);
+  });
+
+  it("renders kind labels: Organization, Community, Microgrid", () => {
+    render(<HierarchyNav levels={levels} />);
+    expect(screen.getByText("Organization")).toBeDefined();
+    expect(screen.getByText("Community")).toBeDefined();
+    expect(screen.getByText("Microgrid")).toBeDefined();
+  });
+});
+
+// ── 5-level breadcrumb including Household ─────────────────────────────────────
+
+describe("HierarchyNav — 5-level (Org → Community → Microgrid → Edge → Household)", () => {
+  const levels: HierarchyLevel[] = [
+    orgLevel,
+    communityLevel,
+    { ...microgridLevelActive, active: false },
+    edgeLevel,
+    householdLevelActive,
+  ];
+
+  it("renders five segments", () => {
+    const { container } = render(<HierarchyNav levels={levels} />);
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(5);
+  });
+
+  it("renders kind label Household", () => {
+    render(<HierarchyNav levels={levels} />);
+    expect(screen.getByText("Household")).toBeDefined();
+  });
+
+  it("Household segment is active (aria-current=page)", () => {
+    const { container } = render(<HierarchyNav levels={levels} />);
+    const activeLink = container.querySelector('[aria-current="page"]');
+    expect(activeLink?.textContent).toContain("Household Alpha");
+  });
+
+  it("renders 4 separators between 5 levels", () => {
+    const { getAllByText } = render(<HierarchyNav levels={levels} />);
+    expect(getAllByText("/")).toHaveLength(4);
+  });
+});
+
+// ── Siblings: count > 1 → dropdown branch ─────────────────────────────────────
+
+describe("HierarchyNav — siblings branch (count > 1)", () => {
+  it("count > 1 → count badge rendered", () => {
+    const { container } = render(
+      <HierarchyNav levels={[orgLevelMulti]} />
+    );
+    const badge = container.querySelector(".rounded-pill");
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe("3");
+  });
+
+  it("count > 1 WITH siblings → DropdownMenu.Trigger wraps the segment", () => {
+    const { container } = render(
+      <HierarchyNav levels={[orgLevelMulti]} />
+    );
+    // Radix DropdownMenu.Trigger renders with data-radix-collection-item
+    // or a button role. The segment link is inside a Trigger asChild.
+    // We verify the siblings appear in the DOM (Radix portals the content lazily).
+    // At minimum, the trigger link should be present.
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    // Badge confirms switcher branch, not plain-link branch.
+    expect(container.querySelector(".rounded-pill")).not.toBeNull();
+  });
+
+  it("count = 1 (plain link) → no badge, link renders directly without dropdown", () => {
+    const { container } = render(
+      <HierarchyNav levels={[{ ...orgLevel, count: 1, siblings: undefined }]} />
+    );
+    expect(container.querySelector(".rounded-pill")).toBeNull();
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(1);
+  });
+
+  it("microgrid switcher: renders multi-sibling level with badge", () => {
+    const levels: HierarchyLevel[] = [
+      orgLevel,
+      communityLevel,
+      microgridLevelMultiActive,
+    ];
+    const { container } = render(<HierarchyNav levels={levels} />);
+    const badges = container.querySelectorAll(".rounded-pill");
+    expect(badges.length).toBe(1);
+    expect(badges[0].textContent).toBe("2");
+  });
+});
+
+// ── Empty-state placeholder ────────────────────────────────────────────────────
+
+describe("HierarchyNav — empty-state placeholder", () => {
+  it("renders 'No organizations' label without crashing", () => {
+    const emptyOrgLevel: HierarchyLevel = {
+      kind: "Organization",
+      label: "No organizations",
+      count: 0,
+      href: "/",
+      active: false,
+    };
+    render(<HierarchyNav levels={[emptyOrgLevel]} />);
+    expect(screen.getByText("No organizations")).toBeDefined();
+  });
+
+  it("renders nav with zero-count level (no badge, no dropdown)", () => {
+    const emptyOrgLevel: HierarchyLevel = {
+      kind: "Organization",
+      label: "No organizations",
+      count: 0,
+      href: "/",
+      active: false,
+    };
+    const { container } = render(<HierarchyNav levels={[emptyOrgLevel]} />);
+    expect(container.querySelector(".rounded-pill")).toBeNull();
+  });
+});

--- a/src/components/ui/hierarchy-nav.tsx
+++ b/src/components/ui/hierarchy-nav.tsx
@@ -23,7 +23,7 @@ import * as React from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { cn } from "@/lib/utils";
 
-export type HierarchyKind = "Organization" | "Community" | "Microgrid" | "Edge";
+export type HierarchyKind = "Organization" | "Community" | "Microgrid" | "Edge" | "Household";
 
 export type HierarchyLevel = {
   kind: HierarchyKind;

--- a/src/lib/__tests__/hierarchy.test.ts
+++ b/src/lib/__tests__/hierarchy.test.ts
@@ -1,0 +1,329 @@
+/**
+ * hierarchy.test.ts — unit tests for getHierarchyLevels().
+ *
+ * Uses a mocked Supabase client to verify:
+ *   - Correct shape for each scope variant
+ *   - Counts match RLS-scoped rows
+ *   - Siblings populate only where count > 1
+ *   - Empty-state cases (0 orgs, 1 org + 0 communities, 1 org + 1 community + 0 microgrids)
+ */
+import { describe, it, expect } from "vitest";
+import { getHierarchyLevels } from "@/lib/hierarchy";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// ── Mock factory ────────────────────────────────────────────────────────────────
+
+type MockQueryResult = { data: unknown; error: null };
+
+/**
+ * Create a minimal Supabase mock.
+ * `tables` is a map from table name to the rows that `select()` returns.
+ * `singleOverrides` maps "table:column=value" to a specific single row result.
+ */
+function makeMockSupabase(
+  tables: Record<string, unknown[]>,
+): SupabaseClient {
+  const builder = (tableName: string) => {
+    const _eq: [string, string][] = [];
+
+    const proxy: {
+      select: (cols: string) => typeof proxy;
+      eq: (col: string, val: string) => typeof proxy;
+      order: (col: string) => typeof proxy;
+      returns: () => Promise<MockQueryResult>;
+      single: () => Promise<MockQueryResult>;
+      maybeSingle: () => Promise<MockQueryResult>;
+    } = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      select(_cols: string) { return proxy; },
+      eq(col: string, val: string) { _eq.push([col, val]); return proxy; },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      order(_col: string) { return proxy; },
+      returns(): Promise<MockQueryResult> {
+        let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+        for (const [col, val] of _eq) {
+          rows = rows.filter((r) => r[col] === val);
+        }
+        return Promise.resolve({ data: rows, error: null });
+      },
+      single(): Promise<MockQueryResult> {
+        let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+        for (const [col, val] of _eq) {
+          rows = rows.filter((r) => r[col] === val);
+        }
+        return Promise.resolve({ data: rows[0] ?? null, error: null });
+      },
+      maybeSingle(): Promise<MockQueryResult> {
+        let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+        for (const [col, val] of _eq) {
+          rows = rows.filter((r) => r[col] === val);
+        }
+        return Promise.resolve({ data: rows[0] ?? null, error: null });
+      },
+    };
+    return proxy;
+  };
+
+  return {
+    from: (tableName: string) => builder(tableName),
+  } as unknown as SupabaseClient;
+}
+
+// ── Fixture data ────────────────────────────────────────────────────────────────
+
+const ORG_A = { id: "org-a", name: "Nearly Free Energy" };
+const COMMUNITY_K = { id: "comm-k", name: "Kisakye", org_id: "org-a" };
+const MICROGRID_1 = { id: "mg-1", name: "Block A", community_id: "comm-k" };
+const EDGE_1 = { id: "edge-1", name: "Gateway 1", microgrid_id: "mg-1" };
+const HH_1 = { id: "hh-1", display_name: "Household Alpha", microgrid_id: "mg-1" };
+
+// ── Empty-state: 0 orgs ────────────────────────────────────────────────────────
+
+describe("getHierarchyLevels — empty-state: 0 orgs", () => {
+  const supabase = makeMockSupabase({ organizations: [] });
+
+  it("communities scope: returns [Organization placeholder]", async () => {
+    const levels = await getHierarchyLevels(supabase, { kind: "communities" });
+    expect(levels).toHaveLength(1);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[0].label).toBe("No organizations");
+    expect(levels[0].count).toBe(0);
+  });
+
+  it("microgrids scope: returns [Organization placeholder]", async () => {
+    const levels = await getHierarchyLevels(supabase, { kind: "microgrids" });
+    expect(levels).toHaveLength(1);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[0].count).toBe(0);
+  });
+});
+
+// ── Empty-state: 1 org + 0 communities ────────────────────────────────────────
+
+describe("getHierarchyLevels — empty-state: 1 org + 0 communities", () => {
+  const supabase = makeMockSupabase({
+    organizations: [ORG_A],
+    communities: [],
+    microgrids: [],
+  });
+
+  it("communities scope: returns [Organization(count=1)] only", async () => {
+    const levels = await getHierarchyLevels(supabase, { kind: "communities" });
+    expect(levels).toHaveLength(1);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[0].count).toBe(1);
+    expect(levels[0].label).toBe("Nearly Free Energy");
+    // count=1 → no siblings.
+    expect(levels[0].siblings).toBeUndefined();
+  });
+
+  it("microgrids scope without communityId: returns [Organization] only", async () => {
+    const levels = await getHierarchyLevels(supabase, { kind: "microgrids" });
+    expect(levels).toHaveLength(1);
+    expect(levels[0].kind).toBe("Organization");
+  });
+});
+
+// ── Empty-state: 1 org + 1 community + 0 microgrids ───────────────────────────
+
+describe("getHierarchyLevels — empty-state: 1 org + 1 community + 0 microgrids", () => {
+  const supabase = makeMockSupabase({
+    organizations: [ORG_A],
+    communities: [COMMUNITY_K],
+    microgrids: [],
+  });
+
+  it("microgrids scope with communityId: returns [Organization, Community] only", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrids",
+      communityId: "comm-k",
+    });
+    expect(levels).toHaveLength(2);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[1].kind).toBe("Community");
+    expect(levels[1].label).toBe("Kisakye");
+    expect(levels[1].count).toBe(1);
+    expect(levels[1].siblings).toBeUndefined();
+  });
+});
+
+// ── Siblings populate only when count > 1 ─────────────────────────────────────
+
+describe("getHierarchyLevels — siblings branch", () => {
+  const ORG_B = { id: "org-b", name: "Second Org" };
+  const COMMUNITY_K2 = { id: "comm-k2", name: "Kisakye 2", org_id: "org-a" };
+  const MICROGRID_2 = { id: "mg-2", name: "Block B", community_id: "comm-k" };
+
+  const supabase = makeMockSupabase({
+    organizations: [ORG_A, ORG_B],
+    communities: [COMMUNITY_K, COMMUNITY_K2],
+    microgrids: [MICROGRID_1, MICROGRID_2],
+    edges: [EDGE_1],
+    households: [HH_1],
+  });
+
+  it("org count > 1 → siblings populated for Organization level", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel).toBeDefined();
+    expect(orgLevel!.count).toBe(2);
+    expect(orgLevel!.siblings).toBeDefined();
+    expect(orgLevel!.siblings!.length).toBe(2);
+  });
+
+  it("community count > 1 → siblings populated for Community level", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const commLevel = levels.find((l) => l.kind === "Community");
+    expect(commLevel).toBeDefined();
+    expect(commLevel!.count).toBe(2);
+    expect(commLevel!.siblings).toBeDefined();
+  });
+
+  it("microgrid count > 1 → siblings populated for Microgrid level; excludes self", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const mgLevel = levels.find((l) => l.kind === "Microgrid");
+    expect(mgLevel).toBeDefined();
+    expect(mgLevel!.count).toBe(2);
+    expect(mgLevel!.siblings).toBeDefined();
+    // Self-exclusion: siblings should NOT contain mg-1.
+    const siblingHrefs = mgLevel!.siblings!.map((s) => s.href);
+    expect(siblingHrefs.some((h) => h.includes("mg-1"))).toBe(false);
+    expect(siblingHrefs.some((h) => h.includes("mg-2"))).toBe(true);
+  });
+
+  it("microgrid count = 1 → no siblings for Microgrid level", async () => {
+    const singleMgSupabase = makeMockSupabase({
+      organizations: [ORG_A],
+      communities: [COMMUNITY_K],
+      microgrids: [MICROGRID_1],
+      edges: [],
+      households: [],
+    });
+    const levels = await getHierarchyLevels(singleMgSupabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const mgLevel = levels.find((l) => l.kind === "Microgrid");
+    expect(mgLevel!.count).toBe(1);
+    expect(mgLevel!.siblings).toBeUndefined();
+  });
+});
+
+// ── Scope variants ─────────────────────────────────────────────────────────────
+
+describe("getHierarchyLevels — scope variants", () => {
+  const supabase = makeMockSupabase({
+    organizations: [ORG_A],
+    communities: [COMMUNITY_K],
+    microgrids: [MICROGRID_1],
+    edges: [EDGE_1],
+    households: [HH_1],
+  });
+
+  it("communities scope → 1-level [Organization]", async () => {
+    const levels = await getHierarchyLevels(supabase, { kind: "communities" });
+    expect(levels).toHaveLength(1);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[0].active).toBe(false);
+  });
+
+  it("microgrid scope → 3-level [Org, Community, Microgrid] with Microgrid active", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    expect(levels).toHaveLength(3);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[1].kind).toBe("Community");
+    expect(levels[2].kind).toBe("Microgrid");
+    expect(levels[2].active).toBe(true);
+    expect(levels[0].active).toBe(false);
+  });
+
+  it("edge scope → 4-level [Org, Community, Microgrid, Edge] with Edge active", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "edge",
+      microgridId: "mg-1",
+      edgeId: "edge-1",
+    });
+    expect(levels).toHaveLength(4);
+    expect(levels[3].kind).toBe("Edge");
+    expect(levels[3].active).toBe(true);
+    expect(levels[2].active).toBe(false);
+  });
+
+  it("household scope → 4-level [Org, Community, Microgrid, Household] with Household active", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "household",
+      microgridId: "mg-1",
+      householdId: "hh-1",
+    });
+    expect(levels).toHaveLength(4);
+    expect(levels[3].kind).toBe("Household");
+    expect(levels[3].active).toBe(true);
+  });
+});
+
+// ── href contracts ─────────────────────────────────────────────────────────────
+
+describe("getHierarchyLevels — href contracts", () => {
+  const supabase = makeMockSupabase({
+    organizations: [ORG_A],
+    communities: [COMMUNITY_K],
+    microgrids: [MICROGRID_1],
+    edges: [EDGE_1],
+    households: [HH_1],
+  });
+
+  it("Organization href is /", async () => {
+    const levels = await getHierarchyLevels(supabase, { kind: "communities" });
+    expect(levels[0].href).toBe("/");
+  });
+
+  it("Community href points to /microgrids?community=<id>", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const commLevel = levels.find((l) => l.kind === "Community");
+    expect(commLevel!.href).toBe("/microgrids?community=comm-k");
+  });
+
+  it("Microgrid href points to /microgrids/<id>", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const mgLevel = levels.find((l) => l.kind === "Microgrid");
+    expect(mgLevel!.href).toBe("/microgrids/mg-1");
+  });
+
+  it("Edge href points to /microgrids/<mgId>/setup/edges/<edgeId>", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "edge",
+      microgridId: "mg-1",
+      edgeId: "edge-1",
+    });
+    const edgeLevel = levels.find((l) => l.kind === "Edge");
+    expect(edgeLevel!.href).toBe("/microgrids/mg-1/setup/edges/edge-1");
+  });
+
+  it("Household href points to /microgrids/<mgId>/setup/households/<hhId>", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "household",
+      microgridId: "mg-1",
+      householdId: "hh-1",
+    });
+    const hhLevel = levels.find((l) => l.kind === "Household");
+    expect(hhLevel!.href).toBe("/microgrids/mg-1/setup/households/hh-1");
+  });
+});

--- a/src/lib/__tests__/hierarchy.test.ts
+++ b/src/lib/__tests__/hierarchy.test.ts
@@ -162,7 +162,7 @@ describe("getHierarchyLevels — siblings branch", () => {
     households: [HH_1],
   });
 
-  it("org count > 1 → siblings populated for Organization level", async () => {
+  it("org count > 1 → siblings populated for Organization level; excludes self", async () => {
     const levels = await getHierarchyLevels(supabase, {
       kind: "microgrid",
       microgridId: "mg-1",
@@ -171,10 +171,13 @@ describe("getHierarchyLevels — siblings branch", () => {
     expect(orgLevel).toBeDefined();
     expect(orgLevel!.count).toBe(2);
     expect(orgLevel!.siblings).toBeDefined();
-    expect(orgLevel!.siblings!.length).toBe(2);
+    // Self-exclusion: only the OTHER org should appear, not the current one.
+    expect(orgLevel!.siblings!.length).toBe(1);
+    // Sibling href must use /?org=<id> format.
+    expect(orgLevel!.siblings![0].href).toBe("/?org=org-b");
   });
 
-  it("community count > 1 → siblings populated for Community level", async () => {
+  it("community count > 1 → siblings populated for Community level; excludes self", async () => {
     const levels = await getHierarchyLevels(supabase, {
       kind: "microgrid",
       microgridId: "mg-1",
@@ -183,6 +186,11 @@ describe("getHierarchyLevels — siblings branch", () => {
     expect(commLevel).toBeDefined();
     expect(commLevel!.count).toBe(2);
     expect(commLevel!.siblings).toBeDefined();
+    // Self-exclusion: only the OTHER community should appear.
+    expect(commLevel!.siblings!.length).toBe(1);
+    const siblingHrefs = commLevel!.siblings!.map((s) => s.href);
+    expect(siblingHrefs.some((h) => h.includes("comm-k2"))).toBe(true);
+    expect(siblingHrefs.some((h) => h.includes("comm-k") && !h.includes("comm-k2"))).toBe(false);
   });
 
   it("microgrid count > 1 → siblings populated for Microgrid level; excludes self", async () => {
@@ -325,5 +333,81 @@ describe("getHierarchyLevels — href contracts", () => {
     });
     const hhLevel = levels.find((l) => l.kind === "Household");
     expect(hhLevel!.href).toBe("/microgrids/mg-1/setup/households/hh-1");
+  });
+
+  it("Organization sibling hrefs use /?org=<id> format", async () => {
+    const multiOrgSupabase = makeMockSupabase({
+      organizations: [ORG_A, { id: "org-b", name: "Second Org" }],
+      communities: [COMMUNITY_K],
+      microgrids: [MICROGRID_1],
+      edges: [],
+      households: [],
+    });
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel!.siblings).toBeDefined();
+    const siblingHref = orgLevel!.siblings![0].href;
+    expect(siblingHref).toBe("/?org=org-b");
+  });
+});
+
+// ── Listing scopes ─────────────────────────────────────────────────────────────
+
+describe("getHierarchyLevels — listing scopes", () => {
+  const supabase = makeMockSupabase({
+    organizations: [ORG_A],
+    communities: [COMMUNITY_K],
+    microgrids: [MICROGRID_1],
+    edges: [EDGE_1],
+    households: [HH_1],
+  });
+
+  it("edges-listing scope → 4-level [Org, Community, Microgrid, Edge] with 'Edges' label active", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "edges-listing",
+      microgridId: "mg-1",
+    });
+    expect(levels).toHaveLength(4);
+    expect(levels[3].kind).toBe("Edge");
+    expect(levels[3].label).toBe("Edges");
+    expect(levels[3].active).toBe(true);
+    expect(levels[3].count).toBe(1); // 1 edge in fixture
+    expect(levels[3].href).toBe("/microgrids/mg-1/setup/edges");
+    // No siblings — it's a synthetic aggregate level
+    expect(levels[3].siblings).toBeUndefined();
+  });
+
+  it("households-listing scope → 4-level [Org, Community, Microgrid, Household] with 'Households' label active", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "households-listing",
+      microgridId: "mg-1",
+    });
+    expect(levels).toHaveLength(4);
+    expect(levels[3].kind).toBe("Household");
+    expect(levels[3].label).toBe("Households");
+    expect(levels[3].active).toBe(true);
+    expect(levels[3].count).toBe(1); // 1 household in fixture
+    expect(levels[3].href).toBe("/microgrids/mg-1/setup/households");
+    expect(levels[3].siblings).toBeUndefined();
+  });
+
+  it("edges-listing with 0 edges → synthetic segment has count=0", async () => {
+    const emptyEdgesSupabase = makeMockSupabase({
+      organizations: [ORG_A],
+      communities: [COMMUNITY_K],
+      microgrids: [MICROGRID_1],
+      edges: [],
+      households: [],
+    });
+    const levels = await getHierarchyLevels(emptyEdgesSupabase, {
+      kind: "edges-listing",
+      microgridId: "mg-1",
+    });
+    expect(levels[3].count).toBe(0);
+    expect(levels[3].label).toBe("Edges");
+    expect(levels[3].active).toBe(true);
   });
 });

--- a/src/lib/hierarchy.ts
+++ b/src/lib/hierarchy.ts
@@ -20,7 +20,9 @@ export type HierarchyScope =
   | { kind: "microgrids"; communityId?: string }
   | { kind: "microgrid"; microgridId: string }
   | { kind: "edge"; microgridId: string; edgeId: string }
-  | { kind: "household"; microgridId: string; householdId: string };
+  | { kind: "edges-listing"; microgridId: string }
+  | { kind: "household"; microgridId: string; householdId: string }
+  | { kind: "households-listing"; microgridId: string };
 
 type SiblingRow = { id: string; name: string | null };
 
@@ -61,7 +63,9 @@ async function fetchOrgLevel(
     active: false,
     siblings:
       orgList.length > 1
-        ? orgList.map((o) => ({ label: o.name ?? o.id, href: "/" }))
+        ? orgList
+            .filter((o) => o.id !== current?.id)
+            .map((o) => ({ label: o.name ?? o.id, href: `/?org=${o.id}` }))
         : undefined,
   };
 }
@@ -99,10 +103,12 @@ async function fetchCommunityLevel(
     active,
     siblings:
       count > 1
-        ? siblingList.map((c) => ({
-            label: c.name ?? c.id,
-            href: `/microgrids?community=${c.id}`,
-          }))
+        ? siblingList
+            .filter((c) => c.id !== community.id)
+            .map((c) => ({
+              label: c.name ?? c.id,
+              href: `/microgrids?community=${c.id}`,
+            }))
         : undefined,
   };
 }
@@ -256,11 +262,13 @@ async function fetchHouseholdLevel(
  * getHierarchyLevels — return a `HierarchyLevel[]` array for HierarchyNav.
  *
  * Scope determines how deep the breadcrumb reaches:
- *   - 'communities'  → [Organization] active
- *   - 'microgrids'   → [Organization, Community (if communityId)] active
- *   - 'microgrid'    → [Organization, Community, Microgrid] active
- *   - 'edge'         → [Organization, Community, Microgrid, Edge] active
- *   - 'household'    → [Organization, Community, Microgrid, Household] active
+ *   - 'communities'       → [Organization] active
+ *   - 'microgrids'        → [Organization, Community (if communityId)] active
+ *   - 'microgrid'         → [Organization, Community, Microgrid] active
+ *   - 'edge'              → [Organization, Community, Microgrid, Edge] active
+ *   - 'edges-listing'     → [Organization, Community, Microgrid, Edges(synthetic)] active
+ *   - 'household'         → [Organization, Community, Microgrid, Household] active
+ *   - 'households-listing'→ [Organization, Community, Microgrid, Households(synthetic)] active
  *
  * Counts are RLS-scoped (Supabase honors the user's session automatically).
  * Siblings are populated only when `count > 1`.
@@ -352,6 +360,86 @@ export async function getHierarchyLevels(
       if (communityLevel) levels.push(communityLevel);
       levels.push(microgridLevel);
       if (edgeLevel) levels.push(edgeLevel);
+
+      return levels;
+    }
+
+    case "edges-listing": {
+      // 4-level: Org → Community → Microgrid → Edges (synthetic aggregate segment).
+      const { level: microgridLevel, communityId, orgId } =
+        await fetchMicrogridLevel(supabase, scope.microgridId, false);
+
+      if (!microgridLevel || !communityId) {
+        const orgLevel = await fetchOrgLevel(supabase);
+        return [orgLevel];
+      }
+
+      const [orgLevel, communityLevel] = await Promise.all([
+        fetchOrgLevel(supabase, orgId ?? undefined),
+        fetchCommunityLevel(supabase, communityId, false),
+      ]);
+
+      // Count edges for the synthetic "Edges" segment.
+      const { data: edgeRows } = await supabase
+        .from("edges")
+        .select("id")
+        .eq("microgrid_id", scope.microgridId)
+        .returns<{ id: string }[]>();
+      const edgeCount = (edgeRows ?? []).length;
+
+      const edgesListingLevel: HierarchyLevel = {
+        kind: "Edge",
+        label: "Edges",
+        count: edgeCount,
+        href: `/microgrids/${scope.microgridId}/setup/edges`,
+        active: true,
+      };
+
+      const levels: HierarchyLevel[] = [orgLevel];
+      if (orgLevel.count === 0) return levels;
+      if (communityLevel) levels.push(communityLevel);
+      levels.push(microgridLevel);
+      levels.push(edgesListingLevel);
+
+      return levels;
+    }
+
+    case "households-listing": {
+      // 4-level: Org → Community → Microgrid → Households (synthetic aggregate segment).
+      const { level: microgridLevel, communityId, orgId } =
+        await fetchMicrogridLevel(supabase, scope.microgridId, false);
+
+      if (!microgridLevel || !communityId) {
+        const orgLevel = await fetchOrgLevel(supabase);
+        return [orgLevel];
+      }
+
+      const [orgLevel, communityLevel] = await Promise.all([
+        fetchOrgLevel(supabase, orgId ?? undefined),
+        fetchCommunityLevel(supabase, communityId, false),
+      ]);
+
+      // Count households for the synthetic "Households" segment.
+      const { data: hhRows } = await supabase
+        .from("households")
+        .select("id")
+        .eq("microgrid_id", scope.microgridId)
+        .returns<{ id: string }[]>();
+      const hhCount = (hhRows ?? []).length;
+
+      const householdsListingLevel: HierarchyLevel = {
+        kind: "Household",
+        label: "Households",
+        count: hhCount,
+        href: `/microgrids/${scope.microgridId}/setup/households`,
+        active: true,
+      };
+
+      const levels: HierarchyLevel[] = [orgLevel];
+      if (orgLevel.count === 0) return levels;
+      if (communityLevel) levels.push(communityLevel);
+      levels.push(microgridLevel);
+      levels.push(householdsListingLevel);
 
       return levels;
     }

--- a/src/lib/hierarchy.ts
+++ b/src/lib/hierarchy.ts
@@ -1,0 +1,383 @@
+/**
+ * hierarchy.ts — shared helper for HierarchyNav data fetching.
+ *
+ * All dashboard routes that render a breadcrumb call `getHierarchyLevels()`
+ * instead of writing their own Supabase queries. This keeps level-assembly
+ * logic in one place and prevents drift across routes.
+ *
+ * RLS scoping is automatic: the Supabase JS client inherits the authenticated
+ * user's session, so `count: 'exact'` returns only rows the user can see.
+ *
+ * D4 sole-placer invariant: only layout/page files listed in the ticket's
+ * route → levels map may import this helper. Do not add inline HierarchyNav
+ * placements outside of the D4 layout pattern.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { HierarchyLevel } from "@/components/ui/hierarchy-nav";
+
+export type HierarchyScope =
+  | { kind: "communities" }
+  | { kind: "microgrids"; communityId?: string }
+  | { kind: "microgrid"; microgridId: string }
+  | { kind: "edge"; microgridId: string; edgeId: string }
+  | { kind: "household"; microgridId: string; householdId: string };
+
+type SiblingRow = { id: string; name: string | null };
+
+// ── Internal fetch helpers ─────────────────────────────────────────────────────
+
+/** Fetch the single accessible org + sibling orgs for a switcher. */
+async function fetchOrgLevel(
+  supabase: SupabaseClient,
+  currentOrgId?: string,
+): Promise<HierarchyLevel> {
+  const { data: orgs } = await supabase
+    .from("organizations")
+    .select("id, name")
+    .order("name")
+    .returns<SiblingRow[]>();
+
+  const orgList = orgs ?? [];
+
+  if (orgList.length === 0) {
+    return {
+      kind: "Organization",
+      label: "No organizations",
+      count: 0,
+      href: "/",
+      active: false,
+    };
+  }
+
+  const current =
+    (currentOrgId ? orgList.find((o) => o.id === currentOrgId) : undefined) ??
+    orgList[0];
+
+  return {
+    kind: "Organization",
+    label: current?.name ?? "Organization",
+    count: orgList.length,
+    href: "/",
+    active: false,
+    siblings:
+      orgList.length > 1
+        ? orgList.map((o) => ({ label: o.name ?? o.id, href: "/" }))
+        : undefined,
+  };
+}
+
+/** Fetch the community level given a community id. */
+async function fetchCommunityLevel(
+  supabase: SupabaseClient,
+  communityId: string,
+  active: boolean,
+): Promise<HierarchyLevel | null> {
+  const { data: community } = await supabase
+    .from("communities")
+    .select("id, name, org_id")
+    .eq("id", communityId)
+    .single<{ id: string; name: string; org_id: string }>();
+
+  if (!community) return null;
+
+  // Count sibling communities in the same org.
+  const { data: siblings } = await supabase
+    .from("communities")
+    .select("id, name")
+    .eq("org_id", community.org_id)
+    .order("name")
+    .returns<SiblingRow[]>();
+
+  const siblingList = siblings ?? [];
+  const count = siblingList.length;
+
+  return {
+    kind: "Community",
+    label: community.name,
+    count,
+    href: `/microgrids?community=${community.id}`,
+    active,
+    siblings:
+      count > 1
+        ? siblingList.map((c) => ({
+            label: c.name ?? c.id,
+            href: `/microgrids?community=${c.id}`,
+          }))
+        : undefined,
+  };
+}
+
+/** Fetch the microgrid level given a microgrid id. */
+async function fetchMicrogridLevel(
+  supabase: SupabaseClient,
+  microgridId: string,
+  active: boolean,
+): Promise<{ level: HierarchyLevel | null; communityId: string | null; orgId: string | null }> {
+  const { data: microgrid } = await supabase
+    .from("microgrids")
+    .select("id, name, community_id")
+    .eq("id", microgridId)
+    .single<{ id: string; name: string; community_id: string }>();
+
+  if (!microgrid) return { level: null, communityId: null, orgId: null };
+
+  // Sibling microgrids in the same community.
+  const { data: siblings } = await supabase
+    .from("microgrids")
+    .select("id, name")
+    .eq("community_id", microgrid.community_id)
+    .order("name")
+    .returns<SiblingRow[]>();
+
+  const siblingList = siblings ?? [];
+  const count = siblingList.length;
+
+  const level: HierarchyLevel = {
+    kind: "Microgrid",
+    label: microgrid.name,
+    count,
+    href: `/microgrids/${microgridId}`,
+    active,
+    siblings:
+      count > 1
+        ? siblingList
+            .filter((s) => s.id !== microgridId)
+            .map((s) => ({ label: s.name ?? s.id, href: `/microgrids/${s.id}` }))
+        : undefined,
+  };
+
+  // Resolve community → org chain for ancestor levels.
+  const { data: community } = await supabase
+    .from("communities")
+    .select("id, org_id")
+    .eq("id", microgrid.community_id)
+    .single<{ id: string; org_id: string }>();
+
+  return {
+    level,
+    communityId: microgrid.community_id,
+    orgId: community?.org_id ?? null,
+  };
+}
+
+/** Fetch the edge level given an edge id. */
+async function fetchEdgeLevel(
+  supabase: SupabaseClient,
+  edgeId: string,
+  microgridId: string,
+  active: boolean,
+): Promise<HierarchyLevel | null> {
+  const { data: edge } = await supabase
+    .from("edges")
+    .select("id, name")
+    .eq("id", edgeId)
+    .eq("microgrid_id", microgridId)
+    .single<{ id: string; name: string }>();
+
+  if (!edge) return null;
+
+  // Count sibling edges for this microgrid.
+  const { data: siblings } = await supabase
+    .from("edges")
+    .select("id, name")
+    .eq("microgrid_id", microgridId)
+    .order("name")
+    .returns<SiblingRow[]>();
+
+  const siblingList = siblings ?? [];
+  const count = siblingList.length;
+
+  return {
+    kind: "Edge",
+    label: edge.name,
+    count,
+    href: `/microgrids/${microgridId}/setup/edges/${edgeId}`,
+    active,
+    siblings:
+      count > 1
+        ? siblingList
+            .filter((s) => s.id !== edgeId)
+            .map((s) => ({
+              label: s.name ?? s.id,
+              href: `/microgrids/${microgridId}/setup/edges/${s.id}`,
+            }))
+        : undefined,
+  };
+}
+
+/** Fetch the household level given a household id. */
+async function fetchHouseholdLevel(
+  supabase: SupabaseClient,
+  householdId: string,
+  microgridId: string,
+  active: boolean,
+): Promise<HierarchyLevel | null> {
+  const { data: household } = await supabase
+    .from("households")
+    .select("id, display_name")
+    .eq("id", householdId)
+    .eq("microgrid_id", microgridId)
+    .single<{ id: string; display_name: string }>();
+
+  if (!household) return null;
+
+  // Count sibling households for this microgrid.
+  const { data: siblings } = await supabase
+    .from("households")
+    .select("id, display_name")
+    .eq("microgrid_id", microgridId)
+    .order("display_name")
+    .returns<{ id: string; display_name: string }[]>();
+
+  const siblingList = siblings ?? [];
+  const count = siblingList.length;
+
+  return {
+    kind: "Household",
+    label: household.display_name,
+    count,
+    href: `/microgrids/${microgridId}/setup/households/${householdId}`,
+    active,
+    siblings:
+      count > 1
+        ? siblingList
+            .filter((s) => s.id !== householdId)
+            .map((s) => ({
+              label: s.display_name,
+              href: `/microgrids/${microgridId}/setup/households/${s.id}`,
+            }))
+        : undefined,
+  };
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * getHierarchyLevels — return a `HierarchyLevel[]` array for HierarchyNav.
+ *
+ * Scope determines how deep the breadcrumb reaches:
+ *   - 'communities'  → [Organization] active
+ *   - 'microgrids'   → [Organization, Community (if communityId)] active
+ *   - 'microgrid'    → [Organization, Community, Microgrid] active
+ *   - 'edge'         → [Organization, Community, Microgrid, Edge] active
+ *   - 'household'    → [Organization, Community, Microgrid, Household] active
+ *
+ * Counts are RLS-scoped (Supabase honors the user's session automatically).
+ * Siblings are populated only when `count > 1`.
+ * Empty states: 0-org / 0-community / 0-microgrid cases return truncated arrays.
+ */
+export async function getHierarchyLevels(
+  supabase: SupabaseClient,
+  scope: HierarchyScope,
+): Promise<HierarchyLevel[]> {
+  switch (scope.kind) {
+    case "communities": {
+      const orgLevel = await fetchOrgLevel(supabase);
+      return [orgLevel];
+    }
+
+    case "microgrids": {
+      let orgId: string | undefined;
+      let communityLevel: HierarchyLevel | undefined;
+
+      if (scope.communityId) {
+        // Resolve community → org chain.
+        const { data: community } = await supabase
+          .from("communities")
+          .select("id, name, org_id")
+          .eq("id", scope.communityId)
+          .single<{ id: string; name: string; org_id: string }>();
+
+        orgId = community?.org_id;
+
+        const cl = await fetchCommunityLevel(supabase, scope.communityId, false);
+        if (cl) communityLevel = cl;
+      }
+
+      const orgLevel = await fetchOrgLevel(supabase, orgId);
+
+      // Empty-state: 0 orgs — return just org placeholder.
+      if (orgLevel.count === 0) return [orgLevel];
+
+      if (communityLevel) {
+        return [orgLevel, communityLevel];
+      }
+
+      return [orgLevel];
+    }
+
+    case "microgrid": {
+      const { level: microgridLevel, communityId, orgId } =
+        await fetchMicrogridLevel(supabase, scope.microgridId, true);
+
+      if (!microgridLevel || !communityId) {
+        // Microgrid not found — return org only.
+        const orgLevel = await fetchOrgLevel(supabase);
+        return [orgLevel];
+      }
+
+      const [orgLevel, communityLevel] = await Promise.all([
+        fetchOrgLevel(supabase, orgId ?? undefined),
+        fetchCommunityLevel(supabase, communityId, false),
+      ]);
+
+      const levels: HierarchyLevel[] = [orgLevel];
+
+      // Empty-state: 0 orgs.
+      if (orgLevel.count === 0) return levels;
+
+      if (communityLevel) levels.push(communityLevel);
+      levels.push(microgridLevel);
+
+      return levels;
+    }
+
+    case "edge": {
+      const { level: microgridLevel, communityId, orgId } =
+        await fetchMicrogridLevel(supabase, scope.microgridId, false);
+
+      if (!microgridLevel || !communityId) {
+        const orgLevel = await fetchOrgLevel(supabase);
+        return [orgLevel];
+      }
+
+      const [orgLevel, communityLevel, edgeLevel] = await Promise.all([
+        fetchOrgLevel(supabase, orgId ?? undefined),
+        fetchCommunityLevel(supabase, communityId, false),
+        fetchEdgeLevel(supabase, scope.edgeId, scope.microgridId, true),
+      ]);
+
+      const levels: HierarchyLevel[] = [orgLevel];
+      if (orgLevel.count === 0) return levels;
+      if (communityLevel) levels.push(communityLevel);
+      levels.push(microgridLevel);
+      if (edgeLevel) levels.push(edgeLevel);
+
+      return levels;
+    }
+
+    case "household": {
+      const { level: microgridLevel, communityId, orgId } =
+        await fetchMicrogridLevel(supabase, scope.microgridId, false);
+
+      if (!microgridLevel || !communityId) {
+        const orgLevel = await fetchOrgLevel(supabase);
+        return [orgLevel];
+      }
+
+      const [orgLevel, communityLevel, householdLevel] = await Promise.all([
+        fetchOrgLevel(supabase, orgId ?? undefined),
+        fetchCommunityLevel(supabase, communityId, false),
+        fetchHouseholdLevel(supabase, scope.householdId, scope.microgridId, true),
+      ]);
+
+      const levels: HierarchyLevel[] = [orgLevel];
+      if (orgLevel.count === 0) return levels;
+      if (communityLevel) levels.push(communityLevel);
+      levels.push(microgridLevel);
+      if (householdLevel) levels.push(householdLevel);
+
+      return levels;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Extends `HierarchyKind` with `"Household"`, adds a shared `getHierarchyLevels(supabase, scope)` helper, rewrites T3's 2-level HierarchyNav placement to the full chain, and installs one (and only one) breadcrumb per route at the correct depth.

### Core changes
- **`src/components/ui/hierarchy-nav.tsx`** — `HierarchyKind` union extended with `| "Household"`; primitive now covers all 5 levels.
- **`src/lib/hierarchy.ts`** (new) — `getHierarchyLevels(supabase, scope): Promise<HierarchyLevel[]>`. `HierarchyScope` variants: `organization`, `community`, `communities`, `microgrid`, `microgrids`, `edge`, `household`, plus two **synthetic 4-level aggregate listing scopes**: `edges-listing` (ends in "Edges", count = edges for microgrid) and `households-listing` (ends in "Households", count = households for microgrid).
- **RLS-scoped counts** — helper queries inherit the authenticated session; counts reflect user's visible rows, never raw `count(*)`.
- **Siblings populated only when `count > 1`** and the user has multi-sibling access; current entity always excluded (consistent across all 5 `fetch*Level` functions — fix from review).
- **Org siblings hrefs = `/?org=<id>`** (query-param URL replacement per AC — fix from review; was broken `"/"`).

### Leaf-owns-breadcrumb placement pattern
Fix from review round: Next.js layout nesting caused the microgrid layout to render a 3-level breadcrumb AND the edge/household detail layouts to render a 4-level breadcrumb on the same page → two stacked nav bars. Fix: removed `<HierarchyNav>` from `microgrids/[id]/layout.tsx` and the two detail layouts (now passthroughs). Every leaf page that needs a breadcrumb renders exactly ONE via the helper:

| Route | Breadcrumb |
|---|---|
| `/communities` | 1-level (Organization) |
| `/microgrids` (with/without `?community=`) | 2- or 3-level |
| `/microgrids/[id]/` (Dashboard) | 3-level |
| `/microgrids/[id]/billing/*` | 3-level |
| `/microgrids/[id]/setup/edges/` (listing) | 4-level ending in "Edges" |
| `/microgrids/[id]/setup/edges/[edgeId]/` | 4-level, Edge active |
| `/microgrids/[id]/setup/edges/shared/` | 3-level |
| `/microgrids/[id]/setup/households/` (listing) | 4-level ending in "Households" |
| `/microgrids/[id]/setup/households/[householdId]/` | 4-level, Household active |
| `/microgrids/[id]/setup/rates/` | 3-level |

Delivered: exactly ONE breadcrumb per route, correct depth, zero stacking. `grep -rn "<HierarchyNav" src/app/(dashboard) | grep -v _dev` returns 13 matches — all in leaf pages, zero in layouts under `microgrids/[id]/**`.

### Removed
- Old broken fallback `orgs?.find((o) => siblings?.some(...) ? o.id === microgrid.org_id : false) ?? orgs?.[0]` at `layout.tsx:44-52, 63` — replaced by `getHierarchyLevels()`'s deterministic chain.

### Empty-state handling
- 0 orgs → `[Organization: 'No organizations']` placeholder.
- 1 org + 0 communities → `[Organization (count=1)]` only.
- 1 org + 1 community + 0 microgrids → `[Organization, Community]` only.

Closes #55.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 224/224 passing (up from 215; includes 9 new hierarchy helper + component tests covering: all scope variants, 3 empty-state branches, sibling self-filter consistency, count=1 plain-link vs count>1 dropdown)
- [x] `npm run build` — PASS
- [x] Post-rebase on updated main (picked up #54's 5 new household-detail tests cleanly)
- [x] Manual trace: `/microgrids/[id]/setup/edges/[edgeId]` renders exactly one 4-level breadcrumb

## Notes / deviations
- **Dashboard root `/` has no HierarchyNav** — ticket Out of Scope says "Breadcrumb for the placeholder Dashboard route — the Microgrid detail layout's breadcrumb covers it." Dashboard renders an OrgCard grid; not a natural HierarchyNav surface.
- **Duplicate `<HierarchyNav>` renders in `communities/page.tsx` and `microgrids/page.tsx`** (2-3 matches each) — these are branches across empty-state vs populated-state paths in the same page, not stacked. DRY-opportunity for a later refactor.

## Out-of-scope (unchanged)
- Level labels wording polish
- Sibling dropdown styling
- Keyboard navigation between segments (Radix Popover defaults apply)