### PR TITLE
Validate edgeId as UUID in POST /api/devices (#67)

### DIFF
--- a/src/app/api/devices/__tests__/route.test.ts
+++ b/src/app/api/devices/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * POST /api/devices — unit tests (F #67)
+ *
+ * All Supabase I/O is mocked — no real DB hits.
+ *
+ * Cases:
+ *   (a) Missing edgeId → 400 "Request body must include edgeId and devices"
+ *   (b) Non-UUID edgeId ("edge0") → 400 "Invalid edgeId — expected UUID."
+ *   (c) Valid UUID + devices not an array → 400 "devices must be a non-empty array"
+ *   (d) Valid UUID + empty devices array → 400 "devices must be a non-empty array"
+ *   (e) Valid UUID + valid device row → 200 { saved: [...] }
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Supabase mock ────────────────────────────────────────────────────────────
+
+const mockSelect = vi.fn();
+const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/devices", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+const VALID_DEVICE = {
+  componentId: "meter0",
+  deviceType: "consumption_meter",
+  name: "Main Meter",
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("POST /api/devices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // (a) Missing edgeId field → 400 with presence-check message
+  it("(a) returns 400 when edgeId is missing", async () => {
+    const { POST } = await import("../route");
+    const req = makeRequest({ devices: [VALID_DEVICE] });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Request body must include edgeId and devices");
+  });
+
+  // (b) Non-UUID edgeId → 400 with UUID error message
+  it("(b) returns 400 when edgeId is not a UUID", async () => {
+    const { POST } = await import("../route");
+    const req = makeRequest({ edgeId: "edge0", devices: [VALID_DEVICE] });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid edgeId — expected UUID.");
+  });
+
+  // (c) Valid UUID + devices not an array → 400
+  it("(c) returns 400 when devices is not an array", async () => {
+    const { POST } = await import("../route");
+    const req = makeRequest({ edgeId: VALID_UUID, devices: "not-an-array" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("devices must be a non-empty array");
+  });
+
+  // (d) Valid UUID + empty devices array → 400 (preserves current behavior)
+  it("(d) returns 400 when devices is an empty array", async () => {
+    const { POST } = await import("../route");
+    const req = makeRequest({ edgeId: VALID_UUID, devices: [] });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("devices must be a non-empty array");
+  });
+
+  // (e) Valid UUID + valid device row → 200 with saved rows
+  it("(e) returns 200 with saved rows for valid payload", async () => {
+    const savedRow = {
+      id: "device-uuid-1",
+      name: "Main Meter",
+      device_type: "consumption_meter",
+      openems_component_id: "meter0",
+    };
+
+    mockSelect.mockResolvedValueOnce({ data: [savedRow], error: null });
+
+    const { POST } = await import("../route");
+    const req = makeRequest({
+      edgeId: VALID_UUID,
+      devices: [VALID_DEVICE],
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ saved: [savedRow] });
+
+    // Verify Supabase was called with snake_case mapped rows
+    expect(mockFrom).toHaveBeenCalledWith("devices");
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          edge_id: VALID_UUID,
+          openems_component_id: "meter0",
+          device_type: "consumption_meter",
+          name: "Main Meter",
+        }),
+      ]),
+      expect.objectContaining({ onConflict: "edge_id,openems_component_id" })
+    );
+  });
+});

--- a/src/app/api/devices/route.ts
+++ b/src/app/api/devices/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * POST /api/devices
  *
@@ -54,6 +57,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (typeof edgeId !== "string" || !edgeId.trim()) {
     return NextResponse.json(
       { error: "edgeId must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+
+  if (!UUID_RE.test(edgeId)) {
+    return NextResponse.json(
+      { error: "Invalid edgeId — expected UUID." },
       { status: 400 }
     );
   }


### PR DESCRIPTION
## Summary
Adds an early UUID-shape guard on `edgeId` in `POST /api/devices` so non-UUID callers get a clear 400 instead of an opaque Postgres 500. Scoped narrow — existing presence/type validation is preserved.

- Regex `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i` (any UUID version, case-insensitive).
- Guard placed immediately after the existing non-empty-string check.
- Error body: `{ error: "Invalid edgeId — expected UUID." }` with HTTP 400.
- Happy path + all existing validation untouched (empty-array still 400, response shape still `{ saved: [row] }`).

Establishes `src/app/api/**/__tests__/*.test.ts` as the new convention for API-route tests (vitest config already covers `.ts`/`.tsx` via the `app` project).

Closes #67.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 253/253 passing (5 new cases in `src/app/api/devices/__tests__/route.test.ts`: missing edgeId / non-UUID edgeId / non-array devices / empty array / valid UUID happy path)
- [x] `npm run build` — PASS

## Notes
- Zero new dependencies (no zod / ajv — inline regex is appropriate for one field).
- Supabase client mocked via `vi.mock("@/lib/supabase/server")` — no real DB hits in tests.