### PR TITLE
Dispatch channel address by deviceType, not nature (#68)

### DIFF
--- a/src/app/api/openems/discover/route.ts
+++ b/src/app/api/openems/discover/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { createClient } from "@/lib/supabase/server";
 import { classifyDeviceType } from "@/lib/openems/classify";
+import { channelAddressFor } from "@/lib/openems/channel-address";
 import type { DiscoveredDevice, EdgeDiscoveryResponse } from "@/lib/openems/types";
 
 /**
@@ -15,15 +16,6 @@ const SUPPORTED_NATURE_IDS = [
   "io.openems.edge.evcs.api.Evcs",
   "io.openems.edge.inverter.api.Inverter",
 ];
-
-/**
- * Derive a channel address from a component ID and its primary nature.
- * Consumption / grid / PV meters use ActiveConsumptionEnergy; others fall back
- * to the same convention until richer channel mapping is needed.
- */
-function channelAddressFor(componentId: string): string {
-  return `${componentId}/ActiveConsumptionEnergy`;
-}
 
 /**
  * GET /api/openems/discover?edgeId=<id>
@@ -87,7 +79,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
       if (!matchedNature) continue;
 
-      const openemsChannelAddress = channelAddressFor(componentId);
+      const suggestedDeviceType = classifyDeviceType(component.factoryId, matchedNature);
+      const openemsChannelAddress = channelAddressFor(componentId, suggestedDeviceType);
 
       discovered.push({
         componentId,
@@ -95,16 +88,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         alias: component.alias,
         nature: matchedNature,
         openemsChannelAddress,
-        suggestedDeviceType: classifyDeviceType(component.factoryId, matchedNature),
+        suggestedDeviceType,
         alreadyAdded: false, // filled in below after dedup check
       });
     }
 
-    // Dedup check: look up existing devices rows for this edge by channel address.
+    // Dedup check: look up existing devices rows for this edge by component ID.
     // We resolve the DB edge row via the edge's openems_edge_id.
     if (discovered.length > 0) {
-      const channelAddresses = discovered.map((d) => d.openemsChannelAddress);
-
       // Find the edge row in DB (the API receives the OpenEMS edge ID string,
       // but the DB edge PK is a UUID; join via openems_edge_id).
       const { data: edgeRows } = await supabase
@@ -126,17 +117,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
           (existingDevices ?? []).map((d) => d.openems_component_id ?? "")
         );
 
-        // Mark already-added entries. We key on componentId (= openems_component_id)
-        // because the existing schema uses UNIQUE (edge_id, openems_component_id).
-        // The ticket specifies (edge_id, openems_channel_address) as the dedup key;
-        // channel address is derived deterministically from componentId, so they are
-        // equivalent for this edge.
+        // Mark already-added entries. Dedup keys on componentId (= openems_component_id)
+        // via the UNIQUE (edge_id, openems_component_id) constraint in 00001_schema.sql:145.
+        // Channel address is derived per deviceType and may be null for non-billable types
+        // (battery, inverter, grid_meter, pv_meter). The dedup key is deviceType-independent
+        // — a component can only appear once per edge regardless of which channel it maps to.
         for (const device of discovered) {
           device.alreadyAdded = existingComponentIds.has(device.componentId);
         }
-
-        // Suppress unused variable warning for channelAddresses
-        void channelAddresses;
       }
     }
 

--- a/src/components/DiscoverDevices.tsx
+++ b/src/components/DiscoverDevices.tsx
@@ -109,8 +109,10 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
   }, [openemsEdgeId]);
 
   const handleSave = useCallback(async () => {
-    // Only save rows that are not already added
-    const toSave = devices.filter((d) => !d.alreadyAdded);
+    // Only save rows that are not already added and have a billable channel address.
+    // Null-channel rows (battery, inverter, grid_meter, pv_meter) are excluded by default;
+    // force-saving without a channel is deferred to a future ticket.
+    const toSave = devices.filter((d) => !d.alreadyAdded && d.openemsChannelAddress !== null);
     if (toSave.length === 0) return;
 
     setSaveError(null);
@@ -166,7 +168,8 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
     []
   );
 
-  const pendingCount = devices.filter((d) => !d.alreadyAdded).length;
+  // Pending = not already added AND has a billable channel (null-channel rows are excluded from Save)
+  const pendingCount = devices.filter((d) => !d.alreadyAdded && d.openemsChannelAddress !== null).length;
   // Derived flags so TypeScript doesn't narrow phase away inside JSX blocks
   const isSaving = phase === "saving";
   const isDiscovering = phase === "discovering";
@@ -251,6 +254,42 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
                       <Chip tone="neutral" state="disabled">
                         Already added
                       </Chip>
+                    </div>
+                  );
+                }
+
+                // Null-channel devices: no single auto-billing channel exists for this
+                // device type. Render as muted row with explanatory help text. Excluded
+                // from the Save payload (force-save is a future ticket).
+                if (device.openemsChannelAddress === null) {
+                  return (
+                    <div
+                      key={device.componentId}
+                      className="rounded-md border border-border bg-muted px-4 py-3"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium text-muted-foreground">
+                              {device.alias || device.componentId}
+                            </p>
+                            <StatusChip
+                              kind="deviceType"
+                              status={device.suggestedDeviceType}
+                              state="disabled"
+                            />
+                          </div>
+                          <p className="font-mono text-xs text-muted-foreground">
+                            {device.componentId}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {device.factoryId}
+                          </p>
+                        </div>
+                      </div>
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        No auto-billing channel for this device type; device metadata saved without an auto-query channel.
+                      </p>
                     </div>
                   );
                 }

--- a/src/components/__tests__/DiscoverDevices.test.tsx
+++ b/src/components/__tests__/DiscoverDevices.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 /**
- * DiscoverDevices component tests (F #57).
+ * DiscoverDevices component tests (F #57, #68).
  *
  * Covers:
  *   (a) suggested device_type renders in the dropdown
  *   (b) dropdown override propagates to the save payload
  *   (c) Save calls POST /api/devices with the correct payload shape
  *   (d) 'Already added' chip renders as disabled for a component matching an existing device row
+ *   (e) null-channel rows render muted with help text and are excluded from Save payload (#68)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -23,14 +24,15 @@ vi.mock("next/navigation", () => ({
 function makeDevice(
   componentId: string,
   suggestedDeviceType: DiscoveredDevice["suggestedDeviceType"] = "consumption_meter",
-  alreadyAdded = false
+  alreadyAdded = false,
+  openemsChannelAddress: string | null = `${componentId}/ActiveConsumptionEnergy`
 ): DiscoveredDevice {
   return {
     componentId,
     factoryId: `io.openems.edge.meter.${componentId}`,
     alias: `Meter ${componentId}`,
     nature: "io.openems.edge.meter.api.ElectricityMeter",
-    openemsChannelAddress: `${componentId}/ActiveConsumptionEnergy`,
+    openemsChannelAddress,
     suggestedDeviceType,
     alreadyAdded,
   };
@@ -286,6 +288,85 @@ describe("DiscoverDevices", () => {
       // The already-added row should have opacity-60 class
       const disabledRow = container.querySelector(".opacity-60");
       expect(disabledRow).not.toBeNull();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (e) null-channel rows — muted rendering + excluded from Save (#68)
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(e) null-channel rows (battery, inverter, grid_meter, pv_meter)", () => {
+    it("renders muted row with help text when openemsChannelAddress is null", async () => {
+      const devices = [makeDevice("ess0", "battery", false, null)];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/No auto-billing channel for this device type/i)
+        ).toBeDefined();
+      });
+    });
+
+    it("excludes null-channel device from the POST /api/devices payload on bulk save", async () => {
+      // One null-channel device (battery) + one billable device (consumption_meter)
+      const devices = [
+        makeDevice("ess0", "battery", false, null),
+        makeDevice("meter0", "consumption_meter", false, "meter0/ActiveConsumptionEnergy"),
+      ];
+
+      // First call: discover
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      // Second call: save
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ saved: [{ id: "new-uuid" }] }),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => screen.getByText("Save devices"));
+      fireEvent.click(screen.getByRole("button", { name: /save devices/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        const [url, init] = fetchMock.mock.calls[1];
+        expect(url).toBe("/api/devices");
+
+        const body = JSON.parse(init?.body as string);
+        // Only meter0 (consumption_meter) should be in the payload — ess0 has no channel
+        expect(body.devices).toHaveLength(1);
+        expect(body.devices[0].componentId).toBe("meter0");
+      });
+    });
+
+    it("does not show Save button when all new rows have null channel", async () => {
+      const devices = [makeDevice("ess0", "battery", false, null)];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/No auto-billing channel for this device type/i)
+        ).toBeDefined();
+        expect(screen.queryByRole("button", { name: /save devices/i })).toBeNull();
+      });
     });
   });
 

--- a/src/lib/openems/__tests__/channel-address.test.ts
+++ b/src/lib/openems/__tests__/channel-address.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { channelAddressFor } from "../channel-address";
+
+describe("channelAddressFor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // consumption_meter → ActiveConsumptionEnergy
+  it("returns ActiveConsumptionEnergy for consumption_meter", () => {
+    expect(channelAddressFor("meter0", "consumption_meter")).toBe(
+      "meter0/ActiveConsumptionEnergy"
+    );
+  });
+
+  // ev_charger → ActiveConsumptionEnergy (EVCS inherits ElectricityMeter shape)
+  it("returns ActiveConsumptionEnergy for ev_charger", () => {
+    expect(channelAddressFor("evcs0", "ev_charger")).toBe(
+      "evcs0/ActiveConsumptionEnergy"
+    );
+  });
+
+  // grid_meter → null
+  it("returns null for grid_meter", () => {
+    expect(channelAddressFor("meter0", "grid_meter")).toBeNull();
+  });
+
+  // pv_meter → null
+  it("returns null for pv_meter", () => {
+    expect(channelAddressFor("pvMeter0", "pv_meter")).toBeNull();
+  });
+
+  // battery → null
+  it("returns null for battery", () => {
+    expect(channelAddressFor("ess0", "battery")).toBeNull();
+  });
+
+  // inverter → null
+  it("returns null for inverter", () => {
+    expect(channelAddressFor("inverter0", "inverter")).toBeNull();
+  });
+
+  // other → null + console.warn
+  it("returns null for other and emits console.warn", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = channelAddressFor("unknown0", "other");
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("other")
+    );
+  });
+});

--- a/src/lib/openems/channel-address.ts
+++ b/src/lib/openems/channel-address.ts
@@ -1,0 +1,61 @@
+/**
+ * channelAddressFor — maps a classified DeviceType to its OpenEMS billing channel.
+ *
+ * Returns null for device types that do not have a single well-defined
+ * consumption-energy channel (battery, inverter, grid_meter, pv_meter, other).
+ * Callers must handle null explicitly — do not fall back to ActiveConsumptionEnergy.
+ *
+ * Dispatch is on the *classified* DeviceType (from classifyDeviceType), not on
+ * the raw OpenEMS nature string.
+ */
+
+import type { DeviceType } from "@/lib/types/domain";
+
+export function channelAddressFor(
+  componentId: string,
+  deviceType: DeviceType
+): string | null {
+  switch (deviceType) {
+    case "consumption_meter":
+    case "ev_charger":
+      // EVCS inherits ElectricityMeter shape in OpenEMS — same channel applies.
+      return `${componentId}/ActiveConsumptionEnergy`;
+
+    case "grid_meter":
+      // Grid meters expose signed ActiveEnergy or separate
+      // ActiveProductionEnergy / ActiveConsumptionEnergy pairs.
+      // No single scalar is correct for household billing; deferred.
+      return null;
+
+    case "pv_meter":
+      // Bi-directional semantics; not billed as household consumption.
+      return null;
+
+    case "battery":
+      // ESS exposes ActiveChargeEnergy / ActiveDischargeEnergy / Soc —
+      // not single-valued for billing.
+      return null;
+
+    case "inverter":
+      // Inverters are monitored via an upstream ProductionMeter,
+      // not billed directly.
+      return null;
+
+    case "other":
+      console.warn(
+        `channelAddressFor: unmapped deviceType "${deviceType}" for component "${componentId}"`
+      );
+      return null;
+
+    default: {
+      // Exhaustiveness guard — if DeviceType gains a new variant, TypeScript
+      // will error here (unreachable assignment).
+      const _exhaustive: never = deviceType;
+      void _exhaustive;
+      console.warn(
+        `channelAddressFor: unknown deviceType "${deviceType}" for component "${componentId}"`
+      );
+      return null;
+    }
+  }
+}

--- a/src/lib/openems/types.ts
+++ b/src/lib/openems/types.ts
@@ -6,9 +6,11 @@
  * tables and flow through DeviceConfig in src/lib/adapters/types.ts.
  *
  * Channel address convention for energy reads:
- *   `${componentId}/ActiveConsumptionEnergy`
- * This suffix is OpenEMS-specific; non-consumption channels (battery SoC, PV
- * production) resolve their channel name from device_type in the adapter.
+ *   `${componentId}/ActiveConsumptionEnergy` — for consumption_meter and ev_charger
+ *   `null` — for battery, inverter, grid_meter, pv_meter (no single billing channel)
+ *
+ * The channel is derived per deviceType via channelAddressFor() in
+ * src/lib/openems/channel-address.ts. Non-consumption channels are deferred.
  */
 
 /** JSON-RPC request envelope */
@@ -84,7 +86,7 @@ export type DiscoveredDevice = {
   factoryId: string;
   alias: string;
   nature: string;
-  openemsChannelAddress: string; // e.g. "meter0/ActiveConsumptionEnergy"
+  openemsChannelAddress: string | null; // e.g. "meter0/ActiveConsumptionEnergy"; null for non-billable types
   suggestedDeviceType: import("@/lib/types/domain").DeviceType;
   alreadyAdded?: boolean;
 };


### PR DESCRIPTION
## Summary
Fixes the hardcoded `ActiveConsumptionEnergy` channel in discover flow. Dispatches on the classified `DeviceType` (not raw nature) because `ElectricityMeter` nature covers consumption / grid / PV meters with different channel semantics.

### Mapping
| deviceType | Channel |
|---|---|
| `consumption_meter` | `${componentId}/ActiveConsumptionEnergy` |
| `ev_charger` | `${componentId}/ActiveConsumptionEnergy` (EVCS inherits ElectricityMeter shape) |
| `grid_meter` | `null` (signed `ActiveEnergy` — TBD for billing) |
| `pv_meter` | `null` (bi-directional — not billed as household consumption) |
| `battery` | `null` (ESS has multiple energy channels — TBD) |
| `inverter` | `null` (monitored, not billed directly) |
| `other` | `null` + `console.warn` |

### Changes
- **New helper**: `src/lib/openems/channel-address.ts` (exhaustive `switch` with TypeScript `never` exhaustiveness guard). Colocated with `classify.ts`.
- **Type widened**: `DiscoveredDevice.openemsChannelAddress: string | null`.
- **Discover route**: imports from the helper, passes `suggestedDeviceType` instead of `nature`. Dedup comment updated to reflect null possibility.
- **DiscoverDevices UI**: null-channel rows render with muted tokens (`bg-muted` / `text-muted-foreground`) + inline help text "No auto-billing channel for this device type; device metadata saved without an auto-query channel." `handleSave`'s `toSave` filter excludes null-channel rows. `pendingCount` aligned. Save button hidden when all rows are null-channel.
- **New tests**: `src/lib/openems/__tests__/channel-address.test.ts` — 7 cases (one per DeviceType); `other` case asserts `console.warn` via `vi.spyOn`.
- **Component test**: `DiscoverDevices.test.tsx` gains 3 new cases (muted render + help text / exclusion from POST payload / no Save when all rows null-channel).

Closes #68.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 258/258 passing (7 new helper tests + 3 new UI tests)
- [x] `npm run build` — PASS

## Notes
- No migration changes — `devices.openems_channel_address` column does not exist; channel is transient (derived at read time). Wrong channel → downstream energy reads return null; no persisted bad data.
- No force-save affordance for null-channel rows — operator cannot save those in this ticket. Deferred.
- Exhaustive `switch` with `const _exhaustive: never = deviceType` guard — future DeviceType enum additions surface as TS errors.