### PR TITLE
Add shared UX-layer primitives (Input, RadioGroup, RadioCard, Banner) (#71)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.0",
@@ -2374,6 +2375,38 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.0",

--- a/src/components/ui/__tests__/banner.test.tsx
+++ b/src/components/ui/__tests__/banner.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Banner } from "../banner";
+
+describe("Banner — tone class mapping", () => {
+  it("tone='info' renders bg-muted and text-foreground", () => {
+    const { container } = render(
+      <Banner tone="info" title="Info banner">Body text</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("bg-muted");
+    expect(el.className).toContain("text-foreground");
+  });
+
+  it("tone='success' renders bg-success-muted and text-success-fg", () => {
+    const { container } = render(
+      <Banner tone="success" title="Success banner">Body text</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("bg-success-muted");
+    expect(el.className).toContain("text-success-fg");
+  });
+
+  it("tone='warn' renders bg-warning-muted and text-warning-fg", () => {
+    const { container } = render(
+      <Banner tone="warn" title="Warn banner">Body text</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("bg-warning-muted");
+    expect(el.className).toContain("text-warning-fg");
+  });
+
+  it("tone='destructive' renders bg-destructive-muted and text-destructive-fg", () => {
+    const { container } = render(
+      <Banner tone="destructive" title="Destructive banner">Body text</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("bg-destructive-muted");
+    expect(el.className).toContain("text-destructive-fg");
+  });
+});
+
+describe("Banner — left-edge border tokens", () => {
+  it("tone='info' has border-l-4 border-border", () => {
+    const { container } = render(
+      <Banner tone="info" title="Info">Body</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("border-l-4");
+    expect(el.className).toContain("border-border");
+  });
+
+  it("tone='success' has border-l-4 border-success", () => {
+    const { container } = render(
+      <Banner tone="success" title="Success">Body</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("border-l-4");
+    expect(el.className).toContain("border-success");
+  });
+
+  it("tone='warn' has border-l-4 border-warning", () => {
+    const { container } = render(
+      <Banner tone="warn" title="Warn">Body</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("border-l-4");
+    expect(el.className).toContain("border-warning");
+  });
+
+  it("tone='destructive' has border-l-4 border-destructive", () => {
+    const { container } = render(
+      <Banner tone="destructive" title="Destructive">Body</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("border-l-4");
+    expect(el.className).toContain("border-destructive");
+  });
+});
+
+describe("Banner — role", () => {
+  it("tone='destructive' renders role='alert'", () => {
+    const { container } = render(
+      <Banner tone="destructive" title="Alert!">Danger</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.getAttribute("role")).toBe("alert");
+  });
+
+  it("tone='info' renders role='status'", () => {
+    const { container } = render(
+      <Banner tone="info" title="Info">Info body</Banner>
+    );
+    const el = container.firstElementChild!;
+    expect(el.getAttribute("role")).toBe("status");
+  });
+});
+
+describe("Banner — action", () => {
+  it("action click fires its own handler (Banner does not swallow it)", () => {
+    const onActionClick = vi.fn();
+    render(
+      <Banner
+        tone="info"
+        title="Info banner"
+        action={<button onClick={onActionClick}>Take action</button>}
+      >
+        Body text
+      </Banner>
+    );
+
+    screen.getByRole("button", { name: "Take action" }).click();
+    expect(onActionClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("action is rendered as-is (not wrapped in an extra button)", () => {
+    const { container } = render(
+      <Banner
+        tone="warn"
+        title="Warning"
+        action={<a href="/fix">Fix it</a>}
+      >
+        Body
+      </Banner>
+    );
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe("Fix it");
+    // Verify it's not inside a button (Banner doesn't wrap)
+    expect(link?.closest("button")).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { Input } from "../input";
+
+describe("Input", () => {
+  it("onChange fires with the typed value", () => {
+    const onChange = vi.fn();
+    const { container } = render(<Input onChange={onChange} />);
+    const input = container.querySelector("input")!;
+    fireEvent.change(input, { target: { value: "hello" } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect((input as HTMLInputElement).value).toBe("hello");
+  });
+
+  it("disabled prop prevents onChange from firing", () => {
+    const onChange = vi.fn();
+    const { container } = render(<Input disabled onChange={onChange} />);
+    const input = container.querySelector("input")!;
+    fireEvent.change(input, { target: { value: "hello" } });
+    // fireEvent bypasses browser disabled state; confirm the attribute is set
+    expect(input.hasAttribute("disabled")).toBe(true);
+    // onChange is NOT called when the element is properly disabled in the browser,
+    // but jsdom's fireEvent does not enforce that. We confirm the attribute is present
+    // and the component passes disabled through.
+    expect(input.getAttribute("disabled")).toBeDefined();
+  });
+
+  it("className merges via cn()", () => {
+    const { container } = render(<Input className="custom-class" />);
+    const input = container.querySelector("input")!;
+    // The custom class should be present alongside the base classes
+    expect(input.className).toContain("custom-class");
+    // Base class should also be present — verifies cn() merges rather than replaces
+    expect(input.className).toContain("rounded-md");
+  });
+});

--- a/src/components/ui/__tests__/radio-card.test.tsx
+++ b/src/components/ui/__tests__/radio-card.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { RadioGroup } from "../radio-group";
+import { RadioCard } from "../radio-card";
+
+describe("RadioCard", () => {
+  it("clicking the card body selects the radio (label wraps item)", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="">
+        <RadioCard value="opt-a" title="Option A" id="card-a" />
+      </RadioGroup>
+    );
+
+    // The label element should have htmlFor matching the radio input id
+    const label = container.querySelector("label");
+    const radio = container.querySelector("button[role='radio']") as HTMLElement | null
+      ?? container.querySelector("[role='radio']") as HTMLElement | null;
+
+    expect(label).not.toBeNull();
+    expect(radio).not.toBeNull();
+    expect(label?.getAttribute("for")).toBe(radio?.getAttribute("id"));
+  });
+
+  it("selected state applies border-primary and bg-primary/5 via has-[] selector classes", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="opt-b">
+        <RadioCard value="opt-b" title="Option B" id="card-b" />
+      </RadioGroup>
+    );
+
+    const label = container.querySelector("label");
+    // The has-[] selector classes must be present in the className string so Tailwind
+    // can apply them at runtime when the inner radio is checked.
+    expect(label?.className).toContain("has-[[data-state=checked]]:border-primary");
+    expect(label?.className).toContain("has-[[data-state=checked]]:bg-primary/5");
+  });
+
+  it("disabled={true} renders data-disabled attribute and opacity-50 cursor-not-allowed classes", () => {
+    const { container } = render(
+      <RadioGroup>
+        <RadioCard value="opt-c" title="Option C" disabled id="card-c" />
+      </RadioGroup>
+    );
+
+    const label = container.querySelector("label");
+    expect(label?.hasAttribute("data-disabled")).toBe(true);
+    expect(label?.className).toContain("opacity-50");
+    expect(label?.className).toContain("cursor-not-allowed");
+  });
+
+  it("focus-visible ring class is present in label className for keyboard focus", () => {
+    const { container } = render(
+      <RadioGroup>
+        <RadioCard value="opt-d" title="Option D" id="card-d" />
+      </RadioGroup>
+    );
+
+    const label = container.querySelector("label");
+    // focus-within:ring-ring is the focus-visible class applied via focus-within
+    expect(label?.className).toContain("focus-within:ring-ring");
+  });
+
+  it("useId() generates an id when id prop is omitted", () => {
+    const { container } = render(
+      <RadioGroup>
+        <RadioCard value="opt-e" title="Option E" />
+      </RadioGroup>
+    );
+
+    const label = container.querySelector("label");
+    const radio = container.querySelector("[role='radio']");
+
+    // Both should have a non-empty id / for attribute
+    expect(label?.getAttribute("for")).toBeTruthy();
+    expect(radio?.getAttribute("id")).toBeTruthy();
+    // And they should match each other
+    expect(label?.getAttribute("for")).toBe(radio?.getAttribute("id"));
+  });
+});

--- a/src/components/ui/__tests__/radio-group.test.tsx
+++ b/src/components/ui/__tests__/radio-group.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RadioGroup, RadioGroupItem } from "../radio-group";
+
+describe("RadioGroup", () => {
+  it("onValueChange fires with the selected value on item click", () => {
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup onValueChange={onValueChange}>
+        <RadioGroupItem value="alpha" id="item-alpha" />
+        <RadioGroupItem value="beta" id="item-beta" />
+      </RadioGroup>
+    );
+
+    const [alphaItem] = screen.getAllByRole("radio");
+    fireEvent.click(alphaItem);
+
+    // Radix RadioGroup fires onValueChange with the value of the clicked item
+    expect(onValueChange).toHaveBeenCalledWith("alpha");
+  });
+
+  it("container has DOM role radiogroup", () => {
+    const { container } = render(
+      <RadioGroup>
+        <RadioGroupItem value="x" id="item-x" />
+      </RadioGroup>
+    );
+    // Radix Root renders with role="radiogroup"
+    const radioGroup = container.querySelector("[role='radiogroup']");
+    expect(radioGroup).not.toBeNull();
+  });
+
+  it("each item has DOM role radio", () => {
+    render(
+      <RadioGroup>
+        <RadioGroupItem value="one" id="item-one" />
+        <RadioGroupItem value="two" id="item-two" />
+      </RadioGroup>
+    );
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(2);
+  });
+});

--- a/src/components/ui/banner.tsx
+++ b/src/components/ui/banner.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+// Banner — project-specific informational/alert banner.
+// Added in #71 (UX0 Shared UX-layer primitives).
+//
+// Usage:
+//   <Banner tone="destructive" title="Edge offline">
+//     The edge device has not reported in over 24 hours.
+//     <Link href="/setup">Reconfigure</Link>
+//   </Banner>
+//
+// `action` is rendered as-is; Banner does NOT wrap it in a button. Caller supplies a
+// <Link>, <button>, or custom element so that routing and interactive semantics are
+// owned by the call site.
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type BannerTone = "info" | "success" | "warn" | "destructive";
+
+export interface BannerProps {
+  tone: BannerTone;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+const toneClasses: Record<BannerTone, string> = {
+  info: "bg-muted text-foreground border-l-4 border-border",
+  success: "bg-success-muted text-success-fg border-l-4 border-success",
+  warn: "bg-warning-muted text-warning-fg border-l-4 border-warning",
+  destructive: "bg-destructive-muted text-destructive-fg border-l-4 border-destructive",
+};
+
+export function Banner({ tone, title, children, action, className }: BannerProps) {
+  // Destructive banners are alert-level; others are status (or neutral informational).
+  const role = tone === "destructive" ? "alert" : "status";
+
+  return (
+    <div
+      role={role}
+      className={cn("p-4 rounded-md", toneClasses[tone], className)}
+    >
+      {/* Title */}
+      <h3 className="text-sm font-semibold leading-snug">
+        {title}
+      </h3>
+
+      {/* Body */}
+      <div className="mt-1 text-sm leading-relaxed">
+        {children}
+      </div>
+
+      {/* Action — rendered as-is; caller supplies interactive element */}
+      {action !== undefined && (
+        <div className="mt-3">
+          {action}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+// Input — shadcn-compatible Input primitive.
+// Added in #71 (UX0 Shared UX-layer primitives). Run `npx shadcn@latest add input` to regenerate
+// from the canonical shadcn template if the project adopts shadcn CLI fully.
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.ComponentPropsWithoutRef<"input">;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        ref={ref}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-border bg-card px-3 py-1 text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/radio-card.tsx
+++ b/src/components/ui/radio-card.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// RadioCard — project-specific composition layering RadioGroupItem into a styled card.
+// Added in #71 (UX0 Shared UX-layer primitives). NOT a shadcn primitive — project-specific.
+//
+// Usage:
+//   <RadioGroup value={selected} onValueChange={setSelected}>
+//     <RadioCard value="opt-a" title="Option A" description="..." meta="..." />
+//     <RadioCard value="opt-b" title="Option B" disabled />
+//   </RadioGroup>
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { RadioGroupItem } from "./radio-group";
+
+export interface RadioCardProps {
+  value: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  meta?: React.ReactNode;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+export const RadioCard = React.forwardRef<HTMLLabelElement, RadioCardProps>(
+  function RadioCard(
+    { value, title, description, meta, disabled = false, className, id },
+    ref
+  ) {
+    const generatedId = React.useId();
+    const resolvedId = id ?? generatedId;
+
+    return (
+      <label
+        ref={ref}
+        htmlFor={resolvedId}
+        data-disabled={disabled ? "" : undefined}
+        className={cn(
+          // Base card layout
+          "flex items-start gap-3 rounded-md border border-border bg-card p-4 cursor-pointer transition-colors",
+          // Selected state — applied via Radix data attributes on the label's sibling item;
+          // since the label wraps the item, we use has-[] selectors if available, but for
+          // broad compat we rely on the RadioGroup parent to provide data-state via context.
+          // The actual selected/unselected border + bg is toggled by the RadioGroupItem's
+          // data-state="checked" propagating up via CSS. We expose both classes for test
+          // assertions; the consumer controls value.
+          "has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5",
+          // Disabled state
+          disabled && "opacity-50 cursor-not-allowed",
+          // Focus-visible ring (applied via the inner RadioGroupItem focus)
+          "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1",
+          className
+        )}
+      >
+        {/* The hidden-ish radio input — still accessible, positioned inside the label */}
+        <RadioGroupItem
+          id={resolvedId}
+          value={value}
+          disabled={disabled}
+          className="mt-0.5 shrink-0"
+        />
+
+        {/* Card text content */}
+        <div className="flex-1 min-w-0">
+          {/* Title — bold */}
+          <div className="text-sm font-semibold text-foreground leading-snug">
+            {title}
+          </div>
+
+          {/* Description — muted */}
+          {description !== undefined && (
+            <div className="mt-0.5 text-sm text-muted-foreground leading-snug">
+              {description}
+            </div>
+          )}
+
+          {/* Meta — small monospace caption */}
+          {meta !== undefined && (
+            <div className="mt-1 font-mono text-xs text-muted-foreground">
+              {meta}
+            </div>
+          )}
+        </div>
+      </label>
+    );
+  }
+);

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// RadioGroup — shadcn-compatible RadioGroup primitive built on Radix UI.
+// Added in #71 (UX0 Shared UX-layer primitives). Run `npx shadcn@latest add radio-group` to
+// regenerate from the canonical shadcn template if the project adopts shadcn CLI fully.
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ComponentRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Root
+    ref={ref}
+    className={cn("grid gap-2", className)}
+    {...props}
+  />
+));
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ComponentRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      "aspect-square h-4 w-4 rounded-full border border-border text-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <span className="block h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };


### PR DESCRIPTION
## Summary
Foundational primitives for the upcoming UX1a/UX1b/UX2/UX3 workstream. Front-loads the shared `src/components/ui/` additions so those tickets can ship in parallel without merge conflicts.

### Primitives added
- **`<Input>`** — shadcn pattern matching `select.tsx` (forwardRef + `React.ComponentPropsWithoutRef<'input'>` + `cn()` merge).
- **`<RadioGroup>` + `<RadioGroupItem>`** — wraps `@radix-ui/react-radio-group` (added to `dependencies`).
- **`<RadioCard>`** — project-specific composition. Props: `value, title, description?, meta?, disabled?, className?, id?`. Accessibility: `<label htmlFor={resolvedId}>` wrapping `<RadioGroupItem id={resolvedId}>`; `React.useId()` fallback. Selected state via `has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5` (pure CSS, no JS state). Disabled: `data-disabled` attr + `opacity-50 cursor-not-allowed`. Focus ring via `focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1` on the outer label (inner RadioGroupItem owns its own `focus-visible:ring-1` keyboard-only ring).
- **`<Banner>`** — props `{ tone: 'info'|'success'|'warn'|'destructive', title, children, action?, className? }`. Token mapping:
  - `info` → `bg-muted` + `text-foreground` + `border-border`
  - `success` → `bg-success-muted` + `text-success-fg` + `border-success`
  - `warn` → `bg-warning-muted` + `text-warning-fg` + `border-warning`
  - `destructive` → `bg-destructive-muted` + `text-destructive-fg` + `border-destructive`
  
  Left-edge border (`border-l-4`) for color-blind accessibility. `role="alert"` for destructive; `role="status"` for others. `action` rendered as-is (Banner doesn't wrap in a button).

### Tests (23 new across 4 files)
- `input.test.tsx` — onChange fires, disabled attr renders, className merges.
- `radio-group.test.tsx` — onValueChange fires on click; DOM roles `radiogroup`/`radio`.
- `radio-card.test.tsx` — label→radio wiring; selected-state classes; disabled attrs/classes; focus ring.
- `banner.test.tsx` — all 4 tones produce correct token pairs; action click fires handler; destructive renders `role="alert"`.

Closes #71.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 286/286 passing (23 new)
- [x] `npm run build` — PASS

## Notes / deviations
- Used `fireEvent.click` from `@testing-library/react` instead of `@testing-library/user-event` — the latter is not installed, and the ticket's token-discipline + scope rules forbid adding test-lib deps in this ticket. Equivalent coverage via Radix's click handlers.
- `focus-within` vs `focus-visible` on the outer card: inner RadioGroupItem handles keyboard-only focus via its own `focus-visible:ring-1` ring; the outer `focus-within` gives a visual cue on any focus source. Acceptable trade-off for the composition.
- `disabled` test on Input asserts the attribute renders rather than simulating a blocked onChange — jsdom's `fireEvent.change` ignores `disabled`, so that's the best practical assertion.

### Out of scope (explicitly deferred)
- Migrations of raw `<input>` tags in `TierEditor.tsx`, `HouseholdTable.tsx`, `households-section.tsx` → UX2/UX3.
- Toast/notification system.
- Auto-dismiss Banner variant.
- Wizard component → UX2.