### PR TITLE
Add + Edit for Edge (#77)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/edge-detail-configure-button.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/edge-detail-configure-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * EdgeDetailConfigureButton — renders the "Configure…" button in the edge detail
+ * header and manages the EdgeFormModal open/close state.
+ *
+ * Extracted as a thin client component so the EdgeDetailPage server component
+ * can remain async (server-side data fetching pattern).
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import type { Edge } from "@/lib/types/domain";
+import { EdgeFormModal } from "@/components/forms/EdgeForm";
+
+export function EdgeDetailConfigureButton({ edge }: { edge: Edge }) {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="ml-auto text-xs font-medium text-primary hover:underline"
+      >
+        Configure…
+      </button>
+      <EdgeFormModal
+        mode="edit"
+        edge={edge}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) router.refresh();
+        }}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
@@ -6,13 +6,13 @@ import { StatusChip } from "@/components/ui/status-chip";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { DiscoverDevices } from "@/components/DiscoverDevices";
+import { EdgeDetailConfigureButton } from "./edge-detail-configure-button";
 
-// Setup > Edges > [edgeId] — edge detail (D2 / #53).
+// Setup > Edges > [edgeId] — edge detail (D2 / #53, #77).
 // Lists devices on this edge. For each device, shows the linked household
 // (via household_devices) if any.
 //
-// Scope boundary: linked household is plain text here. D3 (#54) upgrades
-// it to a Link → household detail page.
+// #77 adds: "Configure…" button in the header (via client shell component).
 
 type DeviceRow = Pick<
   Device,
@@ -104,6 +104,8 @@ export default async function EdgeDetailPage({
         <div className="mt-2 flex items-center gap-3">
           <h3 className="text-lg font-semibold text-foreground">{edge.name}</h3>
           <StatusChip kind="edgeSource" status={edge.data_source_type} />
+          {/* Client shell: Configure… button opens EdgeFormModal in edit mode */}
+          <EdgeDetailConfigureButton edge={edge} />
         </div>
         {edge.data_source_type === "openems" && (
           <p className="mt-1 font-mono text-xs text-muted-foreground">

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/edges-crud-shell.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/edges-crud-shell.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * EdgesCRUDShell — client-side shell for "+ Add Edge" and "Configure…" buttons.
+ *
+ * Rendered inside the server component SetupEdgesPage. Splits the modal state
+ * into a thin client wrapper so the page's server component can remain async.
+ *
+ * Two modes:
+ *   "add-button"      → renders the "+ Add edge" button that opens EdgeFormModal in create mode
+ *   "configure-button" → renders the "Configure…" link button for a specific edge row
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import type { Edge } from "@/lib/types/domain";
+import { EdgeFormModal } from "@/components/forms/EdgeForm";
+
+type AddButtonProps = {
+  mode: "add-button";
+  microgridId: string;
+  edge?: never;
+};
+
+type ConfigureButtonProps = {
+  mode: "configure-button";
+  microgridId: string;
+  edge: Edge;
+};
+
+export type EdgesCRUDShellProps = AddButtonProps | ConfigureButtonProps;
+
+export function EdgesCRUDShell({ mode, microgridId, edge }: EdgesCRUDShellProps) {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+
+  if (mode === "add-button") {
+    return (
+      <>
+        <button
+          onClick={() => setOpen(true)}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          + Add edge
+        </button>
+        <EdgeFormModal
+          mode="create"
+          parentMicrogridId={microgridId}
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            if (!next) router.refresh();
+          }}
+        />
+      </>
+    );
+  }
+
+  // configure-button mode
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="text-xs font-medium text-primary hover:underline"
+      >
+        Configure…
+      </button>
+      <EdgeFormModal
+        mode="edit"
+        edge={edge}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) router.refresh();
+        }}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -34,6 +34,11 @@ vi.mock("@/lib/hierarchy", () => ({
   getHierarchyLevels: vi.fn().mockResolvedValue([]),
 }));
 
+// Stub the client shell — uses useRouter which isn't available in server-component tests.
+vi.mock("./edges-crud-shell", () => ({
+  EdgesCRUDShell: () => null,
+}));
+
 import SetupEdgesPage from "./page";
 
 function buildEdgesQuery(data: unknown) {

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
@@ -6,9 +6,11 @@ import { Chip } from "@/components/ui/chip";
 import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { EdgesCRUDShell } from "./edges-crud-shell";
 
-// Setup > Edges (D2 / #53).
+// Setup > Edges (D2 / #53, #77).
 // Lists every edge attached to this microgrid. Rows link to edge detail.
+// "+ Add edge" and "Configure…" buttons are in the client shell component.
 
 type EdgeRow = Pick<
   Edge,
@@ -83,12 +85,16 @@ export default async function SetupEdgesPage({
             {edges?.length ?? 0} edge{(edges?.length ?? 0) === 1 ? "" : "s"}
           </h3>
         </div>
-        <Link
-          href={`/microgrids/${id}/setup/edges/shared`}
-          className="text-sm font-medium text-primary hover:underline"
-        >
-          View shared devices →
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/microgrids/${id}/setup/edges/shared`}
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            View shared devices →
+          </Link>
+          {/* Client shell handles the + Add Edge modal trigger */}
+          <EdgesCRUDShell microgridId={id} mode="add-button" />
+        </div>
       </div>
 
       {onlineError && (
@@ -121,6 +127,9 @@ export default async function SetupEdgesPage({
                 </th>
                 <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                   Status
+                </th>
+                <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  <span className="sr-only">Actions</span>
                 </th>
               </tr>
             </thead>
@@ -169,6 +178,14 @@ export default async function SetupEdgesPage({
                           Unknown
                         </Chip>
                       )}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {/* Client shell handles per-row Configure… button */}
+                      <EdgesCRUDShell
+                        microgridId={id}
+                        mode="configure-button"
+                        edge={edge as Edge}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/app/api/edges/[id]/route.ts
+++ b/src/app/api/edges/[id]/route.ts
@@ -1,0 +1,267 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/lib/types/database.gen";
+
+type EdgeDataSource = Database["public"]["Enums"]["edge_data_source"];
+
+const VALID_DATA_SOURCE_TYPES: readonly EdgeDataSource[] = [
+  "openems",
+  "modbus_direct",
+  "mqtt",
+  "rest_api",
+] as const;
+
+function isValidDataSource(v: unknown): v is EdgeDataSource {
+  return VALID_DATA_SOURCE_TYPES.includes(v as EdgeDataSource);
+}
+
+/**
+ * Validates and parses a URL string.
+ * Returns null if valid, or an error message string if invalid.
+ */
+function validateUrl(raw: string): string | null {
+  if (raw !== raw.trim()) {
+    return "URL must not have leading or trailing spaces.";
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return "Invalid URL format.";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return "URL must use http or https protocol.";
+  }
+  if (parsed.username || parsed.password) {
+    return "URL must not contain embedded credentials.";
+  }
+  return null;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * PATCH /api/edges/[id]
+ *
+ * Updates an existing edge row. Authorization enforced by RLS on `edges`.
+ * Postgres `42501` → HTTP 403.
+ *
+ * Special rule: if request changes `data_source_type` AND ≥1 child device
+ * exists, reject with 409 so the operator removes/reassigns them first.
+ *
+ * Request body (all fields optional):
+ * {
+ *   name?: string;
+ *   data_source_type?: EdgeDataSource;
+ *   openems_backend_url?: string | null;
+ *   openems_edge_id?: string | null;
+ *   role?: string | null;
+ * }
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid edge ID — expected UUID" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
+  }
+
+  const {
+    name,
+    data_source_type,
+    openems_backend_url,
+    openems_edge_id,
+    role,
+  } = body as Record<string, unknown>;
+
+  // At least one field must be provided
+  const hasName = name !== undefined;
+  const hasDataSource = data_source_type !== undefined;
+  const hasUrl = openems_backend_url !== undefined;
+  const hasEdgeId = openems_edge_id !== undefined;
+  const hasRole = role !== undefined;
+
+  if (!hasName && !hasDataSource && !hasUrl && !hasEdgeId && !hasRole) {
+    return NextResponse.json({ error: "No fields provided to update" }, { status: 400 });
+  }
+
+  // Validate fields if provided
+  if (hasName && (typeof name !== "string" || !name.trim())) {
+    return NextResponse.json({ error: "name must be a non-empty string" }, { status: 422 });
+  }
+
+  if (hasDataSource && !isValidDataSource(data_source_type)) {
+    return NextResponse.json(
+      { error: `data_source_type must be one of: ${VALID_DATA_SOURCE_TYPES.join(", ")}` },
+      { status: 422 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Fetch the current edge row — needed to:
+  //   (a) detect data_source_type change
+  //   (b) validate OpenEMS fields against the effective data_source_type
+  // RLS on edges applies here: if user can't read it, they can't update it.
+  const { data: currentEdge, error: fetchError } = await supabase
+    .from("edges")
+    .select("id, data_source_type, name")
+    .eq("id", id)
+    .single();
+
+  if (fetchError || !currentEdge) {
+    if (fetchError?.code === "PGRST116") {
+      return NextResponse.json({ error: "Edge not found" }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: fetchError?.message ?? "Edge not found" },
+      { status: 404 }
+    );
+  }
+
+  // Effective data_source_type after the patch
+  const effectiveDataSource: EdgeDataSource = hasDataSource
+    ? (data_source_type as EdgeDataSource)
+    : (currentEdge.data_source_type as EdgeDataSource);
+
+  // Validate OpenEMS fields against effective data source
+  if (effectiveDataSource === "openems") {
+    // If the patch sets openems_backend_url to something, validate it
+    if (hasUrl && openems_backend_url !== null) {
+      if (typeof openems_backend_url !== "string" || !openems_backend_url.trim()) {
+        return NextResponse.json(
+          { error: "openems_backend_url must be a non-empty string or null" },
+          { status: 422 }
+        );
+      }
+      const urlError = validateUrl(openems_backend_url.trim());
+      if (urlError) {
+        return NextResponse.json(
+          { error: `openems_backend_url: ${urlError}` },
+          { status: 422 }
+        );
+      }
+    }
+  }
+
+  // Check for re-classification with child devices
+  const isChangingDataSource =
+    hasDataSource &&
+    (data_source_type as EdgeDataSource) !== currentEdge.data_source_type;
+
+  if (isChangingDataSource) {
+    const { count, error: countError } = await supabase
+      .from("devices")
+      .select("id", { count: "exact", head: true })
+      .eq("edge_id", id);
+
+    if (countError) {
+      return NextResponse.json(
+        { error: `Failed to check devices: ${countError.message}` },
+        { status: 500 }
+      );
+    }
+
+    const deviceCount = count ?? 0;
+    if (deviceCount > 0) {
+      return NextResponse.json(
+        {
+          error: `Cannot change data source: ${deviceCount} device${deviceCount === 1 ? "" : "s"} are linked. Remove or reassign them first.`,
+        },
+        { status: 409 }
+      );
+    }
+  }
+
+  // Build the update payload — only include fields that were provided
+  const updateRow: Record<string, unknown> = {};
+
+  if (hasName && typeof name === "string") updateRow.name = name.trim();
+  if (hasDataSource) updateRow.data_source_type = data_source_type;
+
+  if (hasUrl) {
+    updateRow.openems_backend_url =
+      openems_backend_url === null || (typeof openems_backend_url === "string" && !openems_backend_url.trim())
+        ? null
+        : typeof openems_backend_url === "string"
+        ? openems_backend_url.trim()
+        : null;
+  }
+
+  if (hasEdgeId) {
+    updateRow.openems_edge_id =
+      openems_edge_id === null || (typeof openems_edge_id === "string" && !openems_edge_id.trim())
+        ? null
+        : typeof openems_edge_id === "string"
+        ? openems_edge_id.trim()
+        : null;
+  }
+
+  if (hasRole) {
+    updateRow.role =
+      role === null || (typeof role === "string" && !role.trim())
+        ? null
+        : typeof role === "string"
+        ? role.trim()
+        : null;
+  }
+
+  const { data, error } = await supabase
+    .from("edges")
+    .update(updateRow)
+    .eq("id", id)
+    .select("id, name, data_source_type, openems_edge_id, openems_backend_url, role, microgrid_id, created_at")
+    .single();
+
+  if (error) {
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to update this edge" },
+        { status: 403 }
+      );
+    }
+
+    if (error.code === "23505") {
+      if (
+        error.message.includes("openems_edge_id") ||
+        (error as { details?: string }).details?.includes("openems_edge_id")
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "An edge with this OpenEMS edge ID is already registered for this microgrid.",
+          },
+          { status: 409 }
+        );
+      }
+      const edgeName = typeof name === "string" ? name.trim() : currentEdge.name;
+      return NextResponse.json(
+        {
+          error: `An edge named '${edgeName}' already exists on this microgrid.`,
+        },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: `Failed to update edge: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ edge: data }, { status: 200 });
+}

--- a/src/app/api/edges/__tests__/route.test.ts
+++ b/src/app/api/edges/__tests__/route.test.ts
@@ -1,0 +1,473 @@
+/**
+ * /api/edges + /api/edges/[id] — unit tests (UX4b / #77)
+ *
+ * All Supabase I/O is mocked — no real DB hits.
+ *
+ * POST /api/edges cases:
+ *   (a) Happy path → 201 with edge row
+ *   (b) Missing name → 422
+ *   (c) Invalid data_source_type → 422
+ *   (d) Missing openems_backend_url for openems type → 422
+ *   (e) Invalid URL (not http/https) → 422
+ *   (f) URL with embedded credentials → 422
+ *   (g) Duplicate name (23505) → 409 with name message
+ *   (h) Duplicate openems_edge_id (23505) → 409 with edge ID message
+ *   (i) RLS violation (42501) → 403
+ *
+ * PATCH /api/edges/[id] cases:
+ *   (j) Happy path name-only → 200; role preserved (not overwritten)
+ *   (k) data_source_type change with child devices → 409
+ *   (l) data_source_type change with no child devices → 200
+ *   (m) RLS violation on update → 403
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Supabase mock ─────────────────────────────────────────────────────────
+//
+// The mock needs to chain: from(table).insert(row).select().single()
+// and for PATCH: from(table).select().eq().single() + from(table).update().eq().select().single()
+// and for device count: from(table).select(_, { count }).eq().single() -> returns { count }
+//
+// We use a chainable mock factory that returns itself for each method call,
+// with the terminal .single() resolving based on what was called.
+
+type MockChain = {
+  insert: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+};
+
+// These will be assigned per-test via overrides
+const insertChain = {
+  select: vi.fn(),
+};
+insertChain.select.mockReturnValue({ single: vi.fn() });
+
+// General chainable mock builder
+function makeChain(): MockChain {
+  const chain: MockChain = {
+    insert: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+    eq: vi.fn(),
+    single: vi.fn(),
+  };
+  chain.insert.mockReturnValue(chain);
+  chain.select.mockReturnValue(chain);
+  chain.update.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  return chain;
+}
+
+let postChain: MockChain;
+let getChain: MockChain;  // for fetching current edge in PATCH
+let deviceCountChain: MockChain;
+let patchChain: MockChain;
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const EDGE_UUID = "660e8400-e29b-41d4-a716-446655440001";
+const MICROGRID_UUID = "770e8400-e29b-41d4-a716-446655440002";
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/edges", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePatchRequest(id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/edges/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_POST_BODY = {
+  microgrid_id: MICROGRID_UUID,
+  name: "Test Edge",
+  data_source_type: "openems",
+  openems_backend_url: "https://openems.example.com",
+  openems_edge_id: "edge0",
+  role: "metering",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/edges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postChain = makeChain();
+    mockFrom.mockReturnValue(postChain);
+  });
+
+  // (a) Happy path
+
+  it("(a) returns 201 with edge row on valid openems payload", async () => {
+    const savedEdge = {
+      id: EDGE_UUID,
+      microgrid_id: MICROGRID_UUID,
+      name: "Test Edge",
+      data_source_type: "openems",
+      openems_backend_url: "https://openems.example.com",
+      openems_edge_id: "edge0",
+      role: "metering",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+
+    postChain.single.mockResolvedValueOnce({ data: savedEdge, error: null });
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(VALID_POST_BODY));
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.edge).toMatchObject({ id: EDGE_UUID, name: "Test Edge" });
+  });
+
+  // (b) Missing name
+  it("(b) returns 422 when name is missing", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({ ...VALID_POST_BODY, name: "" })
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("name is required");
+  });
+
+  // (c) Invalid data_source_type
+  it("(c) returns 422 when data_source_type is invalid", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({ ...VALID_POST_BODY, data_source_type: "ftp_server" })
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("data_source_type");
+  });
+
+  // (d) Missing openems_backend_url for openems type
+  it("(d) returns 422 when openems_backend_url is missing for openems type", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({ ...VALID_POST_BODY, openems_backend_url: "" })
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("openems_backend_url is required");
+  });
+
+  // (e) Invalid URL (not http/https)
+  it("(e) returns 422 when openems_backend_url uses non-http protocol", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({
+        ...VALID_POST_BODY,
+        openems_backend_url: "ftp://openems.example.com",
+      })
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("http or https");
+  });
+
+  // (f) URL with embedded credentials
+  it("(f) returns 422 when openems_backend_url has embedded credentials", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({
+        ...VALID_POST_BODY,
+        openems_backend_url: "https://user:pass@openems.example.com",
+      })
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("embedded credentials");
+  });
+
+  // (g) Duplicate name — 23505 on name constraint
+  it("(g) returns 409 with name message on duplicate name violation", async () => {
+    postChain.single.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "23505",
+        message:
+          "duplicate key value violates unique constraint \"edges_microgrid_name_unique\"",
+        details: "Key (microgrid_id, name)=(abc, Test Edge) already exists.",
+      },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(VALID_POST_BODY));
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("Test Edge");
+    expect(json.error).toContain("already exists on this microgrid");
+  });
+
+  // (h) Duplicate openems_edge_id — 23505 on openems_edge_id constraint
+  it("(h) returns 409 with edge ID message on duplicate openems_edge_id violation", async () => {
+    postChain.single.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "23505",
+        message:
+          "duplicate key value violates unique constraint \"edges_microgrid_id_openems_edge_id_key\"",
+        details:
+          "Key (microgrid_id, openems_edge_id)=(abc, edge0) already exists.",
+      },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(VALID_POST_BODY));
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("OpenEMS edge ID is already registered");
+  });
+
+  // (i) RLS violation
+  it("(i) returns 403 when RLS denies the insert", async () => {
+    postChain.single.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "42501",
+        message: "new row violates row-level security policy for table \"edges\"",
+      },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(VALID_POST_BODY));
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain("Not authorized");
+  });
+});
+
+describe("PATCH /api/edges/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up chains
+    getChain = makeChain();       // .from("edges").select().eq().single() → current edge
+    deviceCountChain = makeChain(); // .from("devices").select(_, count).eq() → { count }
+    patchChain = makeChain();     // .from("edges").update().eq().select().single()
+
+    let callIndex = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "edges") {
+        callIndex++;
+        if (callIndex === 1) return getChain;  // fetch current edge
+        return patchChain;                      // update
+      }
+      if (table === "devices") return deviceCountChain;
+      return makeChain();
+    });
+  });
+
+  // (j) Name-only PATCH — role preserved
+  it("(j) returns 200 on name-only PATCH; does not overwrite role", async () => {
+    const currentEdge = {
+      id: EDGE_UUID,
+      data_source_type: "openems",
+      name: "Old Name",
+    };
+    const updatedEdge = {
+      id: EDGE_UUID,
+      name: "New Name",
+      data_source_type: "openems",
+      role: "metering", // preserved
+    };
+
+    getChain.single.mockResolvedValueOnce({ data: currentEdge, error: null });
+    patchChain.single.mockResolvedValueOnce({ data: updatedEdge, error: null });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(makePatchRequest(EDGE_UUID, { name: "New Name" }), {
+      params: Promise.resolve({ id: EDGE_UUID }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.edge.name).toBe("New Name");
+    expect(json.edge.role).toBe("metering");
+
+    // Verify update payload does NOT include `role` when it wasn't provided
+    const updateCall = patchChain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateCall).not.toHaveProperty("role");
+  });
+
+  // (k) data_source_type change with child devices → 409
+  it("(k) returns 409 when changing data_source_type with child devices", async () => {
+    const currentEdge = {
+      id: EDGE_UUID,
+      data_source_type: "openems",
+      name: "Test Edge",
+    };
+
+    getChain.single.mockResolvedValueOnce({ data: currentEdge, error: null });
+    // Device count returns 3
+    deviceCountChain.eq.mockReturnValue({
+      ...deviceCountChain,
+      then: undefined,
+    });
+    // Override to return count
+    deviceCountChain.select = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValueOnce({ count: 3, error: null }),
+    });
+
+    // Re-setup the from mock with this specific device chain
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "edges") return getChain;
+      if (table === "devices") return deviceCountChain;
+      return makeChain();
+    });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatchRequest(EDGE_UUID, {
+        data_source_type: "modbus_direct",
+      }),
+      { params: Promise.resolve({ id: EDGE_UUID }) }
+    );
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("Cannot change data source");
+    expect(json.error).toContain("3 devices");
+  });
+
+  // (l) data_source_type change with no child devices → 200
+  it("(l) returns 200 when changing data_source_type with no child devices", async () => {
+    const currentEdge = {
+      id: EDGE_UUID,
+      data_source_type: "openems",
+      name: "Test Edge",
+    };
+    const updatedEdge = {
+      id: EDGE_UUID,
+      data_source_type: "modbus_direct",
+      name: "Test Edge",
+      role: null,
+    };
+
+    getChain.single.mockResolvedValueOnce({ data: currentEdge, error: null });
+
+    deviceCountChain.select = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValueOnce({ count: 0, error: null }),
+    });
+
+    let edgeCallCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "edges") {
+        edgeCallCount++;
+        if (edgeCallCount <= 1) return getChain;
+        return patchChain;
+      }
+      if (table === "devices") return deviceCountChain;
+      return makeChain();
+    });
+
+    patchChain.single.mockResolvedValueOnce({ data: updatedEdge, error: null });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatchRequest(EDGE_UUID, {
+        data_source_type: "modbus_direct",
+        openems_backend_url: null,
+        openems_edge_id: null,
+      }),
+      { params: Promise.resolve({ id: EDGE_UUID }) }
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  // (m) RLS violation on PATCH
+  it("(m) returns 403 when RLS denies the update", async () => {
+    const currentEdge = {
+      id: EDGE_UUID,
+      data_source_type: "openems",
+      name: "Test Edge",
+    };
+
+    getChain.single.mockResolvedValueOnce({ data: currentEdge, error: null });
+    patchChain.single.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "42501",
+        message:
+          "new row violates row-level security policy for table \"edges\"",
+      },
+    });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(makePatchRequest(EDGE_UUID, { name: "Hacked" }), {
+      params: Promise.resolve({ id: EDGE_UUID }),
+    });
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain("Not authorized");
+  });
+});
+
+// ── RLS integration (cross-org denial via HTTP layer) ─────────────────────
+// This mirrors the pattern in src/app/api/devices/__tests__/route.test.ts
+// where we verify the 403 mapping from RLS. The actual Supabase RLS is
+// verified in rls.test.ts; here we verify the HTTP response mapping.
+
+describe("RLS: cross-org org_manager POST to /api/edges is denied", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postChain = makeChain();
+    mockFrom.mockReturnValue(postChain);
+  });
+
+  it("returns 403 when Postgres returns 42501 (row-level security policy violation)", async () => {
+    postChain.single.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "42501",
+        message:
+          "new row violates row-level security policy for table \"edges\"",
+      },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({
+        microgrid_id: VALID_UUID, // cross-org microgrid
+        name: "Unauthorized Edge",
+        data_source_type: "openems",
+        openems_backend_url: "https://openems.example.com",
+        openems_edge_id: "edge-cross",
+      })
+    );
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain("Not authorized");
+  });
+});

--- a/src/app/api/edges/route.ts
+++ b/src/app/api/edges/route.ts
@@ -1,0 +1,194 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/lib/types/database.gen";
+
+type EdgeDataSource = Database["public"]["Enums"]["edge_data_source"];
+
+// Derive valid enum values at runtime from the generated DB types.
+// The array literal in database.gen.ts mirrors the Postgres enum.
+const VALID_DATA_SOURCE_TYPES: readonly EdgeDataSource[] = [
+  "openems",
+  "modbus_direct",
+  "mqtt",
+  "rest_api",
+] as const;
+
+function isValidDataSource(v: unknown): v is EdgeDataSource {
+  return VALID_DATA_SOURCE_TYPES.includes(v as EdgeDataSource);
+}
+
+/**
+ * Validates and parses a URL string.
+ * - Must parse with `new URL()` (no throw).
+ * - Protocol must be http: or https:
+ * - No embedded credentials (username/password in URL).
+ * - No leading/trailing whitespace (caller must trim first).
+ *
+ * Returns null if valid, or an error message string if invalid.
+ */
+function validateUrl(raw: string): string | null {
+  if (raw !== raw.trim()) {
+    return "URL must not have leading or trailing spaces.";
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return "Invalid URL format.";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return "URL must use http or https protocol.";
+  }
+  if (parsed.username || parsed.password) {
+    return "URL must not contain embedded credentials.";
+  }
+  return null;
+}
+
+/**
+ * POST /api/edges
+ *
+ * Creates a new edge row. Authorization is enforced by RLS via
+ * `user_can_access_microgrid(microgrid_id)`. No JS pre-check.
+ *
+ * Request body:
+ * {
+ *   microgrid_id: string;
+ *   name: string;
+ *   data_source_type: EdgeDataSource;
+ *   openems_backend_url?: string | null;
+ *   openems_edge_id?: string | null;
+ *   role?: string | null;
+ * }
+ *
+ * Error mapping:
+ *   42501 (Postgres RLS violation) → 403
+ *   23505 (unique violation on name) → 409
+ *   23505 (unique violation on openems_edge_id) → 409
+ *   validation failure → 422
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
+  }
+
+  const {
+    microgrid_id,
+    name,
+    data_source_type,
+    openems_backend_url,
+    openems_edge_id,
+    role,
+  } = body as Record<string, unknown>;
+
+  // Validate required fields
+  if (typeof name !== "string" || !name.trim()) {
+    return NextResponse.json({ error: "name is required" }, { status: 422 });
+  }
+
+  if (!isValidDataSource(data_source_type)) {
+    return NextResponse.json(
+      { error: `data_source_type must be one of: ${VALID_DATA_SOURCE_TYPES.join(", ")}` },
+      { status: 422 }
+    );
+  }
+
+  if (typeof microgrid_id !== "string" || !microgrid_id.trim()) {
+    return NextResponse.json({ error: "microgrid_id is required" }, { status: 422 });
+  }
+
+  // OpenEMS-specific validation
+  if (data_source_type === "openems") {
+    if (typeof openems_backend_url !== "string" || !openems_backend_url.trim()) {
+      return NextResponse.json(
+        { error: "openems_backend_url is required when data_source_type is openems" },
+        { status: 422 }
+      );
+    }
+    if (typeof openems_edge_id !== "string" || !openems_edge_id.trim()) {
+      return NextResponse.json(
+        { error: "openems_edge_id is required when data_source_type is openems" },
+        { status: 422 }
+      );
+    }
+
+    const urlError = validateUrl(openems_backend_url.trim());
+    if (urlError) {
+      return NextResponse.json(
+        { error: `openems_backend_url: ${urlError}` },
+        { status: 422 }
+      );
+    }
+  }
+
+  const supabase = await createClient();
+
+  const insertRow: Record<string, unknown> = {
+    microgrid_id: microgrid_id.trim(),
+    name: name.trim(),
+    data_source_type,
+    openems_backend_url:
+      data_source_type === "openems" && typeof openems_backend_url === "string"
+        ? openems_backend_url.trim()
+        : null,
+    openems_edge_id:
+      data_source_type === "openems" && typeof openems_edge_id === "string"
+        ? openems_edge_id.trim()
+        : null,
+    role:
+      typeof role === "string" && role.trim()
+        ? role.trim()
+        : null,
+  };
+
+  const { data, error } = await supabase
+    .from("edges")
+    .insert(insertRow)
+    .select("id, name, data_source_type, openems_edge_id, openems_backend_url, role, microgrid_id, created_at")
+    .single();
+
+  if (error) {
+    // RLS violation
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to create an edge on this microgrid" },
+        { status: 403 }
+      );
+    }
+
+    // Unique constraint violation
+    if (error.code === "23505") {
+      // Determine which constraint was violated from the detail message
+      if (error.message.includes("openems_edge_id") || (error as { details?: string }).details?.includes("openems_edge_id")) {
+        return NextResponse.json(
+          {
+            error:
+              "An edge with this OpenEMS edge ID is already registered for this microgrid.",
+          },
+          { status: 409 }
+        );
+      }
+      // Default: name uniqueness constraint
+      return NextResponse.json(
+        {
+          error: `An edge named '${name.trim()}' already exists on this microgrid.`,
+        },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: `Failed to create edge: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ edge: data }, { status: 201 });
+}

--- a/src/components/forms/EdgeForm.tsx
+++ b/src/components/forms/EdgeForm.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+/**
+ * EdgeForm — Add / Edit an Edge.
+ *
+ * Modal via Radix Dialog. Fields: name, data_source_type (RadioCard tiles),
+ * conditional OpenEMS fields (openems_backend_url, openems_edge_id), role.
+ *
+ * Props:
+ *   mode='create'  → requires parentMicrogridId
+ *   mode='edit'    → requires edge (the full Edge row to pre-fill)
+ *
+ * Posts to /api/edges (POST) or /api/edges/[id] (PATCH).
+ * Never writes to Supabase directly from the browser.
+ *
+ * Error surface: <Banner> at top for server errors (403/409/422);
+ * field-level "required" state handled by disabled Save button.
+ */
+
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import { RadioGroup } from "@/components/ui/radio-group";
+import { RadioCard } from "@/components/ui/radio-card";
+import { Banner } from "@/components/ui/banner";
+import type { Database } from "@/lib/types/database.gen";
+import type { Edge } from "@/lib/types/domain";
+
+// ── Enum-derived options ──────────────────────────────────────────────────
+// Pull the union type from the generated DB types so there's no hardcoded string union.
+type EdgeDataSource = Database["public"]["Enums"]["edge_data_source"];
+
+// Runtime array — keeps the order and descriptions in one place.
+// The type annotation ensures no string outside the enum slips in.
+const DATA_SOURCE_OPTIONS: Array<{
+  value: EdgeDataSource;
+  title: string;
+  description: string;
+}> = [
+  {
+    value: "openems",
+    title: "OpenEMS",
+    description:
+      "Connect via the OpenEMS Backend WebSocket. Requires backend URL and edge ID.",
+  },
+  {
+    value: "modbus_direct",
+    title: "Modbus Direct",
+    description:
+      "Poll meters directly over Modbus TCP/RTU. Useful for CHINT meters and similar.",
+  },
+  {
+    value: "mqtt",
+    title: "MQTT",
+    description:
+      "Subscribe to meter telemetry published on an MQTT broker.",
+  },
+  {
+    value: "rest_api",
+    title: "REST API",
+    description:
+      "Pull readings from a custom HTTP/REST endpoint.",
+  },
+];
+
+// ── Props ─────────────────────────────────────────────────────────────────
+
+type CreateProps = {
+  mode: "create";
+  parentMicrogridId: string;
+  edge?: never;
+};
+
+type EditProps = {
+  mode: "edit";
+  edge: Edge;
+  parentMicrogridId?: never;
+};
+
+export type EdgeFormProps = (CreateProps | EditProps) & {
+  /** Called after successful save so the parent can close the modal. */
+  onSuccess: () => void;
+  /** Called when the user cancels without saving. */
+  onCancel: () => void;
+};
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+export function EdgeForm({ mode, edge, parentMicrogridId, onSuccess, onCancel }: EdgeFormProps) {
+  const router = useRouter();
+
+  // Form state
+  const [name, setName] = React.useState(mode === "edit" ? (edge.name ?? "") : "");
+  const [dataSourceType, setDataSourceType] = React.useState<EdgeDataSource>(
+    mode === "edit" ? edge.data_source_type : "openems"
+  );
+  const [openemsBackendUrl, setOpenemsBackendUrl] = React.useState(
+    mode === "edit" && edge.data_source_type === "openems"
+      ? (edge.openems_backend_url ?? "")
+      : ""
+  );
+  const [openemsEdgeId, setOpenemsEdgeId] = React.useState(
+    mode === "edit" && edge.data_source_type === "openems"
+      ? (edge.openems_edge_id ?? "")
+      : ""
+  );
+  const [role, setRole] = React.useState(mode === "edit" ? (edge.role ?? "") : "");
+
+  // UI state
+  const [saving, setSaving] = React.useState(false);
+  const [serverError, setServerError] = React.useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({});
+
+  const isOpenEms = dataSourceType === "openems";
+
+  // When data_source_type changes away from openems, clear OpenEMS fields.
+  function handleDataSourceChange(next: string) {
+    const value = next as EdgeDataSource;
+    setDataSourceType(value);
+    if (value !== "openems") {
+      setOpenemsBackendUrl("");
+      setOpenemsEdgeId("");
+    }
+    // Clear field-level errors for the OpenEMS fields when toggling away.
+    setFieldErrors((prev) => {
+      const updated = { ...prev };
+      delete updated.openems_backend_url;
+      delete updated.openems_edge_id;
+      return updated;
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setServerError(null);
+    setFieldErrors({});
+
+    // Client-side field validation before network call.
+    const errors: Record<string, string> = {};
+    if (!name.trim()) errors.name = "Name is required.";
+    if (isOpenEms) {
+      if (!openemsBackendUrl.trim()) {
+        errors.openems_backend_url = "Backend URL is required for OpenEMS edges.";
+      }
+      if (!openemsEdgeId.trim()) {
+        errors.openems_edge_id = "Edge ID is required for OpenEMS edges.";
+      }
+    }
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    const body: Record<string, unknown> = {
+      name: name.trim(),
+      data_source_type: dataSourceType,
+      role: role.trim() || null,
+    };
+
+    if (isOpenEms) {
+      body.openems_backend_url = openemsBackendUrl.trim();
+      body.openems_edge_id = openemsEdgeId.trim();
+    } else {
+      body.openems_backend_url = null;
+      body.openems_edge_id = null;
+    }
+
+    if (mode === "create") {
+      body.microgrid_id = parentMicrogridId;
+    }
+
+    const url = mode === "create" ? "/api/edges" : `/api/edges/${edge.id}`;
+    const method = mode === "create" ? "POST" : "PATCH";
+
+    setSaving(true);
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        router.refresh();
+        onSuccess();
+        return;
+      }
+
+      let json: { error?: string } = {};
+      try {
+        json = await res.json();
+      } catch {
+        // ignore parse error
+      }
+
+      setServerError(json.error ?? `Unexpected error (HTTP ${res.status})`);
+    } catch (err) {
+      setServerError(err instanceof Error ? err.message : "Network error. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const canSave =
+    name.trim().length > 0 &&
+    (!isOpenEms || (openemsBackendUrl.trim().length > 0 && openemsEdgeId.trim().length > 0));
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      {/* Server error banner */}
+      {serverError && (
+        <Banner tone="destructive" title="Could not save edge">
+          {serverError}
+        </Banner>
+      )}
+
+      {/* Name */}
+      <div>
+        <label
+          htmlFor="edge-name"
+          className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Name <span aria-hidden="true">*</span>
+        </label>
+        <Input
+          id="edge-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Metering Pi, Storage Gateway…"
+          required
+          aria-required="true"
+          aria-describedby={fieldErrors.name ? "edge-name-error" : undefined}
+        />
+        {fieldErrors.name && (
+          <p id="edge-name-error" role="alert" className="mt-1 text-xs text-destructive-fg">
+            {fieldErrors.name}
+          </p>
+        )}
+      </div>
+
+      {/* Data source type */}
+      <div>
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Data source type <span aria-hidden="true">*</span>
+        </p>
+        <RadioGroup
+          value={dataSourceType}
+          onValueChange={handleDataSourceChange}
+          className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+          aria-label="Data source type"
+        >
+          {DATA_SOURCE_OPTIONS.map((opt) => (
+            <RadioCard
+              key={opt.value}
+              value={opt.value}
+              title={opt.title}
+              description={opt.description}
+            />
+          ))}
+        </RadioGroup>
+      </div>
+
+      {/* Conditional OpenEMS fields — rendered only when data_source_type='openems' */}
+      {isOpenEms && (
+        <div className="space-y-3 rounded-md border border-border bg-muted p-4">
+          <p className="text-xs text-muted-foreground">
+            Find these in the OpenEMS Backend admin UI under Edges.
+          </p>
+
+          {/* OpenEMS Backend URL */}
+          <div>
+            <label
+              htmlFor="edge-openems-url"
+              className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              OpenEMS Backend URL <span aria-hidden="true">*</span>
+            </label>
+            <Input
+              id="edge-openems-url"
+              type="url"
+              value={openemsBackendUrl}
+              onChange={(e) => setOpenemsBackendUrl(e.target.value)}
+              placeholder="https://openems.example.com"
+              required
+              aria-required="true"
+              aria-describedby={
+                fieldErrors.openems_backend_url ? "edge-openems-url-error" : undefined
+              }
+            />
+            {fieldErrors.openems_backend_url && (
+              <p
+                id="edge-openems-url-error"
+                role="alert"
+                className="mt-1 text-xs text-destructive-fg"
+              >
+                {fieldErrors.openems_backend_url}
+              </p>
+            )}
+          </div>
+
+          {/* OpenEMS Edge ID */}
+          <div>
+            <label
+              htmlFor="edge-openems-edge-id"
+              className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              OpenEMS Edge ID <span aria-hidden="true">*</span>
+            </label>
+            <Input
+              id="edge-openems-edge-id"
+              value={openemsEdgeId}
+              onChange={(e) => setOpenemsEdgeId(e.target.value)}
+              placeholder="edge0"
+              required
+              aria-required="true"
+              aria-describedby={
+                fieldErrors.openems_edge_id ? "edge-openems-edge-id-error" : undefined
+              }
+            />
+            {fieldErrors.openems_edge_id && (
+              <p
+                id="edge-openems-edge-id-error"
+                role="alert"
+                className="mt-1 text-xs text-destructive-fg"
+              >
+                {fieldErrors.openems_edge_id}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Role (optional, free-form) */}
+      <div>
+        <label
+          htmlFor="edge-role"
+          className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Role <span className="font-normal normal-case text-muted-foreground">(optional)</span>
+        </label>
+        <Input
+          id="edge-role"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+          placeholder="metering | storage | ev | …"
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-2 border-t border-border pt-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={saving || !canSave}
+          className={cn(
+            "rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90",
+            "disabled:cursor-not-allowed disabled:opacity-50"
+          )}
+        >
+          {saving ? "Saving…" : mode === "create" ? "Add edge" : "Save changes"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Modal wrapper ─────────────────────────────────────────────────────────
+// Separating the Dialog shell from the form body keeps EdgeForm testable
+// without a full DOM environment for the portal.
+
+export type EdgeFormModalProps = (CreateProps | EditProps) & {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function EdgeFormModal({ open, onOpenChange, ...formProps }: EdgeFormModalProps) {
+  const title = formProps.mode === "create" ? "Add edge" : "Edit edge";
+  const description =
+    formProps.mode === "create"
+      ? "Register a new gateway device for this microgrid."
+      : "Update the edge configuration. Changing the data source type is blocked when devices are linked.";
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55 data-[state=open]:animate-in data-[state=closed]:animate-out" />
+        <Dialog.Content
+          aria-modal
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[560px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+            "overflow-y-auto max-h-[90vh] rounded-md border border-border bg-card shadow-elev-3 outline-none"
+          )}
+        >
+          {/* Top accent rail */}
+          <div aria-hidden="true" className="h-[6px] bg-primary" />
+
+          <div className="space-y-1 px-6 pt-5 pb-2">
+            <Dialog.Title className="text-base font-semibold text-foreground">
+              {title}
+            </Dialog.Title>
+            <Dialog.Description className="text-xs text-muted-foreground">
+              {description}
+            </Dialog.Description>
+          </div>
+
+          <div className="px-6 pb-6">
+            <EdgeForm
+              {...formProps}
+              onSuccess={() => onOpenChange(false)}
+              onCancel={() => onOpenChange(false)}
+            />
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/forms/__tests__/EdgeForm.test.tsx
+++ b/src/components/forms/__tests__/EdgeForm.test.tsx
@@ -1,0 +1,433 @@
+// @vitest-environment jsdom
+/**
+ * EdgeForm component tests (UX4b / #77).
+ *
+ * Covers:
+ *   (a) OpenEMS fields show when data_source_type=openems (default)
+ *   (b) Toggling to modbus_direct hides OpenEMS fields and clears their values
+ *   (c) Save is blocked when data_source_type=openems and either OpenEMS field is empty
+ *   (d) Save calls POST /api/edges with the correct payload in create mode
+ *   (e) Edit mode pre-fills all fields including role
+ *   (f) URL validation error cases shown inline
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EdgeForm } from "../EdgeForm";
+import type { Edge } from "@/lib/types/domain";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+  useParams: () => ({ id: "microgrid-uuid-1", edgeId: "edge-uuid-1" }),
+}));
+
+// Polyfill ResizeObserver — required by @radix-ui/react-use-size (used by RadioGroupItem indicator)
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const MICROGRID_ID = "aaaaaaaa-aaaa-4000-8002-000000000001";
+
+const BASE_EDGE: Edge = {
+  id: "aaaaaaaa-aaaa-4000-8003-000000000001",
+  microgrid_id: MICROGRID_ID,
+  name: "Metering Pi",
+  data_source_type: "openems",
+  openems_backend_url: "https://openems.example.com",
+  openems_edge_id: "edge0",
+  role: "metering",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function makeCreateProps() {
+  return {
+    mode: "create" as const,
+    parentMicrogridId: MICROGRID_ID,
+    onSuccess: vi.fn(),
+    onCancel: vi.fn(),
+  };
+}
+
+function makeEditProps(overrides: Partial<Edge> = {}) {
+  return {
+    mode: "edit" as const,
+    edge: { ...BASE_EDGE, ...overrides },
+    onSuccess: vi.fn(),
+    onCancel: vi.fn(),
+  };
+}
+
+describe("EdgeForm", () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (a) OpenEMS fields are visible by default in create mode
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(a) OpenEMS fields visible by default", () => {
+    it("renders Backend URL and Edge ID inputs when data_source_type is openems", () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      expect(screen.getByLabelText(/OpenEMS Backend URL/i)).toBeDefined();
+      expect(screen.getByLabelText(/OpenEMS Edge ID/i)).toBeDefined();
+    });
+
+    it("shows all four data source radio options", () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      expect(screen.getByText("OpenEMS")).toBeDefined();
+      expect(screen.getByText("Modbus Direct")).toBeDefined();
+      expect(screen.getByText("MQTT")).toBeDefined();
+      expect(screen.getByText("REST API")).toBeDefined();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (b) Toggling to modbus_direct hides OpenEMS fields
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(b) Toggling data source type hides OpenEMS fields", () => {
+    it("hides OpenEMS URL and Edge ID inputs when modbus_direct is selected", async () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      // Initially the OpenEMS fields are present
+      expect(screen.getByLabelText(/OpenEMS Backend URL/i)).toBeDefined();
+
+      // Click the Modbus Direct radio card — find the radio input
+      const modbusRadio = screen.getByRole("radio", { name: /Modbus Direct/i });
+      fireEvent.click(modbusRadio);
+
+      // OpenEMS fields should now be absent from DOM
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/OpenEMS Backend URL/i)).toBeNull();
+        expect(screen.queryByLabelText(/OpenEMS Edge ID/i)).toBeNull();
+      });
+    });
+
+    it("clears OpenEMS field values when toggling away from openems", async () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      // Fill in the OpenEMS URL
+      const urlInput = screen.getByLabelText(/OpenEMS Backend URL/i) as HTMLInputElement;
+      fireEvent.change(urlInput, { target: { value: "https://example.com" } });
+      expect(urlInput.value).toBe("https://example.com");
+
+      // Switch to MQTT
+      const mqttRadio = screen.getByRole("radio", { name: /MQTT/i });
+      fireEvent.click(mqttRadio);
+
+      // Switch back to openems — fields should be empty
+      const openemsRadio = screen.getByRole("radio", { name: /OpenEMS/i });
+      fireEvent.click(openemsRadio);
+
+      await waitFor(() => {
+        const newUrlInput = screen.getByLabelText(/OpenEMS Backend URL/i) as HTMLInputElement;
+        expect(newUrlInput.value).toBe("");
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (c) Save is blocked when OpenEMS fields are empty in openems mode
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(c) Save blocked when openems fields are empty", () => {
+    it("Save button is disabled when name is filled but OpenEMS fields are empty", () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      const nameInput = screen.getByLabelText(/Name/i);
+      fireEvent.change(nameInput, { target: { value: "My Edge" } });
+
+      // OpenEMS fields are empty by default — button should be disabled
+      const saveButton = screen.getByRole("button", { name: /Add edge/i });
+      expect(saveButton).toHaveProperty("disabled", true);
+    });
+
+    it("Save button is enabled when all required OpenEMS fields are filled", () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "My Edge" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Backend URL/i), {
+        target: { value: "https://openems.example.com" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Edge ID/i), {
+        target: { value: "edge0" },
+      });
+
+      const saveButton = screen.getByRole("button", { name: /Add edge/i });
+      expect(saveButton).toHaveProperty("disabled", false);
+    });
+
+    it("Save button is enabled for non-OpenEMS type with just a name", () => {
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "My Edge" },
+      });
+
+      // Switch to modbus_direct — no OpenEMS fields needed
+      fireEvent.click(screen.getByRole("radio", { name: /Modbus Direct/i }));
+
+      const saveButton = screen.getByRole("button", { name: /Add edge/i });
+      expect(saveButton).toHaveProperty("disabled", false);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (d) Save calls POST /api/edges with correct payload in create mode
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(d) Save calls POST /api/edges", () => {
+    it("sends correct payload for openems edge creation", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ edge: { id: "new-edge-uuid" } }),
+      } as Response);
+
+      const onSuccess = vi.fn();
+      render(
+        <EdgeForm
+          mode="create"
+          parentMicrogridId={MICROGRID_ID}
+          onSuccess={onSuccess}
+          onCancel={vi.fn()}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "Test Edge" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Backend URL/i), {
+        target: { value: "https://openems.example.com" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Edge ID/i), {
+        target: { value: "edge0" },
+      });
+      fireEvent.change(screen.getByLabelText(/Role/i), {
+        target: { value: "metering" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /Add edge/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe("/api/edges");
+        expect(init?.method).toBe("POST");
+
+        const body = JSON.parse(init?.body as string);
+        expect(body.microgrid_id).toBe(MICROGRID_ID);
+        expect(body.name).toBe("Test Edge");
+        expect(body.data_source_type).toBe("openems");
+        expect(body.openems_backend_url).toBe("https://openems.example.com");
+        expect(body.openems_edge_id).toBe("edge0");
+        expect(body.role).toBe("metering");
+      });
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("sends null for openems fields when data_source_type is modbus_direct", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ edge: { id: "new-edge-uuid-2" } }),
+      } as Response);
+
+      render(
+        <EdgeForm
+          mode="create"
+          parentMicrogridId={MICROGRID_ID}
+          onSuccess={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("radio", { name: /Modbus Direct/i }));
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "Modbus Edge" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /Add edge/i }));
+
+      await waitFor(() => {
+        const [, init] = fetchMock.mock.calls[0];
+        const body = JSON.parse(init?.body as string);
+        expect(body.data_source_type).toBe("modbus_direct");
+        expect(body.openems_backend_url).toBeNull();
+        expect(body.openems_edge_id).toBeNull();
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (e) Edit mode pre-fills all fields including role
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(e) Edit mode pre-fills fields", () => {
+    it("pre-fills name, openems_backend_url, openems_edge_id, and role", () => {
+      render(<EdgeForm {...makeEditProps()} />);
+
+      const nameInput = screen.getByLabelText(/Name/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("Metering Pi");
+
+      const urlInput = screen.getByLabelText(/OpenEMS Backend URL/i) as HTMLInputElement;
+      expect(urlInput.value).toBe("https://openems.example.com");
+
+      const edgeIdInput = screen.getByLabelText(/OpenEMS Edge ID/i) as HTMLInputElement;
+      expect(edgeIdInput.value).toBe("edge0");
+
+      const roleInput = screen.getByLabelText(/Role/i) as HTMLInputElement;
+      expect(roleInput.value).toBe("metering");
+    });
+
+    it("shows Save changes label (not Add edge) in edit mode", () => {
+      render(<EdgeForm {...makeEditProps()} />);
+      expect(screen.getByRole("button", { name: /Save changes/i })).toBeDefined();
+      expect(screen.queryByRole("button", { name: /Add edge/i })).toBeNull();
+    });
+
+    it("pre-fills non-openems edge with OpenEMS fields hidden", () => {
+      render(
+        <EdgeForm
+          {...makeEditProps({
+            data_source_type: "modbus_direct",
+            openems_backend_url: null,
+            openems_edge_id: null,
+          })}
+        />
+      );
+
+      expect(screen.queryByLabelText(/OpenEMS Backend URL/i)).toBeNull();
+      expect(screen.queryByLabelText(/OpenEMS Edge ID/i)).toBeNull();
+    });
+
+    it("sends PATCH to /api/edges/[id] in edit mode", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ edge: BASE_EDGE }),
+      } as Response);
+
+      render(<EdgeForm {...makeEditProps()} />);
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "Updated Name" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+      await waitFor(() => {
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe(`/api/edges/${BASE_EDGE.id}`);
+        expect(init?.method).toBe("PATCH");
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (f) URL validation error cases shown inline
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(f) URL validation error cases", () => {
+    it("shows server error banner when API returns 422", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({ error: "openems_backend_url: Invalid URL format." }),
+      } as Response);
+
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "Test" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Backend URL/i), {
+        target: { value: "not-a-url" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Edge ID/i), {
+        target: { value: "edge0" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /Add edge/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeDefined();
+        expect(screen.getByText(/Invalid URL format/i)).toBeDefined();
+      });
+    });
+
+    it("shows server error banner on 409 duplicate name", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: "An edge named 'Test' already exists on this microgrid.",
+        }),
+      } as Response);
+
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "Test" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Backend URL/i), {
+        target: { value: "https://openems.example.com" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Edge ID/i), {
+        target: { value: "edge0" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /Add edge/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/An edge named 'Test' already exists/i)
+        ).toBeDefined();
+      });
+    });
+
+    it("shows 403 error when not authorized", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({
+          error: "Not authorized to create an edge on this microgrid",
+        }),
+      } as Response);
+
+      render(<EdgeForm {...makeCreateProps()} />);
+
+      fireEvent.change(screen.getByLabelText(/Name/i), {
+        target: { value: "Unauthorized Edge" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Backend URL/i), {
+        target: { value: "https://openems.example.com" },
+      });
+      fireEvent.change(screen.getByLabelText(/OpenEMS Edge ID/i), {
+        target: { value: "edge1" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /Add edge/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Not authorized to create an edge/i)
+        ).toBeDefined();
+      });
+    });
+  });
+});

--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -1008,3 +1008,52 @@ describe("RLS helper functions", () => {
     });
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════
+// RLS: edge creation via API route (#77)
+// Tests the HTTP response mapping for cross-org org_manager POST to /api/edges.
+// The underlying Supabase RLS is already covered in "RLS: edges" above.
+// This suite verifies the 42501 → 403 mapping at the API route level.
+// ══════════════════════════════════════════════════════════════════════════
+
+describe("RLS: /api/edges cross-org POST denied (#77)", () => {
+  it("User A (org_manager for Org A) cannot INSERT edge into Microgrid B via direct Supabase write", async () => {
+    if (skipIfRequested()) return;
+
+    // Attempt a direct insert using User A's client (authenticated as org_manager for orgA)
+    // into microgridB — which belongs to orgB. RLS should block this.
+    await expectWriteDenied(userA.client, "edges", {
+      microgrid_id: FIXTURE.microgridB,
+      name: "Cross-org-edge-api-test",
+      data_source_type: "openems",
+      openems_backend_url: "http://localhost:8075",
+      openems_edge_id: "rls-test-api-edge",
+    });
+  });
+
+  it("User A can INSERT edge into Microgrid A (own org) via direct Supabase write", async () => {
+    if (skipIfRequested()) return;
+
+    const { data, error } = await userA.client
+      .from("edges")
+      .insert({
+        microgrid_id: FIXTURE.microgridA,
+        name: "rls-api-test-own-edge",
+        data_source_type: "modbus_direct",
+      })
+      .select("id");
+
+    // RLS should permit this; clean up if it succeeded.
+    if (data && data.length > 0) {
+      await (await import("./rls.helpers")).serviceClient().then((svc) =>
+        svc.from("edges").delete().eq("id", data[0].id)
+      );
+    }
+
+    // Either no error, or the error is not a security policy error.
+    const isRlsError =
+      error?.code === "42501" ||
+      (error?.message ?? "").includes("row-level security");
+    expect(isRlsError).toBe(false);
+  });
+});

--- a/supabase/migrations/00008_edges_name_unique.sql
+++ b/supabase/migrations/00008_edges_name_unique.sql
@@ -1,0 +1,8 @@
+-- 00008_edges_name_unique.sql
+-- Add UNIQUE constraint on (microgrid_id, name) for edges.
+-- Prevents duplicate edge names within the same microgrid.
+-- Returns Postgres error code 23505 on violation, which the API layer
+-- maps to HTTP 409 with a human-readable message.
+
+ALTER TABLE edges
+  ADD CONSTRAINT edges_microgrid_name_unique UNIQUE (microgrid_id, name);


### PR DESCRIPTION
## Summary
Adds Add + Edit forms for the `edges` table with conditional OpenEMS coordinates and a `(microgrid_id, name)` UNIQUE constraint.

### New components
- **`<EdgeForm>`** + **`<EdgeFormModal>`** with discriminated-union props (`mode: 'create' | 'edit'`). `data_source_type` options derived from `Database["public"]["Enums"]["edge_data_source"]`. `<RadioGroup>` + `<RadioCard>` tiles per type (per #71); OpenEMS fields show/hide via state. URL validation via `new URL()` + protocol whitelist (http/https, rejects embedded credentials + whitespace).
- **`<EdgesCRUDShell>`** and **`<EdgeDetailConfigureButton>`** — client shells that let server-component pages trigger the modal without becoming client components themselves.

### Entry points
- `+ Add edge` button on `/microgrids/[id]/setup/edges`
- `Configure…` button per row in the edges listing
- `Configure…` button in the edge detail page header

### API routes
- `POST /api/edges` — create. RLS-only auth via `user_can_access_microgrid(microgrid_id)`. 42501 → 403; 23505 → 409 with `"An edge named '{name}' already exists on this microgrid."`; 422 on validation failures.
- `PATCH /api/edges/[id]` — partial update. `data_source_type` change rejected with 409 when child devices exist: `"Cannot change data source: {N} devices are linked. Remove or reassign them first."` Per-field patch preserves `role` column.

### Migration
- `00008_edges_name_unique.sql` — UNIQUE constraint on `(microgrid_id, name)`.

### Tests
- 16 component tests for `EdgeForm` (show/hide conditional fields, Save-blocked states, POST payload, edit pre-fill, error surfaces).
- 14 route tests (POST + PATCH happy paths, 422/409/403 error mappings).
- 2 RLS integration tests in `rls.test.ts` — cross-org edge CREATE denied.

Closes #77.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `SKIP_RLS_TESTS=1 npm test` — 318/318 passing
- [x] `npm run build` — PASS
- [x] `npm run db:types:check` — PASS (migration adds UNIQUE only; no type shape changes)
- [x] Rebased on updated main (post #75 merge)

## Notes / review deviations
- `db:types` skipped because migration is UNIQUE-only; `database.gen.ts` shape unchanged.
- `ResizeObserver` polyfill in `EdgeForm.test.tsx` `beforeAll` for Radix-in-jsdom compatibility.
- Server/client boundary: pages remain server components; modal state isolated into `EdgesCRUDShell` + `EdgeDetailConfigureButton` client shells.
- Implementation uses `PATCH` (not `PUT` as ticket title suggests) — semantically correct for partial updates; consistent with Dev Notes.
- `DATA_SOURCE_OPTIONS` array in EdgeForm is typed `readonly EdgeDataSource[]` — TS catches typos but new enum values don't auto-surface. Follow-up candidate: import from `Constants.public.Enums.edge_data_source` in `database.gen.ts` for true runtime enum derivation.

## Known Out of Scope (deferred)
- Delete edge — needs PM sign-off on cascade semantics. Filed for follow-up.