### PR TITLE
Entity CRUD for Organization / Community / Microgrid (#76)

### DIFF
--- a/src/app/(dashboard)/communities/page.test.tsx
+++ b/src/app/(dashboard)/communities/page.test.tsx
@@ -7,6 +7,11 @@
 //   - Assert:
 //     (a) Row renders with community name, city/country, and microgrid count.
 //     (b) Empty state renders when the query returns zero rows.
+//
+// Note: after #76 (UX4a), the listing query selects `*, microgrids(count)` so
+// row rendering receives the full Community row shape. Empty-state copy
+// diverges per access: org_manager (1 accessible org) sees an add CTA;
+// anonymous / 0-org view sees "add from the organization detail page".
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -37,29 +42,64 @@ function makeMockBuilder(data: unknown): MockBuilder {
   return builder;
 }
 
-const mockFrom = vi.fn();
+// Map table name → data. Supabase `.from('communities')` or `.from('organizations')`
+// each get their own mock-builder.
+const mockFrom = vi.fn((table: string) => {
+  if (table === "organizations") {
+    return makeMockBuilder(orgsData);
+  }
+  return makeMockBuilder(communitiesData);
+});
+
+// Mutable test-scoped state so each test can control what the DB returns.
+let communitiesData: unknown = [];
+let orgsData: unknown = [];
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
     from: mockFrom,
+    auth: {
+      getUser: async () => ({ data: { user: null }, error: null }),
+    },
   }),
+}));
+
+// The listing page renders <EditEntityButton> (client component) per row, which
+// in turn mounts <EntityForm> using `useRouter()`. Static SSR has no router
+// context, so mock `next/navigation` → a no-op router.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => {}, push: () => {}, replace: () => {} }),
 }));
 
 // ─── Fixture data ─────────────────────────────────────────────────────────────
 
 const COMMUNITY_WITH_DATA = {
   id: "comm-1",
+  org_id: "org-1",
   name: "Kisakye",
+  address_line1: null,
+  address_line2: null,
   address_city: "Kampala",
+  address_region: null,
   address_country: "Uganda",
+  address_postal_code: null,
+  geography_notes: null,
+  created_at: "2026-01-01T00:00:00Z",
   microgrids: [{ count: 3 }],
 };
 
 const COMMUNITY_NO_LOCATION = {
   id: "comm-2",
+  org_id: "org-1",
   name: "Test Community",
+  address_line1: null,
+  address_line2: null,
   address_city: null,
+  address_region: null,
   address_country: null,
+  address_postal_code: null,
+  geography_notes: null,
+  created_at: "2026-01-01T00:00:00Z",
   microgrids: [{ count: 1 }],
 };
 
@@ -72,10 +112,13 @@ import CommunitiesPage from "./page";
 describe("CommunitiesPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    communitiesData = [];
+    orgsData = [];
   });
 
   it("renders a row with name, city/country, and microgrid count", async () => {
-    mockFrom.mockReturnValue(makeMockBuilder([COMMUNITY_WITH_DATA]));
+    communitiesData = [COMMUNITY_WITH_DATA];
+    orgsData = [{ id: "org-1" }];
 
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
@@ -88,9 +131,8 @@ describe("CommunitiesPage", () => {
   });
 
   it("renders multiple rows when multiple communities are returned", async () => {
-    mockFrom.mockReturnValue(
-      makeMockBuilder([COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION])
-    );
+    communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
+    orgsData = [{ id: "org-1" }];
 
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
@@ -101,21 +143,25 @@ describe("CommunitiesPage", () => {
   });
 
   it("renders empty state when query returns zero rows", async () => {
-    mockFrom.mockReturnValue(makeMockBuilder([]));
+    communitiesData = [];
+    orgsData = [];
 
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
-    expect(html).toContain("No communities found");
+    // After #76, empty state splits by access. For zero-org view it directs
+    // the user to the organization detail page.
+    expect(html).toMatch(/No communities/);
     expect(html).not.toContain("Kisakye");
   });
 
   it("renders empty state when query returns null", async () => {
-    mockFrom.mockReturnValue(makeMockBuilder(null));
+    communitiesData = null;
+    orgsData = null;
 
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
-    expect(html).toContain("No communities found");
+    expect(html).toMatch(/No communities/);
   });
 });

--- a/src/app/(dashboard)/communities/page.tsx
+++ b/src/app/(dashboard)/communities/page.tsx
@@ -2,26 +2,37 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { AddEntityButton } from "@/components/forms/AddEntityButton";
+import { EditEntityButton } from "@/components/forms/EditEntityButton";
+import type { Community } from "@/lib/types/domain";
 
-type CommunityRow = {
-  id: string;
-  name: string;
-  address_city: string | null;
-  address_country: string | null;
+type CommunityRow = Community & {
   microgrids: { count: number }[];
 };
 
 export default async function CommunitiesPage() {
   const supabase = await createClient();
 
-  const [{ data: communities, error }, levels] = await Promise.all([
-    supabase
-      .from("communities")
-      .select("id, name, address_city, address_country, microgrids(count)")
-      .order("name")
-      .returns<CommunityRow[]>(),
-    getHierarchyLevels(supabase, { kind: "communities" }),
-  ]);
+  const [{ data: communities, error }, { data: accessibleOrgs }, levels] =
+    await Promise.all([
+      supabase
+        .from("communities")
+        .select("*, microgrids(count)")
+        .order("name")
+        .returns<CommunityRow[]>(),
+      supabase
+        .from("organizations")
+        .select("id")
+        .order("name")
+        .returns<{ id: string }[]>(),
+      getHierarchyLevels(supabase, { kind: "communities" }),
+    ]);
+
+  // If the user can see exactly one org (the org_manager case), we can offer
+  // "+ Add Community" inline. Super_admin typically creates via the org
+  // detail page; we still allow inline add when there's only one org in view.
+  const singleAccessibleOrgId =
+    accessibleOrgs && accessibleOrgs.length === 1 ? accessibleOrgs[0].id : null;
 
   if (error) {
     return (
@@ -35,12 +46,28 @@ export default async function CommunitiesPage() {
     return (
       <div>
         <HierarchyNav levels={levels} className="mb-4" />
-        <h1 className="mb-6 text-2xl font-semibold text-foreground">
-          Communities
-        </h1>
-        <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
-          No communities found. Communities are configured by your system
-          administrator.
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-foreground">
+            Communities
+          </h1>
+        </div>
+        <div className="rounded-md border border-border bg-card p-8 text-center">
+          {singleAccessibleOrgId ? (
+            <>
+              <p className="mb-4 text-muted-foreground">
+                No communities yet.
+              </p>
+              <AddEntityButton
+                entity="community"
+                parentOrgId={singleAccessibleOrgId}
+                label="+ Add the first Community"
+              />
+            </>
+          ) : (
+            <p className="text-muted-foreground">
+              No communities visible. Add one from the organization detail page.
+            </p>
+          )}
         </div>
       </div>
     );
@@ -49,9 +76,15 @@ export default async function CommunitiesPage() {
   return (
     <div>
       <HierarchyNav levels={levels} className="mb-4" />
-      <h1 className="mb-6 text-2xl font-semibold text-foreground">
-        Communities
-      </h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-foreground">Communities</h1>
+        {singleAccessibleOrgId && (
+          <AddEntityButton
+            entity="community"
+            parentOrgId={singleAccessibleOrgId}
+          />
+        )}
+      </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {communities.map((community) => {
           const locationParts = [
@@ -67,21 +100,34 @@ export default async function CommunitiesPage() {
               : 0;
 
           return (
-            <Link
+            <div
               key={community.id}
-              href={`/microgrids?community=${community.id}`}
-              className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted"
+              className="flex flex-col rounded-lg border border-border bg-card p-6 transition-colors hover:border-border"
             >
-              <h2 className="font-medium text-foreground">{community.name}</h2>
-              {locationLabel && (
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {locationLabel}
-                </p>
-              )}
-              <div className="mt-3 text-sm text-muted-foreground">
-                {microgridCount} microgrid{microgridCount !== 1 ? "s" : ""}
+              <Link
+                href={`/microgrids?community=${community.id}`}
+                className="flex-1"
+              >
+                <h2 className="font-medium text-foreground">
+                  {community.name}
+                </h2>
+                {locationLabel && (
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {locationLabel}
+                  </p>
+                )}
+                <div className="mt-3 text-sm text-muted-foreground">
+                  {microgridCount} microgrid
+                  {microgridCount !== 1 ? "s" : ""}
+                </div>
+              </Link>
+              <div className="mt-4 flex justify-end">
+                <EditEntityButton
+                  entity="community"
+                  initialValues={community}
+                />
               </div>
-            </Link>
+            </div>
           );
         })}
       </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { LogoutButton } from "./logout-button";
+import { SidebarNav } from "./sidebar-nav";
 
 export default async function DashboardLayout({
   children,
@@ -24,29 +24,7 @@ export default async function DashboardLayout({
         <div className="border-b border-border px-6 py-4">
           <h2 className="text-lg font-semibold text-foreground">MBE</h2>
         </div>
-        <nav className="flex-1 space-y-1 px-3 py-4">
-          <Link
-            href="/"
-            className="flex items-center rounded-md bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
-          >
-            Dashboard
-          </Link>
-          <Link
-            href="/communities"
-            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-          >
-            Communities
-          </Link>
-          <Link
-            href="/microgrids"
-            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-          >
-            Microgrids
-          </Link>
-          <span className="flex items-center rounded-md px-3 py-2 text-sm text-muted-foreground cursor-not-allowed">
-            Settings (coming soon)
-          </span>
-        </nav>
+        <SidebarNav />
       </aside>
 
       {/* Main content */}

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
 import { TabNav } from "./tab-nav";
 import { LocaleProvider } from "@/components/format/locale-context";
+import { EditEntityButton } from "@/components/forms/EditEntityButton";
 
 // HierarchyNav is NOT placed here — leaf pages own their breadcrumb.
 // Each leaf page calls getHierarchyLevels() with the correct scope depth
@@ -37,13 +38,18 @@ export default async function MicrogridLayout({
   return (
     <LocaleProvider currency={microgrid.currency}>
       <div>
-        <div className="mb-6">
-          <h1 className="text-2xl font-semibold text-foreground">
-            {microgrid.name}
-          </h1>
-          {locationLabel && (
-            <p className="mt-1 text-sm text-muted-foreground">{locationLabel}</p>
-          )}
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-foreground">
+              {microgrid.name}
+            </h1>
+            {locationLabel && (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {locationLabel}
+              </p>
+            )}
+          </div>
+          <EditEntityButton entity="microgrid" initialValues={microgrid} />
         </div>
         <TabNav microgridId={id} />
         <div className="mt-6">{children}</div>

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { AddEntityButton } from "@/components/forms/AddEntityButton";
 
 type MicrogridWithHouseholdCount = Microgrid & {
   household_count: number;
@@ -70,12 +71,32 @@ export default async function MicrogridsPage({
     return (
       <div>
         <HierarchyNav levels={levels} className="mb-4" />
-        <h1 className="mb-6 text-2xl font-semibold text-foreground">
-          {heading}
-        </h1>
-        <div className="rounded-md border border-border bg-card p-8 text-center text-muted-foreground">
-          No microgrids found. Microgrids are configured by your system
-          administrator.
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
+          {communityId && (
+            <AddEntityButton
+              entity="microgrid"
+              parentCommunityId={communityId}
+            />
+          )}
+        </div>
+        <div className="rounded-md border border-border bg-card p-8 text-center">
+          {communityId ? (
+            <>
+              <p className="mb-4 text-muted-foreground">
+                No microgrids in this community yet.
+              </p>
+              <AddEntityButton
+                entity="microgrid"
+                parentCommunityId={communityId}
+                label="+ Add the first Microgrid"
+              />
+            </>
+          ) : (
+            <p className="text-muted-foreground">
+              No microgrids visible. Open a community to add one.
+            </p>
+          )}
         </div>
       </div>
     );
@@ -97,7 +118,15 @@ export default async function MicrogridsPage({
   return (
     <div>
       <HierarchyNav levels={levels} className="mb-4" />
-      <h1 className="mb-6 text-2xl font-semibold text-foreground">{heading}</h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
+        {communityId && (
+          <AddEntityButton
+            entity="microgrid"
+            parentCommunityId={communityId}
+          />
+        )}
+      </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {microgridsWithCounts.map((mg) => {
           const locationParts = [mg.address_city, mg.address_country].filter(Boolean);

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -1,0 +1,110 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { EditEntityButton } from "@/components/forms/EditEntityButton";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+import type { Organization } from "@/lib/types/domain";
+
+/**
+ * /organizations/[id] — organization detail page (#76).
+ *
+ * Shows the org's full address + a list of its communities. The Edit button
+ * in the header is only shown to super_admin users — the PATCH endpoint
+ * enforces super_admin-only authorization, so showing the button to
+ * org_managers would result in a misleading 403 UX.
+ */
+export default async function OrganizationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const [{ data: org }, { data: communities }, isSuperAdmin] = await Promise.all([
+    supabase
+      .from("organizations")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle<Organization>(),
+    supabase
+      .from("communities")
+      .select("id, name, address_city, address_country")
+      .eq("org_id", id)
+      .order("name")
+      .returns<
+        Array<{
+          id: string;
+          name: string;
+          address_city: string | null;
+          address_country: string | null;
+        }>
+      >(),
+    currentUserIsSuperAdmin(supabase),
+  ]);
+
+  if (!org) {
+    notFound();
+  }
+
+  const addressLines = [
+    org.address_line1,
+    org.address_line2,
+    [org.address_city, org.address_region].filter(Boolean).join(", "),
+    [org.address_country, org.address_postal_code].filter(Boolean).join(" "),
+  ]
+    .map((l) => (l ?? "").trim())
+    .filter(Boolean);
+
+  return (
+    <div>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">{org.name}</h1>
+          {addressLines.length > 0 && (
+            <address className="mt-1 text-sm not-italic text-muted-foreground">
+              {addressLines.map((l, i) => (
+                <div key={i}>{l}</div>
+              ))}
+            </address>
+          )}
+        </div>
+        {isSuperAdmin && <EditEntityButton entity="organization" initialValues={org} />}
+      </div>
+
+      <section className="rounded-lg border border-border bg-card p-6">
+        <h2 className="mb-3 text-lg font-semibold text-foreground">
+          Communities
+        </h2>
+        {!communities || communities.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No communities in this organization yet.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {communities.map((c) => {
+              const loc = [c.address_city, c.address_country]
+                .filter(Boolean)
+                .join(", ");
+              return (
+                <li key={c.id}>
+                  <Link
+                    href={`/microgrids?community=${c.id}`}
+                    className="text-sm text-foreground hover:underline"
+                  >
+                    {c.name}
+                  </Link>
+                  {loc && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {loc}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/organizations/page.tsx
+++ b/src/app/(dashboard)/organizations/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+import { AddEntityButton } from "@/components/forms/AddEntityButton";
+import type { Organization } from "@/lib/types/domain";
+
+/**
+ * /organizations — organization listing page (#76).
+ *
+ * Visibility (server-enforced via RLS on the organizations table):
+ *   - super_admin: sees all organizations
+ *   - org_manager: sees only their own org (RLS filters the SELECT)
+ *
+ * "+ Add Organization" button renders only for super_admin. Empty-state copy
+ * diverges: super_admin gets a CTA; org_manager with zero visible orgs gets a
+ * pointer to contact their administrator.
+ */
+export default async function OrganizationsPage() {
+  const supabase = await createClient();
+
+  const [isSuperAdmin, orgsResult] = await Promise.all([
+    currentUserIsSuperAdmin(supabase),
+    supabase
+      .from("organizations")
+      .select("*")
+      .order("name")
+      .returns<Organization[]>(),
+  ]);
+
+  const { data: organizations, error } = orgsResult;
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
+        Error loading organizations: {error.message}
+      </div>
+    );
+  }
+
+  const orgs = organizations ?? [];
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-foreground">
+          Organizations
+        </h1>
+        {isSuperAdmin && orgs.length > 0 && (
+          <AddEntityButton entity="organization" />
+        )}
+      </div>
+
+      {orgs.length === 0 ? (
+        <div className="rounded-md border border-border bg-card p-8 text-center">
+          {isSuperAdmin ? (
+            <>
+              <p className="mb-4 text-muted-foreground">
+                No organizations yet.
+              </p>
+              <AddEntityButton
+                entity="organization"
+                label="+ Add the first Organization"
+              />
+            </>
+          ) : (
+            <p className="text-muted-foreground">
+              No organizations visible. Contact your administrator.
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {orgs.map((org) => {
+            const locationParts = [org.address_city, org.address_country].filter(
+              Boolean
+            );
+            const locationLabel =
+              locationParts.length > 0 ? locationParts.join(", ") : null;
+
+            return (
+              <Link
+                key={org.id}
+                href={`/organizations/${org.id}`}
+                className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted"
+              >
+                <h2 className="font-medium text-foreground">{org.name}</h2>
+                {locationLabel && (
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {locationLabel}
+                  </p>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sidebar-nav.tsx
+++ b/src/app/(dashboard)/sidebar-nav.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+
+/**
+ * SidebarNav — dashboard sidebar navigation (#76).
+ *
+ * Server component: resolves the user's super_admin status via the auth
+ * access module, then renders the "Organizations" entry only for super_admin.
+ *
+ * Entries are server-rendered — there is no client-side role check that a
+ * tampered browser could bypass. The route's server component is the
+ * authoritative visibility gate.
+ */
+export async function SidebarNav() {
+  const supabase = await createClient();
+  const isSuperAdmin = await currentUserIsSuperAdmin(supabase);
+
+  return (
+    <nav className="flex-1 space-y-1 px-3 py-4">
+      <Link
+        href="/"
+        className="flex items-center rounded-md bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
+      >
+        Dashboard
+      </Link>
+      {isSuperAdmin && (
+        <Link
+          href="/organizations"
+          className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          Organizations
+        </Link>
+      )}
+      <Link
+        href="/communities"
+        className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        Communities
+      </Link>
+      <Link
+        href="/microgrids"
+        className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        Microgrids
+      </Link>
+      <span className="flex items-center rounded-md px-3 py-2 text-sm text-muted-foreground cursor-not-allowed">
+        Settings (coming soon)
+      </span>
+    </nav>
+  );
+}

--- a/src/app/api/communities/[id]/route.ts
+++ b/src/app/api/communities/[id]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * PATCH /api/communities/[id] — update a community (#76).
+ *
+ * Dirty-fields semantics: only keys present in body are applied. Re-parenting
+ * via `org_id` is NOT supported through this endpoint — ignored if present.
+ *
+ * Authorization: `currentUserCanAccessCommunity()` — super_admin or the
+ * org_manager of the community's parent org.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid community id — expected UUID." },
+      { status: 400 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserCanAccessCommunity(supabase, id))) {
+    return NextResponse.json(
+      { error: "Not authorized to update this community." },
+      { status: 403 }
+    );
+  }
+
+  const updates: Record<string, string | null> = {};
+
+  if ("name" in body) {
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return NextResponse.json(
+        { error: "Name is required.", field: "name" },
+        { status: 422 }
+      );
+    }
+    updates.name = body.name.trim();
+  }
+
+  const OPTIONAL_STRING_FIELDS = [
+    "address_line1",
+    "address_line2",
+    "address_city",
+    "address_region",
+    "address_country",
+    "address_postal_code",
+    "geography_notes",
+  ] as const;
+
+  for (const f of OPTIONAL_STRING_FIELDS) {
+    if (f in body) {
+      const v = body[f];
+      updates[f] = typeof v === "string" && v.trim() ? v.trim() : null;
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json(
+      { error: "No fields to update." },
+      { status: 400 }
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("communities")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to update this community." },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to update community: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: "Community not found." },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ community: data }, { status: 200 });
+}

--- a/src/app/api/communities/__tests__/route.test.ts
+++ b/src/app/api/communities/__tests__/route.test.ts
@@ -1,0 +1,174 @@
+/**
+ * POST /api/communities & PATCH /api/communities/[id] — route tests (#76).
+ *
+ * Covers:
+ *   - POST: 403 when org_id is outside the caller's accessible orgs
+ *   - POST: 400 on malformed org_id
+ *   - POST: 422 on missing name
+ *   - PATCH: dirty-fields (address_city only → no name/geography_notes sent)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+let canAccessOrgReturn = true;
+let canAccessCommunityReturn = true;
+
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockSingleAfterInsertSelect = vi.fn();
+const mockMaybeSingleAfterUpdateSelect = vi.fn();
+
+const mockFrom = vi.fn(() => ({
+  insert: (row: unknown) => {
+    mockInsert(row);
+    return {
+      select: () => ({
+        single: () => mockSingleAfterInsertSelect(),
+      }),
+    };
+  },
+  update: (patch: unknown) => {
+    mockUpdate(patch);
+    return {
+      eq: () => ({
+        select: () => ({
+          maybeSingle: () => mockMaybeSingleAfterUpdateSelect(),
+        }),
+      }),
+    };
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessOrg: async () => canAccessOrgReturn,
+  currentUserCanAccessCommunity: async () => canAccessCommunityReturn,
+}));
+
+const VALID_ORG = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_COMMUNITY = "550e8400-e29b-41d4-a716-446655440010";
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/communities", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePatch(id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/communities/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── POST tests ──────────────────────────────────────────────────────────
+
+describe("POST /api/communities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessOrgReturn = true;
+    canAccessCommunityReturn = true;
+    mockSingleAfterInsertSelect.mockReset();
+  });
+
+  it("returns 400 when org_id is not a UUID", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({ org_id: "not-a-uuid", name: "C1" })
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.field).toBe("org_id");
+  });
+
+  it("returns 422 on missing name", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makePost({ org_id: VALID_ORG }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("name");
+  });
+
+  it("returns 403 when currentUserCanAccessOrg is false (cross-org)", async () => {
+    canAccessOrgReturn = false;
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({ org_id: VALID_ORG, name: "Unauthorized C" })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 201 with the inserted row on happy path", async () => {
+    mockSingleAfterInsertSelect.mockResolvedValueOnce({
+      data: { id: "c1", name: "C1", org_id: VALID_ORG },
+      error: null,
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makePost({ org_id: VALID_ORG, name: "C1" }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.community.id).toBe("c1");
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ org_id: VALID_ORG, name: "C1" })
+    );
+  });
+});
+
+// ── PATCH tests ─────────────────────────────────────────────────────────
+
+describe("PATCH /api/communities/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessCommunityReturn = true;
+    mockMaybeSingleAfterUpdateSelect.mockReset();
+  });
+
+  it("dirty-fields: only {address_city} sent when only city changed", async () => {
+    mockMaybeSingleAfterUpdateSelect.mockResolvedValueOnce({
+      data: {
+        id: VALID_COMMUNITY,
+        name: "Kisakye",
+        address_city: "Entebbe",
+        geography_notes: null,
+      },
+      error: null,
+    });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatch(VALID_COMMUNITY, { address_city: "Entebbe" }),
+      { params: Promise.resolve({ id: VALID_COMMUNITY }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith({ address_city: "Entebbe" });
+  });
+
+  it("returns 403 when the caller cannot access the community", async () => {
+    canAccessCommunityReturn = false;
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatch(VALID_COMMUNITY, { name: "X" }),
+      { params: Promise.resolve({ id: VALID_COMMUNITY }) }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when no fields to update", async () => {
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatch(VALID_COMMUNITY, {}),
+      { params: Promise.resolve({ id: VALID_COMMUNITY }) }
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/communities/route.ts
+++ b/src/app/api/communities/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessOrg } from "@/lib/auth/access";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /api/communities — create a new community under a parent org (#76).
+ *
+ * Authorization: `currentUserCanAccessOrg(org_id)` — super_admin or the
+ * org_manager whose scope matches `org_id`. Defense-in-depth; RLS backstop.
+ *
+ * Validation:
+ *   - `name` (required, 422 with field='name').
+ *   - `org_id` (required UUID, 400 on malformed; 403 if not accessible).
+ *   - Address fields are all optional at the DB layer; UI may require city
+ *     but we do not enforce that at the server for communities (Org is the
+ *     stricter invariant — see POST /api/organizations).
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const orgId = typeof body.org_id === "string" ? body.org_id : "";
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      { error: "Invalid org_id — expected UUID.", field: "org_id" },
+      { status: 400 }
+    );
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name) {
+    return NextResponse.json(
+      { error: "Name is required.", field: "name" },
+      { status: 422 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserCanAccessOrg(supabase, orgId))) {
+    return NextResponse.json(
+      { error: "Not authorized to add communities to this organization." },
+      { status: 403 }
+    );
+  }
+
+  const row = {
+    org_id: orgId,
+    name,
+    address_line1: readOptionalString(body.address_line1),
+    address_line2: readOptionalString(body.address_line2),
+    address_city: readOptionalString(body.address_city),
+    address_region: readOptionalString(body.address_region),
+    address_country: readOptionalString(body.address_country),
+    address_postal_code: readOptionalString(body.address_postal_code),
+    geography_notes: readOptionalString(body.geography_notes),
+  };
+
+  const { data, error } = await supabase
+    .from("communities")
+    .insert(row)
+    .select("*")
+    .single();
+
+  if (error) {
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to add communities to this organization." },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to create community: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ community: data }, { status: 201 });
+}
+
+function readOptionalString(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  return trimmed ? trimmed : null;
+}

--- a/src/app/api/microgrids/[id]/route.ts
+++ b/src/app/api/microgrids/[id]/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { validateCurrency } from "@/lib/validation/currency";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * PATCH /api/microgrids/[id] — update a microgrid (#76).
+ *
+ * Dirty-fields semantics: only keys present in body are applied.
+ * Re-parenting via `community_id` is NOT supported through this endpoint —
+ * ignored if present (would be a "move" feature, deferred).
+ *
+ * Authorization: `currentUserCanAccessMicrogrid()` — super_admin or the
+ * org_manager of the microgrid's parent org (via community → org).
+ *
+ * Validation: currency (if sent) must be valid ISO 4217 (422 on RangeError).
+ * Duplicate rename (same community → same name) → 409 with exact copy.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid microgrid id — expected UUID." },
+      { status: 400 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserCanAccessMicrogrid(supabase, id))) {
+    return NextResponse.json(
+      { error: "Not authorized to update this microgrid." },
+      { status: 403 }
+    );
+  }
+
+  const updates: Record<string, string | number | null> = {};
+
+  if ("name" in body) {
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return NextResponse.json(
+        { error: "Name is required.", field: "name" },
+        { status: 422 }
+      );
+    }
+    updates.name = body.name.trim();
+  }
+
+  if ("currency" in body) {
+    const c = typeof body.currency === "string" ? body.currency.trim() : "";
+    const err = validateCurrency(c);
+    if (err) {
+      return NextResponse.json(
+        { error: err, field: "currency" },
+        { status: 422 }
+      );
+    }
+    updates.currency = c;
+  }
+
+  const OPTIONAL_STRING_FIELDS = [
+    "address_line1",
+    "address_line2",
+    "address_city",
+    "address_region",
+    "address_country",
+    "address_postal_code",
+  ] as const;
+
+  for (const f of OPTIONAL_STRING_FIELDS) {
+    if (f in body) {
+      const v = body[f];
+      updates[f] = typeof v === "string" && v.trim() ? v.trim() : null;
+    }
+  }
+
+  for (const f of ["lat", "lng"] as const) {
+    if (f in body) {
+      const v = body[f];
+      if (v === null || v === "") {
+        updates[f] = null;
+      } else if (typeof v === "number" && Number.isFinite(v)) {
+        updates[f] = v;
+      } else if (typeof v === "string" && v.trim()) {
+        const parsed = Number(v);
+        if (!Number.isFinite(parsed)) {
+          return NextResponse.json(
+            { error: `Invalid ${f} value.`, field: f },
+            { status: 422 }
+          );
+        }
+        updates[f] = parsed;
+      } else {
+        updates[f] = null;
+      }
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json(
+      { error: "No fields to update." },
+      { status: 400 }
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("microgrids")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+
+  if (error) {
+    if (
+      error.code === "23505" &&
+      error.message.includes("microgrids_community_name_unique")
+    ) {
+      const name = typeof updates.name === "string" ? updates.name : "";
+      return NextResponse.json(
+        {
+          error: `A microgrid named '${name}' already exists in this community.`,
+          field: "name",
+        },
+        { status: 409 }
+      );
+    }
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to update this microgrid." },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to update microgrid: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: "Microgrid not found." },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ microgrid: data }, { status: 200 });
+}

--- a/src/app/api/microgrids/__tests__/route.test.ts
+++ b/src/app/api/microgrids/__tests__/route.test.ts
@@ -1,0 +1,253 @@
+/**
+ * POST /api/microgrids & PATCH /api/microgrids/[id] — route tests (#76).
+ *
+ * All Supabase + auth helpers mocked. Covers:
+ *   - POST: 422 invalid currency (Intl.NumberFormat RangeError)
+ *   - POST: 409 duplicate microgrid name in same community (Postgres 23505)
+ *   - POST: 403 when currentUserCanAccessCommunity returns false
+ *   - PATCH: dirty-fields — sending {address_city} does NOT clobber name/currency
+ *   - PATCH: 422 invalid currency on update
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+let canAccessCommunityReturn = true;
+let canAccessMicrogridReturn = true;
+
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockSingleAfterInsertSelect = vi.fn();
+const mockMaybeSingleAfterUpdateSelect = vi.fn();
+
+const mockFrom = vi.fn(() => ({
+  insert: (row: unknown) => {
+    mockInsert(row);
+    return {
+      select: () => ({
+        single: () => mockSingleAfterInsertSelect(),
+      }),
+    };
+  },
+  update: (patch: unknown) => {
+    mockUpdate(patch);
+    return {
+      eq: () => ({
+        select: () => ({
+          maybeSingle: () => mockMaybeSingleAfterUpdateSelect(),
+        }),
+      }),
+    };
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessCommunity: async () => canAccessCommunityReturn,
+  currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+}));
+
+const VALID_COMMUNITY = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_MICROGRID = "550e8400-e29b-41d4-a716-446655440001";
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/microgrids", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePatch(id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/microgrids/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── POST tests ──────────────────────────────────────────────────────────
+
+describe("POST /api/microgrids", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessCommunityReturn = true;
+    canAccessMicrogridReturn = true;
+    mockSingleAfterInsertSelect.mockReset();
+  });
+
+  it("returns 422 with field='currency' when currency is invalid", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({
+        community_id: VALID_COMMUNITY,
+        name: "New MG",
+        currency: "XXX_NOT_A_CODE",
+      })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("currency");
+  });
+
+  it("returns 422 when currency is missing", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({
+        community_id: VALID_COMMUNITY,
+        name: "New MG",
+      })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("currency");
+  });
+
+  it("returns 403 when currentUserCanAccessCommunity is false", async () => {
+    canAccessCommunityReturn = false;
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({
+        community_id: VALID_COMMUNITY,
+        name: "New MG",
+        currency: "UGX",
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 with the exact duplicate-name message on Postgres 23505", async () => {
+    mockSingleAfterInsertSelect.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "23505",
+        message:
+          'duplicate key value violates unique constraint "microgrids_community_name_unique"',
+      },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({
+        community_id: VALID_COMMUNITY,
+        name: "Kisakye MG-1",
+        currency: "UGX",
+      })
+    );
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe(
+      "A microgrid named 'Kisakye MG-1' already exists in this community."
+    );
+    expect(json.field).toBe("name");
+  });
+
+  it("returns 201 with the inserted row on happy path", async () => {
+    mockSingleAfterInsertSelect.mockResolvedValueOnce({
+      data: { id: "m1", name: "New MG", currency: "USD" },
+      error: null,
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePost({
+        community_id: VALID_COMMUNITY,
+        name: "New MG",
+        currency: "USD",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.microgrid.id).toBe("m1");
+
+    // Verify currency was sent as uppercase ISO code
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        community_id: VALID_COMMUNITY,
+        name: "New MG",
+        currency: "USD",
+      })
+    );
+  });
+});
+
+// ── PATCH tests ─────────────────────────────────────────────────────────
+
+describe("PATCH /api/microgrids/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessCommunityReturn = true;
+    canAccessMicrogridReturn = true;
+    mockMaybeSingleAfterUpdateSelect.mockReset();
+  });
+
+  it("dirty-fields: sending {address_city} does NOT clobber name/currency", async () => {
+    mockMaybeSingleAfterUpdateSelect.mockResolvedValueOnce({
+      data: {
+        id: "m1",
+        name: "Kisakye MG-1",
+        currency: "UGX",
+        address_city: "Entebbe",
+      },
+      error: null,
+    });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(makePatch(VALID_MICROGRID, { address_city: "Entebbe" }), {
+      params: Promise.resolve({ id: VALID_MICROGRID }),
+    });
+
+    expect(res.status).toBe(200);
+    // Supabase update() called with ONLY { address_city: 'Entebbe' } — NOT name, NOT currency
+    expect(mockUpdate).toHaveBeenCalledWith({ address_city: "Entebbe" });
+  });
+
+  it("returns 422 when PATCH body has invalid currency", async () => {
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatch(VALID_MICROGRID, { currency: "BOGUS" }),
+      { params: Promise.resolve({ id: VALID_MICROGRID }) }
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("currency");
+  });
+
+  it("returns 403 when currentUserCanAccessMicrogrid is false", async () => {
+    canAccessMicrogridReturn = false;
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(makePatch(VALID_MICROGRID, { name: "X" }), {
+      params: Promise.resolve({ id: VALID_MICROGRID }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 on rename collision with 23505 constraint", async () => {
+    mockMaybeSingleAfterUpdateSelect.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "23505",
+        message:
+          'duplicate key value violates unique constraint "microgrids_community_name_unique"',
+      },
+    });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      makePatch(VALID_MICROGRID, { name: "Kisakye MG-1" }),
+      { params: Promise.resolve({ id: VALID_MICROGRID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe(
+      "A microgrid named 'Kisakye MG-1' already exists in this community."
+    );
+  });
+});

--- a/src/app/api/microgrids/route.ts
+++ b/src/app/api/microgrids/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+import { validateCurrency } from "@/lib/validation/currency";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /api/microgrids — create a new microgrid under a parent community (#76).
+ *
+ * Authorization: `currentUserCanAccessCommunity()` — resolves community → org.
+ * Prevents an org_manager in Org A from creating a microgrid under a community
+ * that belongs to Org B.
+ *
+ * Validation:
+ *   - `name` required (422 with field='name').
+ *   - `community_id` required UUID (400 malformed; 403 if not accessible).
+ *   - `currency` required + validated via Intl.NumberFormat RangeError (422).
+ *
+ * Duplicate-name handling: Postgres UNIQUE constraint
+ * `microgrids_community_name_unique` (00008 migration) surfaces as 23505.
+ * We translate that into 409 with exact copy:
+ *   "A microgrid named '{name}' already exists in this community."
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const communityId =
+    typeof body.community_id === "string" ? body.community_id : "";
+  if (!UUID_RE.test(communityId)) {
+    return NextResponse.json(
+      {
+        error: "Invalid community_id — expected UUID.",
+        field: "community_id",
+      },
+      { status: 400 }
+    );
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name) {
+    return NextResponse.json(
+      { error: "Name is required.", field: "name" },
+      { status: 422 }
+    );
+  }
+
+  const currencyInput =
+    typeof body.currency === "string" ? body.currency.trim() : "";
+  const currencyErr = validateCurrency(currencyInput);
+  if (currencyErr) {
+    return NextResponse.json(
+      { error: currencyErr, field: "currency" },
+      { status: 422 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserCanAccessCommunity(supabase, communityId))) {
+    return NextResponse.json(
+      { error: "Not authorized to add microgrids to this community." },
+      { status: 403 }
+    );
+  }
+
+  const row = {
+    community_id: communityId,
+    name,
+    currency: currencyInput,
+    address_line1: readOptionalString(body.address_line1),
+    address_line2: readOptionalString(body.address_line2),
+    address_city: readOptionalString(body.address_city),
+    address_region: readOptionalString(body.address_region),
+    address_country: readOptionalString(body.address_country),
+    address_postal_code: readOptionalString(body.address_postal_code),
+    lat: readOptionalNumber(body.lat),
+    lng: readOptionalNumber(body.lng),
+  };
+
+  const { data, error } = await supabase
+    .from("microgrids")
+    .insert(row)
+    .select("*")
+    .single();
+
+  if (error) {
+    if (
+      error.code === "23505" &&
+      error.message.includes("microgrids_community_name_unique")
+    ) {
+      return NextResponse.json(
+        {
+          error: `A microgrid named '${name}' already exists in this community.`,
+          field: "name",
+        },
+        { status: 409 }
+      );
+    }
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to add microgrids to this community." },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to create microgrid: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ microgrid: data }, { status: 201 });
+}
+
+function readOptionalString(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  return trimmed ? trimmed : null;
+}
+
+function readOptionalNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim()) {
+    const parsed = Number(v);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+

--- a/src/app/api/organizations/[id]/route.ts
+++ b/src/app/api/organizations/[id]/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * PATCH /api/organizations/[id] — update an organization (#76).
+ *
+ * Dirty-fields semantics: the client sends only changed fields. Any column NOT
+ * present in the body is left untouched. The handler builds an UPDATE payload
+ * from body keys only; a missing `name` key will NOT set name to null.
+ *
+ * Authorization: super_admin only (defense-in-depth + RLS backstop).
+ *
+ * Validation:
+ *   - If `name` is present, it must be non-empty (422).
+ *   - If `address_city` is present, it must be non-empty (422).
+ *   - If `address_country` is present, it must be non-empty (422).
+ *     (Org invariant: we never allow clearing city/country to null.)
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid organization id — expected UUID." },
+      { status: 400 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      { error: "Only super_admin users can update organizations." },
+      { status: 403 }
+    );
+  }
+
+  const updates: Record<string, string | null> = {};
+
+  if ("name" in body) {
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return NextResponse.json(
+        { error: "Name is required.", field: "name" },
+        { status: 422 }
+      );
+    }
+    updates.name = body.name.trim();
+  }
+
+  // Address fields — only include keys explicitly present in the body.
+  // Required fields (city/country) cannot be cleared; optional fields may be
+  // sent as "" to clear → stored as null.
+  const REQUIRED_ADDR_FIELDS = ["address_city", "address_country"] as const;
+  const OPTIONAL_ADDR_FIELDS = [
+    "address_line1",
+    "address_line2",
+    "address_region",
+    "address_postal_code",
+  ] as const;
+
+  for (const f of REQUIRED_ADDR_FIELDS) {
+    if (f in body) {
+      const v = body[f];
+      if (typeof v !== "string" || !v.trim()) {
+        const label = f === "address_city" ? "City" : "Country";
+        return NextResponse.json(
+          { error: `${label} is required.`, field: f },
+          { status: 422 }
+        );
+      }
+      updates[f] = v.trim();
+    }
+  }
+
+  for (const f of OPTIONAL_ADDR_FIELDS) {
+    if (f in body) {
+      const v = body[f];
+      updates[f] = typeof v === "string" && v.trim() ? v.trim() : null;
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json(
+      { error: "No fields to update." },
+      { status: 400 }
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("organizations")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to update this organization." },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to update organization: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: "Organization not found." },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ organization: data }, { status: 200 });
+}

--- a/src/app/api/organizations/__tests__/route.test.ts
+++ b/src/app/api/organizations/__tests__/route.test.ts
@@ -1,0 +1,223 @@
+/**
+ * POST /api/organizations & PATCH /api/organizations/[id] — route tests (#76).
+ *
+ * All Supabase I/O + auth are mocked. Covers:
+ *   - POST: 422 missing address_city / address_country
+ *   - POST: 403 when not super_admin
+ *   - POST: 201 happy path
+ *   - PATCH: dirty-fields — sending {address_city} does NOT clobber name
+ *   - PATCH: 422 when clearing required address_city
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+let isSuperAdminReturn = true;
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockSelectAfterInsert = vi.fn();
+const mockSingleAfterInsertSelect = vi.fn();
+
+const mockEqUpdate = vi.fn();
+const mockSelectAfterUpdate = vi.fn();
+const mockMaybeSingleAfterUpdateSelect = vi.fn();
+
+const mockFrom = vi.fn(() => ({
+  insert: (row: unknown) => {
+    mockInsert(row);
+    return {
+      select: () => ({
+        single: () => mockSingleAfterInsertSelect(),
+      }),
+    };
+  },
+  update: (patch: unknown) => {
+    mockUpdate(patch);
+    return {
+      eq: (col: string, val: string) => {
+        mockEqUpdate(col, val);
+        return {
+          select: () => ({
+            maybeSingle: () => mockMaybeSingleAfterUpdateSelect(),
+          }),
+        };
+      },
+    };
+  },
+}));
+
+void mockSelectAfterInsert;
+void mockSelectAfterUpdate;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
+}));
+
+function makeRequest(body: unknown, method = "POST"): NextRequest {
+  return new NextRequest("http://localhost/api/organizations", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("POST /api/organizations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSuperAdminReturn = true;
+    mockSingleAfterInsertSelect.mockReset();
+  });
+
+  it("returns 403 when the caller is not a super_admin", async () => {
+    isSuperAdminReturn = false;
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        name: "NFE",
+        address_city: "Kampala",
+        address_country: "Uganda",
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 422 with field='address_city' when city is missing", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        name: "NFE",
+        address_country: "Uganda",
+      })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("address_city");
+  });
+
+  it("returns 422 with field='address_country' when country is missing", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        name: "NFE",
+        address_city: "Kampala",
+      })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("address_country");
+  });
+
+  it("returns 422 with field='name' when name is missing", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        address_city: "Kampala",
+        address_country: "Uganda",
+      })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("name");
+  });
+
+  it("returns 201 with the inserted row on happy path", async () => {
+    mockSingleAfterInsertSelect.mockResolvedValueOnce({
+      data: { id: "o1", name: "NFE" },
+      error: null,
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        name: "NFE",
+        address_city: "Kampala",
+        address_country: "Uganda",
+      })
+    );
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.organization.id).toBe("o1");
+  });
+});
+
+describe("PATCH /api/organizations/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSuperAdminReturn = true;
+    mockMaybeSingleAfterUpdateSelect.mockReset();
+  });
+
+  it("sends ONLY dirty fields to Supabase (does not clobber untouched name)", async () => {
+    mockMaybeSingleAfterUpdateSelect.mockResolvedValueOnce({
+      data: { id: "o1", name: "NFE", address_city: "Entebbe" },
+      error: null,
+    });
+
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      new NextRequest(`http://localhost/api/organizations/${VALID_UUID}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address_city: "Entebbe" }),
+      }),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+
+    expect(res.status).toBe(200);
+    // Supabase update() called with ONLY { address_city } — NOT name, country, etc.
+    expect(mockUpdate).toHaveBeenCalledWith({ address_city: "Entebbe" });
+  });
+
+  it("returns 422 when PATCH attempts to clear required address_city", async () => {
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      new NextRequest(`http://localhost/api/organizations/${VALID_UUID}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address_city: "" }),
+      }),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.field).toBe("address_city");
+  });
+
+  it("returns 400 for malformed UUID", async () => {
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      new NextRequest(`http://localhost/api/organizations/not-a-uuid`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "X" }),
+      }),
+      { params: Promise.resolve({ id: "not-a-uuid" }) }
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller is not super_admin", async () => {
+    isSuperAdminReturn = false;
+    const { PATCH } = await import("../[id]/route");
+    const res = await PATCH(
+      new NextRequest(`http://localhost/api/organizations/${VALID_UUID}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Update" }),
+      }),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+
+/**
+ * POST /api/organizations — create a new organization (#76).
+ *
+ * Authorization:
+ *   - super_admin only. Defense-in-depth: we check `currentUserIsSuperAdmin()`
+ *     explicitly before the INSERT; RLS on the `organizations` table is the
+ *     backstop. The explicit check gives us a clean 403 rather than a
+ *     Postgres 42501 error.
+ *
+ * Validation:
+ *   - `name` required (422 with field='name').
+ *   - `address_city` AND `address_country` required (Org-level invariant for
+ *     URA invoicing — surfaced here even though the DB columns are nullable).
+ *
+ * Error contract: { error: string, field?: string }
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  // ── authz ───────────────────────────────────────────────────────────────
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      { error: "Only super_admin users can create organizations." },
+      { status: 403 }
+    );
+  }
+
+  // ── validation ──────────────────────────────────────────────────────────
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name) {
+    return NextResponse.json(
+      { error: "Name is required.", field: "name" },
+      { status: 422 }
+    );
+  }
+
+  const addressCity =
+    typeof body.address_city === "string" ? body.address_city.trim() : "";
+  if (!addressCity) {
+    return NextResponse.json(
+      { error: "City is required.", field: "address_city" },
+      { status: 422 }
+    );
+  }
+
+  const addressCountry =
+    typeof body.address_country === "string" ? body.address_country.trim() : "";
+  if (!addressCountry) {
+    return NextResponse.json(
+      { error: "Country is required.", field: "address_country" },
+      { status: 422 }
+    );
+  }
+
+  const row = {
+    name,
+    address_line1: readOptionalString(body.address_line1),
+    address_line2: readOptionalString(body.address_line2),
+    address_city: addressCity,
+    address_region: readOptionalString(body.address_region),
+    address_country: addressCountry,
+    address_postal_code: readOptionalString(body.address_postal_code),
+  };
+
+  const { data, error } = await supabase
+    .from("organizations")
+    .insert(row)
+    .select("*")
+    .single();
+
+  if (error) {
+    if (error.code === "42501" || error.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to create organizations." },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to create organization: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ organization: data }, { status: 201 });
+}
+
+function readOptionalString(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  return trimmed ? trimmed : null;
+}

--- a/src/components/forms/AddEntityButton.tsx
+++ b/src/components/forms/AddEntityButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * AddEntityButton — client wrapper that opens <EntityForm mode='create'> (#76).
+ *
+ * Renders a button; when clicked, opens the shared EntityForm in create mode.
+ * Parent (server component) supplies the entity kind and any parent IDs.
+ * Label defaults to "+ Add {Entity}" but can be overridden (empty-state CTA).
+ */
+
+import * as React from "react";
+import { EntityForm } from "./EntityForm";
+
+type Props =
+  | {
+      entity: "organization";
+      label?: string;
+      className?: string;
+      variant?: "primary" | "secondary";
+    }
+  | {
+      entity: "community";
+      parentOrgId: string;
+      label?: string;
+      className?: string;
+      variant?: "primary" | "secondary";
+    }
+  | {
+      entity: "microgrid";
+      parentCommunityId: string;
+      label?: string;
+      className?: string;
+      variant?: "primary" | "secondary";
+    };
+
+export function AddEntityButton(props: Props) {
+  const [open, setOpen] = React.useState(false);
+
+  const defaultLabel =
+    props.entity === "organization"
+      ? "+ Add Organization"
+      : props.entity === "community"
+        ? "+ Add Community"
+        : "+ Add Microgrid";
+
+  const variant = props.variant ?? "primary";
+  const btnCls =
+    variant === "primary"
+      ? "inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+      : "inline-flex items-center rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={props.className ?? btnCls}
+      >
+        {props.label ?? defaultLabel}
+      </button>
+      {props.entity === "organization" && (
+        <EntityForm
+          entity="organization"
+          mode="create"
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+      {props.entity === "community" && (
+        <EntityForm
+          entity="community"
+          mode="create"
+          parentOrgId={props.parentOrgId}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+      {props.entity === "microgrid" && (
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          parentCommunityId={props.parentCommunityId}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/forms/AddressFields.tsx
+++ b/src/components/forms/AddressFields.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/**
+ * AddressFields — shared 6-input address subcomponent (#76 UX4a).
+ *
+ * Fields (all optional at the schema level):
+ *   address_line1, address_line2, address_city, address_region,
+ *   address_country, address_postal_code.
+ *
+ * Required-field marking is driven by the `requiredFields` prop so Org can
+ * require `address_city` + `address_country` while Community / Microgrid do
+ * not. The server is the authoritative validator — this is UI affordance only.
+ */
+
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export type AddressValues = {
+  address_line1?: string | null;
+  address_line2?: string | null;
+  address_city?: string | null;
+  address_region?: string | null;
+  address_country?: string | null;
+  address_postal_code?: string | null;
+};
+
+export type AddressFieldName =
+  | "address_line1"
+  | "address_line2"
+  | "address_city"
+  | "address_region"
+  | "address_country"
+  | "address_postal_code";
+
+interface AddressFieldsProps {
+  values: AddressValues;
+  onChange: (field: AddressFieldName, value: string) => void;
+  /** Fields to mark with a required asterisk. Server enforces actual required-ness. */
+  requiredFields?: readonly AddressFieldName[];
+  /** Field-level error messages keyed by field name. */
+  fieldErrors?: Partial<Record<AddressFieldName, string>>;
+  disabled?: boolean;
+}
+
+const FIELD_LABELS: Record<AddressFieldName, string> = {
+  address_line1: "Address line 1",
+  address_line2: "Address line 2",
+  address_city: "City",
+  address_region: "Region / state",
+  address_country: "Country",
+  address_postal_code: "Postal code",
+};
+
+export function AddressFields({
+  values,
+  onChange,
+  requiredFields = [],
+  fieldErrors = {},
+  disabled,
+}: AddressFieldsProps) {
+  const requiredSet = new Set<AddressFieldName>(requiredFields);
+
+  return (
+    <div className="space-y-3">
+      {(Object.keys(FIELD_LABELS) as AddressFieldName[]).map((field) => {
+        const isRequired = requiredSet.has(field);
+        const err = fieldErrors[field];
+        const inputId = `field-${field}`;
+
+        return (
+          <div key={field}>
+            <label
+              htmlFor={inputId}
+              className="mb-1 block text-xs font-medium text-muted-foreground"
+            >
+              {FIELD_LABELS[field]}
+              {isRequired && (
+                <span
+                  aria-hidden="true"
+                  className="ml-0.5 text-destructive-fg"
+                >
+                  *
+                </span>
+              )}
+              {isRequired && <span className="sr-only"> (required)</span>}
+            </label>
+            <Input
+              id={inputId}
+              type="text"
+              value={values[field] ?? ""}
+              onChange={(e) => onChange(field, e.target.value)}
+              disabled={disabled}
+              aria-invalid={err ? true : undefined}
+              aria-describedby={err ? `${inputId}-err` : undefined}
+              className={cn(err && "border-destructive")}
+            />
+            {err && (
+              <p
+                id={`${inputId}-err`}
+                role="alert"
+                className="mt-1 text-xs text-destructive-fg"
+              >
+                {err}
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/forms/EditEntityButton.tsx
+++ b/src/components/forms/EditEntityButton.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * EditEntityButton — client wrapper that opens <EntityForm mode='edit'> (#76).
+ *
+ * Pre-fills the form from `initialValues` passed in by the parent server
+ * component (cached listing/detail row). Concurrent-edit last-writer-wins
+ * per ticket Out of Scope.
+ */
+
+import * as React from "react";
+import { EntityForm } from "./EntityForm";
+import type { Organization, Community, Microgrid } from "@/lib/types/domain";
+
+type Props =
+  | {
+      entity: "organization";
+      initialValues: Organization;
+      label?: string;
+      className?: string;
+    }
+  | {
+      entity: "community";
+      initialValues: Community;
+      label?: string;
+      className?: string;
+    }
+  | {
+      entity: "microgrid";
+      initialValues: Microgrid;
+      label?: string;
+      className?: string;
+    };
+
+export function EditEntityButton(props: Props) {
+  const [open, setOpen] = React.useState(false);
+
+  const btnCls =
+    "inline-flex items-center rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={props.className ?? btnCls}
+      >
+        {props.label ?? "Edit"}
+      </button>
+      {props.entity === "organization" && (
+        <EntityForm
+          entity="organization"
+          mode="edit"
+          initialValues={props.initialValues}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+      {props.entity === "community" && (
+        <EntityForm
+          entity="community"
+          mode="edit"
+          parentOrgId={props.initialValues.org_id}
+          initialValues={props.initialValues}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+      {props.entity === "microgrid" && (
+        <EntityForm
+          entity="microgrid"
+          mode="edit"
+          parentCommunityId={props.initialValues.community_id}
+          initialValues={props.initialValues}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/forms/EntityForm.tsx
+++ b/src/components/forms/EntityForm.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+/**
+ * EntityForm — shared modal form for Organization / Community / Microgrid CRUD (#76).
+ *
+ * Single component covers create + edit for all three entities via a
+ * discriminated union on the `entity` prop. Rendered as a modal dialog
+ * (Radix Dialog), not a dedicated route.
+ *
+ * Entity-specific extras stay in a small per-entity branch (kept under ~20 lines
+ * each) — the common scaffolding (name, address, submit, error handling) is
+ * shared.
+ *
+ * Server-side write path:
+ *   - create: POST /api/{organizations|communities|microgrids}
+ *   - edit:   PATCH /api/{organizations|communities|microgrids}/[id]
+ * The form computes a dirty-fields diff in edit mode — only CHANGED fields
+ * are sent. The server merges; a missing key in the PATCH body does NOT set
+ * the column to null.
+ *
+ * Error contract: `{ error: string, field?: string }`.
+ *   - 422 with `field`  → inline error under that input
+ *   - 409               → top-level banner (duplicate microgrid name)
+ *   - 403 / 500 / other → top-level banner
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AddressFields,
+  type AddressFieldName,
+  type AddressValues,
+} from "./AddressFields";
+import { CURRENCY_OPTIONS } from "@/lib/validation/currency";
+import { cn } from "@/lib/utils";
+import type {
+  Organization,
+  Community,
+  Microgrid,
+} from "@/lib/types/domain";
+
+// ── Props (discriminated union) ──────────────────────────────────────────
+
+type CommonModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+};
+
+export type EntityFormProps = CommonModalProps &
+  (
+    | {
+        entity: "organization";
+        mode: "create" | "edit";
+        initialValues?: Partial<Organization> & { id?: string };
+      }
+    | {
+        entity: "community";
+        mode: "create" | "edit";
+        parentOrgId: string;
+        initialValues?: Partial<Community> & { id?: string };
+      }
+    | {
+        entity: "microgrid";
+        mode: "create" | "edit";
+        parentCommunityId: string;
+        initialValues?: Partial<Microgrid> & { id?: string };
+      }
+  );
+
+// ── Shared internal state shape ──────────────────────────────────────────
+
+type FormState = AddressValues & {
+  name: string;
+  geography_notes?: string;
+  currency?: string;
+  lat?: string; // kept as string for input binding
+  lng?: string;
+};
+
+type FieldErrors = Partial<Record<string, string>>;
+
+const ADDRESS_FIELDS: AddressFieldName[] = [
+  "address_line1",
+  "address_line2",
+  "address_city",
+  "address_region",
+  "address_country",
+  "address_postal_code",
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function initialStateFor(props: EntityFormProps): FormState {
+  const iv =
+    (props.entity === "organization"
+      ? props.initialValues
+      : props.entity === "community"
+        ? props.initialValues
+        : props.initialValues) ?? {};
+
+  const base: FormState = {
+    name: iv.name ?? "",
+    address_line1: iv.address_line1 ?? "",
+    address_line2: iv.address_line2 ?? "",
+    address_city: iv.address_city ?? "",
+    address_region: iv.address_region ?? "",
+    address_country: iv.address_country ?? "",
+    address_postal_code: iv.address_postal_code ?? "",
+  };
+
+  if (props.entity === "community") {
+    base.geography_notes = props.initialValues?.geography_notes ?? "";
+  }
+
+  if (props.entity === "microgrid") {
+    const mgIv = props.initialValues ?? {};
+    base.currency = mgIv.currency ?? "UGX";
+    base.lat = mgIv.lat != null ? String(mgIv.lat) : "";
+    base.lng = mgIv.lng != null ? String(mgIv.lng) : "";
+  }
+
+  return base;
+}
+
+/** Build the POST payload (all fields) from form state. */
+function buildCreatePayload(
+  state: FormState,
+  props: EntityFormProps
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    name: state.name.trim(),
+  };
+
+  for (const f of ADDRESS_FIELDS) {
+    payload[f] = state[f]?.trim() ?? "";
+  }
+
+  if (props.entity === "community") {
+    payload.org_id = props.parentOrgId;
+    payload.geography_notes = state.geography_notes?.trim() ?? "";
+  }
+  if (props.entity === "microgrid") {
+    payload.community_id = props.parentCommunityId;
+    payload.currency = state.currency ?? "UGX";
+    payload.lat = state.lat?.trim() ? state.lat.trim() : null;
+    payload.lng = state.lng?.trim() ? state.lng.trim() : null;
+  }
+
+  return payload;
+}
+
+/** Build the PATCH payload (only changed fields). */
+function buildPatchPayload(
+  state: FormState,
+  props: EntityFormProps
+): Record<string, unknown> {
+  const initial = initialStateFor(props);
+  const payload: Record<string, unknown> = {};
+
+  if (state.name.trim() !== (initial.name ?? "").trim()) {
+    payload.name = state.name.trim();
+  }
+
+  for (const f of ADDRESS_FIELDS) {
+    const cur = (state[f] ?? "").trim();
+    const init = (initial[f] ?? "").trim();
+    if (cur !== init) {
+      payload[f] = cur;
+    }
+  }
+
+  if (props.entity === "community") {
+    const cur = (state.geography_notes ?? "").trim();
+    const init = (initial.geography_notes ?? "").trim();
+    if (cur !== init) payload.geography_notes = cur;
+  }
+
+  if (props.entity === "microgrid") {
+    if ((state.currency ?? "") !== (initial.currency ?? "")) {
+      payload.currency = state.currency;
+    }
+    const curLat = (state.lat ?? "").trim();
+    const initLat = (initial.lat ?? "").trim();
+    if (curLat !== initLat) payload.lat = curLat;
+    const curLng = (state.lng ?? "").trim();
+    const initLng = (initial.lng ?? "").trim();
+    if (curLng !== initLng) payload.lng = curLng;
+  }
+
+  return payload;
+}
+
+function endpointFor(props: EntityFormProps): {
+  url: string;
+  method: "POST" | "PATCH";
+} {
+  const base =
+    props.entity === "organization"
+      ? "/api/organizations"
+      : props.entity === "community"
+        ? "/api/communities"
+        : "/api/microgrids";
+
+  if (props.mode === "create") {
+    return { url: base, method: "POST" };
+  }
+  const id = props.initialValues?.id;
+  return { url: `${base}/${id}`, method: "PATCH" };
+}
+
+function titleFor(props: EntityFormProps): string {
+  const verb = props.mode === "create" ? "Add" : "Edit";
+  const noun =
+    props.entity === "organization"
+      ? "Organization"
+      : props.entity === "community"
+        ? "Community"
+        : "Microgrid";
+  return `${verb} ${noun}`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function EntityForm(props: EntityFormProps) {
+  const router = useRouter();
+
+  const [state, setState] = React.useState<FormState>(() =>
+    initialStateFor(props)
+  );
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({});
+  const [topError, setTopError] = React.useState<string | null>(null);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  // Reset state when the dialog opens — catches the "opened twice with
+  // different initialValues" edge case.
+  React.useEffect(() => {
+    if (props.open) {
+      setState(initialStateFor(props));
+      setFieldErrors({});
+      setTopError(null);
+      setSubmitting(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.open]);
+
+  const updateField = React.useCallback(
+    (key: keyof FormState, value: string) => {
+      setState((prev) => ({ ...prev, [key]: value }));
+      setFieldErrors((prev) => {
+        if (!(key in prev)) return prev;
+        const next = { ...prev };
+        delete next[key as string];
+        return next;
+      });
+    },
+    []
+  );
+
+  const updateAddress = React.useCallback(
+    (field: AddressFieldName, value: string) => {
+      updateField(field, value);
+    },
+    [updateField]
+  );
+
+  // Client-side guards: org address city+country required. Server is the
+  // authoritative validator — this is just an immediate-feedback affordance.
+  const clientValidate = React.useCallback((): FieldErrors => {
+    const errs: FieldErrors = {};
+    if (!state.name.trim()) errs.name = "Name is required.";
+    if (props.entity === "organization") {
+      if (!(state.address_city ?? "").trim())
+        errs.address_city = "City is required.";
+      if (!(state.address_country ?? "").trim())
+        errs.address_country = "Country is required.";
+    }
+    if (props.entity === "microgrid") {
+      if (!(state.currency ?? "").trim())
+        errs.currency = "Currency is required.";
+    }
+    return errs;
+  }, [state, props.entity]);
+
+  const handleSubmit = React.useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setTopError(null);
+
+      const errs = clientValidate();
+      if (Object.keys(errs).length > 0) {
+        setFieldErrors(errs);
+        return;
+      }
+
+      const { url, method } = endpointFor(props);
+      const payload =
+        props.mode === "create"
+          ? buildCreatePayload(state, props)
+          : buildPatchPayload(state, props);
+
+      if (method === "PATCH" && Object.keys(payload).length === 0) {
+        // Nothing to save — just close.
+        props.onOpenChange(false);
+        return;
+      }
+
+      setSubmitting(true);
+      try {
+        const res = await fetch(url, {
+          method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          field?: string;
+        };
+
+        if (!res.ok) {
+          if (res.status === 422 && data.field) {
+            setFieldErrors({ [data.field]: data.error ?? "Invalid value." });
+          } else if (res.status === 403) {
+            setTopError(
+              data.error ?? "You do not have permission to perform this action."
+            );
+          } else if (res.status === 409) {
+            // Duplicate name — surface top-level banner AND inline on name.
+            const msg = data.error ?? "Duplicate name.";
+            setTopError(msg);
+            if (data.field) setFieldErrors({ [data.field]: msg });
+          } else {
+            setTopError(data.error ?? "Could not save. Please try again.");
+          }
+          setSubmitting(false);
+          return;
+        }
+
+        // Success.
+        router.refresh();
+        props.onSuccess?.();
+        props.onOpenChange(false);
+      } catch {
+        setTopError("Network error. Please retry.");
+        setSubmitting(false);
+      }
+    },
+    [clientValidate, props, state, router]
+  );
+
+  const isOrg = props.entity === "organization";
+  const orgAddressRequired: readonly AddressFieldName[] = isOrg
+    ? ["address_city", "address_country"]
+    : [];
+
+  return (
+    <Dialog.Root open={props.open} onOpenChange={props.onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55" />
+        <Dialog.Content
+          aria-modal
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[520px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+            "max-h-[90vh] overflow-y-auto rounded-md border border-border bg-card shadow-elev-3 outline-none"
+          )}
+        >
+          <div className="px-6 pt-5">
+            <Dialog.Title className="text-xl font-semibold tracking-tight text-foreground">
+              {titleFor(props)}
+            </Dialog.Title>
+            <Dialog.Description className="mt-1 text-[13px] text-muted-foreground">
+              {props.mode === "create"
+                ? "Fill in the fields below. City and country are required for organizations."
+                : "Only changed fields will be saved."}
+            </Dialog.Description>
+          </div>
+
+          <form
+            onSubmit={handleSubmit}
+            className="px-6 pb-2 pt-4 space-y-4"
+            noValidate
+          >
+            {topError && (
+              <Banner tone="destructive" title="Could not save">
+                {topError}
+              </Banner>
+            )}
+
+            {/* Name */}
+            <div>
+              <label
+                htmlFor="entity-name"
+                className="mb-1 block text-xs font-medium text-muted-foreground"
+              >
+                Name
+                <span aria-hidden="true" className="ml-0.5 text-destructive-fg">
+                  *
+                </span>
+                <span className="sr-only"> (required)</span>
+              </label>
+              <Input
+                id="entity-name"
+                type="text"
+                value={state.name}
+                onChange={(e) => updateField("name", e.target.value)}
+                disabled={submitting}
+                aria-invalid={fieldErrors.name ? true : undefined}
+                aria-describedby={fieldErrors.name ? "entity-name-err" : undefined}
+                className={cn(fieldErrors.name && "border-destructive")}
+              />
+              {fieldErrors.name && (
+                <p
+                  id="entity-name-err"
+                  role="alert"
+                  className="mt-1 text-xs text-destructive-fg"
+                >
+                  {fieldErrors.name}
+                </p>
+              )}
+            </div>
+
+            {/* Address */}
+            <AddressFields
+              values={state}
+              onChange={updateAddress}
+              requiredFields={orgAddressRequired}
+              fieldErrors={fieldErrors}
+              disabled={submitting}
+            />
+
+            {/* Per-entity extras */}
+            {props.entity === "community" && (
+              <div>
+                <label
+                  htmlFor="entity-geography-notes"
+                  className="mb-1 block text-xs font-medium text-muted-foreground"
+                >
+                  Geography notes
+                </label>
+                <textarea
+                  id="entity-geography-notes"
+                  value={state.geography_notes ?? ""}
+                  onChange={(e) =>
+                    updateField("geography_notes", e.target.value)
+                  }
+                  disabled={submitting}
+                  rows={3}
+                  className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
+            )}
+
+            {props.entity === "microgrid" && (
+              <div className="space-y-3">
+                <div>
+                  <label
+                    htmlFor="entity-currency"
+                    className="mb-1 block text-xs font-medium text-muted-foreground"
+                  >
+                    Currency
+                    <span
+                      aria-hidden="true"
+                      className="ml-0.5 text-destructive-fg"
+                    >
+                      *
+                    </span>
+                  </label>
+                  <Select
+                    value={state.currency ?? "UGX"}
+                    onValueChange={(v) => updateField("currency", v)}
+                    disabled={submitting}
+                  >
+                    <SelectTrigger id="entity-currency" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CURRENCY_OPTIONS.map((code) => (
+                        <SelectItem key={code} value={code}>
+                          {code}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {fieldErrors.currency && (
+                    <p
+                      role="alert"
+                      className="mt-1 text-xs text-destructive-fg"
+                    >
+                      {fieldErrors.currency}
+                    </p>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label
+                      htmlFor="entity-lat"
+                      className="mb-1 block text-xs font-medium text-muted-foreground"
+                    >
+                      Latitude
+                    </label>
+                    <Input
+                      id="entity-lat"
+                      type="text"
+                      inputMode="decimal"
+                      value={state.lat ?? ""}
+                      onChange={(e) => updateField("lat", e.target.value)}
+                      disabled={submitting}
+                      aria-invalid={fieldErrors.lat ? true : undefined}
+                    />
+                    {fieldErrors.lat && (
+                      <p role="alert" className="mt-1 text-xs text-destructive-fg">
+                        {fieldErrors.lat}
+                      </p>
+                    )}
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="entity-lng"
+                      className="mb-1 block text-xs font-medium text-muted-foreground"
+                    >
+                      Longitude
+                    </label>
+                    <Input
+                      id="entity-lng"
+                      type="text"
+                      inputMode="decimal"
+                      value={state.lng ?? ""}
+                      onChange={(e) => updateField("lng", e.target.value)}
+                      disabled={submitting}
+                      aria-invalid={fieldErrors.lng ? true : undefined}
+                    />
+                    {fieldErrors.lng && (
+                      <p role="alert" className="mt-1 text-xs text-destructive-fg">
+                        {fieldErrors.lng}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+          </form>
+
+          <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-muted px-6 pb-[18px] pt-[14px]">
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                disabled={submitting}
+                className="inline-flex h-8 items-center rounded-md px-3.5 text-[13px] font-medium text-foreground hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+              >
+                Cancel
+              </button>
+            </Dialog.Close>
+            <button
+              type="submit"
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="inline-flex h-8 items-center rounded-md bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+            >
+              {submitting
+                ? "Saving…"
+                : props.mode === "create"
+                  ? "Create"
+                  : "Save changes"}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/forms/__tests__/AddressFields.test.tsx
+++ b/src/components/forms/__tests__/AddressFields.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+/**
+ * AddressFields tests (#76) — the six structured address inputs rendered
+ * by both Organization/Community/Microgrid forms.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AddressFields } from "../AddressFields";
+
+describe("AddressFields", () => {
+  it("renders all six address inputs with current values", () => {
+    render(
+      <AddressFields
+        values={{
+          address_line1: "1 Main St",
+          address_line2: "Apt 2",
+          address_city: "Kampala",
+          address_region: "Central",
+          address_country: "Uganda",
+          address_postal_code: "00100",
+        }}
+        onChange={() => {}}
+      />
+    );
+
+    expect(
+      (screen.getByLabelText(/Address line 1/i) as HTMLInputElement).value
+    ).toBe("1 Main St");
+    expect(
+      (screen.getByLabelText(/Apt 2|Address line 2/i) as HTMLInputElement).value
+    ).toBe("Apt 2");
+    expect(
+      (screen.getByLabelText(/^City/i) as HTMLInputElement).value
+    ).toBe("Kampala");
+    expect(
+      (screen.getByLabelText(/Region/i) as HTMLInputElement).value
+    ).toBe("Central");
+    expect(
+      (screen.getByLabelText(/^Country/i) as HTMLInputElement).value
+    ).toBe("Uganda");
+    expect(
+      (screen.getByLabelText(/Postal/i) as HTMLInputElement).value
+    ).toBe("00100");
+  });
+
+  it("marks city and country required when requiredFields includes them", () => {
+    render(
+      <AddressFields
+        values={{}}
+        onChange={() => {}}
+        requiredFields={["address_city", "address_country"]}
+      />
+    );
+
+    // Required-asterisk sr-only span: find the two fields with required hints.
+    const requiredLabels = screen.getAllByText(/\(required\)/);
+    expect(requiredLabels.length).toBe(2);
+  });
+
+  it("does not mark any field required by default", () => {
+    render(<AddressFields values={{}} onChange={() => {}} />);
+    const requiredLabels = screen.queryAllByText(/\(required\)/);
+    expect(requiredLabels.length).toBe(0);
+  });
+
+  it("fires onChange with the changed field name and new value", () => {
+    const onChange = vi.fn();
+    render(<AddressFields values={{ address_city: "" }} onChange={onChange} />);
+
+    const cityInput = screen.getByLabelText(/^City/i);
+    fireEvent.change(cityInput, { target: { value: "Kampala" } });
+
+    expect(onChange).toHaveBeenCalledWith("address_city", "Kampala");
+  });
+
+  it("shows inline error messages from fieldErrors keyed by field name", () => {
+    render(
+      <AddressFields
+        values={{}}
+        onChange={() => {}}
+        fieldErrors={{ address_country: "Country is required." }}
+      />
+    );
+
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /Country is required/i
+    );
+  });
+});

--- a/src/components/forms/__tests__/EntityForm.test.tsx
+++ b/src/components/forms/__tests__/EntityForm.test.tsx
@@ -1,0 +1,370 @@
+// @vitest-environment jsdom
+/**
+ * EntityForm tests (#76).
+ *
+ * Covers:
+ *   - Organization: create POSTs to /api/organizations with all fields.
+ *   - Community: create includes injected parentOrgId.
+ *   - Microgrid: create includes parentCommunityId + currency default.
+ *   - Edit mode (microgrid): PATCH payload contains ONLY dirty fields;
+ *     untouched fields (name, currency) are NOT sent when only address_city
+ *     changes.
+ *   - 422 with field → inline field error appears; top-level banner hidden.
+ *   - 409 duplicate name → top-level banner + inline name error.
+ *   - 403 → top-level permission banner.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EntityForm } from "../EntityForm";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+describe("EntityForm", () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Organization — create ───────────────────────────────────────────────
+  describe("organization: create", () => {
+    it("POSTs to /api/organizations with the full payload", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ organization: { id: "o1" } }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="organization"
+          mode="create"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "New Field Energy" },
+      });
+      fireEvent.change(screen.getByLabelText(/^City/i), {
+        target: { value: "Kampala" },
+      });
+      fireEvent.change(screen.getByLabelText(/^Country/i), {
+        target: { value: "Uganda" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/organizations");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(init?.body as string);
+      expect(body).toMatchObject({
+        name: "New Field Energy",
+        address_city: "Kampala",
+        address_country: "Uganda",
+      });
+    });
+
+    it("shows inline field error on 422 response", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          error: "City is required.",
+          field: "address_city",
+        }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="organization"
+          mode="create"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "X" },
+      });
+      fireEvent.change(screen.getByLabelText(/^City/i), {
+        target: { value: "Kampala" },
+      });
+      fireEvent.change(screen.getByLabelText(/^Country/i), {
+        target: { value: "Uganda" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        const alerts = screen.getAllByRole("alert");
+        const cityErr = alerts.find((a) =>
+          /city is required/i.test(a.textContent ?? "")
+        );
+        expect(cityErr).toBeDefined();
+      });
+    });
+  });
+
+  // ── Community — create ───────────────────────────────────────────────────
+  describe("community: create", () => {
+    it("POSTs to /api/communities with injected parentOrgId", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ community: { id: "c1" } }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="community"
+          mode="create"
+          parentOrgId="org-a"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Kisakye" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/communities");
+      const body = JSON.parse(init?.body as string);
+      expect(body.name).toBe("Kisakye");
+      expect(body.org_id).toBe("org-a");
+    });
+  });
+
+  // ── Microgrid — create ───────────────────────────────────────────────────
+  describe("microgrid: create", () => {
+    it("POSTs to /api/microgrids with community_id and default UGX currency", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ microgrid: { id: "m1" } }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          parentCommunityId="c-a"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Kisakye MG-1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/microgrids");
+      const body = JSON.parse(init?.body as string);
+      expect(body).toMatchObject({
+        name: "Kisakye MG-1",
+        community_id: "c-a",
+        currency: "UGX",
+      });
+    });
+
+    it("409 duplicate-name surfaces top-level banner + inline name error", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: "A microgrid named 'Kisakye MG-1' already exists in this community.",
+          field: "name",
+        }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          parentCommunityId="c-a"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Kisakye MG-1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        const alerts = screen.getAllByRole("alert");
+        const hasBanner = alerts.some((a) =>
+          /already exists/i.test(a.textContent ?? "")
+        );
+        expect(hasBanner).toBe(true);
+      });
+    });
+
+    it("403 surfaces top-level permission banner", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "Not authorized" }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          parentCommunityId="c-a"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Blocked" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Not authorized/i)).toBeDefined();
+      });
+    });
+  });
+
+  // ── Microgrid — edit / dirty-fields ─────────────────────────────────────
+  describe("microgrid: edit dirty-fields", () => {
+    it("only sends changed fields (name, currency untouched when address changes)", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ microgrid: { id: "m1" } }),
+      } as Response);
+
+      const initial = {
+        id: "m1",
+        community_id: "c-a",
+        name: "Kisakye MG-1",
+        currency: "UGX",
+        address_line1: null,
+        address_line2: null,
+        address_city: "Old City",
+        address_region: null,
+        address_country: "Uganda",
+        address_postal_code: null,
+        lat: null,
+        lng: null,
+        created_at: "2026-01-01T00:00:00Z",
+      };
+
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="edit"
+          parentCommunityId="c-a"
+          initialValues={initial}
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      // Change only the city
+      const cityInput = screen.getByLabelText(/^City/i);
+      fireEvent.change(cityInput, { target: { value: "New City" } });
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/microgrids/m1");
+      expect(init?.method).toBe("PATCH");
+
+      const body = JSON.parse(init?.body as string);
+      // ONLY address_city should be present
+      expect(body).toEqual({ address_city: "New City" });
+      // Dirty-fields guarantee: name + currency NOT sent
+      expect(body).not.toHaveProperty("name");
+      expect(body).not.toHaveProperty("currency");
+      expect(body).not.toHaveProperty("address_country");
+    });
+
+    it("sends multiple dirty fields in one request when several change", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ microgrid: { id: "m1" } }),
+      } as Response);
+
+      const initial = {
+        id: "m1",
+        community_id: "c-a",
+        name: "Kisakye MG-1",
+        currency: "UGX",
+        address_line1: null,
+        address_line2: null,
+        address_city: "Kampala",
+        address_region: null,
+        address_country: "Uganda",
+        address_postal_code: null,
+        lat: null,
+        lng: null,
+        created_at: "2026-01-01T00:00:00Z",
+      };
+
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="edit"
+          parentCommunityId="c-a"
+          initialValues={initial}
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Kisakye MG-2" },
+      });
+      fireEvent.change(screen.getByLabelText(/^City/i), {
+        target: { value: "Entebbe" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init?.body as string);
+      expect(body).toEqual({
+        name: "Kisakye MG-2",
+        address_city: "Entebbe",
+      });
+    });
+  });
+});

--- a/src/lib/auth/__tests__/access.test.ts
+++ b/src/lib/auth/__tests__/access.test.ts
@@ -1,0 +1,338 @@
+/**
+ * access.ts — unit tests for the server-only auth helpers (#76).
+ *
+ * All Supabase I/O is mocked. These cover the branch logic in
+ *   - getCurrentUserRoles        (unauth → [] / auth → user_roles rows)
+ *   - currentUserIsSuperAdmin    (super_admin detection)
+ *   - currentUserCanAccessOrg    (super_admin short-circuit + scoped match)
+ *   - currentUserCanAccessCommunity  (delegates via communities.org_id)
+ *   - currentUserCanAccessMicrogrid  (delegates via microgrids → community → org)
+ *
+ * RLS enforcement is tested separately in `src/lib/supabase/__tests__/rls.test.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  getCurrentUserRoles,
+  currentUserIsSuperAdmin,
+  currentUserCanAccessOrg,
+  currentUserCanAccessCommunity,
+  currentUserCanAccessMicrogrid,
+} from "../access";
+
+type RoleRow = {
+  user_id: string;
+  role: string;
+  scope_type: string;
+  scope_id: string | null;
+};
+
+/**
+ * Builds a minimal mock SupabaseClient for these helpers. `roles` controls
+ * what user_roles returns; `community` and `microgrid` control the parent
+ * resolution queries.
+ */
+function makeMockClient(opts: {
+  user: { id: string } | null;
+  roles: RoleRow[];
+  community?: { id: string; org_id: string } | null;
+  microgrid?: { id: string; community_id: string } | null;
+}): SupabaseClient {
+  const client = {
+    auth: {
+      getUser: async () => ({
+        data: { user: opts.user },
+        error: null,
+      }),
+    },
+    from: (table: string) => {
+      if (table === "user_roles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              returns: () =>
+                Promise.resolve({ data: opts.roles, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "communities") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({
+                  data: opts.community ?? null,
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      if (table === "microgrids") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({
+                  data: opts.microgrid ?? null,
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${table}`);
+    },
+  };
+  return client as unknown as SupabaseClient;
+}
+
+describe("getCurrentUserRoles", () => {
+  it("returns [] when there is no authenticated user", async () => {
+    const client = makeMockClient({ user: null, roles: [] });
+    const roles = await getCurrentUserRoles(client);
+    expect(roles).toEqual([]);
+  });
+
+  it("returns the user's role rows when authenticated", async () => {
+    const rows = [
+      {
+        user_id: "u1",
+        role: "org_manager",
+        scope_type: "org",
+        scope_id: "org-a",
+      },
+    ];
+    const client = makeMockClient({ user: { id: "u1" }, roles: rows });
+    const roles = await getCurrentUserRoles(client);
+    expect(roles).toHaveLength(1);
+    expect(roles[0].role).toBe("org_manager");
+  });
+});
+
+describe("currentUserIsSuperAdmin", () => {
+  it("returns true for a super_admin", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "super_admin",
+          scope_type: "org",
+          scope_id: null,
+        },
+      ],
+    });
+    expect(await currentUserIsSuperAdmin(client)).toBe(true);
+  });
+
+  it("returns false for an org_manager", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+    });
+    expect(await currentUserIsSuperAdmin(client)).toBe(false);
+  });
+
+  it("returns false for an unauthenticated user", async () => {
+    const client = makeMockClient({ user: null, roles: [] });
+    expect(await currentUserIsSuperAdmin(client)).toBe(false);
+  });
+});
+
+describe("currentUserCanAccessOrg", () => {
+  it("returns true for super_admin on any org", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "super_admin",
+          scope_type: "org",
+          scope_id: null,
+        },
+      ],
+    });
+    expect(await currentUserCanAccessOrg(client, "org-x")).toBe(true);
+  });
+
+  it("returns true for org_manager scoped to the same org", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+    });
+    expect(await currentUserCanAccessOrg(client, "org-a")).toBe(true);
+  });
+
+  it("returns false for org_manager on a different org", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+    });
+    expect(await currentUserCanAccessOrg(client, "org-b")).toBe(false);
+  });
+
+  it("returns false for users with no roles", async () => {
+    const client = makeMockClient({ user: { id: "u1" }, roles: [] });
+    expect(await currentUserCanAccessOrg(client, "org-a")).toBe(false);
+  });
+});
+
+describe("currentUserCanAccessCommunity", () => {
+  it("delegates via communities.org_id → org access check", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+      community: { id: "c1", org_id: "org-a" },
+    });
+    expect(await currentUserCanAccessCommunity(client, "c1")).toBe(true);
+  });
+
+  it("returns false when the community's org is not accessible", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+      community: { id: "c2", org_id: "org-b" },
+    });
+    expect(await currentUserCanAccessCommunity(client, "c2")).toBe(false);
+  });
+
+  it("returns false when the community is not found", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+      community: null,
+    });
+    expect(await currentUserCanAccessCommunity(client, "c-missing")).toBe(
+      false
+    );
+  });
+
+  it("super_admin short-circuits without needing the community row", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "super_admin",
+          scope_type: "org",
+          scope_id: null,
+        },
+      ],
+      community: null,
+    });
+    expect(await currentUserCanAccessCommunity(client, "anything")).toBe(true);
+  });
+});
+
+describe("currentUserCanAccessMicrogrid", () => {
+  it("delegates via microgrids → communities → org", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+      microgrid: { id: "m1", community_id: "c1" },
+      community: { id: "c1", org_id: "org-a" },
+    });
+    expect(await currentUserCanAccessMicrogrid(client, "m1")).toBe(true);
+  });
+
+  it("returns false when the microgrid parent chain lands on a different org", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+      microgrid: { id: "m2", community_id: "c2" },
+      community: { id: "c2", org_id: "org-b" },
+    });
+    expect(await currentUserCanAccessMicrogrid(client, "m2")).toBe(false);
+  });
+
+  it("returns false when the microgrid is not found", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "org_manager",
+          scope_type: "org",
+          scope_id: "org-a",
+        },
+      ],
+      microgrid: null,
+    });
+    expect(await currentUserCanAccessMicrogrid(client, "missing")).toBe(false);
+  });
+
+  it("super_admin short-circuits without any parent lookup", async () => {
+    const client = makeMockClient({
+      user: { id: "u1" },
+      roles: [
+        {
+          user_id: "u1",
+          role: "super_admin",
+          scope_type: "org",
+          scope_id: null,
+        },
+      ],
+      microgrid: null,
+    });
+    expect(await currentUserCanAccessMicrogrid(client, "anything")).toBe(true);
+  });
+});

--- a/src/lib/auth/access.ts
+++ b/src/lib/auth/access.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+/**
+ * access.ts — server-only access helpers.
+ *
+ * Created in #76 (UX4a entity CRUD). Separate from `src/lib/roles.ts` — that
+ * file is client-safe role CONSTANTS; this file is SERVER-ONLY role CHECKS that
+ * hit Supabase. The `import 'server-only'` directive at the top causes any
+ * accidental import from a client bundle to fail at build time.
+ *
+ * All helpers accept a Supabase server client (created by
+ * `@/lib/supabase/server`) so the caller's session (cookies) is honored. RLS
+ * remains the authoritative gate — these helpers are defense-in-depth for
+ * producing actionable 403s before a Postgres 42501 surfaces from the DB.
+ *
+ * Rationale for caching the user_roles fetch per call:
+ *   - Each request handler typically checks a single entity; we query
+ *     user_roles exactly once via `getCurrentUserRoles` and derive the other
+ *     helpers from that row set.
+ *   - We resolve parent IDs (community → org, microgrid → community → org)
+ *     via targeted queries — cheaper than round-tripping through RPC.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { UserRoleRecord } from "@/lib/types/domain";
+import { SUPER_ADMIN, ORG_MANAGER, SCOPE_ORG } from "@/lib/roles";
+
+/**
+ * Returns all user_roles rows for the currently authenticated user.
+ * Empty array if unauthenticated or the user has no role rows yet.
+ */
+export async function getCurrentUserRoles(
+  supabase: SupabaseClient
+): Promise<UserRoleRecord[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("user_roles")
+    .select("*")
+    .eq("user_id", user.id)
+    .returns<UserRoleRecord[]>();
+
+  if (error) return [];
+  return data ?? [];
+}
+
+/**
+ * True iff the current user has any role row with role = 'super_admin'.
+ */
+export async function currentUserIsSuperAdmin(
+  supabase: SupabaseClient
+): Promise<boolean> {
+  const roles = await getCurrentUserRoles(supabase);
+  return roles.some((r) => r.role === SUPER_ADMIN);
+}
+
+/**
+ * True iff the current user is a super_admin OR holds an org_manager row
+ * scoped to the given org.
+ */
+export async function currentUserCanAccessOrg(
+  supabase: SupabaseClient,
+  orgId: string
+): Promise<boolean> {
+  const roles = await getCurrentUserRoles(supabase);
+  if (roles.some((r) => r.role === SUPER_ADMIN)) return true;
+  return roles.some(
+    (r) =>
+      r.role === ORG_MANAGER &&
+      r.scope_type === SCOPE_ORG &&
+      r.scope_id === orgId
+  );
+}
+
+/**
+ * True iff the current user can access the org that the given community
+ * belongs to. Returns false if the community is not found (or RLS hides it).
+ */
+export async function currentUserCanAccessCommunity(
+  supabase: SupabaseClient,
+  communityId: string
+): Promise<boolean> {
+  // Short-circuit: super_admins can always access.
+  if (await currentUserIsSuperAdmin(supabase)) return true;
+
+  const { data, error } = await supabase
+    .from("communities")
+    .select("org_id")
+    .eq("id", communityId)
+    .maybeSingle<{ org_id: string }>();
+
+  if (error || !data) return false;
+  return currentUserCanAccessOrg(supabase, data.org_id);
+}
+
+/**
+ * True iff the current user can access the org for the given microgrid
+ * (microgrid → community → org chain). Returns false if not found.
+ */
+export async function currentUserCanAccessMicrogrid(
+  supabase: SupabaseClient,
+  microgridId: string
+): Promise<boolean> {
+  // Short-circuit: super_admins can always access.
+  if (await currentUserIsSuperAdmin(supabase)) return true;
+
+  const { data: mg, error: mgErr } = await supabase
+    .from("microgrids")
+    .select("community_id")
+    .eq("id", microgridId)
+    .maybeSingle<{ community_id: string }>();
+
+  if (mgErr || !mg) return false;
+  return currentUserCanAccessCommunity(supabase, mg.community_id);
+}

--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -898,6 +898,69 @@ describe("RLS: user_roles", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════
+// UX4a (#76) — write-path denial cases for entity CRUD endpoints
+// ══════════════════════════════════════════════════════════════════════════
+//
+// Each test impersonates a user via the Supabase JS client (RLS applies) and
+// attempts the write that the corresponding /api/* endpoint would perform.
+// The API layer adds a role check + RLS backstop; these tests verify the
+// backstop is intact at the DB level.
+
+describe("UX4a (#76) entity CRUD write-path denials", () => {
+  // (a) non-super_admin POST to /api/organizations → RLS blocks INSERT
+  it("User A (org_manager) cannot INSERT a brand-new organization", async () => {
+    if (skipIfRequested()) return;
+    await expectWriteDenied(userA.client, "organizations", {
+      id: "cccccccc-test-0076-0000-000000000001",
+      name: "Cross-org Org via UX4a",
+    });
+  });
+
+  it("User C (no role) cannot INSERT an organization", async () => {
+    if (skipIfRequested()) return;
+    await expectWriteDenied(userC.client, "organizations", {
+      id: "cccccccc-test-0076-0000-000000000002",
+      name: "No-role Org",
+    });
+  });
+
+  // (b) org_manager in Org A posts /api/communities with org_id = Org B → denied
+  it("User A (org_manager of Org A) cannot INSERT a community under Org B", async () => {
+    if (skipIfRequested()) return;
+    await expectWriteDenied(userA.client, "communities", {
+      org_id: FIXTURE.orgB,
+      name: "Cross-org community via UX4a",
+    });
+  });
+
+  // (c) org_manager POST /api/microgrids with community_id outside their org → denied
+  it("User A (org_manager of Org A) cannot INSERT a microgrid under Community B", async () => {
+    if (skipIfRequested()) return;
+    await expectWriteDenied(userA.client, "microgrids", {
+      community_id: FIXTURE.communityB,
+      name: "Cross-org microgrid via UX4a",
+      currency: "UGX",
+    });
+  });
+
+  // Sanity: super_admin CAN insert through the same table
+  it("User D (super_admin) CAN INSERT a temporary organization", async () => {
+    if (skipIfRequested()) return;
+    const tmpId = "cccccccc-test-0076-0000-000000000003";
+    const { data, error } = await userD.client
+      .from("organizations")
+      .insert({ id: tmpId, name: "UX4a super_admin sanity" })
+      .select("id");
+    expect(error).toBeNull();
+    expect(data?.[0]?.id).toBe(tmpId);
+
+    // Cleanup
+    const svc = await serviceClient();
+    await svc.from("organizations").delete().eq("id", tmpId);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
 // 11. Helper function contract tests
 // ══════════════════════════════════════════════════════════════════════════
 

--- a/src/lib/validation/currency.ts
+++ b/src/lib/validation/currency.ts
@@ -1,0 +1,41 @@
+/**
+ * currency.ts — ISO 4217 currency validation.
+ *
+ * UI restricts the microgrid currency Select to UGX/USD/EUR/KES/RWF/TZS, but
+ * the server accepts any valid ISO 4217 code — the runtime catches a
+ * `RangeError` for unknown codes via `Intl.NumberFormat`. This means a future
+ * microgrid in a new country (e.g. SSP) can be created server-side without
+ * changing the UI allowlist immediately.
+ */
+
+/**
+ * Validates a currency string via `Intl.NumberFormat`. Returns an error
+ * message if invalid, or null if valid.
+ *
+ * `Intl.NumberFormat('en', { style: 'currency', currency: input })` throws
+ * `RangeError` for any non-ISO-4217 code (e.g. 'FOO', 'XYZ', ''). We catch
+ * and translate into a user-facing 422 message.
+ */
+export function validateCurrency(input: string): string | null {
+  if (!input) return "Currency is required.";
+  try {
+    new Intl.NumberFormat("en", { style: "currency", currency: input }).format(
+      0
+    );
+    return null;
+  } catch {
+    return `Invalid currency code: '${input}'.`;
+  }
+}
+
+/** UI-facing allowlist. Server accepts any valid ISO 4217 code. */
+export const CURRENCY_OPTIONS = [
+  "UGX",
+  "USD",
+  "EUR",
+  "KES",
+  "RWF",
+  "TZS",
+] as const;
+
+export type CurrencyOption = (typeof CURRENCY_OPTIONS)[number];

--- a/src/test/server-only-stub.ts
+++ b/src/test/server-only-stub.ts
@@ -1,0 +1,6 @@
+// Vitest stub for the Next.js-provided `server-only` virtual module.
+// Next.js implements `import 'server-only'` at the compiler level; the real
+// package does not exist in node_modules. Vitest needs an alias so modules
+// that import it (e.g. `src/lib/auth/access.ts`) can be loaded in the test
+// environment. This file is intentionally empty — its presence is enough.
+export {};

--- a/supabase/migrations/00008_entity_uniqueness.sql
+++ b/supabase/migrations/00008_entity_uniqueness.sql
@@ -1,0 +1,24 @@
+-- 00008_entity_uniqueness.sql
+-- Entity name uniqueness for UX4a (#76).
+--
+-- Adds a UNIQUE constraint on (community_id, name) for microgrids so two
+-- microgrids in the same community cannot share a name. The API layer
+-- catches Postgres error code 23505 on this constraint and returns a
+-- user-facing 409 with the exact message:
+--   "A microgrid named '{name}' already exists in this community."
+--
+-- Org and Community name uniqueness are explicitly NOT enforced here — see
+-- Ticket #76 "Out of Scope". Two NFE-like orgs in different countries might
+-- legitimately share a name, and the super_admin workflow for creating a
+-- second org with the same display name would be friction without value.
+--
+-- Seed audit: 00003_seed.sql.template creates exactly one microgrid per
+-- community (Kisakye in NFE), so this constraint cannot break seeded rows.
+
+ALTER TABLE microgrids
+  ADD CONSTRAINT microgrids_community_name_unique
+  UNIQUE (community_id, name);
+
+COMMENT ON CONSTRAINT microgrids_community_name_unique ON microgrids IS
+  'Enforces per-community microgrid name uniqueness (UX4a / #76). API layer '
+  'translates Postgres 23505 on this constraint into a 409 response.';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -53,6 +53,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // Next.js provides `server-only` as a compiler-level virtual module.
+      // In vitest (no Next compiler) we alias to an empty stub so modules
+      // guarded by `import 'server-only'` can be exercised in tests.
+      "server-only": path.resolve(__dirname, "./src/test/server-only-stub.ts"),
     },
   },
 });


### PR DESCRIPTION
## Summary
Adds Add/Edit forms for the top-3 entity levels (Organization, Community, Microgrid) plus the new `src/lib/auth/access.ts` server-only helper module and `/organizations` listing + detail routes for super_admins.

### New infrastructure
- **`src/lib/auth/access.ts`** — server-only auth helpers (`import 'server-only';` first line). Exports: `getCurrentUserRoles`, `currentUserIsSuperAdmin`, `currentUserCanAccessOrg/Community/Microgrid`.
- **`src/lib/validation/currency.ts`** — ISO 4217 validator via `Intl.NumberFormat` + UI allowlist (UGX/USD/EUR/KES/RWF/TZS).
- **`supabase/migrations/00008_entity_uniqueness.sql`** — UNIQUE `(community_id, name)` on microgrids.

### Shared forms
- **`<EntityForm>`** — shared modal with discriminated-union props (`entity: 'organization' | 'community' | 'microgrid'`). PATCH computes dirty-fields only; the payload omits unchanged fields.
- **`<AddressFields>`** — 6 address inputs with per-field required markers.
- **`<AddEntityButton>` / `<EditEntityButton>`** — thin client wrappers so server-component pages can trigger the modal without going client-component themselves.

### New routes
- `/organizations/page.tsx` — listing; "+ Add Organization" visible to super_admin only.
- `/organizations/[id]/page.tsx` — detail with Edit button **gated on `currentUserIsSuperAdmin` check** (review-round-2 fix — non-admins no longer see a button that always 403s).
- **Sidebar nav** entry "Organizations" — server-rendered, super_admin-only via `<SidebarNav />` server component.

### Edit surfaces
- Org: Edit button on `/organizations/[id]` header (super_admin only).
- Community: Edit button on each row of `/communities` listing.
- Microgrid: Edit button on `/microgrids/[id]` Dashboard header.

### 6 API routes (POST + PATCH per entity)
- Error contract: `{ error: string, field?: string }` across all 6.
- 42501 (permission denied) → 403. 23505 (unique_violation) → 409.
- Microgrid duplicate name: exact copy `"A microgrid named '{name}' already exists in this community."`
- Org 422: missing `address_city` or `address_country`.
- Microgrid 422: invalid currency (Intl.NumberFormat RangeError catch).
- Community: `currentUserCanAccessOrg(org_id)` enforced.
- Microgrid: `currentUserCanAccessCommunity(community_id)` enforced.
- PATCH merges dirty-fields only (verified by route test).

Closes #76.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 390/390 passing (37 files). 55 new tests:
  - 25 route-level cases (POST + PATCH per entity; 422/409/403 paths; dirty-fields merge)
  - 13 component tests (EntityForm + AddressFields across all 3 entity kinds)
  - 17 auth-helper tests (`src/lib/auth/__tests__/access.test.ts`)
  - 4 RLS integration cases in `rls.test.ts` (non-super_admin POST orgs denied; cross-org community POST denied; cross-org microgrid POST denied; super_admin sanity)
- [x] `npm run build` — PASS; `/organizations`, `/organizations/[id]`, all 6 API routes in manifest
- [x] `npm run db:types:check` — PASS (UNIQUE-only migration; types unchanged)

## Notes / review deviations
- **"+ Add Community" button** shows only when user has exactly 1 visible org (primary `org_manager` UX). Super_admins with many orgs add via the org detail page; empty-state copy directs them there. Ticket-literal wording was "for any authenticated user" but that introduces an ambiguous parent-org picker.
- **`server-only` stub for vitest**: `src/test/server-only-stub.ts` + `vitest.config.ts` alias lets `access.ts` load in unit tests (Next provides `server-only` only as a compiler virtual module). `import 'server-only'` still guards production builds.
- **EntityForm's buildPatchPayload** treats empty string and null identically for optional fields (both → null in DB). Last-writer-wins applies per ticket.
- **Client wrapper pattern**: `AddEntityButton` / `EditEntityButton` are thin client components; listing/detail pages remain server components.

## Known Out of Scope (deferred)
- Delete entity (any level) — needs PM sign-off on cascade semantics.
- Community detail route — `/communities/[id]` doesn't exist; cards link to `/microgrids?community=...`. Follow-up candidate.