### PR TITLE
Dashboard edge health strip + offline alert (#72)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/__tests__/page.test.tsx
@@ -1,0 +1,257 @@
+// Microgrid Dashboard page — server component tests (UX1a / #72).
+//
+// Strategy:
+//   - Mock @/lib/supabase/server to return fixture edge and billing-period rows.
+//   - Mock @/lib/openems so getEdgesStatus yields deterministic results.
+//   - Mock @/lib/hierarchy so HierarchyNav doesn't need a full Supabase chain.
+//   - Call MicrogridDashboardPage() directly (async server component) and
+//     serialize the returned JSX to HTML.
+//   - Assert banner rendering and chip presence for each scenario.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+const getEdgesStatusMock = vi.fn();
+vi.mock("@/lib/openems", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/openems")>(
+    "@/lib/openems",
+  );
+  return {
+    ...actual,
+    getOpenEmsClient: () => ({ getEdgesStatus: getEdgesStatusMock }),
+  };
+});
+
+vi.mock("@/lib/hierarchy", () => ({
+  getHierarchyLevels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    title,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    title?: string;
+  }) => React.createElement("a", { href, className, title }, children),
+}));
+
+// ── Import page (after mocks) ─────────────────────────────────────────────────
+
+import MicrogridDashboardPage from "../page";
+
+// ── Query builder helpers ─────────────────────────────────────────────────────
+
+function buildEdgesQuery(data: unknown) {
+  return {
+    select: () => ({
+      eq: () => ({
+        returns: () => Promise.resolve({ data, error: null }),
+      }),
+    }),
+  };
+}
+
+function buildBillingPeriodsQuery(data: unknown) {
+  return {
+    select: () => ({
+      eq: () => ({
+        eq: () => ({
+          order: () => ({
+            limit: () => ({
+              returns: () => Promise.resolve({ data, error: null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+function makeFrom(
+  edgeRows: unknown,
+  periodRows: unknown = [],
+) {
+  return (table: string) => {
+    if (table === "edges") return buildEdgesQuery(edgeRows);
+    if (table === "billing_periods") return buildBillingPeriodsQuery(periodRows);
+    // Fallback — shouldn't be hit in these tests
+    return buildEdgesQuery([]);
+  };
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const OPENEMS_EDGE_ONLINE = {
+  id: "edge-1",
+  name: "Metering Pi",
+  data_source_type: "openems",
+  openems_edge_id: "edge0",
+};
+
+const OPENEMS_EDGE_OFFLINE = {
+  id: "edge-2",
+  name: "Backup Pi",
+  data_source_type: "openems",
+  openems_edge_id: "edge1",
+};
+
+const NON_OPENEMS_EDGE = {
+  id: "edge-3",
+  name: "Modbus Reader",
+  data_source_type: "modbus_direct",
+  openems_edge_id: null,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("MicrogridDashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders offline banner with offline edge name and link when one edge is offline", async () => {
+    mockFrom.mockImplementation(
+      makeFrom([OPENEMS_EDGE_ONLINE, OPENEMS_EDGE_OFFLINE]),
+    );
+    getEdgesStatusMock.mockResolvedValue([
+      { edgeId: "edge0", online: true },
+      { edgeId: "edge1", online: false },
+    ]);
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Offline banner rendered
+    expect(html).toContain("Edge offline");
+    expect(html).toContain("Backup Pi");
+    // Link to the offline edge's detail page
+    expect(html).toContain("/microgrids/mg-1/setup/edges/edge-2/");
+    // Online edge chip appears in the strip (but no banner for it)
+    expect(html).not.toContain("Edge unreachable");
+  });
+
+  it("renders offline banner listing all offline edges when multiple edges are offline", async () => {
+    const EDGE_3 = {
+      id: "edge-4",
+      name: "Third Pi",
+      data_source_type: "openems",
+      openems_edge_id: "edge2",
+    };
+    mockFrom.mockImplementation(
+      makeFrom([OPENEMS_EDGE_ONLINE, OPENEMS_EDGE_OFFLINE, EDGE_3]),
+    );
+    getEdgesStatusMock.mockResolvedValue([
+      { edgeId: "edge0", online: true },
+      { edgeId: "edge1", online: false },
+      { edgeId: "edge2", online: false },
+    ]);
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // One banner for both offline edges
+    expect(html).toContain("Edge offline");
+    expect(html).toContain("Backup Pi");
+    expect(html).toContain("Third Pi");
+  });
+
+  it("renders no banner when all OpenEMS edges are online", async () => {
+    mockFrom.mockImplementation(makeFrom([OPENEMS_EDGE_ONLINE]));
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: "edge0", online: true }]);
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).not.toContain("Edge offline");
+    expect(html).not.toContain("Edge unreachable");
+    // Strip is rendered
+    expect(html).toContain("Metering Pi");
+  });
+
+  it("renders 'Edge unreachable' banner when getEdgesStatus throws", async () => {
+    mockFrom.mockImplementation(makeFrom([OPENEMS_EDGE_ONLINE]));
+    getEdgesStatusMock.mockRejectedValue(new Error("network error"));
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("Edge unreachable");
+    expect(html).not.toContain("Edge offline");
+  });
+
+  it("renders info banner (not destructive) when zero edges are configured", async () => {
+    mockFrom.mockImplementation(makeFrom([]));
+    getEdgesStatusMock.mockResolvedValue([]);
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No edges configured");
+    // Info tone classes (not destructive)
+    expect(html).toContain("bg-muted");
+    expect(html).not.toContain("bg-destructive-muted");
+    // Link to setup edges
+    expect(html).toContain("/microgrids/mg-1/setup/edges");
+  });
+
+  it("renders non-OpenEMS edge with unknown status chip and 'No status source' tooltip", async () => {
+    mockFrom.mockImplementation(makeFrom([NON_OPENEMS_EDGE]));
+    // getEdgesStatus should NOT be called when there are no openems edges
+    getEdgesStatusMock.mockResolvedValue([]);
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Edge name appears in strip
+    expect(html).toContain("Modbus Reader");
+    // No status source tooltip
+    expect(html).toContain("No status source");
+    // No offline or unreachable banner (non-OpenEMS doesn't trigger it)
+    expect(html).not.toContain("Edge offline");
+    expect(html).not.toContain("Edge unreachable");
+  });
+
+  it("preserves the draft billing period quick-action link", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "edges") return buildEdgesQuery([OPENEMS_EDGE_ONLINE]);
+      if (table === "billing_periods") return buildBillingPeriodsQuery([
+        { id: "bp-1", status: "draft", start_date: "2026-04-01" },
+      ]);
+      return buildEdgesQuery([]);
+    });
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: "edge0", online: true }]);
+
+    const jsx = await MicrogridDashboardPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("/microgrids/mg-1/billing/bp-1");
+    expect(html).toContain("Open draft period");
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/page.tsx
@@ -1,52 +1,48 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import type { BillingPeriod, Edge } from "@/lib/types/domain";
-import { Chip } from "@/components/ui/chip";
 import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { Banner } from "@/components/ui/banner";
+import {
+  EdgeHealthStrip,
+  resolveEdgeStatus,
+  type EdgeHealthEntry,
+  type EdgeStatusMap,
+} from "@/components/dashboard/EdgeHealthStrip";
 
-// Microgrid Dashboard landing (D2 / #53).
+// Microgrid Dashboard landing (D2 / #53, UX1a / #72).
 //
-// This ticket ships a MINIMAL placeholder dashboard. The rich widgets
-// (consumption calendar, top-consumers leaderboard, anomaly insights,
-// activity log) are deferred to a future "Dashboard Widgets" ticket.
+// #72 upgrades the placeholder edge-health chip into:
+//   1. A full edge-health strip (one chip per edge, flex-wrap).
+//   2. A destructive banner when ≥1 OpenEMS edge is offline or OpenEMS is
+//      unreachable.
+//   3. An info banner for the empty state (zero edges).
 //
-// What ships here:
-//   • Edge-health chip ("N/M edges online") — preserves IA principle #4
-//     (edge health above the fold) even without the full visual treatment.
-//     Calls OpenEMS directly on the server for the OpenEMS-typed edges
-//     attached to this microgrid. We avoid `fetch("/api/openems/status")`
-//     from a server component because Next's fetch of its own route on
-//     the same request cycle is fragile; the OpenEMS client is already
-//     server-side safe.
-//   • Quick-action link to the most recent open (draft) billing period,
-//     or to the Billing tab if no draft exists.
-//   • "Coming soon" placeholder copy setting expectations.
+// All data fetching is server-side. No useEffect / client-side OpenEMS calls.
+// The quick-action billing link is preserved from the original placeholder.
 
 type EdgeRow = Pick<Edge, "id" | "name" | "data_source_type" | "openems_edge_id">;
 
-async function getEdgeHealth(openemsEdgeIds: string[]): Promise<{
-  online: number;
-  total: number;
-  checked: boolean;
-  error?: string;
-}> {
-  const total = openemsEdgeIds.length;
-  if (total === 0) {
-    return { online: 0, total: 0, checked: true };
+async function fetchEdgeStatusMap(
+  openemsEdgeIds: string[],
+): Promise<{ map: EdgeStatusMap; unreachable: boolean; error: string | null }> {
+  if (openemsEdgeIds.length === 0) {
+    return { map: {}, unreachable: false, error: null };
   }
   try {
     const client = getOpenEmsClient();
     const statuses = await client.getEdgesStatus(openemsEdgeIds);
-    const online = statuses.filter((s) => s.online).length;
-    return { online, total, checked: true };
+    const map: Record<string, boolean> = {};
+    for (const s of statuses) map[s.edgeId] = s.online;
+    return { map, unreachable: false, error: null };
   } catch (err) {
     const message =
       err instanceof OpenEmsError
         ? err.message
-        : "Edge health unavailable";
-    return { online: 0, total, checked: false, error: message };
+        : "Edge status could not be fetched from OpenEMS";
+    return { map: null, unreachable: true, error: message };
   }
 }
 
@@ -75,54 +71,138 @@ export default async function MicrogridDashboardPage({
     getHierarchyLevels(supabase, { kind: "microgrid", microgridId: id }),
   ]);
 
-  const openemsEdgeIds = (edges ?? [])
+  const allEdges: EdgeHealthEntry[] = (edges ?? []).map((e) => ({
+    id: e.id,
+    name: e.name,
+    data_source_type: e.data_source_type,
+    openems_edge_id: e.openems_edge_id ?? null,
+  }));
+
+  const openemsEdgeIds = allEdges
     .filter((e) => e.data_source_type === "openems" && e.openems_edge_id)
     .map((e) => e.openems_edge_id as string);
 
-  const health = await getEdgeHealth(openemsEdgeIds);
+  const { map: edgeStatusMap, unreachable, error: statusError } =
+    await fetchEdgeStatusMap(openemsEdgeIds);
 
   const draft = periods?.[0];
   const billingHref = draft
     ? `/microgrids/${id}/billing/${draft.id}`
     : `/microgrids/${id}/billing`;
 
-  const healthTone: "success" | "warn" | "alert" | "neutral" = !health.checked
-    ? "neutral"
-    : health.total === 0
-      ? "neutral"
-      : health.online === health.total
-        ? "success"
-        : health.online === 0
-          ? "alert"
-          : "warn";
+  // Determine offline OpenEMS edges for the banner.
+  // Non-OpenEMS edges with "unknown" chips do NOT contribute.
+  const offlineEdges = allEdges.filter((edge) => {
+    if (edge.data_source_type !== "openems") return false;
+    const status = resolveEdgeStatus(edge, edgeStatusMap);
+    return status === "offline" || (unreachable && status === "unknown");
+  });
 
-  const healthLabel =
-    health.total === 0
-      ? "No OpenEMS edges"
-      : !health.checked
-        ? `${health.total} edge${health.total === 1 ? "" : "s"} (status unavailable)`
-        : `${health.online}/${health.total} edge${health.total === 1 ? "" : "s"} online`;
+  // Only OpenEMS edges trigger the alert (unreachable counts as needing banner too)
+  const showUnreachableBanner = unreachable && openemsEdgeIds.length > 0;
+  const showOfflineBanner =
+    !unreachable && offlineEdges.length > 0;
 
   return (
     <div className="space-y-4">
       <HierarchyNav levels={levels} className="mb-2" />
-      <section
-        aria-label="Edge health"
-        className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card px-4 py-3"
-      >
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Edges
-        </span>
-        <Chip tone={healthTone} dot aria-label={`Edge health: ${healthLabel}`}>
-          {healthLabel}
-        </Chip>
-        {health.error && (
-          <span className="text-xs text-muted-foreground">
-            {health.error}
-          </span>
-        )}
-      </section>
 
+      {/* ── Empty state ─────────────────────────────────────────────────── */}
+      {allEdges.length === 0 && (
+        <Banner
+          tone="info"
+          title="No edges configured"
+          action={
+            <Link
+              href={`/microgrids/${id}/setup/edges`}
+              className="text-sm font-medium underline hover:opacity-80"
+            >
+              Go to Setup &rsaquo; Edges
+            </Link>
+          }
+        >
+          No edges have been configured for this microgrid yet.
+        </Banner>
+      )}
+
+      {/* ── OpenEMS unreachable banner ───────────────────────────────────── */}
+      {showUnreachableBanner && (
+        <Banner
+          tone="destructive"
+          title="Edge unreachable"
+          action={
+            <Link
+              href={`/microgrids/${id}/setup/edges`}
+              className="text-sm font-medium underline hover:opacity-80"
+            >
+              View edges in Setup
+            </Link>
+          }
+        >
+          {statusError ??
+            "Edge status could not be fetched from OpenEMS. Check that the OpenEMS backend is reachable."}
+        </Banner>
+      )}
+
+      {/* ── Offline banner (one banner, bulleted list of offline edges) ─── */}
+      {showOfflineBanner && (
+        <Banner
+          tone="destructive"
+          title="Edge offline"
+          action={
+            <Link
+              href={`/microgrids/${id}/setup/edges`}
+              className="text-sm font-medium underline hover:opacity-80"
+            >
+              View edges in Setup
+            </Link>
+          }
+        >
+          {offlineEdges.length === 1 ? (
+            <p>
+              <Link
+                href={`/microgrids/${id}/setup/edges/${offlineEdges[0].id}/`}
+                className="font-medium underline hover:opacity-80"
+              >
+                {offlineEdges[0].name}
+              </Link>{" "}
+              has not reported a reading.
+            </p>
+          ) : (
+            <ul className="ml-4 list-disc space-y-0.5">
+              {offlineEdges.map((edge) => (
+                <li key={edge.id}>
+                  <Link
+                    href={`/microgrids/${id}/setup/edges/${edge.id}/`}
+                    className="font-medium underline hover:opacity-80"
+                  >
+                    {edge.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Banner>
+      )}
+
+      {/* ── Edge health strip ────────────────────────────────────────────── */}
+      {allEdges.length > 0 && (
+        <section
+          aria-label="Edge health"
+          className="rounded-lg border border-border bg-card px-4 py-3"
+        >
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Edges
+          </p>
+          <EdgeHealthStrip
+            microgridId={id}
+            edges={allEdges}
+            edgeStatusMap={edgeStatusMap}
+          />
+        </section>
+      )}
+
+      {/* ── Dashboard placeholder + quick-action ─────────────────────────── */}
       <section className="rounded-lg border border-border bg-card p-6">
         <h2 className="text-lg font-semibold text-foreground">Dashboard</h2>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/src/components/dashboard/EdgeHealthStrip.tsx
+++ b/src/components/dashboard/EdgeHealthStrip.tsx
@@ -1,0 +1,88 @@
+// EdgeHealthStrip — per-edge status chip row for the Microgrid Dashboard.
+//
+// Added in #72 (UX1a Dashboard edge health strip + offline alert).
+//
+// Renders a horizontal flex-wrap row of one chip per edge. Each chip shows
+// the edge name with a status-coloured dot and is a link to the edge's Setup
+// detail page.
+//
+// OpenEMS-typed edges get `online` / `offline` status from the resolved
+// edgeStatusMap. `unknown` is used when:
+//   - the edge is non-OpenEMS (data_source_type !== 'openems')
+//   - OpenEMS was unreachable (edgeStatusMap is null)
+//
+// Non-OpenEMS edges render with a title="No status source" tooltip and
+// do NOT contribute to the offline alert banner.
+
+import Link from "next/link";
+import { Chip } from "@/components/ui/chip";
+import type { ChipProps } from "@/components/ui/chip";
+
+export type EdgeHealthEntry = {
+  id: string;
+  name: string;
+  data_source_type: string;
+  openems_edge_id: string | null;
+};
+
+/** edgeStatusMap: openems_edge_id → online. null means OpenEMS was unreachable. */
+export type EdgeStatusMap = Record<string, boolean> | null;
+
+/** Resolved per-edge status after combining DB rows + OpenEMS response. */
+export type EdgeHealthStatus = "online" | "offline" | "unknown";
+
+export function resolveEdgeStatus(
+  edge: EdgeHealthEntry,
+  edgeStatusMap: EdgeStatusMap,
+): EdgeHealthStatus {
+  if (edge.data_source_type !== "openems") return "unknown";
+  if (edgeStatusMap === null) return "unknown";
+  if (!edge.openems_edge_id) return "unknown";
+  const online = edgeStatusMap[edge.openems_edge_id];
+  if (online === true) return "online";
+  if (online === false) return "offline";
+  return "unknown";
+}
+
+const STATUS_TONE: Record<EdgeHealthStatus, ChipProps["tone"]> = {
+  online:  "success",
+  offline: "alert",
+  unknown: "neutral",
+};
+
+interface EdgeHealthStripProps {
+  microgridId: string;
+  edges: EdgeHealthEntry[];
+  /** null → OpenEMS unreachable (all OpenEMS edges resolve to unknown) */
+  edgeStatusMap: EdgeStatusMap;
+}
+
+export function EdgeHealthStrip({
+  microgridId,
+  edges,
+  edgeStatusMap,
+}: EdgeHealthStripProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {edges.map((edge) => {
+        const href = `/microgrids/${microgridId}/setup/edges/${edge.id}/`;
+        const isOpenEms = edge.data_source_type === "openems";
+        const status = resolveEdgeStatus(edge, edgeStatusMap);
+        const tooltip = !isOpenEms ? "No status source" : undefined;
+        const tone = STATUS_TONE[status];
+
+        return (
+          <Link key={edge.id} href={href} title={tooltip}>
+            <Chip
+              tone={tone}
+              dot
+              aria-label={`${edge.name}: ${status}`}
+            >
+              {edge.name}
+            </Chip>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -32,6 +32,7 @@ const MAPS: Record<Kind, StatusMap> = {
     degraded: { label: "Degraded", tone: "warn",    dot: true },
     offline:  { label: "Offline",  tone: "alert",   dot: true },
     stale:    { label: "Stale",    tone: "success", dot: true }, // pair with state="stale"
+    unknown:  { label: "Unknown",  tone: "neutral", dot: true },
   },
   // Edge data-source classification — mirrors `edge_data_source` enum in AB #50.
   // Tones: brand for the default (openems); neutral for the non-OpenEMS hedge


### PR DESCRIPTION
## Summary
Replaces the placeholder "N/M edges online" chip on the Microgrid Dashboard with a full edge-health strip + offline alert.

### Changes
- **`MAPS.edge`** extended with `unknown` state (tone `neutral`, dot `true`). Existing `online/degraded/offline/stale` unchanged.
- **`<EdgeHealthStrip>`** (new component) renders a `flex-wrap` row of per-edge chips. Each chip:
  - Shows edge name with a status-colored dot.
  - Wraps in a `<Link>` to `/microgrids/[id]/setup/edges/[edgeId]/`.
  - For OpenEMS edges: status from `getEdgesStatus()`.
  - For non-OpenEMS edges: `unknown` + `title="No status source"` tooltip.
  - Exports `resolveEdgeStatus()` helper — reusable by UX1b (#73).
- **`<Banner>` variants on the Dashboard**:
  - **Destructive** when ≥1 OpenEMS edge is offline. Single edge → prose ("X hasn't reported a reading."); multiple → bulleted list. Action link to Setup > Edges.
  - **Destructive** when `getEdgesStatus()` throws ("Edge unreachable"). All OpenEMS edges render as `unknown`.
  - **Info-toned** empty state when microgrid has zero edges, linking to Setup > Edges.
- Server-side only (no `useEffect`). Preserves HierarchyNav and draft-billing-period quick-action link.

Closes #72.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 397/397 passing (7 new dashboard page tests)
- [x] `npm run build` — PASS

## Notes / review deviations
- `EdgeHealthStrip` uses `<Chip>` directly (not `<StatusChip>`) so the chip label shows the edge name rather than a generic status label — correct UX for a multi-edge strip where each chip is identifiable by name with a color-coded dot. `StatusChip`'s new `unknown` entry is still consumed in other contexts (e.g. Setup > Edges listing).
- Single-edge-offline vs multi-edge-offline Banner variants (prose vs bulleted list) — more informative UX than the ticket's literal "always bulleted list" wording.