### PR TITLE
Fix invalid UUID in RLS super_admin INSERT sanity test (#90)

### DIFF
--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -384,7 +384,7 @@ describe("RLS: organizations", () => {
   it("User A cannot INSERT into Org B", async () => {
     if (skipIfRequested()) return;
     await expectWriteDenied(userA.client, "organizations", {
-      id: "cccccccc-test-ffff-0000-000000000001",
+      id: "cccccccc-0076-4000-8000-000000000001",
       name: "Unauthorized Org",
     });
   });
@@ -911,7 +911,7 @@ describe("UX4a (#76) entity CRUD write-path denials", () => {
   it("User A (org_manager) cannot INSERT a brand-new organization", async () => {
     if (skipIfRequested()) return;
     await expectWriteDenied(userA.client, "organizations", {
-      id: "cccccccc-test-0076-0000-000000000001",
+      id: "cccccccc-0076-4000-8000-000000000002",
       name: "Cross-org Org via UX4a",
     });
   });
@@ -919,7 +919,7 @@ describe("UX4a (#76) entity CRUD write-path denials", () => {
   it("User C (no role) cannot INSERT an organization", async () => {
     if (skipIfRequested()) return;
     await expectWriteDenied(userC.client, "organizations", {
-      id: "cccccccc-test-0076-0000-000000000002",
+      id: "cccccccc-0076-4000-8000-000000000003",
       name: "No-role Org",
     });
   });
@@ -946,7 +946,7 @@ describe("UX4a (#76) entity CRUD write-path denials", () => {
   // Sanity: super_admin CAN insert through the same table
   it("User D (super_admin) CAN INSERT a temporary organization", async () => {
     if (skipIfRequested()) return;
-    const tmpId = "cccccccc-test-0076-0000-000000000003";
+    const tmpId = "cccccccc-0076-4000-8000-000000000004";
     const { data, error } = await userD.client
       .from("organizations")
       .insert({ id: tmpId, name: "UX4a super_admin sanity" })


### PR DESCRIPTION
## Summary
Fixes 4 invalid UUID literals in `src/lib/supabase/__tests__/rls.test.ts`. The pattern `cccccccc-test-*` contains the substring "test" which Postgres rejects as non-hex — causing the `User D (super_admin) CAN INSERT a temporary organization` test (L949) to fail on any live-Supabase run with `invalid input syntax for type uuid` rather than the expected success.

Three other occurrences (L387, L914, L922) use the same pattern in expect-denied assertions; they pass accidentally because Postgres rejects before RLS evaluates. All 4 replaced with valid v4-shaped hex-only UUIDs.

### Replacements
| Line | Old (invalid) | New (valid v4-shape) |
|---|---|---|
| 387 | `cccccccc-test-ffff-0000-000000000001` | `cccccccc-0076-4000-8000-000000000001` |
| 914 | `cccccccc-test-0076-0000-000000000001` | `cccccccc-0076-4000-8000-000000000002` |
| 922 | `cccccccc-test-0076-0000-000000000002` | `cccccccc-0076-4000-8000-000000000003` |
| 949 | `cccccccc-test-0076-0000-000000000003` | `cccccccc-0076-4000-8000-000000000004` |

### Explicitly out-of-scope (not touched)
Legitimate non-UUID `-test-` fixtures remain as-is:
- `rls.test.ts:86-89` — email fixtures (`user-a-test@...`)
- `rls.test.ts:144, 152, 1093` — `openems_edge_id` strings
- `rls.test.ts:1104` — community `name` field

Closes #90.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `SKIP_RLS_TESTS=1 npm test` — 465/465 passing
- [x] `npm run build` — PASS
- [ ] Live-Supabase run (requires `SUPABASE_JWT_SECRET` + local Supabase at `http://localhost:54321`) — will be verified by architect; `SKIP_RLS_TESTS=1` path doesn't exercise the fix

## Notes
Pre-existing failure flagged during #79's review. Independent of recent feature work.