### PR TITLE
Add community detail route (/communities/[id]) (#87)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/__tests__/page.test.tsx
@@ -1,0 +1,234 @@
+// Community detail page — server component tests (#87).
+//
+// Strategy:
+//   - Mock @/lib/supabase/server to control what Supabase returns.
+//   - Mock @/lib/hierarchy so HierarchyNav doesn't need a full chain.
+//   - Mock @/lib/auth/access to control currentUserCanAccessCommunity().
+//   - Mock next/navigation.notFound to capture 404 scenarios.
+//   - Call CommunityDetailPage() directly (async server component).
+//   - Serialize to HTML and assert on content.
+//
+// Scenarios:
+//   1. Populated community with 2 microgrids → stats + listing + Edit button.
+//   2. Non-accessible community (cross-org) → notFound().
+//   3. Empty-microgrids community → "No microgrids yet" placeholder.
+//   4. Zero-stats community (0 hh, 0 devices) → stats strip renders zeros.
+//   5. User without access → Edit button not rendered.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+let communityData: unknown = null;
+let canAccessResult = true;
+
+const mockSingle = vi.fn(() =>
+  Promise.resolve({ data: communityData, error: null })
+);
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: mockSingle,
+          maybeSingle: mockSingle,
+        }),
+        maybeSingle: mockSingle,
+      }),
+    }),
+    auth: {
+      getUser: async () => ({ data: { user: null }, error: null }),
+    },
+  }),
+}));
+
+vi.mock("@/lib/hierarchy", () => ({
+  getHierarchyLevels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessCommunity: vi.fn(() => Promise.resolve(canAccessResult)),
+}));
+
+// notFoundMock must be hoisted so the vi.mock factory can reference it before
+// module initialization (vi.mock calls are hoisted to top of file).
+const { notFoundMock } = vi.hoisted(() => {
+  const notFoundMock = vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  });
+  return { notFoundMock };
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+  useRouter: () => ({ refresh: () => {}, push: () => {}, replace: () => {} }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => React.createElement("a", { href, className }, children),
+}));
+
+// ── Import page (after mocks) ─────────────────────────────────────────────────
+
+import CommunityDetailPage from "../page";
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+const BASE_COMMUNITY = {
+  id: "comm-1",
+  org_id: "org-1",
+  name: "Kisakye",
+  address_line1: "123 Main St",
+  address_line2: null,
+  address_city: "Kampala",
+  address_region: "Central Region",
+  address_country: "Uganda",
+  address_postal_code: null,
+  geography_notes: "Near the lake",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function makeGrid(
+  id: string,
+  name: string,
+  city: string | null,
+  hhCount: number,
+  devCount: number
+) {
+  return {
+    id,
+    name,
+    address_city: city,
+    households: [{ count: hhCount }],
+    devices: [{ count: devCount }],
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("CommunityDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    communityData = null;
+    canAccessResult = true;
+    mockSingle.mockImplementation(() =>
+      Promise.resolve({ data: communityData, error: null })
+    );
+  });
+
+  // 1. Populated community with 2 microgrids → stats + listing + Edit button.
+  it("renders stats strip, microgrid listing, and Edit button for accessible user", async () => {
+    communityData = {
+      ...BASE_COMMUNITY,
+      microgrids: [
+        makeGrid("mg-1", "Block A", "Kampala", 5, 3),
+        makeGrid("mg-2", "Block B", "Entebbe", 7, 4),
+      ],
+    };
+    mockSingle.mockResolvedValue({ data: communityData, error: null });
+    canAccessResult = true;
+
+    const jsx = await CommunityDetailPage({
+      params: Promise.resolve({ id: "comm-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Community name in header
+    expect(html).toContain("Kisakye");
+    // Stats: 2 microgrids, 12 households, 7 devices
+    expect(html).toContain("2");
+    expect(html).toContain("12");
+    expect(html).toContain("7");
+    // Microgrid listing
+    expect(html).toContain("Block A");
+    expect(html).toContain("Block B");
+    expect(html).toContain("/microgrids/mg-1");
+    expect(html).toContain("/microgrids/mg-2");
+    // Edit button rendered
+    expect(html).toContain("Edit");
+    // View microgrids link
+    expect(html).toContain(`/microgrids?community=comm-1`);
+  });
+
+  // 2. Non-accessible community (cross-org org_manager) → notFound().
+  it("calls notFound() when community data is null (RLS-filtered or missing)", async () => {
+    communityData = null;
+    mockSingle.mockResolvedValue({ data: null, error: null });
+
+    await expect(
+      CommunityDetailPage({ params: Promise.resolve({ id: "comm-99" }) })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  // 3. Empty-microgrids community → "No microgrids yet" placeholder.
+  it("renders 'No microgrids yet' placeholder when microgrids array is empty", async () => {
+    communityData = {
+      ...BASE_COMMUNITY,
+      microgrids: [],
+    };
+    mockSingle.mockResolvedValue({ data: communityData, error: null });
+
+    const jsx = await CommunityDetailPage({
+      params: Promise.resolve({ id: "comm-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No microgrids yet");
+    // Stats show zeros
+    expect(html).toContain("0");
+  });
+
+  // 4. Zero-stats community → stats strip renders zeros without crashing.
+  it("renders stats strip with zeros for community with 0 households and 0 devices", async () => {
+    communityData = {
+      ...BASE_COMMUNITY,
+      microgrids: [makeGrid("mg-1", "Block A", null, 0, 0)],
+    };
+    mockSingle.mockResolvedValue({ data: communityData, error: null });
+
+    const jsx = await CommunityDetailPage({
+      params: Promise.resolve({ id: "comm-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Microgrid renders, no crash
+    expect(html).toContain("Block A");
+    // Stats: 1 microgrid, 0 households, 0 devices
+    expect(html).toContain("Microgrid");
+    expect(html).toContain("Household");
+    expect(html).toContain("Device");
+  });
+
+  // 5. Edit button hidden for user without access.
+  it("does NOT render Edit button when currentUserCanAccessCommunity returns false", async () => {
+    communityData = {
+      ...BASE_COMMUNITY,
+      microgrids: [makeGrid("mg-1", "Block A", "Kampala", 2, 1)],
+    };
+    mockSingle.mockResolvedValue({ data: communityData, error: null });
+    canAccessResult = false;
+
+    const jsx = await CommunityDetailPage({
+      params: Promise.resolve({ id: "comm-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Community still renders
+    expect(html).toContain("Kisakye");
+    // Edit button must NOT appear
+    expect(html).not.toContain(">Edit<");
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/page.tsx
@@ -1,0 +1,207 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
+import { EditEntityButton } from "@/components/forms/EditEntityButton";
+import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+import type { Community } from "@/lib/types/domain";
+
+/**
+ * /communities/[id] — community detail page (#87).
+ *
+ * Shows community address/geography info, aggregated stats (microgrid count,
+ * household count, device count) and a list of its microgrids. The Edit button
+ * in the header is shown only when `currentUserCanAccessCommunity` resolves
+ * truthy — explicit check, not RLS-implicit.
+ */
+
+type MicrogridRow = {
+  id: string;
+  name: string;
+  address_city: string | null;
+  households: { count: number }[];
+  devices: { count: number }[];
+};
+
+type CommunityWithMicrogrids = Community & {
+  microgrids: MicrogridRow[];
+};
+
+function emDash(value: string | null | undefined): string {
+  return value && value.trim() !== "" ? value : "—";
+}
+
+export default async function CommunityDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const [{ data: community }, canEdit, levels] = await Promise.all([
+    supabase
+      .from("communities")
+      .select(
+        `*, microgrids(id, name, address_city, households(count), devices:edges(devices(count)))`
+      )
+      .eq("id", id)
+      .single<CommunityWithMicrogrids>(),
+    currentUserCanAccessCommunity(supabase, id),
+    getHierarchyLevels(supabase, { kind: "community", communityId: id }),
+  ]);
+
+  if (!community) {
+    notFound();
+  }
+
+  const microgrids = community.microgrids ?? [];
+  const microgridCount = microgrids.length;
+
+  const householdCount = microgrids.reduce((sum, mg) => {
+    const c = mg.households?.[0]?.count ?? 0;
+    return sum + c;
+  }, 0);
+
+  const deviceCount = microgrids.reduce((sum, mg) => {
+    const c = mg.devices?.[0]?.count ?? 0;
+    return sum + c;
+  }, 0);
+
+  return (
+    <div>
+      <HierarchyNav levels={levels} className="mb-4" />
+
+      {/* Page header */}
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">
+            {community.name}
+          </h1>
+          {(community.address_city || community.address_country) && (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {[community.address_city, community.address_country]
+                .filter(Boolean)
+                .join(", ")}
+            </p>
+          )}
+        </div>
+        {canEdit && (
+          <EditEntityButton entity="community" initialValues={community} />
+        )}
+      </div>
+
+      {/* Stats strip */}
+      <div className="mb-6 grid grid-cols-3 gap-4 rounded-lg border border-border bg-card p-4">
+        <div className="text-center">
+          <div className="text-2xl font-semibold text-foreground">
+            {microgridCount}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            Microgrid{microgridCount !== 1 ? "s" : ""}
+          </div>
+        </div>
+        <div className="text-center">
+          <div className="text-2xl font-semibold text-foreground">
+            {householdCount}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            Household{householdCount !== 1 ? "s" : ""}
+          </div>
+        </div>
+        <div className="text-center">
+          <div className="text-2xl font-semibold text-foreground">
+            {deviceCount}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            Device{deviceCount !== 1 ? "s" : ""}
+          </div>
+        </div>
+      </div>
+
+      {/* Community details */}
+      <section className="mb-6 rounded-lg border border-border bg-card p-6">
+        <h2 className="mb-3 text-lg font-semibold text-foreground">Details</h2>
+        <dl className="space-y-2 text-sm">
+          {community.address_line1 !== undefined && (
+            <div className="flex gap-4">
+              <dt className="w-32 text-muted-foreground">Address</dt>
+              <dd className="text-foreground">
+                {emDash(community.address_line1)}
+              </dd>
+            </div>
+          )}
+          {community.address_line2 !== undefined && (
+            <div className="flex gap-4">
+              <dt className="w-32 text-muted-foreground">Address line 2</dt>
+              <dd className="text-foreground">
+                {emDash(community.address_line2)}
+              </dd>
+            </div>
+          )}
+          <div className="flex gap-4">
+            <dt className="w-32 text-muted-foreground">City</dt>
+            <dd className="text-foreground">{emDash(community.address_city)}</dd>
+          </div>
+          <div className="flex gap-4">
+            <dt className="w-32 text-muted-foreground">Region</dt>
+            <dd className="text-foreground">
+              {emDash(community.address_region)}
+            </dd>
+          </div>
+          <div className="flex gap-4">
+            <dt className="w-32 text-muted-foreground">Country</dt>
+            <dd className="text-foreground">
+              {emDash(community.address_country)}
+            </dd>
+          </div>
+          {community.geography_notes !== undefined && (
+            <div className="flex gap-4">
+              <dt className="w-32 text-muted-foreground">Geography notes</dt>
+              <dd className="text-foreground">
+                {emDash(community.geography_notes)}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </section>
+
+      {/* Microgrids listing */}
+      <section className="rounded-lg border border-border bg-card p-6">
+        <h2 className="mb-3 text-lg font-semibold text-foreground">
+          Microgrids in this community
+        </h2>
+        {microgrids.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No microgrids yet.</p>
+        ) : (
+          <ul className="space-y-1">
+            {microgrids.map((mg) => (
+              <li key={mg.id}>
+                <Link
+                  href={`/microgrids/${mg.id}`}
+                  className="text-sm text-foreground hover:underline"
+                >
+                  {mg.name}
+                </Link>
+                {mg.address_city && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {mg.address_city}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="mt-4 border-t border-border pt-4">
+          <Link
+            href={`/microgrids?community=${community.id}`}
+            className="text-sm text-foreground hover:underline"
+          >
+            View microgrids &rarr;
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/page.test.tsx
+++ b/src/app/(dashboard)/communities/page.test.tsx
@@ -126,8 +126,8 @@ describe("CommunitiesPage", () => {
     expect(html).toContain("Kisakye");
     expect(html).toContain("Kampala, Uganda");
     expect(html).toContain("3 microgrids");
-    // Link should point to /microgrids?community=<id>
-    expect(html).toContain("/microgrids?community=comm-1");
+    // Link should point to /communities/<id>
+    expect(html).toContain("/communities/comm-1");
   });
 
   it("renders multiple rows when multiple communities are returned", async () => {

--- a/src/app/(dashboard)/communities/page.tsx
+++ b/src/app/(dashboard)/communities/page.tsx
@@ -3,7 +3,6 @@ import { createClient } from "@/lib/supabase/server";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { AddEntityButton } from "@/components/forms/AddEntityButton";
-import { EditEntityButton } from "@/components/forms/EditEntityButton";
 import type { Community } from "@/lib/types/domain";
 
 type CommunityRow = Community & {
@@ -100,34 +99,24 @@ export default async function CommunitiesPage() {
               : 0;
 
           return (
-            <div
+            <Link
               key={community.id}
+              href={`/communities/${community.id}`}
               className="flex flex-col rounded-lg border border-border bg-card p-6 transition-colors hover:border-border"
             >
-              <Link
-                href={`/microgrids?community=${community.id}`}
-                className="flex-1"
-              >
-                <h2 className="font-medium text-foreground">
-                  {community.name}
-                </h2>
-                {locationLabel && (
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {locationLabel}
-                  </p>
-                )}
-                <div className="mt-3 text-sm text-muted-foreground">
-                  {microgridCount} microgrid
-                  {microgridCount !== 1 ? "s" : ""}
-                </div>
-              </Link>
-              <div className="mt-4 flex justify-end">
-                <EditEntityButton
-                  entity="community"
-                  initialValues={community}
-                />
+              <h2 className="font-medium text-foreground">
+                {community.name}
+              </h2>
+              {locationLabel && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {locationLabel}
+                </p>
+              )}
+              <div className="mt-3 text-sm text-muted-foreground">
+                {microgridCount} microgrid
+                {microgridCount !== 1 ? "s" : ""}
               </div>
-            </div>
+            </Link>
           );
         })}
       </div>

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -89,7 +89,7 @@ export default async function OrganizationDetailPage({
               return (
                 <li key={c.id}>
                   <Link
-                    href={`/microgrids?community=${c.id}`}
+                    href={`/communities/${c.id}`}
                     className="text-sm text-foreground hover:underline"
                   >
                     {c.name}

--- a/src/components/ui/__tests__/hierarchy-nav.test.tsx
+++ b/src/components/ui/__tests__/hierarchy-nav.test.tsx
@@ -27,7 +27,7 @@ const communityLevel: HierarchyLevel = {
   kind: "Community",
   label: "Kisakye",
   count: 1,
-  href: "/microgrids?community=comm-k",
+  href: "/communities/comm-k",
   active: false,
 };
 

--- a/src/lib/__tests__/hierarchy.test.ts
+++ b/src/lib/__tests__/hierarchy.test.ts
@@ -190,7 +190,8 @@ describe("getHierarchyLevels — siblings branch", () => {
     expect(commLevel!.siblings!.length).toBe(1);
     const siblingHrefs = commLevel!.siblings!.map((s) => s.href);
     expect(siblingHrefs.some((h) => h.includes("comm-k2"))).toBe(true);
-    expect(siblingHrefs.some((h) => h.includes("comm-k") && !h.includes("comm-k2"))).toBe(false);
+    // Sibling hrefs now point to /communities/<id>
+    expect(siblingHrefs.every((h) => h.startsWith("/communities/"))).toBe(true);
   });
 
   it("microgrid count > 1 → siblings populated for Microgrid level; excludes self", async () => {
@@ -279,6 +280,29 @@ describe("getHierarchyLevels — scope variants", () => {
     expect(levels[3].kind).toBe("Household");
     expect(levels[3].active).toBe(true);
   });
+
+  it("community scope → 2-level [Org, Community(active=true)]", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "community",
+      communityId: "comm-k",
+    });
+    expect(levels).toHaveLength(2);
+    expect(levels[0].kind).toBe("Organization");
+    expect(levels[0].active).toBe(false);
+    expect(levels[1].kind).toBe("Community");
+    expect(levels[1].label).toBe("Kisakye");
+    expect(levels[1].active).toBe(true);
+    expect(levels[1].href).toBe("/communities/comm-k");
+  });
+
+  it("community scope: unknown communityId → [Organization] fallback", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "community",
+      communityId: "no-such-community",
+    });
+    expect(levels).toHaveLength(1);
+    expect(levels[0].kind).toBe("Organization");
+  });
 });
 
 // ── href contracts ─────────────────────────────────────────────────────────────
@@ -297,13 +321,13 @@ describe("getHierarchyLevels — href contracts", () => {
     expect(levels[0].href).toBe("/");
   });
 
-  it("Community href points to /microgrids?community=<id>", async () => {
+  it("Community href points to /communities/<id>", async () => {
     const levels = await getHierarchyLevels(supabase, {
       kind: "microgrid",
       microgridId: "mg-1",
     });
     const commLevel = levels.find((l) => l.kind === "Community");
-    expect(commLevel!.href).toBe("/microgrids?community=comm-k");
+    expect(commLevel!.href).toBe("/communities/comm-k");
   });
 
   it("Microgrid href points to /microgrids/<id>", async () => {
@@ -333,6 +357,15 @@ describe("getHierarchyLevels — href contracts", () => {
     });
     const hhLevel = levels.find((l) => l.kind === "Household");
     expect(hhLevel!.href).toBe("/microgrids/mg-1/setup/households/hh-1");
+  });
+
+  it("Community href in 'community' scope points to /communities/<id> (active leaf)", async () => {
+    const levels = await getHierarchyLevels(supabase, {
+      kind: "community",
+      communityId: "comm-k",
+    });
+    const commLevel = levels.find((l) => l.kind === "Community");
+    expect(commLevel!.href).toBe("/communities/comm-k");
   });
 
   it("Organization sibling hrefs use /?org=<id> format", async () => {

--- a/src/lib/hierarchy.ts
+++ b/src/lib/hierarchy.ts
@@ -17,6 +17,7 @@ import type { HierarchyLevel } from "@/components/ui/hierarchy-nav";
 
 export type HierarchyScope =
   | { kind: "communities" }
+  | { kind: "community"; communityId: string }
   | { kind: "microgrids"; communityId?: string }
   | { kind: "microgrid"; microgridId: string }
   | { kind: "edge"; microgridId: string; edgeId: string }
@@ -99,7 +100,7 @@ async function fetchCommunityLevel(
     kind: "Community",
     label: community.name,
     count,
-    href: `/microgrids?community=${community.id}`,
+    href: `/communities/${community.id}`,
     active,
     siblings:
       count > 1
@@ -107,7 +108,7 @@ async function fetchCommunityLevel(
             .filter((c) => c.id !== community.id)
             .map((c) => ({
               label: c.name ?? c.id,
-              href: `/microgrids?community=${c.id}`,
+              href: `/communities/${c.id}`,
             }))
         : undefined,
   };
@@ -263,6 +264,7 @@ async function fetchHouseholdLevel(
  *
  * Scope determines how deep the breadcrumb reaches:
  *   - 'communities'       → [Organization] active
+ *   - 'community'         → [Organization, Community(active=true)]
  *   - 'microgrids'        → [Organization, Community (if communityId)] active
  *   - 'microgrid'         → [Organization, Community, Microgrid] active
  *   - 'edge'              → [Organization, Community, Microgrid, Edge] active
@@ -282,6 +284,26 @@ export async function getHierarchyLevels(
     case "communities": {
       const orgLevel = await fetchOrgLevel(supabase);
       return [orgLevel];
+    }
+
+    case "community": {
+      // 2-level: Org → Community(active=true).
+      const communityLevel = await fetchCommunityLevel(supabase, scope.communityId, true);
+      if (!communityLevel) {
+        const orgLevel = await fetchOrgLevel(supabase);
+        return [orgLevel];
+      }
+
+      // Resolve org_id from the community row to anchor the org level.
+      const { data: communityRow } = await supabase
+        .from("communities")
+        .select("org_id")
+        .eq("id", scope.communityId)
+        .single<{ org_id: string }>();
+
+      const orgLevel = await fetchOrgLevel(supabase, communityRow?.org_id);
+      if (orgLevel.count === 0) return [orgLevel];
+      return [orgLevel, communityLevel];
     }
 
     case "microgrids": {


### PR DESCRIPTION
## Summary
- New server-component route `src/app/(dashboard)/communities/[id]/page.tsx` — community detail with stats strip (microgrids / households / devices), address block, microgrids listing, and Edit button gated on `currentUserCanAccessCommunity`
- Relocates `EditEntityButton` from `/communities` listing rows to the detail page header (mirrors Microgrid placement)
- Adds new `HierarchyNav` scope variant `{ kind: 'community', communityId }`; community-card hrefs now point to `/communities/[id]` (microgrids listing reachable via "View microgrids →" link on detail page)
- Component tests cover populated community (2 microgrids), empty community, cross-org denial, and Edit-button gating

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`

Closes #87.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)