### PR TITLE
Derive edge data_source_type options from enum Constants (#88)

### DIFF
--- a/src/app/api/edges/[id]/route.ts
+++ b/src/app/api/edges/[id]/route.ts
@@ -1,15 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/types/database.gen";
+import type { EdgeDataSource } from "@/lib/types/domain";
+import { EDGE_DATA_SOURCE_VALUES } from "@/lib/types/domain";
 
-type EdgeDataSource = Database["public"]["Enums"]["edge_data_source"];
-
-const VALID_DATA_SOURCE_TYPES: readonly EdgeDataSource[] = [
-  "openems",
-  "modbus_direct",
-  "mqtt",
-  "rest_api",
-] as const;
+// Derive valid enum values at runtime from the generated DB constants.
+const VALID_DATA_SOURCE_TYPES = EDGE_DATA_SOURCE_VALUES;
 
 function isValidDataSource(v: unknown): v is EdgeDataSource {
   return VALID_DATA_SOURCE_TYPES.includes(v as EdgeDataSource);

--- a/src/app/api/edges/route.ts
+++ b/src/app/api/edges/route.ts
@@ -1,17 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/types/database.gen";
+import type { EdgeDataSource } from "@/lib/types/domain";
+import { EDGE_DATA_SOURCE_VALUES } from "@/lib/types/domain";
 
-type EdgeDataSource = Database["public"]["Enums"]["edge_data_source"];
-
-// Derive valid enum values at runtime from the generated DB types.
-// The array literal in database.gen.ts mirrors the Postgres enum.
-const VALID_DATA_SOURCE_TYPES: readonly EdgeDataSource[] = [
-  "openems",
-  "modbus_direct",
-  "mqtt",
-  "rest_api",
-] as const;
+// Derive valid enum values at runtime from the generated DB constants.
+const VALID_DATA_SOURCE_TYPES = EDGE_DATA_SOURCE_VALUES;
 
 function isValidDataSource(v: unknown): v is EdgeDataSource {
   return VALID_DATA_SOURCE_TYPES.includes(v as EdgeDataSource);

--- a/src/components/forms/EdgeForm.tsx
+++ b/src/components/forms/EdgeForm.tsx
@@ -25,45 +25,38 @@ import { Input } from "@/components/ui/input";
 import { RadioGroup } from "@/components/ui/radio-group";
 import { RadioCard } from "@/components/ui/radio-card";
 import { Banner } from "@/components/ui/banner";
-import type { Database } from "@/lib/types/database.gen";
-import type { Edge } from "@/lib/types/domain";
+import type { Edge, EdgeDataSource } from "@/lib/types/domain";
+import { EDGE_DATA_SOURCE_VALUES } from "@/lib/types/domain";
 
 // ── Enum-derived options ──────────────────────────────────────────────────
-// Pull the union type from the generated DB types so there's no hardcoded string union.
-type EdgeDataSource = Database["public"]["Enums"]["edge_data_source"];
-
-// Runtime array — keeps the order and descriptions in one place.
-// The type annotation ensures no string outside the enum slips in.
-const DATA_SOURCE_OPTIONS: Array<{
-  value: EdgeDataSource;
-  title: string;
-  description: string;
-}> = [
-  {
-    value: "openems",
+// Labels/descriptions keyed by enum value. For any value not listed here,
+// the render loop falls back to a titleized form of the enum value.
+const DATA_SOURCE_LABELS: Record<string, { title: string; description: string }> = {
+  openems: {
     title: "OpenEMS",
     description:
       "Connect via the OpenEMS Backend WebSocket. Requires backend URL and edge ID.",
   },
-  {
-    value: "modbus_direct",
+  modbus_direct: {
     title: "Modbus Direct",
     description:
       "Poll meters directly over Modbus TCP/RTU. Useful for CHINT meters and similar.",
   },
-  {
-    value: "mqtt",
+  mqtt: {
     title: "MQTT",
-    description:
-      "Subscribe to meter telemetry published on an MQTT broker.",
+    description: "Subscribe to meter telemetry published on an MQTT broker.",
   },
-  {
-    value: "rest_api",
+  rest_api: {
     title: "REST API",
-    description:
-      "Pull readings from a custom HTTP/REST endpoint.",
+    description: "Pull readings from a custom HTTP/REST endpoint.",
   },
-];
+};
+
+/** Fallback title for enum values not present in DATA_SOURCE_LABELS. */
+function titleize(value: string): string {
+  const spaced = value.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
 
 // ── Props ─────────────────────────────────────────────────────────────────
 
@@ -251,14 +244,19 @@ export function EdgeForm({ mode, edge, parentMicrogridId, onSuccess, onCancel }:
           className="grid grid-cols-1 gap-2 sm:grid-cols-2"
           aria-label="Data source type"
         >
-          {DATA_SOURCE_OPTIONS.map((opt) => (
-            <RadioCard
-              key={opt.value}
-              value={opt.value}
-              title={opt.title}
-              description={opt.description}
-            />
-          ))}
+          {EDGE_DATA_SOURCE_VALUES.map((value) => {
+            const label = DATA_SOURCE_LABELS[value];
+            const title = label?.title ?? titleize(value);
+            const description = label?.description ?? "";
+            return (
+              <RadioCard
+                key={value}
+                value={value}
+                title={title}
+                description={description}
+              />
+            );
+          })}
         </RadioGroup>
       </div>
 

--- a/src/components/forms/__tests__/EdgeForm.enum-fallback.test.tsx
+++ b/src/components/forms/__tests__/EdgeForm.enum-fallback.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/**
+ * EdgeForm enum-fallback test (#88).
+ *
+ * Isolated in its own file so the vi.mock hoisting (which applies to the entire
+ * module scope) does not interfere with the existing EdgeForm.test.tsx suite.
+ *
+ * Asserts that an enum value not listed in DATA_SOURCE_LABELS renders as a
+ * RadioCard with the titleized fallback title.
+ */
+
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// vi.mock is hoisted to the top of the file by Vitest — this mock applies to
+// all imports of @/lib/types/database.gen within this file only.
+vi.mock("@/lib/types/database.gen", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/types/database.gen")>();
+  return {
+    ...actual,
+    Constants: {
+      public: {
+        Enums: {
+          edge_data_source: ["openems", "modbus_direct", "mqtt", "rest_api", "bacnet"] as const,
+        },
+      },
+    },
+  };
+});
+
+// Import EdgeForm AFTER the mock declaration so it picks up the patched Constants.
+import { EdgeForm } from "../EdgeForm";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+  useParams: () => ({ id: "microgrid-uuid-1" }),
+}));
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+const MICROGRID_ID = "aaaaaaaa-aaaa-4000-8002-000000000001";
+
+describe("EdgeForm — enum fallback label (#88)", () => {
+  it("renders a 5th RadioCard with titleized fallback title when bacnet is in the enum", () => {
+    render(
+      <EdgeForm
+        mode="create"
+        parentMicrogridId={MICROGRID_ID}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Known values still render with their labelled titles
+    expect(screen.getByText("OpenEMS")).toBeDefined();
+    expect(screen.getByText("Modbus Direct")).toBeDefined();
+    expect(screen.getByText("MQTT")).toBeDefined();
+    expect(screen.getByText("REST API")).toBeDefined();
+
+    // Unknown value "bacnet" renders with the titleized fallback: "Bacnet"
+    expect(screen.getByText("Bacnet")).toBeDefined();
+  });
+});

--- a/src/components/forms/__tests__/EdgeForm.test.tsx
+++ b/src/components/forms/__tests__/EdgeForm.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 /**
- * EdgeForm component tests (UX4b / #77).
+ * EdgeForm component tests (UX4b / #77, #88).
  *
  * Covers:
  *   (a) OpenEMS fields show when data_source_type=openems (default)
@@ -9,6 +9,9 @@
  *   (d) Save calls POST /api/edges with the correct payload in create mode
  *   (e) Edit mode pre-fills all fields including role
  *   (f) URL validation error cases shown inline
+ *
+ * (g) Titleized fallback for unknown enum values is tested in
+ *     EdgeForm.enum-fallback.test.tsx to keep vi.mock hoisting isolated.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -8,6 +8,7 @@
  * Run `npm run db:types` after every schema change to regenerate database.gen.ts,
  * then update this file if any table/column/enum names changed.
  */
+import { Constants } from "./database.gen";
 import type { Database } from "./database.gen";
 
 // ── Tables ────────────────────────────────────────────────────────────────────
@@ -53,6 +54,11 @@ export type UserDirectoryRow =
 /** Row from the microgrid_recent_activity VIEW (migration 00011). */
 export type MicrogridRecentActivityRow =
   Database["public"]["Views"]["microgrid_recent_activity"]["Row"];
+
+// ── Enum runtime values ───────────────────────────────────────────────────────
+
+/** Runtime tuple of all valid edge_data_source enum values (Postgres enum order). */
+export const EDGE_DATA_SOURCE_VALUES = Constants.public.Enums.edge_data_source;
 
 // ── Enums (literal-union types) ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `DATA_SOURCE_OPTIONS` array in `EdgeForm.tsx` with runtime derivation from `Constants.public.Enums.edge_data_source`
- Same refactor in `src/app/api/edges/route.ts` and `src/app/api/edges/[id]/route.ts` (validation arrays)
- New `EDGE_DATA_SOURCE_VALUES` export in `src/lib/types/domain.ts` for reuse
- Presentational labels moved to a separate map with titleize fallback so unknown enum values still render sensibly
- Enum-fallback test in isolated file (`EdgeForm.enum-fallback.test.tsx`) to avoid Vitest module-registry corruption

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (469/469 passing)
- [x] `npm run build`

Closes #88.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)