### PR TITLE
Add entity deletion (Org / Community / Microgrid / Edge) with cascade-safe RPC, blast-radius dialog, type-to-confirm UX (#89)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/page.tsx
@@ -4,6 +4,8 @@ import { createClient } from "@/lib/supabase/server";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { EditEntityButton } from "@/components/forms/EditEntityButton";
+import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
+import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 import { currentUserCanAccessCommunity } from "@/lib/auth/access";
 import type { Community } from "@/lib/types/domain";
 
@@ -34,10 +36,13 @@ function emDash(value: string | null | undefined): string {
 
 export default async function CommunityDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { id } = await params;
+  const sp = searchParams ? await searchParams : undefined;
   const supabase = await createClient();
 
   const [{ data: community }, canEdit, levels] = await Promise.all([
@@ -71,7 +76,8 @@ export default async function CommunityDetailPage({
 
   return (
     <div>
-      <HierarchyNav levels={levels} className="mb-4" />
+      <DeletedSuccessBanner searchParams={sp} />
+      <HierarchyNav levels={levels} className="mb-4 mt-4" />
 
       {/* Page header */}
       <div className="mb-6 flex items-start justify-between gap-4">
@@ -88,7 +94,14 @@ export default async function CommunityDetailPage({
           )}
         </div>
         {canEdit && (
-          <EditEntityButton entity="community" initialValues={community} />
+          <div className="flex items-center gap-2">
+            <EditEntityButton entity="community" initialValues={community} />
+            <DeleteEntityButton
+              entity="community"
+              id={community.id}
+              name={community.name}
+            />
+          </div>
         )}
       </div>
 

--- a/src/app/(dashboard)/microgrids/[id]/__tests__/page-widgets.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/__tests__/page-widgets.test.tsx
@@ -42,6 +42,14 @@ vi.mock("@/lib/hierarchy", () => ({
   getHierarchyLevels: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/components/forms/DeleteEntityButton", () => ({
+  DeleteEntityButton: () => null,
+}));
+
 vi.mock("next/link", () => ({
   default: ({
     href,

--- a/src/app/(dashboard)/microgrids/[id]/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/__tests__/page.test.tsx
@@ -38,6 +38,14 @@ vi.mock("@/lib/hierarchy", () => ({
   getHierarchyLevels: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/components/forms/DeleteEntityButton", () => ({
+  DeleteEntityButton: () => null,
+}));
+
 vi.mock("next/link", () => ({
   default: ({
     href,
@@ -92,10 +100,12 @@ function buildBillingPeriodsQuery(data: unknown) {
 function makeFrom(
   edgeRows: unknown,
   periodRows: unknown = [],
+  microgridRow: unknown = { id: "mg-1", name: "Test Microgrid" },
 ) {
   return (table: string) => {
     if (table === "edges") return buildEdgesQuery(edgeRows);
     if (table === "billing_periods") return buildBillingPeriodsQuery(periodRows);
+    if (table === "microgrids") return buildQuery(microgridRow);
     // All other tables (households, billing_line_items, microgrid_recent_activity)
     // return empty arrays so the page renders without widget data.
     return buildQuery([]);

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -4,6 +4,8 @@ import type { Microgrid } from "@/lib/types/domain";
 import { TabNav } from "./tab-nav";
 import { LocaleProvider } from "@/components/format/locale-context";
 import { EditEntityButton } from "@/components/forms/EditEntityButton";
+import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 // HierarchyNav is NOT placed here — leaf pages own their breadcrumb.
 // Each leaf page calls getHierarchyLevels() with the correct scope depth
@@ -19,11 +21,10 @@ export default async function MicrogridLayout({
   const { id } = await params;
   const supabase = await createClient();
 
-  const { data, error } = await supabase
-    .from("microgrids")
-    .select("*")
-    .eq("id", id)
-    .single();
+  const [{ data, error }, canManage] = await Promise.all([
+    supabase.from("microgrids").select("*").eq("id", id).single(),
+    currentUserCanAccessMicrogrid(supabase, id),
+  ]);
 
   if (error || !data) {
     notFound();
@@ -49,7 +50,16 @@ export default async function MicrogridLayout({
               </p>
             )}
           </div>
-          <EditEntityButton entity="microgrid" initialValues={microgrid} />
+          <div className="flex items-center gap-2">
+            <EditEntityButton entity="microgrid" initialValues={microgrid} />
+            {canManage && (
+              <DeleteEntityButton
+                entity="microgrid"
+                id={microgrid.id}
+                name={microgrid.name}
+              />
+            )}
+          </div>
         </div>
         <TabNav microgridId={id} />
         <div className="mt-6">{children}</div>

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -4,8 +4,6 @@ import type { Microgrid } from "@/lib/types/domain";
 import { TabNav } from "./tab-nav";
 import { LocaleProvider } from "@/components/format/locale-context";
 import { EditEntityButton } from "@/components/forms/EditEntityButton";
-import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
-import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 // HierarchyNav is NOT placed here — leaf pages own their breadcrumb.
 // Each leaf page calls getHierarchyLevels() with the correct scope depth
@@ -21,10 +19,11 @@ export default async function MicrogridLayout({
   const { id } = await params;
   const supabase = await createClient();
 
-  const [{ data, error }, canManage] = await Promise.all([
-    supabase.from("microgrids").select("*").eq("id", id).single(),
-    currentUserCanAccessMicrogrid(supabase, id),
-  ]);
+  const { data, error } = await supabase
+    .from("microgrids")
+    .select("*")
+    .eq("id", id)
+    .single();
 
   if (error || !data) {
     notFound();
@@ -52,13 +51,6 @@ export default async function MicrogridLayout({
           </div>
           <div className="flex items-center gap-2">
             <EditEntityButton entity="microgrid" initialValues={microgrid} />
-            {canManage && (
-              <DeleteEntityButton
-                entity="microgrid"
-                id={microgrid.id}
-                name={microgrid.name}
-              />
-            )}
           </div>
         </div>
         <TabNav microgridId={id} />

--- a/src/app/(dashboard)/microgrids/[id]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/page.tsx
@@ -15,6 +15,8 @@ import { OpenPeriodSummary } from "@/components/dashboard/OpenPeriodSummary";
 import { TopHouseholdsLeaderboard, type LeaderboardEntry } from "@/components/dashboard/TopHouseholdsLeaderboard";
 import { ConsumptionCalendarWidget } from "@/components/dashboard/ConsumptionCalendarWidget";
 import { ActivityLog, type ActivityEvent } from "@/components/dashboard/ActivityLog";
+import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 // Microgrid Dashboard landing (D2 / #53, UX1a / #72, UX1b / #73).
 //
@@ -122,6 +124,12 @@ export default async function MicrogridDashboardPage({
 }) {
   const { id } = await params;
   const supabase = await createClient();
+
+  // ── Microgrid metadata + access check (for Delete button, AC-UI-2) ──────
+  const [{ data: microgridData }, canManage] = await Promise.all([
+    supabase.from("microgrids").select("id, name").eq("id", id).single(),
+    currentUserCanAccessMicrogrid(supabase, id),
+  ]);
 
   // ── Query 1: Edges (+ devices for OpenEMS channels) ─────────────────────
   const { data: edgesRaw } = await supabase
@@ -343,7 +351,16 @@ export default async function MicrogridDashboardPage({
 
   return (
     <div className="space-y-4">
-      <HierarchyNav levels={levels} className="mb-2" />
+      <div className="flex items-center justify-between">
+        <HierarchyNav levels={levels} className="mb-2" />
+        {canManage && microgridData && (
+          <DeleteEntityButton
+            entity="microgrid"
+            id={microgridData.id}
+            name={microgridData.name}
+          />
+        )}
+      </div>
 
       {/* ── Empty state ─────────────────────────────────────────────────── */}
       {allEdges.length === 0 && (

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
@@ -7,6 +7,8 @@ import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { DiscoverDevices } from "@/components/DiscoverDevices";
 import { EdgeDetailConfigureButton } from "./edge-detail-configure-button";
+import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 // Setup > Edges > [edgeId] — edge detail (D2 / #53, #77).
 // Lists devices on this edge. For each device, shows the linked household
@@ -46,6 +48,8 @@ export default async function EdgeDetailPage({
   if (edgeError || !edge) {
     notFound();
   }
+
+  const canManage = await currentUserCanAccessMicrogrid(supabase, id);
 
   const { data: devices, error: devicesError } = await supabase
     .from("devices")
@@ -106,6 +110,9 @@ export default async function EdgeDetailPage({
           <StatusChip kind="edgeSource" status={edge.data_source_type} />
           {/* Client shell: Configure… button opens EdgeFormModal in edit mode */}
           <EdgeDetailConfigureButton edge={edge} />
+          {canManage && (
+            <DeleteEntityButton entity="edge" id={edge.id} name={edge.name} />
+          )}
         </div>
         {edge.data_source_type === "openems" && (
           <p className="mt-1 font-mono text-xs text-muted-foreground">

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
@@ -7,6 +7,7 @@ import { getOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { EdgesCRUDShell } from "./edges-crud-shell";
+import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 
 // Setup > Edges (D2 / #53, #77).
 // Lists every edge attached to this microgrid. Rows link to edge detail.
@@ -40,10 +41,13 @@ async function fetchEdgeOnlineMap(
 
 export default async function SetupEdgesPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { id } = await params;
+  const sp = searchParams ? await searchParams : undefined;
   const supabase = await createClient();
 
   const levels = await getHierarchyLevels(supabase, {
@@ -75,6 +79,7 @@ export default async function SetupEdgesPage({
 
   return (
     <div className="space-y-4">
+      <DeletedSuccessBanner searchParams={sp} />
       <HierarchyNav levels={levels} className="mb-2" />
       <div className="flex items-end justify-between gap-4">
         <div>

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { EditEntityButton } from "@/components/forms/EditEntityButton";
+import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
+import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 import { currentUserIsSuperAdmin } from "@/lib/auth/access";
 import type { Organization } from "@/lib/types/domain";
 
@@ -15,10 +17,13 @@ import type { Organization } from "@/lib/types/domain";
  */
 export default async function OrganizationDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { id } = await params;
+  const sp = searchParams ? await searchParams : undefined;
   const supabase = await createClient();
 
   const [{ data: org }, { data: communities }, isSuperAdmin] = await Promise.all([
@@ -58,7 +63,8 @@ export default async function OrganizationDetailPage({
 
   return (
     <div>
-      <div className="mb-6 flex items-start justify-between gap-4">
+      <DeletedSuccessBanner searchParams={sp} />
+      <div className="mb-6 mt-4 flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold text-foreground">{org.name}</h1>
           {addressLines.length > 0 && (
@@ -69,7 +75,16 @@ export default async function OrganizationDetailPage({
             </address>
           )}
         </div>
-        {isSuperAdmin && <EditEntityButton entity="organization" initialValues={org} />}
+        {isSuperAdmin && (
+          <div className="flex items-center gap-2">
+            <EditEntityButton entity="organization" initialValues={org} />
+            <DeleteEntityButton
+              entity="organization"
+              id={org.id}
+              name={org.name}
+            />
+          </div>
+        )}
       </div>
 
       <section className="rounded-lg border border-border bg-card p-6">

--- a/src/app/(dashboard)/organizations/page.tsx
+++ b/src/app/(dashboard)/organizations/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserIsSuperAdmin } from "@/lib/auth/access";
 import { AddEntityButton } from "@/components/forms/AddEntityButton";
+import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 import type { Organization } from "@/lib/types/domain";
 
 /**
@@ -15,7 +16,12 @@ import type { Organization } from "@/lib/types/domain";
  * diverges: super_admin gets a CTA; org_manager with zero visible orgs gets a
  * pointer to contact their administrator.
  */
-export default async function OrganizationsPage() {
+export default async function OrganizationsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = searchParams ? await searchParams : undefined;
   const supabase = await createClient();
 
   const [isSuperAdmin, orgsResult] = await Promise.all([
@@ -41,7 +47,8 @@ export default async function OrganizationsPage() {
 
   return (
     <div>
-      <div className="mb-6 flex items-center justify-between">
+      <DeletedSuccessBanner searchParams={sp} />
+      <div className="mb-6 mt-4 flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">
           Organizations
         </h1>

--- a/src/app/_dev/components/page.tsx
+++ b/src/app/_dev/components/page.tsx
@@ -82,6 +82,7 @@ export default function ComponentsDevPage() {
   const [closePeriodOpen, setClosePeriodOpen] = React.useState(false);
   const [confirmOpen, setConfirmOpen] = React.useState(false);
   const [confirmNeutralOpen, setConfirmNeutralOpen] = React.useState(false);
+  const [confirmTypedOpen, setConfirmTypedOpen] = React.useState(false);
   const [currentPeriodId, setCurrentPeriodId] = React.useState("1");
 
   return (
@@ -193,6 +194,39 @@ export default function ComponentsDevPage() {
             confirmLabel="Delete"
             tone="destructive"
             onConfirm={() => new Promise((res) => setTimeout(res, 1000))}
+          />
+        </Section>
+
+        {/* ── ConfirmDialog (destructive + type-to-confirm + body) ── */}
+        <Section title="ConfirmDialog — destructive with type-to-confirm + blast-radius body">
+          <button
+            onClick={() => setConfirmTypedOpen(true)}
+            className="inline-flex h-8 items-center rounded-md border border-destructive bg-destructive-muted px-3.5 text-[13px] font-medium text-destructive-fg hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Delete Microgrid (opens dialog)
+          </button>
+          <ConfirmDialog
+            open={confirmTypedOpen}
+            onOpenChange={setConfirmTypedOpen}
+            title="Delete microgrid “Kisakye Main”?"
+            description={`This cannot be undone. Type “Kisakye Main” to confirm.`}
+            body={
+              <ul className="my-2 list-disc space-y-0.5 pl-5">
+                <li>1 edge</li>
+                <li>10 devices</li>
+                <li>10 households</li>
+                <li>1 draft billing period (in progress — unfinalized readings will be lost)</li>
+                <li>2 closed billing periods</li>
+                <li>47 billing line items</li>
+              </ul>
+            }
+            confirmLabel="Delete microgrid"
+            tone="destructive"
+            requireTypedConfirmation={{
+              label: "Type microgrid name to confirm",
+              expected: "Kisakye Main",
+            }}
+            onConfirm={() => new Promise((res) => setTimeout(res, 800))}
           />
         </Section>
 

--- a/src/app/api/communities/[id]/delete-preview/route.ts
+++ b/src/app/api/communities/[id]/delete-preview/route.ts
@@ -1,0 +1,16 @@
+import { buildDeletePreviewHandler } from "@/lib/entity-deletion/preview";
+import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+
+/**
+ * GET /api/communities/[id]/delete-preview — descendant counts for the
+ * blast-radius dialog (#89 / AC-ROUTE-3).
+ *
+ * Permission parity with DELETE: super_admin OR org_manager for the
+ * community's parent org (AC-ROUTE-4).
+ */
+export const GET = buildDeletePreviewHandler({
+  kind: "community",
+  entityLabel: "community",
+  table: "communities",
+  canAccess: (supabase, id) => currentUserCanAccessCommunity(supabase, id),
+});

--- a/src/app/api/communities/[id]/route.ts
+++ b/src/app/api/communities/[id]/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserCanAccessCommunity } from "@/lib/auth/access";
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { countEntityDescendants } from "@/lib/entity-descendants";
+import {
+  errorBody,
+  mapPgError,
+  resolveActorRole,
+  UUID_RE,
+  type EntityDeleteLogPayload,
+} from "@/lib/entity-deletion/shared";
 
 /**
  * PATCH /api/communities/[id] — update a community (#76).
@@ -107,4 +113,120 @@ export async function PATCH(
   }
 
   return NextResponse.json({ community: data }, { status: 200 });
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Entity deletion (#89) — see ./delete-preview/route.ts for the preview GET.
+// ══════════════════════════════════════════════════════════════════════════
+
+/**
+ * DELETE /api/communities/[id] — delete a community (#89).
+ *
+ * Authorization: super_admin OR org_manager with access to the community's
+ * parent org (AC-ROUTE-2 step 2). Uses `currentUserCanAccessCommunity`.
+ *
+ * Cascade policy (trust-preview per AC-ROUTE-6): no pre-DELETE re-count;
+ * the UI friction layer is the safety net. See organization DELETE header
+ * for full rationale; the identical pattern applies here.
+ *
+ * Idempotency: first-delete wins, repeats 404 (AC-ROUTE-7).
+ *
+ * Cascade chain: communities → microgrids → (edges/devices/households/
+ * billing_periods/billing_line_items/rate_schedules/household_devices/
+ * household_users). No user_roles interaction (user_roles are org-scoped,
+ * not community-scoped) — the cascade-bypass GUC is still set to stay
+ * consistent with the other entity DELETE routes and to future-proof if
+ * role scopes ever extend below org level.
+ *
+ * Revalidation (AC-UI-6): both `/organizations/<org_id>` and `/communities`
+ * layouts are busted so nested nav + top-level community list refresh.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      errorBody("Invalid community id — expected UUID."),
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserCanAccessCommunity(supabase, id))) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this community."),
+      { status: 403 }
+    );
+  }
+
+  const { data: community, error: fetchErr } = await supabase
+    .from("communities")
+    .select("id, name, org_id")
+    .eq("id", id)
+    .maybeSingle<{ id: string; name: string; org_id: string }>();
+
+  if (fetchErr) {
+    const mapped = mapPgError(fetchErr, "community");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if (!community) {
+    return NextResponse.json(errorBody("Community not found."), { status: 404 });
+  }
+  if (!community.name || !community.name.trim()) {
+    return NextResponse.json(
+      errorBody("Unnamed entity cannot be typed-to-confirm."),
+      { status: 409 }
+    );
+  }
+
+  const descendantCounts = await countEntityDescendants(
+    supabase,
+    "community",
+    id
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const actorRole = await resolveActorRole(supabase);
+  if (!user || !actorRole) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this community."),
+      { status: 403 }
+    );
+  }
+
+  const { data: rowsDeleted, error: delErr } = await supabase.rpc(
+    "fn_entity_delete_community",
+    { p_id: id }
+  );
+
+  if (delErr) {
+    const mapped = mapPgError(delErr, "community");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if ((rowsDeleted ?? 0) === 0) {
+    return NextResponse.json(errorBody("Community not found."), { status: 404 });
+  }
+
+  const payload: EntityDeleteLogPayload = {
+    event: "entity.delete",
+    entity_kind: "community",
+    entity_id: id,
+    entity_name: community.name,
+    actor_user_id: user.id,
+    actor_role: actorRole,
+    descendant_counts: descendantCounts,
+    at: new Date().toISOString(),
+  };
+  console.info(JSON.stringify(payload));
+
+  revalidatePath(`/organizations/${community.org_id}`, "layout");
+  revalidatePath("/communities", "layout");
+
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/communities/__tests__/delete.test.ts
+++ b/src/app/api/communities/__tests__/delete.test.ts
@@ -1,0 +1,165 @@
+/**
+ * DELETE /api/communities/[id] + GET delete-preview route tests (#89).
+ *
+ * Covers: 400 invalid UUID, 403 unauthorized, 404 not found, 204 happy.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+let canAccessReturn = true;
+let getUserReturn: { user: { id: string } | null } = {
+  user: { id: "user-1" },
+};
+
+const mockFromImpl = vi.fn();
+const mockRpcImpl = vi.fn();
+const mockSupabaseClient = {
+  from: (...args: unknown[]) => mockFromImpl(...args),
+  rpc: (...args: unknown[]) => mockRpcImpl(...args),
+  auth: { getUser: async () => ({ data: getUserReturn }) },
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => mockSupabaseClient,
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessCommunity: async () => canAccessReturn,
+  currentUserCanAccessMicrogrid: async () => canAccessReturn,
+  currentUserIsSuperAdmin: async () => canAccessReturn,
+  getCurrentUserRoles: async () =>
+    canAccessReturn
+      ? [{ role: "org_manager", scope_type: "org", scope_id: "org-1" }]
+      : [],
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+function chainable(result: { data: unknown; error: unknown; count?: number }) {
+  const stub: {
+    eq: (...args: unknown[]) => typeof stub;
+    in: (...args: unknown[]) => typeof stub;
+    maybeSingle: () => Promise<unknown>;
+    then: (onFulfilled: (v: unknown) => unknown) => Promise<unknown>;
+  } = {
+    eq: () => stub,
+    in: () => stub,
+    maybeSingle: () => Promise.resolve(result),
+    then: (onFulfilled) => Promise.resolve(result).then(onFulfilled),
+  };
+  return stub;
+}
+
+function configureEntityLookup(result: {
+  data: { id: string; name: string; org_id: string } | null;
+  error: { code?: string; message: string } | null;
+}) {
+  mockFromImpl.mockImplementation((table: string) => {
+    if (table === "communities") {
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => result }),
+        }),
+      };
+    }
+    return {
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) =>
+        opts?.head
+          ? chainable({ data: null, error: null, count: 0 })
+          : chainable({ data: [], error: null }),
+    };
+  });
+}
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeDelete(id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/communities/${id}`, {
+    method: "DELETE",
+  });
+}
+
+describe("DELETE /api/communities/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessReturn = true;
+    getUserReturn = { user: { id: "user-1" } };
+  });
+
+  it("400 on malformed UUID", async () => {
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete("bogus"), {
+      params: Promise.resolve({ id: "bogus" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("403 when caller cannot access community", async () => {
+    canAccessReturn = false;
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("404 when community does not exist", async () => {
+    configureEntityLookup({ data: null, error: null });
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("204 happy path + rpc dispatched to fn_entity_delete_community", async () => {
+    configureEntityLookup({
+      data: { id: VALID_UUID, name: "Kisakye", org_id: "org-1" },
+      error: null,
+    });
+    mockRpcImpl.mockResolvedValueOnce({ data: 1, error: null });
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(204);
+    expect(mockRpcImpl).toHaveBeenCalledWith("fn_entity_delete_community", {
+      p_id: VALID_UUID,
+    });
+    infoSpy.mockRestore();
+  });
+});
+
+describe("GET /api/communities/[id]/delete-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessReturn = true;
+  });
+
+  it("200 happy path returns { entity, descendant_counts, as_of, parent }", async () => {
+    configureEntityLookup({
+      data: { id: VALID_UUID, name: "Kisakye", org_id: "org-1" },
+      error: null,
+    });
+
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(
+        `http://localhost/api/communities/${VALID_UUID}/delete-preview`
+      ),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.entity.id).toBe(VALID_UUID);
+    expect(json.descendant_counts.kind).toBe("community");
+    expect(typeof json.as_of).toBe("string");
+    // Parent resolves to organization for a community.
+    expect(json.parent).toEqual({ kind: "organization", id: "org-1" });
+  });
+});

--- a/src/app/api/edges/[id]/delete-preview/route.ts
+++ b/src/app/api/edges/[id]/delete-preview/route.ts
@@ -1,0 +1,25 @@
+import { buildDeletePreviewHandler } from "@/lib/entity-deletion/preview";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+
+/**
+ * GET /api/edges/[id]/delete-preview — descendant counts for the
+ * blast-radius dialog (#89 / AC-ROUTE-3).
+ *
+ * Permission parity with DELETE: super_admin OR org_manager for the edge's
+ * microgrid's parent org (AC-ROUTE-4). We resolve `edge.microgrid_id` and
+ * delegate to `currentUserCanAccessMicrogrid`.
+ */
+export const GET = buildDeletePreviewHandler({
+  kind: "edge",
+  entityLabel: "edge",
+  table: "edges",
+  canAccess: async (supabase, id) => {
+    const { data: edge } = await supabase
+      .from("edges")
+      .select("microgrid_id")
+      .eq("id", id)
+      .maybeSingle<{ microgrid_id: string }>();
+    if (!edge) return false;
+    return currentUserCanAccessMicrogrid(supabase, edge.microgrid_id);
+  },
+});

--- a/src/app/api/edges/[id]/delete-preview/route.ts
+++ b/src/app/api/edges/[id]/delete-preview/route.ts
@@ -1,25 +1,78 @@
-import { buildDeletePreviewHandler } from "@/lib/entity-deletion/preview";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { countEntityDescendants } from "@/lib/entity-descendants";
 import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import {
+  UUID_RE,
+  errorBody,
+  mapPgError,
+  resolveParent,
+} from "@/lib/entity-deletion/shared";
 
 /**
  * GET /api/edges/[id]/delete-preview — descendant counts for the
  * blast-radius dialog (#89 / AC-ROUTE-3).
  *
  * Permission parity with DELETE: super_admin OR org_manager for the edge's
- * microgrid's parent org (AC-ROUTE-4). We resolve `edge.microgrid_id` and
- * delegate to `currentUserCanAccessMicrogrid`.
+ * microgrid's parent org (AC-ROUTE-4).
+ *
+ * Order matters: fetch edge first so a non-existent edge produces 404,
+ * not 403 (the `buildDeletePreviewHandler` factory calls canAccess before
+ * the entity fetch, which collapses not-found + not-authorized into 403 for
+ * edge because we must look up microgrid_id from the edge row itself).
  */
-export const GET = buildDeletePreviewHandler({
-  kind: "edge",
-  entityLabel: "edge",
-  table: "edges",
-  canAccess: async (supabase, id) => {
-    const { data: edge } = await supabase
-      .from("edges")
-      .select("microgrid_id")
-      .eq("id", id)
-      .maybeSingle<{ microgrid_id: string }>();
-    if (!edge) return false;
-    return currentUserCanAccessMicrogrid(supabase, edge.microgrid_id);
-  },
-});
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      errorBody("Invalid edge id — expected UUID."),
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Fetch the edge first. A missing edge → 404 (not 403), matching the
+  // three other entity preview endpoints which resolve entity existence
+  // before the permission gate (AC-ROUTE-3 / AC-ROUTE-4).
+  const { data: edge, error: fetchErr } = await supabase
+    .from("edges")
+    .select("id, name, microgrid_id")
+    .eq("id", id)
+    .maybeSingle<{ id: string; name: string; microgrid_id: string }>();
+
+  if (fetchErr) {
+    const mapped = mapPgError(fetchErr, "edge");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if (!edge) {
+    return NextResponse.json(errorBody("Edge not found."), { status: 404 });
+  }
+
+  // Permission check after existence is confirmed.
+  if (!(await currentUserCanAccessMicrogrid(supabase, edge.microgrid_id))) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this edge."),
+      { status: 403 }
+    );
+  }
+
+  const [descendantCounts, parent] = await Promise.all([
+    countEntityDescendants(supabase, "edge", id),
+    resolveParent(supabase, "edge", id),
+  ]);
+
+  return NextResponse.json(
+    {
+      entity: { id: edge.id, name: edge.name },
+      descendant_counts: descendantCounts,
+      as_of: new Date().toISOString(),
+      parent,
+    },
+    { status: 200 }
+  );
+}

--- a/src/app/api/edges/[id]/route.ts
+++ b/src/app/api/edges/[id]/route.ts
@@ -1,7 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import type { EdgeDataSource } from "@/lib/types/domain";
 import { EDGE_DATA_SOURCE_VALUES } from "@/lib/types/domain";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { countEntityDescendants } from "@/lib/entity-descendants";
+import {
+  errorBody,
+  mapPgError,
+  resolveActorRole,
+  type EntityDeleteLogPayload,
+} from "@/lib/entity-deletion/shared";
 
 // Derive valid enum values at runtime from the generated DB constants.
 const VALID_DATA_SOURCE_TYPES = EDGE_DATA_SOURCE_VALUES;
@@ -259,4 +268,116 @@ export async function PATCH(
   }
 
   return NextResponse.json({ edge: data }, { status: 200 });
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Entity deletion (#89) — see ./delete-preview/route.ts for the preview GET.
+// ══════════════════════════════════════════════════════════════════════════
+
+/**
+ * DELETE /api/edges/[id] — delete an edge (#89).
+ *
+ * Authorization: super_admin OR org_manager with access to the edge's
+ * microgrid's parent org (AC-ROUTE-2 step 2). We resolve
+ * `edge.microgrid_id` then delegate to `currentUserCanAccessMicrogrid`.
+ *
+ * Cascade policy (trust-preview per AC-ROUTE-6): see organization DELETE
+ * header. For edges specifically, note that `billing_line_items.device_id`
+ * is ON DELETE SET NULL (not CASCADE) — the descendant counts helper
+ * surfaces this as `billing_line_items_nulled` and the UI labels it as
+ * "lose device linkage" rather than "destroyed."
+ *
+ * Idempotency: first-delete wins, repeats 404 (AC-ROUTE-7).
+ *
+ * Revalidation (AC-UI-6): the microgrid's edges tab + its layout-level
+ * listings are busted.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(errorBody("Invalid edge id — expected UUID."), {
+      status: 400,
+    });
+  }
+
+  const supabase = await createClient();
+
+  // Load edge first so we know its microgrid_id for both authz and redirect.
+  const { data: edge, error: fetchErr } = await supabase
+    .from("edges")
+    .select("id, name, microgrid_id")
+    .eq("id", id)
+    .maybeSingle<{ id: string; name: string; microgrid_id: string }>();
+
+  if (fetchErr) {
+    const mapped = mapPgError(fetchErr, "edge");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if (!edge) {
+    // Authz ambiguity: RLS may have hidden a real row. We deliberately
+    // return 404 here to match #79's "can't see it? it doesn't exist"
+    // pattern — probing the authorization surface with a 403 vs 404
+    // discriminator would leak existence info.
+    return NextResponse.json(errorBody("Edge not found."), { status: 404 });
+  }
+
+  if (!(await currentUserCanAccessMicrogrid(supabase, edge.microgrid_id))) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this edge."),
+      { status: 403 }
+    );
+  }
+
+  if (!edge.name || !edge.name.trim()) {
+    return NextResponse.json(
+      errorBody("Unnamed entity cannot be typed-to-confirm."),
+      { status: 409 }
+    );
+  }
+
+  const descendantCounts = await countEntityDescendants(supabase, "edge", id);
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const actorRole = await resolveActorRole(supabase);
+  if (!user || !actorRole) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this edge."),
+      { status: 403 }
+    );
+  }
+
+  const { data: rowsDeleted, error: delErr } = await supabase.rpc(
+    "fn_entity_delete_edge",
+    { p_id: id }
+  );
+
+  if (delErr) {
+    const mapped = mapPgError(delErr, "edge");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if ((rowsDeleted ?? 0) === 0) {
+    return NextResponse.json(errorBody("Edge not found."), { status: 404 });
+  }
+
+  const payload: EntityDeleteLogPayload = {
+    event: "entity.delete",
+    entity_kind: "edge",
+    entity_id: id,
+    entity_name: edge.name,
+    actor_user_id: user.id,
+    actor_role: actorRole,
+    descendant_counts: descendantCounts,
+    at: new Date().toISOString(),
+  };
+  console.info(JSON.stringify(payload));
+
+  revalidatePath(`/microgrids/${edge.microgrid_id}`, "layout");
+
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/edges/__tests__/delete.test.ts
+++ b/src/app/api/edges/__tests__/delete.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 let canAccessReturn = true;
+let isSuperAdminReturn = true;
 let getUserReturn: { user: { id: string } | null } = {
   user: { id: "user-1" },
 };
@@ -25,9 +26,11 @@ vi.mock("@/lib/supabase/server", () => ({
 vi.mock("@/lib/auth/access", () => ({
   currentUserCanAccessMicrogrid: async () => canAccessReturn,
   currentUserCanAccessCommunity: async () => canAccessReturn,
-  currentUserIsSuperAdmin: async () => canAccessReturn,
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
   getCurrentUserRoles: async () =>
-    canAccessReturn
+    isSuperAdminReturn
+      ? [{ role: "super_admin", scope_type: "org", scope_id: "org-1" }]
+      : canAccessReturn
       ? [{ role: "org_manager", scope_type: "org", scope_id: "org-1" }]
       : [],
 }));
@@ -86,6 +89,7 @@ describe("DELETE /api/edges/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     canAccessReturn = true;
+    isSuperAdminReturn = true;
     getUserReturn = { user: { id: "user-1" } };
   });
 
@@ -144,12 +148,48 @@ describe("DELETE /api/edges/[id]", () => {
     expect(logged.descendant_counts).toHaveProperty("billing_line_items_nulled");
     infoSpy.mockRestore();
   });
+
+  it("204 org_manager happy path — actor_role logged as org_manager (Nit #6)", async () => {
+    // Super admin is NOT the caller; org_manager has access via canAccess.
+    isSuperAdminReturn = false;
+    canAccessReturn = true;
+    configureEdgeLookup({
+      data: { id: VALID_UUID, name: "Edge-1", microgrid_id: "mg-1" },
+      error: null,
+    });
+    mockRpcImpl.mockResolvedValueOnce({ data: 1, error: null });
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(204);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(infoSpy.mock.calls[0][0] as string);
+    expect(logged.actor_role).toBe("org_manager");
+    infoSpy.mockRestore();
+  });
 });
 
 describe("GET /api/edges/[id]/delete-preview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     canAccessReturn = true;
+    isSuperAdminReturn = true;
+  });
+
+  it("404 when edge does not exist (not 403) — Nit #3", async () => {
+    // Edge not found — configureEdgeLookup returns null so the route must
+    // return 404 before reaching the permission check.
+    configureEdgeLookup({ data: null, error: null });
+
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(`http://localhost/api/edges/${VALID_UUID}/delete-preview`),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+    expect(res.status).toBe(404);
   });
 
   it("200 happy path — parent = { kind:'microgrid', id:<microgrid_id> }", async () => {

--- a/src/app/api/edges/__tests__/delete.test.ts
+++ b/src/app/api/edges/__tests__/delete.test.ts
@@ -1,0 +1,171 @@
+/**
+ * DELETE /api/edges/[id] + GET delete-preview route tests (#89).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+let canAccessReturn = true;
+let getUserReturn: { user: { id: string } | null } = {
+  user: { id: "user-1" },
+};
+
+const mockFromImpl = vi.fn();
+const mockRpcImpl = vi.fn();
+const mockSupabaseClient = {
+  from: (...args: unknown[]) => mockFromImpl(...args),
+  rpc: (...args: unknown[]) => mockRpcImpl(...args),
+  auth: { getUser: async () => ({ data: getUserReturn }) },
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => mockSupabaseClient,
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: async () => canAccessReturn,
+  currentUserCanAccessCommunity: async () => canAccessReturn,
+  currentUserIsSuperAdmin: async () => canAccessReturn,
+  getCurrentUserRoles: async () =>
+    canAccessReturn
+      ? [{ role: "org_manager", scope_type: "org", scope_id: "org-1" }]
+      : [],
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+function chainable(result: { data: unknown; error: unknown; count?: number }) {
+  const stub: {
+    eq: (...args: unknown[]) => typeof stub;
+    in: (...args: unknown[]) => typeof stub;
+    maybeSingle: () => Promise<unknown>;
+    then: (onFulfilled: (v: unknown) => unknown) => Promise<unknown>;
+  } = {
+    eq: () => stub,
+    in: () => stub,
+    maybeSingle: () => Promise.resolve(result),
+    then: (onFulfilled) => Promise.resolve(result).then(onFulfilled),
+  };
+  return stub;
+}
+
+function configureEdgeLookup(result: {
+  data:
+    | { id: string; name: string; microgrid_id: string }
+    | null;
+  error: { code?: string; message: string } | null;
+}) {
+  mockFromImpl.mockImplementation((table: string) => {
+    if (table === "edges") {
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => result }),
+        }),
+      };
+    }
+    return {
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) =>
+        opts?.head
+          ? chainable({ data: null, error: null, count: 0 })
+          : chainable({ data: [], error: null }),
+    };
+  });
+}
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeDelete(id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/edges/${id}`, {
+    method: "DELETE",
+  });
+}
+
+describe("DELETE /api/edges/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessReturn = true;
+    getUserReturn = { user: { id: "user-1" } };
+  });
+
+  it("400 malformed UUID", async () => {
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete("bad"), {
+      params: Promise.resolve({ id: "bad" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when edge not found", async () => {
+    configureEdgeLookup({ data: null, error: null });
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("403 when caller cannot access the parent microgrid", async () => {
+    canAccessReturn = false;
+    configureEdgeLookup({
+      data: { id: VALID_UUID, name: "Edge-1", microgrid_id: "mg-1" },
+      error: null,
+    });
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("204 happy path + fn_entity_delete_edge dispatch + log emission", async () => {
+    configureEdgeLookup({
+      data: { id: VALID_UUID, name: "Edge-1", microgrid_id: "mg-1" },
+      error: null,
+    });
+    mockRpcImpl.mockResolvedValueOnce({ data: 1, error: null });
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(204);
+    expect(mockRpcImpl).toHaveBeenCalledWith("fn_entity_delete_edge", {
+      p_id: VALID_UUID,
+    });
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(infoSpy.mock.calls[0][0] as string);
+    expect(logged.entity_kind).toBe("edge");
+    expect(logged.descendant_counts.kind).toBe("edge");
+    // AC-FK-AUDIT: edge counts use `billing_line_items_nulled`, not the
+    // generic `billing_line_items` key.
+    expect(logged.descendant_counts).toHaveProperty("billing_line_items_nulled");
+    infoSpy.mockRestore();
+  });
+});
+
+describe("GET /api/edges/[id]/delete-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessReturn = true;
+  });
+
+  it("200 happy path — parent = { kind:'microgrid', id:<microgrid_id> }", async () => {
+    configureEdgeLookup({
+      data: { id: VALID_UUID, name: "Edge-1", microgrid_id: "mg-1" },
+      error: null,
+    });
+
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(`http://localhost/api/edges/${VALID_UUID}/delete-preview`),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.descendant_counts.kind).toBe("edge");
+    expect(json.parent).toEqual({ kind: "microgrid", id: "mg-1" });
+  });
+});

--- a/src/app/api/microgrids/[id]/delete-preview/route.ts
+++ b/src/app/api/microgrids/[id]/delete-preview/route.ts
@@ -1,0 +1,16 @@
+import { buildDeletePreviewHandler } from "@/lib/entity-deletion/preview";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+
+/**
+ * GET /api/microgrids/[id]/delete-preview — descendant counts for the
+ * blast-radius dialog (#89 / AC-ROUTE-3).
+ *
+ * Permission parity with DELETE: super_admin OR org_manager for the
+ * microgrid's parent org (AC-ROUTE-4).
+ */
+export const GET = buildDeletePreviewHandler({
+  kind: "microgrid",
+  entityLabel: "microgrid",
+  table: "microgrids",
+  canAccess: (supabase, id) => currentUserCanAccessMicrogrid(supabase, id),
+});

--- a/src/app/api/microgrids/[id]/route.ts
+++ b/src/app/api/microgrids/[id]/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 import { validateCurrency } from "@/lib/validation/currency";
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { countEntityDescendants } from "@/lib/entity-descendants";
+import {
+  errorBody,
+  mapPgError,
+  resolveActorRole,
+  UUID_RE,
+  type EntityDeleteLogPayload,
+} from "@/lib/entity-deletion/shared";
 
 /**
  * PATCH /api/microgrids/[id] — update a microgrid (#76).
@@ -158,4 +164,112 @@ export async function PATCH(
   }
 
   return NextResponse.json({ microgrid: data }, { status: 200 });
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Entity deletion (#89) — see ./delete-preview/route.ts for the preview GET.
+// ══════════════════════════════════════════════════════════════════════════
+
+/**
+ * DELETE /api/microgrids/[id] — delete a microgrid (#89).
+ *
+ * Authorization: super_admin OR org_manager with access to the microgrid's
+ * parent org (AC-ROUTE-2 step 2).
+ *
+ * Cascade policy (trust-preview per AC-ROUTE-6): intentional data loss
+ * warning per AC-ROUTE-8 — deleting a microgrid while a `draft` billing
+ * period is active destroys in-progress meter readings + line items that
+ * have not yet been finalized. This is acceptable: the blast-radius dialog
+ * surfaces draft vs closed counts distinctly and the operator committed
+ * to "destroy everything under {name}" by typing the name.
+ *
+ * Idempotency: first-delete wins, repeats 404 (AC-ROUTE-7).
+ *
+ * Revalidation (AC-UI-6): both `/communities/<community_id>` and
+ * `/microgrids` layouts are busted.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      errorBody("Invalid microgrid id — expected UUID."),
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  if (!(await currentUserCanAccessMicrogrid(supabase, id))) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this microgrid."),
+      { status: 403 }
+    );
+  }
+
+  const { data: microgrid, error: fetchErr } = await supabase
+    .from("microgrids")
+    .select("id, name, community_id")
+    .eq("id", id)
+    .maybeSingle<{ id: string; name: string; community_id: string }>();
+
+  if (fetchErr) {
+    const mapped = mapPgError(fetchErr, "microgrid");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if (!microgrid) {
+    return NextResponse.json(errorBody("Microgrid not found."), { status: 404 });
+  }
+  if (!microgrid.name || !microgrid.name.trim()) {
+    return NextResponse.json(
+      errorBody("Unnamed entity cannot be typed-to-confirm."),
+      { status: 409 }
+    );
+  }
+
+  const descendantCounts = await countEntityDescendants(supabase, "microgrid", id);
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const actorRole = await resolveActorRole(supabase);
+  if (!user || !actorRole) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this microgrid."),
+      { status: 403 }
+    );
+  }
+
+  const { data: rowsDeleted, error: delErr } = await supabase.rpc(
+    "fn_entity_delete_microgrid",
+    { p_id: id }
+  );
+
+  if (delErr) {
+    const mapped = mapPgError(delErr, "microgrid");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if ((rowsDeleted ?? 0) === 0) {
+    return NextResponse.json(errorBody("Microgrid not found."), { status: 404 });
+  }
+
+  const payload: EntityDeleteLogPayload = {
+    event: "entity.delete",
+    entity_kind: "microgrid",
+    entity_id: id,
+    entity_name: microgrid.name,
+    actor_user_id: user.id,
+    actor_role: actorRole,
+    descendant_counts: descendantCounts,
+    at: new Date().toISOString(),
+  };
+  console.info(JSON.stringify(payload));
+
+  revalidatePath(`/communities/${microgrid.community_id}`, "layout");
+  revalidatePath("/microgrids", "layout");
+
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/microgrids/__tests__/delete.test.ts
+++ b/src/app/api/microgrids/__tests__/delete.test.ts
@@ -1,0 +1,168 @@
+/**
+ * DELETE /api/microgrids/[id] + GET delete-preview route tests (#89).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+let canAccessReturn = true;
+let getUserReturn: { user: { id: string } | null } = {
+  user: { id: "user-1" },
+};
+
+const mockFromImpl = vi.fn();
+const mockRpcImpl = vi.fn();
+const mockSupabaseClient = {
+  from: (...args: unknown[]) => mockFromImpl(...args),
+  rpc: (...args: unknown[]) => mockRpcImpl(...args),
+  auth: { getUser: async () => ({ data: getUserReturn }) },
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => mockSupabaseClient,
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: async () => canAccessReturn,
+  currentUserCanAccessCommunity: async () => canAccessReturn,
+  currentUserIsSuperAdmin: async () => canAccessReturn,
+  getCurrentUserRoles: async () =>
+    canAccessReturn
+      ? [{ role: "org_manager", scope_type: "org", scope_id: "org-1" }]
+      : [],
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+function chainable(result: { data: unknown; error: unknown; count?: number }) {
+  const stub: {
+    eq: (...args: unknown[]) => typeof stub;
+    in: (...args: unknown[]) => typeof stub;
+    maybeSingle: () => Promise<unknown>;
+    then: (onFulfilled: (v: unknown) => unknown) => Promise<unknown>;
+  } = {
+    eq: () => stub,
+    in: () => stub,
+    maybeSingle: () => Promise.resolve(result),
+    then: (onFulfilled) => Promise.resolve(result).then(onFulfilled),
+  };
+  return stub;
+}
+
+function configureEntityLookup(result: {
+  data: { id: string; name: string; community_id: string } | null;
+  error: { code?: string; message: string } | null;
+}) {
+  mockFromImpl.mockImplementation((table: string) => {
+    if (table === "microgrids") {
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => result }),
+        }),
+      };
+    }
+    return {
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) =>
+        opts?.head
+          ? chainable({ data: null, error: null, count: 0 })
+          : chainable({ data: [], error: null }),
+    };
+  });
+}
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeDelete(id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/microgrids/${id}`, {
+    method: "DELETE",
+  });
+}
+
+describe("DELETE /api/microgrids/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessReturn = true;
+    getUserReturn = { user: { id: "user-1" } };
+  });
+
+  it("400 malformed UUID", async () => {
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete("bad"), {
+      params: Promise.resolve({ id: "bad" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("403 when caller cannot access microgrid", async () => {
+    canAccessReturn = false;
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("404 when microgrid not found", async () => {
+    configureEntityLookup({ data: null, error: null });
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("204 happy path + fn_entity_delete_microgrid dispatch", async () => {
+    configureEntityLookup({
+      data: {
+        id: VALID_UUID,
+        name: "Kisakye Main",
+        community_id: "comm-1",
+      },
+      error: null,
+    });
+    mockRpcImpl.mockResolvedValueOnce({ data: 1, error: null });
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeDelete(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(204);
+    expect(mockRpcImpl).toHaveBeenCalledWith("fn_entity_delete_microgrid", {
+      p_id: VALID_UUID,
+    });
+    infoSpy.mockRestore();
+  });
+});
+
+describe("GET /api/microgrids/[id]/delete-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessReturn = true;
+  });
+
+  it("200 happy path — parent = { kind:'community', id:<community_id> }", async () => {
+    configureEntityLookup({
+      data: {
+        id: VALID_UUID,
+        name: "Kisakye Main",
+        community_id: "comm-1",
+      },
+      error: null,
+    });
+
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(
+        `http://localhost/api/microgrids/${VALID_UUID}/delete-preview`
+      ),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.descendant_counts.kind).toBe("microgrid");
+    expect(json.parent).toEqual({ kind: "community", id: "comm-1" });
+  });
+});

--- a/src/app/api/organizations/[id]/delete-preview/route.ts
+++ b/src/app/api/organizations/[id]/delete-preview/route.ts
@@ -1,0 +1,15 @@
+import { buildDeletePreviewHandler } from "@/lib/entity-deletion/preview";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+
+/**
+ * GET /api/organizations/[id]/delete-preview — descendant counts for the
+ * blast-radius dialog (#89 / AC-ROUTE-3).
+ *
+ * Permission parity with DELETE: super_admin only (AC-ROUTE-4).
+ */
+export const GET = buildDeletePreviewHandler({
+  kind: "organization",
+  entityLabel: "organization",
+  table: "organizations",
+  canAccess: async (supabase) => currentUserIsSuperAdmin(supabase),
+});

--- a/src/app/api/organizations/[id]/route.ts
+++ b/src/app/api/organizations/[id]/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserIsSuperAdmin } from "@/lib/auth/access";
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { countEntityDescendants } from "@/lib/entity-descendants";
+import {
+  errorBody,
+  mapPgError,
+  resolveActorRole,
+  UUID_RE,
+  type EntityDeleteLogPayload,
+} from "@/lib/entity-deletion/shared";
 
 /**
  * PATCH /api/organizations/[id] — update an organization (#76).
@@ -128,4 +134,138 @@ export async function PATCH(
   }
 
   return NextResponse.json({ organization: data }, { status: 200 });
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Entity deletion (#89) — GET delete-preview lives in `./delete-preview/route.ts`.
+// ══════════════════════════════════════════════════════════════════════════
+
+/**
+ * DELETE /api/organizations/[id] — delete an organization (#89).
+ *
+ * Authorization: `super_admin` only (PM decision #2 / AC-ROUTE-2 step 2).
+ *
+ * Cascade policy (trust-preview per AC-ROUTE-6): the DELETE does NOT re-run
+ * `countEntityDescendants` pre-check. The type-to-confirm UI + blast-radius
+ * dialog is the safety layer; racing new descendants in between preview and
+ * confirm is acceptable — the caller has explicitly typed the name and
+ * committed to "destroy everything under {name}."
+ *
+ * Idempotency: first-delete wins, repeats 404 (AC-ROUTE-7). Document rather
+ * than chase 204-on-already-gone.
+ *
+ * Cascade chain: organizations → communities → microgrids → edges → devices
+ * → household_devices + billing_line_items (device_id SET NULL, survives);
+ * microgrids → households → household_users + household_devices; microgrids
+ * → billing_periods → billing_line_items; microgrids → rate_schedules; and,
+ * via 00015's new FK, organizations → user_roles (org-scoped).
+ *
+ * The DELETE is dispatched through `fn_entity_delete_org()` which wraps
+ * `SET LOCAL app.entity_cascade_delete = 'on'` + DELETE in a single
+ * transaction — required so the `user_roles` BEFORE DELETE trigger's
+ * self-revoke guard doesn't roll an org_manager's own-org-delete back.
+ * See 00015 header for the full rationale.
+ *
+ * Revalidation (AC-UI-6): `/organizations` layout is busted post-delete
+ * so the sidebar/nav tree reflects the removal on next navigation.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      errorBody("Invalid organization id — expected UUID."),
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Authorization (defense-in-depth in front of RLS).
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this organization."),
+      { status: 403 }
+    );
+  }
+
+  // Load entity name + existence. 404 if gone; 409 if unnamed (unnamed
+  // entity can't be typed-to-confirm, so the UI branch can't reach here
+  // legitimately — surface a clear error).
+  const { data: org, error: fetchErr } = await supabase
+    .from("organizations")
+    .select("id, name")
+    .eq("id", id)
+    .maybeSingle<{ id: string; name: string }>();
+
+  if (fetchErr) {
+    const mapped = mapPgError(fetchErr, "organization");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+  if (!org) {
+    return NextResponse.json(errorBody("Organization not found."), { status: 404 });
+  }
+  if (!org.name || !org.name.trim()) {
+    return NextResponse.json(
+      errorBody("Unnamed entity cannot be typed-to-confirm."),
+      { status: 409 }
+    );
+  }
+
+  // Pre-count descendants for the log payload (AC-LOG-1). Counts are
+  // advisory per AC-ROUTE-6 — we do not re-verify against the preview.
+  const descendantCounts = await countEntityDescendants(
+    supabase,
+    "organization",
+    id
+  );
+
+  // Resolve actor metadata for the log payload. We never emit the log
+  // for an unauthenticated caller (auth() already gated above), but
+  // belt-and-suspenders in case the order changes.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const actorRole = await resolveActorRole(supabase);
+  if (!user || !actorRole) {
+    return NextResponse.json(
+      errorBody("You do not have permission to delete this organization."),
+      { status: 403 }
+    );
+  }
+
+  // Execute DELETE via the cascade-safe RPC (see fn_entity_delete_org).
+  const { data: rowsDeleted, error: delErr } = await supabase.rpc(
+    "fn_entity_delete_org",
+    { p_id: id }
+  );
+
+  if (delErr) {
+    const mapped = mapPgError(delErr, "organization");
+    return NextResponse.json(errorBody(mapped.message), { status: mapped.status });
+  }
+
+  // RLS-filtered OR already deleted → 404 (AC-ROUTE-7 idempotency).
+  if ((rowsDeleted ?? 0) === 0) {
+    return NextResponse.json(errorBody("Organization not found."), { status: 404 });
+  }
+
+  const payload: EntityDeleteLogPayload = {
+    event: "entity.delete",
+    entity_kind: "organization",
+    entity_id: id,
+    entity_name: org.name,
+    actor_user_id: user.id,
+    actor_role: actorRole,
+    descendant_counts: descendantCounts,
+    at: new Date().toISOString(),
+  };
+  console.info(JSON.stringify(payload));
+
+  revalidatePath("/organizations", "layout");
+
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/organizations/__tests__/delete.test.ts
+++ b/src/app/api/organizations/__tests__/delete.test.ts
@@ -1,0 +1,277 @@
+/**
+ * DELETE /api/organizations/[id] + GET delete-preview route tests (#89).
+ *
+ * Supabase I/O + auth helpers are mocked. Covers:
+ *   - DELETE: 400 invalid UUID
+ *   - DELETE: 403 unauthorized (not super_admin)
+ *   - DELETE: 404 entity not found
+ *   - DELETE: 204 happy path + asserts the structured log payload shape
+ *   - Preview: 200 happy path returns { entity, descendant_counts, as_of, parent }
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+let isSuperAdminReturn = true;
+let getUserReturn: { user: { id: string } | null } = {
+  user: { id: "user-1" },
+};
+
+const mockFromImpl = vi.fn();
+const mockRpcImpl = vi.fn();
+
+const mockSupabaseClient = {
+  from: (...args: unknown[]) => mockFromImpl(...args),
+  rpc: (...args: unknown[]) => mockRpcImpl(...args),
+  auth: {
+    getUser: async () => ({ data: getUserReturn }),
+  },
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => mockSupabaseClient,
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
+  getCurrentUserRoles: async () =>
+    isSuperAdminReturn
+      ? [{ role: "super_admin", scope_type: "org", scope_id: null }]
+      : [],
+  // Preview route doesn't need the community/microgrid helpers, but the
+  // shared module imports them transitively — stub to prevent accidental
+  // real imports from hitting `server-only`.
+  currentUserCanAccessCommunity: async () => true,
+  currentUserCanAccessMicrogrid: async () => true,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// Small helper: build a .from() chain that resolves to the given entity
+// lookup (maybeSingle) result. Other .from() calls default to an empty
+// "no rows" shape — descendant counters and similar calls just come back
+// with `count: 0`.
+function configureEntityLookup(result: {
+  data: { id: string; name: string } | null;
+  error: { code?: string; message: string } | null;
+}) {
+  // Build a thenable stub that also supports unlimited `.eq()` chaining
+  // and an `.in()` terminator. Both count-style (head:true) and non-count
+  // calls resolve to an empty shape — exact counts don't affect the HTTP
+  // contract being tested here.
+  //
+  // The descendant counter uses chains like
+  // `qb.eq("scope_type", "org").eq("scope_id", orgId)` (which awaits the
+  // second `.eq`) and `qb.in("col", values)` as the terminator. The stub
+  // is both a Promise and a chainable — `await` uses the Promise side,
+  // further chained `.eq()` / `.in()` calls return the same stub.
+  function chainable(result: { data: unknown; error: unknown; count?: number }) {
+    const stub: {
+      eq: (...args: unknown[]) => typeof stub;
+      in: (...args: unknown[]) => typeof stub;
+      maybeSingle: () => Promise<unknown>;
+      then: (
+        onFulfilled: (v: unknown) => unknown
+      ) => Promise<unknown>;
+    } = {
+      eq: () => stub,
+      in: () => stub,
+      maybeSingle: () => Promise.resolve(result),
+      then: (onFulfilled) => Promise.resolve(result).then(onFulfilled),
+    };
+    return stub;
+  }
+
+  mockFromImpl.mockImplementation((table: string) => {
+    if (table === "organizations") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => result,
+          }),
+        }),
+      };
+    }
+    return {
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+        if (opts?.head) {
+          return chainable({ data: null, error: null, count: 0 });
+        }
+        return chainable({ data: [], error: null });
+      },
+    };
+  });
+}
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/organizations/${VALID_UUID}`, {
+    method: "DELETE",
+  });
+}
+
+describe("DELETE /api/organizations/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSuperAdminReturn = true;
+    getUserReturn = { user: { id: "user-1" } };
+  });
+
+  it("returns 400 for malformed UUID", async () => {
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(
+      new NextRequest(`http://localhost/api/organizations/not-a-uuid`, {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id: "not-a-uuid" }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Invalid organization id");
+  });
+
+  it("returns 403 when caller is not super_admin", async () => {
+    isSuperAdminReturn = false;
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain("You do not have permission");
+  });
+
+  it("returns 404 when the organization does not exist", async () => {
+    configureEntityLookup({ data: null, error: null });
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Organization not found.");
+  });
+
+  it("returns 204 on happy path and logs entity.delete with the exact AC-LOG-1 payload shape", async () => {
+    configureEntityLookup({
+      data: { id: VALID_UUID, name: "NFE" },
+      error: null,
+    });
+    mockRpcImpl.mockResolvedValueOnce({ data: 1, error: null });
+
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockRpcImpl).toHaveBeenCalledWith("fn_entity_delete_org", {
+      p_id: VALID_UUID,
+    });
+
+    // AC-LOG-1: exact shape + keys.
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(infoSpy.mock.calls[0][0] as string);
+    expect(logged.event).toBe("entity.delete");
+    expect(logged.entity_kind).toBe("organization");
+    expect(logged.entity_id).toBe(VALID_UUID);
+    expect(logged.entity_name).toBe("NFE");
+    expect(logged.actor_user_id).toBe("user-1");
+    expect(logged.actor_role).toBe("super_admin");
+    expect(logged.descendant_counts).toBeDefined();
+    expect(logged.descendant_counts.kind).toBe("organization");
+    expect(logged.at).toMatch(/\d{4}-\d{2}-\d{2}T/);
+
+    infoSpy.mockRestore();
+  });
+
+  it("returns 404 on repeat delete (idempotency per AC-ROUTE-7)", async () => {
+    // Second DELETE — the entity still exists at lookup time (race). The
+    // RPC returns 0 rows deleted (RLS hid it, or it vanished under our
+    // feet). Per AC-ROUTE-7 we map that to 404 so the UI can't blindly
+    // retry a stale tab.
+    configureEntityLookup({
+      data: { id: VALID_UUID, name: "NFE" },
+      error: null,
+    });
+    mockRpcImpl.mockResolvedValueOnce({ data: 0, error: null });
+
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when entity has an empty name (cannot type-to-confirm)", async () => {
+    configureEntityLookup({
+      data: { id: VALID_UUID, name: "" },
+      error: null,
+    });
+    const { DELETE } = await import("../[id]/route");
+    const res = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("Unnamed entity");
+  });
+});
+
+describe("GET /api/organizations/[id]/delete-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSuperAdminReturn = true;
+  });
+
+  it("returns 400 for malformed UUID", async () => {
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(`http://localhost/api/organizations/not-a-uuid/delete-preview`),
+      { params: Promise.resolve({ id: "not-a-uuid" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller cannot access the entity (permission parity AC-ROUTE-4)", async () => {
+    isSuperAdminReturn = false;
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(
+        `http://localhost/api/organizations/${VALID_UUID}/delete-preview`
+      ),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with the expected response shape on happy path", async () => {
+    configureEntityLookup({
+      data: { id: VALID_UUID, name: "NFE" },
+      error: null,
+    });
+
+    const { GET } = await import("../[id]/delete-preview/route");
+    const res = await GET(
+      new NextRequest(
+        `http://localhost/api/organizations/${VALID_UUID}/delete-preview`
+      ),
+      { params: Promise.resolve({ id: VALID_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.entity).toEqual({ id: VALID_UUID, name: "NFE" });
+    expect(json.descendant_counts).toBeDefined();
+    expect(json.descendant_counts.kind).toBe("organization");
+    expect(typeof json.as_of).toBe("string");
+    // parent is null for Org per AC-ROUTE-3.
+    expect(json.parent).toBeNull();
+  });
+});

--- a/src/components/entity-deletion/BlastRadiusList.tsx
+++ b/src/components/entity-deletion/BlastRadiusList.tsx
@@ -26,8 +26,8 @@
  */
 
 import * as React from "react";
-import type { DescendantCounts } from "@/lib/entity-descendants";
-import { descendantCountsAreEmpty } from "@/lib/entity-descendants";
+import type { DescendantCounts } from "@/lib/entity-descendants-types";
+import { descendantCountsAreEmpty } from "@/lib/entity-descendants-types";
 
 // In-module NumberFormat cache; keyed by the resolved browser locale.
 // Matches the pattern used by src/components/format/currency.tsx for

--- a/src/components/entity-deletion/BlastRadiusList.tsx
+++ b/src/components/entity-deletion/BlastRadiusList.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+/**
+ * BlastRadiusList — renders `DescendantCounts` as a human-readable list
+ * inside the entity-delete ConfirmDialog (#89 / AC-UI-4).
+ *
+ * Rendering rules:
+ *   * For each non-zero count, render an `<li>` with plain-language copy.
+ *   * Zero counts are omitted.
+ *   * When every count is zero, render a single line "This entity has no
+ *     descendants." rather than an empty list or a row of zeros.
+ *   * Billing periods render as two separate lines (draft vs closed) —
+ *     never combined — per AC-ROUTE-8 / AC-UI-4. Draft copy includes
+ *     the "unfinalized readings will be lost" phrasing so the operator
+ *     sees that they're destroying in-progress work.
+ *   * For `edge.billing_line_items_nulled` the copy explicitly calls out
+ *     that rows SURVIVE (linkage severed, not destroyed). Same for
+ *     `edge.household_devices` — households themselves are preserved
+ *     but their meter linkage breaks.
+ *   * Numerals format via `Intl.NumberFormat` with `Accept-Language` or
+ *     the default browser locale (pilot numbers <1000 render identically
+ *     across locales — AC-UI-5 note). Do NOT hand-roll a formatter.
+ *
+ * The `asOf` timestamp renders as a small muted caption underneath so
+ * the operator sees the staleness window acknowledged in AC-ROUTE-6.
+ */
+
+import * as React from "react";
+import type { DescendantCounts } from "@/lib/entity-descendants";
+import { descendantCountsAreEmpty } from "@/lib/entity-descendants";
+
+// In-module NumberFormat cache; keyed by the resolved browser locale.
+// Matches the pattern used by src/components/format/currency.tsx for
+// its own cache. Safe for client components — lives across renders.
+const nfCache = new Map<string, Intl.NumberFormat>();
+function nf(): Intl.NumberFormat {
+  const locale =
+    typeof navigator !== "undefined" ? navigator.language : "en-US";
+  let cached = nfCache.get(locale);
+  if (!cached) {
+    cached = new Intl.NumberFormat(locale);
+    nfCache.set(locale, cached);
+  }
+  return cached;
+}
+
+function fmt(n: number): string {
+  return nf().format(n);
+}
+
+function pluralize(n: number, singular: string, plural?: string): string {
+  return n === 1 ? singular : plural ?? `${singular}s`;
+}
+
+/** Build the list of `<li>` nodes for the given counts. */
+function buildItems(counts: DescendantCounts): React.ReactNode[] {
+  const items: React.ReactNode[] = [];
+
+  switch (counts.kind) {
+    case "organization":
+      if (counts.communities > 0)
+        items.push(
+          <li key="communities">
+            {fmt(counts.communities)}{" "}
+            {pluralize(counts.communities, "community", "communities")}
+          </li>
+        );
+      if (counts.microgrids > 0)
+        items.push(
+          <li key="microgrids">
+            {fmt(counts.microgrids)} {pluralize(counts.microgrids, "microgrid")}
+          </li>
+        );
+      if (counts.edges > 0)
+        items.push(
+          <li key="edges">
+            {fmt(counts.edges)} {pluralize(counts.edges, "edge")}
+          </li>
+        );
+      if (counts.devices > 0)
+        items.push(
+          <li key="devices">
+            {fmt(counts.devices)} {pluralize(counts.devices, "device")}
+          </li>
+        );
+      if (counts.households > 0)
+        items.push(
+          <li key="households">
+            {fmt(counts.households)} {pluralize(counts.households, "household")}
+          </li>
+        );
+      if (counts.household_devices > 0)
+        items.push(
+          <li key="hd">
+            {fmt(counts.household_devices)} household↔meter{" "}
+            {pluralize(counts.household_devices, "link")}
+          </li>
+        );
+      if (counts.household_users > 0)
+        items.push(
+          <li key="hu">
+            {fmt(counts.household_users)} household user{" "}
+            {pluralize(counts.household_users, "link")}
+          </li>
+        );
+      if (counts.billing_periods_draft > 0)
+        items.push(
+          <li key="bpd">
+            {fmt(counts.billing_periods_draft)} draft billing{" "}
+            {pluralize(counts.billing_periods_draft, "period")} (in progress —
+            unfinalized readings will be lost)
+          </li>
+        );
+      if (counts.billing_periods_closed > 0)
+        items.push(
+          <li key="bpc">
+            {fmt(counts.billing_periods_closed)} closed billing{" "}
+            {pluralize(counts.billing_periods_closed, "period")}
+          </li>
+        );
+      if (counts.billing_line_items > 0)
+        items.push(
+          <li key="bli">
+            {fmt(counts.billing_line_items)} billing line{" "}
+            {pluralize(counts.billing_line_items, "item")}
+          </li>
+        );
+      if (counts.rate_schedules > 0)
+        items.push(
+          <li key="rs">
+            {fmt(counts.rate_schedules)} rate{" "}
+            {pluralize(counts.rate_schedules, "schedule")}
+          </li>
+        );
+      if (counts.user_roles > 0)
+        items.push(
+          <li key="ur">
+            {fmt(counts.user_roles)} org_manager role{" "}
+            {pluralize(counts.user_roles, "assignment")}
+          </li>
+        );
+      break;
+
+    case "community":
+      if (counts.microgrids > 0)
+        items.push(
+          <li key="microgrids">
+            {fmt(counts.microgrids)} {pluralize(counts.microgrids, "microgrid")}
+          </li>
+        );
+      if (counts.edges > 0)
+        items.push(
+          <li key="edges">
+            {fmt(counts.edges)} {pluralize(counts.edges, "edge")}
+          </li>
+        );
+      if (counts.devices > 0)
+        items.push(
+          <li key="devices">
+            {fmt(counts.devices)} {pluralize(counts.devices, "device")}
+          </li>
+        );
+      if (counts.households > 0)
+        items.push(
+          <li key="households">
+            {fmt(counts.households)} {pluralize(counts.households, "household")}
+          </li>
+        );
+      if (counts.household_devices > 0)
+        items.push(
+          <li key="hd">
+            {fmt(counts.household_devices)} household↔meter{" "}
+            {pluralize(counts.household_devices, "link")}
+          </li>
+        );
+      if (counts.household_users > 0)
+        items.push(
+          <li key="hu">
+            {fmt(counts.household_users)} household user{" "}
+            {pluralize(counts.household_users, "link")}
+          </li>
+        );
+      if (counts.billing_periods_draft > 0)
+        items.push(
+          <li key="bpd">
+            {fmt(counts.billing_periods_draft)} draft billing{" "}
+            {pluralize(counts.billing_periods_draft, "period")} (in progress —
+            unfinalized readings will be lost)
+          </li>
+        );
+      if (counts.billing_periods_closed > 0)
+        items.push(
+          <li key="bpc">
+            {fmt(counts.billing_periods_closed)} closed billing{" "}
+            {pluralize(counts.billing_periods_closed, "period")}
+          </li>
+        );
+      if (counts.billing_line_items > 0)
+        items.push(
+          <li key="bli">
+            {fmt(counts.billing_line_items)} billing line{" "}
+            {pluralize(counts.billing_line_items, "item")}
+          </li>
+        );
+      if (counts.rate_schedules > 0)
+        items.push(
+          <li key="rs">
+            {fmt(counts.rate_schedules)} rate{" "}
+            {pluralize(counts.rate_schedules, "schedule")}
+          </li>
+        );
+      break;
+
+    case "microgrid":
+      if (counts.edges > 0)
+        items.push(
+          <li key="edges">
+            {fmt(counts.edges)} {pluralize(counts.edges, "edge")}
+          </li>
+        );
+      if (counts.devices > 0)
+        items.push(
+          <li key="devices">
+            {fmt(counts.devices)} {pluralize(counts.devices, "device")}
+          </li>
+        );
+      if (counts.households > 0)
+        items.push(
+          <li key="households">
+            {fmt(counts.households)} {pluralize(counts.households, "household")}
+          </li>
+        );
+      if (counts.household_devices > 0)
+        items.push(
+          <li key="hd">
+            {fmt(counts.household_devices)} household↔meter{" "}
+            {pluralize(counts.household_devices, "link")}
+          </li>
+        );
+      if (counts.household_users > 0)
+        items.push(
+          <li key="hu">
+            {fmt(counts.household_users)} household user{" "}
+            {pluralize(counts.household_users, "link")}
+          </li>
+        );
+      if (counts.billing_periods_draft > 0)
+        items.push(
+          <li key="bpd">
+            {fmt(counts.billing_periods_draft)} draft billing{" "}
+            {pluralize(counts.billing_periods_draft, "period")} (in progress —
+            unfinalized readings will be lost)
+          </li>
+        );
+      if (counts.billing_periods_closed > 0)
+        items.push(
+          <li key="bpc">
+            {fmt(counts.billing_periods_closed)} closed billing{" "}
+            {pluralize(counts.billing_periods_closed, "period")}
+          </li>
+        );
+      if (counts.billing_line_items > 0)
+        items.push(
+          <li key="bli">
+            {fmt(counts.billing_line_items)} billing line{" "}
+            {pluralize(counts.billing_line_items, "item")}
+          </li>
+        );
+      if (counts.rate_schedules > 0)
+        items.push(
+          <li key="rs">
+            {fmt(counts.rate_schedules)} rate{" "}
+            {pluralize(counts.rate_schedules, "schedule")}
+          </li>
+        );
+      break;
+
+    case "edge":
+      if (counts.devices > 0)
+        items.push(
+          <li key="devices">
+            {fmt(counts.devices)} {pluralize(counts.devices, "device")}
+          </li>
+        );
+      if (counts.household_devices > 0)
+        items.push(
+          <li key="hd">
+            {fmt(counts.household_devices)} household↔meter{" "}
+            {pluralize(counts.household_devices, "link")} will be severed
+            (households preserved but will need meter re-linking before next
+            close)
+          </li>
+        );
+      if (counts.billing_line_items_nulled > 0)
+        items.push(
+          <li key="blin">
+            {fmt(counts.billing_line_items_nulled)} billing line{" "}
+            {pluralize(counts.billing_line_items_nulled, "item")} will lose
+            their device linkage (historical records preserved)
+          </li>
+        );
+      break;
+  }
+
+  return items;
+}
+
+export interface BlastRadiusListProps {
+  counts: DescendantCounts;
+  /** ISO 8601 timestamp of the preview query — rendered as a muted caption. */
+  asOf: string;
+}
+
+export function BlastRadiusList({ counts, asOf }: BlastRadiusListProps) {
+  const items = buildItems(counts);
+  const empty = descendantCountsAreEmpty(counts);
+
+  // Format the "counts as of" time. Locale-aware with graceful fallback.
+  let asOfLabel = "";
+  try {
+    const d = new Date(asOf);
+    asOfLabel = d.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    asOfLabel = asOf;
+  }
+
+  return (
+    <div>
+      {empty ? (
+        <ul className="my-2 list-disc pl-5">
+          <li>This entity has no descendants.</li>
+        </ul>
+      ) : (
+        <ul className="my-2 list-disc space-y-0.5 pl-5">{items}</ul>
+      )}
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        Counts as of {asOfLabel}
+      </p>
+    </div>
+  );
+}

--- a/src/components/entity-deletion/DeletedSuccessBanner.tsx
+++ b/src/components/entity-deletion/DeletedSuccessBanner.tsx
@@ -1,0 +1,61 @@
+/**
+ * DeletedSuccessBanner — renders a one-shot success banner on the parent
+ * page of a just-deleted entity (#89 / AC-UI-7).
+ *
+ * Reads `?deleted=<kind>&name=<name>` from the incoming server searchParams.
+ * No auto-dismiss logic — navigation or reload clears the query param.
+ * Server component: no hydration cost when the params are absent.
+ *
+ * Usage:
+ *   // In a server page component:
+ *   export default async function Page({ searchParams }) {
+ *     const sp = await searchParams;
+ *     return (
+ *       <>
+ *         <DeletedSuccessBanner searchParams={sp} />
+ *         ...
+ *       </>
+ *     );
+ *   }
+ */
+
+import * as React from "react";
+import { Banner } from "@/components/ui/banner";
+
+type Kind = "organization" | "community" | "microgrid" | "edge";
+
+const KIND_LABEL: Record<Kind, string> = {
+  organization: "Organization",
+  community: "Community",
+  microgrid: "Microgrid",
+  edge: "Edge",
+};
+
+function isKind(v: unknown): v is Kind {
+  return (
+    v === "organization" ||
+    v === "community" ||
+    v === "microgrid" ||
+    v === "edge"
+  );
+}
+
+export interface DeletedSuccessBannerProps {
+  searchParams?: Record<string, string | string[] | undefined>;
+}
+
+export function DeletedSuccessBanner({ searchParams }: DeletedSuccessBannerProps) {
+  const rawKind = searchParams?.deleted;
+  const rawName = searchParams?.name;
+
+  const kindStr = Array.isArray(rawKind) ? rawKind[0] : rawKind;
+  const nameStr = Array.isArray(rawName) ? rawName[0] : rawName;
+
+  if (!isKind(kindStr) || !nameStr) return null;
+
+  return (
+    <Banner tone="success" title={`${KIND_LABEL[kindStr]} deleted`}>
+      <strong>{nameStr}</strong> has been permanently deleted.
+    </Banner>
+  );
+}

--- a/src/components/forms/DeleteEntityButton.tsx
+++ b/src/components/forms/DeleteEntityButton.tsx
@@ -39,7 +39,10 @@ import { useRouter } from "next/navigation";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Banner } from "@/components/ui/banner";
 import { BlastRadiusList } from "@/components/entity-deletion/BlastRadiusList";
-import type { DescendantCounts, EntityKind } from "@/lib/entity-descendants";
+import type {
+  DescendantCounts,
+  EntityKind,
+} from "@/lib/entity-descendants-types";
 
 // Parent redirect shape matches the preview response.
 type Parent =

--- a/src/components/forms/DeleteEntityButton.tsx
+++ b/src/components/forms/DeleteEntityButton.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+/**
+ * DeleteEntityButton — client wrapper for the #89 entity-delete flow.
+ *
+ * Colocated with `EditEntityButton`; one implementation is reused by the
+ * four entity detail pages (organization / community / microgrid / edge).
+ * Permission gating lives in the PARENT server component — do NOT render
+ * this button if the server-side access check failed. This client
+ * component has no auth surface of its own.
+ *
+ * End-to-end click flow (AC-UI-3):
+ *   1. Button click → `isOpening = true`, the button goes `disabled`,
+ *      fire `GET /api/<kind>/<id>/delete-preview`.
+ *   2. Preview 200 → store response, clear `isOpening`, open the
+ *      `<ConfirmDialog>` with `requireTypedConfirmation` + the
+ *      `<BlastRadiusList>` body.
+ *   3. Preview 403/404/500 → clear `isOpening`, DO NOT open the dialog,
+ *      surface a `<Banner tone="destructive">` inline on the detail page
+ *      using `data.error`.
+ *   4. User types name, clicks Confirm → ConfirmDialog's internal async
+ *      confirm fires `DELETE /api/<kind>/<id>`.
+ *   5. DELETE 204 → `router.refresh()` then `router.push(<parent-path>)`
+ *      with `?deleted=<kind>&name=<encoded-name>` so the parent page can
+ *      render its success banner (AC-UI-7).
+ *   6. DELETE error → throw from the confirm handler; ConfirmDialog
+ *      renders the error inline and keeps the dialog open. User can
+ *      Retry or Cancel.
+ *   7. Cancel-then-reopen → always re-fetch preview; never cache in
+ *      component state across opens.
+ *
+ * Visual style: cloned from #79's Revoke button at
+ * `src/components/users/EditUserDialog.tsx:353-358` for consistency with
+ * other destructive affordances shipped recently.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Banner } from "@/components/ui/banner";
+import { BlastRadiusList } from "@/components/entity-deletion/BlastRadiusList";
+import type { DescendantCounts, EntityKind } from "@/lib/entity-descendants";
+
+// Parent redirect shape matches the preview response.
+type Parent =
+  | { kind: "organization"; id: string }
+  | { kind: "community"; id: string }
+  | { kind: "microgrid"; id: string }
+  | null;
+
+interface PreviewResponse {
+  entity: { id: string; name: string };
+  descendant_counts: DescendantCounts;
+  as_of: string;
+  parent: Parent;
+}
+
+export interface DeleteEntityButtonProps {
+  entity: EntityKind;
+  id: string;
+  name: string;
+}
+
+const KIND_LABEL: Record<EntityKind, string> = {
+  organization: "Organization",
+  community: "Community",
+  microgrid: "Microgrid",
+  edge: "Edge",
+};
+
+function apiBaseFor(entity: EntityKind): string {
+  switch (entity) {
+    case "organization":
+      return "/api/organizations";
+    case "community":
+      return "/api/communities";
+    case "microgrid":
+      return "/api/microgrids";
+    case "edge":
+      return "/api/edges";
+  }
+}
+
+function parentPathFor(entity: EntityKind, parent: Parent): string {
+  // Parent path resolution per AC-UI-3 step 5.
+  if (entity === "organization") {
+    return "/organizations";
+  }
+  if (!parent) return "/";
+  switch (parent.kind) {
+    case "organization":
+      return `/organizations/${parent.id}`;
+    case "community":
+      return `/communities/${parent.id}`;
+    case "microgrid":
+      // For edge deletes, redirect back to the edges sub-route.
+      if (entity === "edge") return `/microgrids/${parent.id}/setup/edges`;
+      return `/microgrids/${parent.id}`;
+  }
+}
+
+export function DeleteEntityButton({ entity, id, name }: DeleteEntityButtonProps) {
+  const router = useRouter();
+  const [isOpening, setIsOpening] = React.useState(false);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [preview, setPreview] = React.useState<PreviewResponse | null>(null);
+  const [topError, setTopError] = React.useState<string | null>(null);
+
+  const kindLabel = KIND_LABEL[entity];
+
+  async function handleOpen() {
+    setTopError(null);
+    setIsOpening(true);
+    try {
+      const res = await fetch(`${apiBaseFor(entity)}/${id}/delete-preview`, {
+        method: "GET",
+        // Default credentials: include cookies so the session authenticates.
+      });
+      if (!res.ok) {
+        let errMsg = `Unable to load delete preview (${res.status}).`;
+        try {
+          const data = (await res.json()) as { error?: string };
+          if (data.error) errMsg = data.error;
+        } catch {
+          // body not JSON — stick with default message.
+        }
+        setTopError(errMsg);
+        setIsOpening(false);
+        return;
+      }
+      const data = (await res.json()) as PreviewResponse;
+      setPreview(data);
+      setDialogOpen(true);
+      setIsOpening(false);
+    } catch (err) {
+      setTopError(
+        err instanceof Error
+          ? err.message
+          : "Unable to load delete preview."
+      );
+      setIsOpening(false);
+    }
+  }
+
+  async function handleConfirm(): Promise<void> {
+    if (!preview) throw new Error("Delete preview is missing.");
+    const res = await fetch(`${apiBaseFor(entity)}/${id}`, {
+      method: "DELETE",
+    });
+    if (res.status === 204) {
+      // Bust the Server-Component cache for the CURRENT route, then push.
+      // The DELETE route also calls `revalidatePath(..., "layout")` for
+      // parent-scoped trees (AC-UI-6), so the combination covers both
+      // the current route and nav/sidebar caches.
+      router.refresh();
+      const parentPath = parentPathFor(entity, preview.parent);
+      const qs = new URLSearchParams({
+        deleted: entity,
+        name: preview.entity.name,
+      }).toString();
+      const target =
+        parentPath + (parentPath.includes("?") ? "&" : "?") + qs;
+      router.push(target);
+      return;
+    }
+    // Non-204 → throw with the server error so ConfirmDialog renders it.
+    let msg = `Failed to delete ${kindLabel.toLowerCase()}.`;
+    try {
+      const data = (await res.json()) as { error?: string };
+      if (data.error) msg = data.error;
+    } catch {
+      // body wasn't JSON — use default.
+    }
+    throw new Error(msg);
+  }
+
+  // Clear the preview when the dialog closes so we always re-fetch on reopen.
+  React.useEffect(() => {
+    if (!dialogOpen) {
+      setPreview(null);
+    }
+  }, [dialogOpen]);
+
+  // Style mirrors #79's Revoke button (destructive tokenized).
+  const btnCls =
+    "inline-flex h-8 items-center rounded-md border border-destructive bg-destructive-muted px-3.5 text-[13px] font-medium text-destructive-fg hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={isOpening}
+        className={btnCls}
+      >
+        {isOpening ? `Loading…` : `Delete ${kindLabel}`}
+      </button>
+      {topError && (
+        <div className="mt-2">
+          <Banner tone="destructive" title={`Couldn’t open delete dialog`}>
+            {topError}
+          </Banner>
+        </div>
+      )}
+      {preview && (
+        <ConfirmDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          tone="destructive"
+          title={`Delete ${kindLabel.toLowerCase()} “${name}”?`}
+          description={`This cannot be undone. Type “${name}” to confirm.`}
+          body={
+            <BlastRadiusList
+              counts={preview.descendant_counts}
+              asOf={preview.as_of}
+            />
+          }
+          confirmLabel={`Delete ${kindLabel.toLowerCase()}`}
+          requireTypedConfirmation={{
+            label: `Type ${kindLabel.toLowerCase()} name to confirm`,
+            expected: preview.entity.name,
+          }}
+          onConfirm={handleConfirm}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/ui/__tests__/confirm-dialog.test.tsx
+++ b/src/components/ui/__tests__/confirm-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, act, waitFor } from "@testing-library/react";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 import { ConfirmDialog } from "../confirm-dialog";
 
 // Radix Dialog requires a portal target in jsdom.
@@ -76,5 +76,116 @@ describe("ConfirmDialog", () => {
       const cancelBtn = screen.getByRole("button", { name: "Cancel" });
       expect(document.activeElement).toBe(cancelBtn);
     });
+  });
+
+  // ── #89 entity-delete extensions ──────────────────────────────────────
+
+  it("(d) requireTypedConfirmation: confirm is disabled until input matches expected, then enabled", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete organization?"
+        description='Type "NFE" to confirm.'
+        confirmLabel="Delete organization"
+        tone="destructive"
+        requireTypedConfirmation={{
+          label: "Type organization name to confirm",
+          expected: "NFE",
+        }}
+        onConfirm={onConfirm}
+      />
+    );
+
+    const confirmBtn = screen.getByRole("button", {
+      name: "Delete organization",
+    }) as HTMLButtonElement;
+    expect(confirmBtn.disabled).toBe(true);
+
+    const input = screen.getByLabelText(
+      "Type organization name to confirm"
+    ) as HTMLInputElement;
+
+    // Wrong value → still disabled.
+    fireEvent.change(input, { target: { value: "nfe" } });
+    expect(confirmBtn.disabled).toBe(true);
+
+    // Matching (case-sensitive, trimmed) → enabled.
+    fireEvent.change(input, { target: { value: "NFE" } });
+    expect(confirmBtn.disabled).toBe(false);
+
+    // Click confirm → onConfirm fires.
+    await act(async () => {
+      confirmBtn.click();
+    });
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("(e) requireTypedConfirmation present: focus lands on the input (not Cancel)", async () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete organization?"
+        confirmLabel="Delete"
+        tone="destructive"
+        requireTypedConfirmation={{
+          label: "Type organization name to confirm",
+          expected: "NFE",
+        }}
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await waitFor(() => {
+      const input = screen.getByLabelText("Type organization name to confirm");
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  it("(f) Dialog.Content carries role='alertdialog'", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete meter?"
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    const alertDialog = screen.getByRole("alertdialog");
+    expect(alertDialog).toBeTruthy();
+  });
+
+  it("(g) body prop: renders under description and is referenced by aria-describedby", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete organization?"
+        description="Permanent action."
+        body={
+          <ul>
+            <li data-testid="body-item">1 community</li>
+          </ul>
+        }
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByTestId("body-item")).toBeTruthy();
+
+    const alertDialog = screen.getByRole("alertdialog");
+    const describedBy = alertDialog.getAttribute("aria-describedby");
+    expect(describedBy).toContain("confirm-dialog-body");
+    expect(describedBy).toContain("confirm-dialog-desc");
   });
 });

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -3,18 +3,29 @@
 // ConfirmDialog — single-purpose destructive confirm dialog.
 //
 // Interaction contract:
-//   • Single-purpose destructive confirm. No type-to-confirm friction
-//     (use <ClosePeriodDialog> for that).
+//   • Single-purpose destructive confirm. Can optionally require the user
+//     to type a specific string to enable the Confirm button (see
+//     `requireTypedConfirmation` — added in #89 for the entity-delete
+//     blast-radius dialog). For the richer "Close Period" multi-channel
+//     confirm, keep using <ClosePeriodDialog>.
 //   • Cancel button is the first focusable element (defensive default
-//     for destructive flows). Implemented via onOpenAutoFocus forwarding
-//     focus to the Cancel button ref.
+//     for destructive flows). When `requireTypedConfirmation` is set,
+//     focus moves to the typed-input instead — it is the only actionable
+//     element at that moment and focusing Cancel would be a keyboard-nav
+//     oddity. Documented below.
 //   • `onConfirm` may be async; component shows loading state (spinner
 //     on confirm button) during the promise. Cancel remains enabled.
 //   • On error, displays the thrown Error.message inline and offers a
 //     Retry button; does NOT auto-close.
 //   • On success, closes by calling onOpenChange(false).
+//   • Accessibility: `role="alertdialog"` on the content element (the
+//     correct WAI-ARIA pattern for destructive confirmations), and
+//     `aria-describedby` wires up to both `description` and `body` when
+//     supplied so screen-readers announce the blast-radius counts on
+//     open.
 //   • Use cases: Delete Period, Delete Meter, Delete Tenant, last-tier
-//     warning, etc. Use <ClosePeriodDialog> only for billing-period close.
+//     warning, entity-delete (#89). Use <ClosePeriodDialog> only for
+//     billing-period close.
 //
 // Tone:
 //   • "destructive" — confirm button uses bg-destructive/text-destructive-foreground.
@@ -28,34 +39,68 @@ export interface ConfirmDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
+  /**
+   * Short plain-string description. Renders above the optional `body`.
+   * Prefer `body` when you need a list, table, or other rich structure.
+   */
   description?: string;
+  /**
+   * Rich-content area (ReactNode) rendered below `description` and above
+   * the typed-confirmation input row. Used by the entity-delete flow to
+   * surface the blast-radius list inside the dialog.
+   */
+  body?: React.ReactNode;
   confirmLabel: string;
   tone: "destructive" | "neutral";
   onConfirm: () => Promise<void>;
+  /**
+   * When supplied, renders a labelled input above the footer. The
+   * Confirm button stays `disabled` until `input.value.trim() ===
+   * expected.trim()` (case-sensitive, trimmed). Focus moves to the
+   * input on open instead of Cancel.
+   */
+  requireTypedConfirmation?: {
+    label: string;
+    expected: string;
+  };
 }
 
 type State = "idle" | "loading" | "error";
+
+// Stable ids for a11y wiring. `aria-describedby` takes a space-separated
+// list of ids — we include whichever ones are actually in the DOM.
+const DESC_ID = "confirm-dialog-desc";
+const BODY_ID = "confirm-dialog-body";
 
 export function ConfirmDialog({
   open,
   onOpenChange,
   title,
   description,
+  body,
   confirmLabel,
   tone,
   onConfirm,
+  requireTypedConfirmation,
 }: ConfirmDialogProps) {
   const [state, setState] = React.useState<State>("idle");
   const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
+  const [typedValue, setTypedValue] = React.useState("");
   const cancelRef = React.useRef<HTMLButtonElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   // Reset state whenever the dialog opens.
   React.useEffect(() => {
     if (open) {
       setState("idle");
       setErrorMsg(null);
+      setTypedValue("");
     }
   }, [open]);
+
+  const typedMatches = requireTypedConfirmation
+    ? typedValue.trim() === requireTypedConfirmation.expected.trim()
+    : true;
 
   const handleConfirm = async () => {
     setState("loading");
@@ -74,19 +119,36 @@ export function ConfirmDialog({
       ? "bg-destructive text-destructive-foreground border-destructive hover:opacity-90"
       : "bg-primary text-primary-foreground border-primary hover:opacity-90";
 
+  // Compose aria-describedby — include only ids that will actually render.
+  const describedByIds = [
+    description ? DESC_ID : null,
+    body !== undefined ? BODY_ID : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55 data-[state=open]:animate-in data-[state=closed]:animate-out" />
         <Dialog.Content
+          role="alertdialog"
           aria-modal
-          aria-describedby={description ? "confirm-dialog-desc" : undefined}
+          aria-describedby={describedByIds || undefined}
           onOpenAutoFocus={(e) => {
             e.preventDefault();
-            cancelRef.current?.focus();
+            // When a type-to-confirm input is present, it is the only
+            // actionable element on open — focus it so keyboard users can
+            // start typing immediately. Otherwise keep the defensive
+            // cancel-first order.
+            if (requireTypedConfirmation) {
+              inputRef.current?.focus();
+            } else {
+              cancelRef.current?.focus();
+            }
           }}
           className={cn(
-            "fixed left-1/2 top-1/2 z-50 w-[400px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+            "fixed left-1/2 top-1/2 z-50 w-[460px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
             "overflow-hidden rounded-md border border-border bg-card shadow-elev-3 outline-none",
           )}
         >
@@ -113,13 +175,47 @@ export function ConfirmDialog({
             </Dialog.Title>
             {description && (
               <Dialog.Description
-                id="confirm-dialog-desc"
+                id={DESC_ID}
                 className="mt-1 text-[13px] leading-relaxed text-muted-foreground"
               >
                 {description}
               </Dialog.Description>
             )}
           </div>
+
+          {body !== undefined && (
+            <div
+              id={BODY_ID}
+              className="px-6 pb-1 text-[13px] leading-relaxed text-foreground"
+            >
+              {body}
+            </div>
+          )}
+
+          {requireTypedConfirmation && (
+            <div className="mt-3 px-6 pb-1">
+              <label
+                htmlFor="confirm-dialog-typed-input"
+                className="mb-1 block text-[12px] font-medium text-foreground"
+              >
+                {requireTypedConfirmation.label}
+              </label>
+              <input
+                ref={inputRef}
+                id="confirm-dialog-typed-input"
+                type="text"
+                value={typedValue}
+                onChange={(e) => setTypedValue(e.target.value)}
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                aria-label={requireTypedConfirmation.label}
+                className="block w-full rounded-md border border-border bg-card px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                placeholder={requireTypedConfirmation.expected}
+              />
+            </div>
+          )}
 
           {state === "error" && errorMsg && (
             <div className="px-6 pt-2">
@@ -130,7 +226,8 @@ export function ConfirmDialog({
           )}
 
           <div className="mt-4 flex items-center justify-end gap-2 bg-muted px-6 pb-[18px] pt-[14px]">
-            {/* Cancel renders first — a11y cancel-first focus order. */}
+            {/* Cancel renders first — a11y cancel-first focus order when
+                no type-to-confirm input is present (see onOpenAutoFocus). */}
             <Dialog.Close asChild>
               <button
                 ref={cancelRef}
@@ -143,8 +240,9 @@ export function ConfirmDialog({
             {state === "error" ? (
               <button
                 onClick={handleConfirm}
+                disabled={!typedMatches}
                 className={cn(
-                  "inline-flex h-8 items-center rounded-md border px-3.5 text-[13px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "inline-flex h-8 items-center rounded-md border px-3.5 text-[13px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed",
                   confirmBtnCls,
                 )}
               >
@@ -153,7 +251,7 @@ export function ConfirmDialog({
             ) : (
               <button
                 onClick={handleConfirm}
-                disabled={state === "loading"}
+                disabled={state === "loading" || !typedMatches}
                 className={cn(
                   "inline-flex h-8 items-center gap-2 rounded-md border px-3.5 text-[13px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed",
                   confirmBtnCls,

--- a/src/lib/entity-deletion/preview.ts
+++ b/src/lib/entity-deletion/preview.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+/**
+ * Shared `delete-preview` GET handler factory (#89).
+ *
+ * Each of the four entity-kind routes (`organizations/[id]/delete-preview`,
+ * `communities/[id]/delete-preview`, `microgrids/[id]/delete-preview`,
+ * `edges/[id]/delete-preview`) imports this and wraps it with a permission
+ * predicate + the matching `EntityKind` literal. Keeps the response shape
+ * (incl. `as_of` + `parent` fields per AC-ROUTE-3) in lock-step across
+ * surfaces.
+ *
+ * Response shape (AC-ROUTE-3):
+ *   {
+ *     entity: { id: string; name: string },
+ *     descendant_counts: DescendantCounts,       // discriminated union
+ *     as_of: string,                             // ISO 8601
+ *     parent: Parent                             // null for organization
+ *   }
+ *
+ * Permission parity with DELETE: AC-ROUTE-4. Exposing descendant counts
+ * to a caller who can't delete would leak scope info; gate at the same
+ * level as the DELETE sibling.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import {
+  countEntityDescendants,
+  type EntityKind,
+} from "@/lib/entity-descendants";
+import { UUID_RE, errorBody, mapPgError, resolveParent } from "./shared";
+
+export interface PreviewHandlerOptions {
+  kind: EntityKind;
+  /**
+   * Human-readable entity label used in error copy (`Organization not
+   * found.`, `Invalid microgrid id...`). Lowercase singular.
+   */
+  entityLabel: string;
+  /**
+   * Permission predicate. Must match the DELETE sibling route's check
+   * exactly (AC-ROUTE-4). Returns `true` when the caller may see counts.
+   */
+  canAccess: (supabase: SupabaseClient, id: string) => Promise<boolean>;
+  /**
+   * Returns the DB table the entity lives in (organizations, communities,
+   * microgrids, edges).
+   */
+  table: "organizations" | "communities" | "microgrids" | "edges";
+}
+
+/**
+ * Build the Next.js GET handler for a `delete-preview` route.
+ */
+export function buildDeletePreviewHandler(opts: PreviewHandlerOptions) {
+  return async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+  ): Promise<NextResponse> {
+    const { id } = await params;
+
+    if (!UUID_RE.test(id)) {
+      return NextResponse.json(
+        errorBody(`Invalid ${opts.entityLabel} id — expected UUID.`),
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+
+    if (!(await opts.canAccess(supabase, id))) {
+      return NextResponse.json(
+        errorBody(`You do not have permission to delete this ${opts.entityLabel}.`),
+        { status: 403 }
+      );
+    }
+
+    // Resolve the entity name. RLS-visible only; unauthorized callers
+    // were already 403'd above, so a null here means "not found."
+    const { data: entity, error: fetchErr } = await supabase
+      .from(opts.table)
+      .select("id, name")
+      .eq("id", id)
+      .maybeSingle<{ id: string; name: string }>();
+
+    if (fetchErr) {
+      const mapped = mapPgError(fetchErr, opts.entityLabel);
+      return NextResponse.json(errorBody(mapped.message), {
+        status: mapped.status,
+      });
+    }
+    if (!entity) {
+      return NextResponse.json(
+        errorBody(
+          `${opts.entityLabel[0].toUpperCase()}${opts.entityLabel.slice(1)} not found.`
+        ),
+        { status: 404 }
+      );
+    }
+
+    const [descendantCounts, parent] = await Promise.all([
+      countEntityDescendants(supabase, opts.kind, id),
+      resolveParent(supabase, opts.kind, id),
+    ]);
+
+    return NextResponse.json(
+      {
+        entity: { id: entity.id, name: entity.name },
+        descendant_counts: descendantCounts,
+        as_of: new Date().toISOString(),
+        parent,
+      },
+      { status: 200 }
+    );
+  };
+}

--- a/src/lib/entity-deletion/shared.ts
+++ b/src/lib/entity-deletion/shared.ts
@@ -1,0 +1,142 @@
+import "server-only";
+
+/**
+ * Shared helpers for the entity-deletion route handlers (#89).
+ *
+ * Owned here so the four DELETE/preview route handlers share identical
+ * logging, error-mapping, and parent-resolution logic. If you add a new
+ * entity-deletion surface, reuse these helpers rather than re-implementing.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { DescendantCounts, EntityKind } from "@/lib/entity-descendants";
+import { SUPER_ADMIN } from "@/lib/roles";
+import { getCurrentUserRoles } from "@/lib/auth/access";
+
+export const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type Parent =
+  | { kind: "organization"; id: string }
+  | { kind: "community"; id: string }
+  | { kind: "microgrid"; id: string }
+  | null;
+
+/**
+ * Resolve the parent entity for an entity about to be deleted. Used to
+ * populate the `parent` field in the delete-preview response so the
+ * client can redirect post-DELETE without a second round-trip (AC-UI-3
+ * step 5 / AC-ROUTE-3).
+ */
+export async function resolveParent(
+  supabase: SupabaseClient,
+  kind: EntityKind,
+  id: string
+): Promise<Parent> {
+  switch (kind) {
+    case "organization":
+      return null;
+    case "community": {
+      const { data } = await supabase
+        .from("communities")
+        .select("org_id")
+        .eq("id", id)
+        .maybeSingle<{ org_id: string }>();
+      if (!data) return null;
+      return { kind: "organization", id: data.org_id };
+    }
+    case "microgrid": {
+      const { data } = await supabase
+        .from("microgrids")
+        .select("community_id")
+        .eq("id", id)
+        .maybeSingle<{ community_id: string }>();
+      if (!data) return null;
+      return { kind: "community", id: data.community_id };
+    }
+    case "edge": {
+      const { data } = await supabase
+        .from("edges")
+        .select("microgrid_id")
+        .eq("id", id)
+        .maybeSingle<{ microgrid_id: string }>();
+      if (!data) return null;
+      return { kind: "microgrid", id: data.microgrid_id };
+    }
+  }
+}
+
+/**
+ * The structured log payload emitted on successful DELETE per AC-LOG-1.
+ * Serialized via `console.info(JSON.stringify(payload))` so Vercel's log
+ * drain picks it up as a single line. Do NOT leak this shape into HTTP
+ * responses; it's for logs + tests only.
+ */
+export interface EntityDeleteLogPayload {
+  event: "entity.delete";
+  entity_kind: EntityKind;
+  entity_id: string;
+  entity_name: string;
+  actor_user_id: string;
+  actor_role: "super_admin" | "org_manager";
+  descendant_counts: DescendantCounts;
+  at: string;
+}
+
+/**
+ * Returns the highest-privilege role the actor holds. `super_admin` wins
+ * over `org_manager` per AC-LOG-1. Returns `null` only for unauthenticated
+ * callers (in which case the route should already have 401/403'd).
+ */
+export async function resolveActorRole(
+  supabase: SupabaseClient
+): Promise<"super_admin" | "org_manager" | null> {
+  const roles = await getCurrentUserRoles(supabase);
+  if (roles.length === 0) return null;
+  if (roles.some((r) => r.role === SUPER_ADMIN)) return "super_admin";
+  return "org_manager";
+}
+
+/**
+ * Mirrors the `{ error: string }` shape used by #79's user-delete route
+ * and the rest of the MBE API surface. Keep the key shape identical
+ * across all #89 routes so a future shared error-helper stays uniform.
+ */
+export function errorBody(message: string): { error: string } {
+  return { error: message };
+}
+
+/**
+ * Map a Postgres error surfaced by supabase-js into an HTTP status code
+ * and human-readable message. Used by the DELETE routes for their
+ * terminal Postgres error branch (AC-ROUTE-2 step 6).
+ *
+ * Safe-by-default: unknown errors map to 500 with a generic message —
+ * we do NOT leak raw SQLSTATEs or stack traces to the client.
+ */
+export function mapPgError(
+  err: { code?: string; message?: string },
+  entityLabel: string
+): { status: number; message: string } {
+  const code = err.code;
+  const msg = err.message ?? "";
+
+  if (code === "42501" || msg.includes("row-level security")) {
+    return {
+      status: 403,
+      message: `You do not have permission to delete this ${entityLabel}.`,
+    };
+  }
+  // 40000 is reserved for the last-super_admin guard — in the #89 flow
+  // this only fires via the user_roles BEFORE DELETE trigger that we
+  // bypass with the cascade GUC. Preserve the mapping for defensive
+  // coverage in case the bypass is ever disabled.
+  if (code === "40000") {
+    return { status: 409, message: msg || "Conflict." };
+  }
+  // Filter obviously-SQL-internal shapes from the payload.
+  if (msg && !/ERROR|SQLSTATE|syntax|relation/i.test(msg)) {
+    return { status: 500, message: msg };
+  }
+  return { status: 500, message: "Unexpected database error." };
+}

--- a/src/lib/entity-descendants-types.ts
+++ b/src/lib/entity-descendants-types.ts
@@ -1,0 +1,123 @@
+/**
+ * entity-descendants-types.ts — client-safe types + pure helpers for the
+ * entity-deletion flow (#89).
+ *
+ * Split from `entity-descendants.ts` (which imports `server-only`) so that
+ * client components (e.g. `<BlastRadiusList>`, `<DeleteEntityButton>`) can
+ * consume the `DescendantCounts` type and the pure emptiness check without
+ * pulling the server-only Supabase query logic into the client bundle.
+ *
+ * DO NOT put any Supabase-touching code here — add it to
+ * `entity-descendants.ts` instead.
+ */
+
+export type EntityKind = "organization" | "community" | "microgrid" | "edge";
+
+export type DescendantCounts =
+  | {
+      kind: "organization";
+      communities: number;
+      microgrids: number;
+      edges: number;
+      devices: number;
+      households: number;
+      household_devices: number;
+      household_users: number;
+      billing_periods_draft: number;
+      billing_periods_closed: number;
+      billing_line_items: number;
+      rate_schedules: number;
+      user_roles: number;
+    }
+  | {
+      kind: "community";
+      microgrids: number;
+      edges: number;
+      devices: number;
+      households: number;
+      household_devices: number;
+      household_users: number;
+      billing_periods_draft: number;
+      billing_periods_closed: number;
+      billing_line_items: number;
+      rate_schedules: number;
+    }
+  | {
+      kind: "microgrid";
+      edges: number;
+      devices: number;
+      households: number;
+      household_devices: number;
+      household_users: number;
+      billing_periods_draft: number;
+      billing_periods_closed: number;
+      billing_line_items: number;
+      rate_schedules: number;
+    }
+  | {
+      kind: "edge";
+      devices: number;
+      household_devices: number;
+      /**
+       * Billing line items whose `device_id` will be SET NULL (NOT deleted)
+       * by cascading the edge → device chain. Historical billing rows
+       * survive per schema design (00001_schema.sql:241).
+       */
+      billing_line_items_nulled: number;
+    };
+
+/**
+ * True iff every descendant field on the given counts object is zero.
+ * Used by the dialog body to render a single "no descendants" line
+ * instead of a row of zeros (AC-UI-4 empty-entity case).
+ */
+export function descendantCountsAreEmpty(counts: DescendantCounts): boolean {
+  switch (counts.kind) {
+    case "organization":
+      return (
+        counts.communities === 0 &&
+        counts.microgrids === 0 &&
+        counts.edges === 0 &&
+        counts.devices === 0 &&
+        counts.households === 0 &&
+        counts.household_devices === 0 &&
+        counts.household_users === 0 &&
+        counts.billing_periods_draft === 0 &&
+        counts.billing_periods_closed === 0 &&
+        counts.billing_line_items === 0 &&
+        counts.rate_schedules === 0 &&
+        counts.user_roles === 0
+      );
+    case "community":
+      return (
+        counts.microgrids === 0 &&
+        counts.edges === 0 &&
+        counts.devices === 0 &&
+        counts.households === 0 &&
+        counts.household_devices === 0 &&
+        counts.household_users === 0 &&
+        counts.billing_periods_draft === 0 &&
+        counts.billing_periods_closed === 0 &&
+        counts.billing_line_items === 0 &&
+        counts.rate_schedules === 0
+      );
+    case "microgrid":
+      return (
+        counts.edges === 0 &&
+        counts.devices === 0 &&
+        counts.households === 0 &&
+        counts.household_devices === 0 &&
+        counts.household_users === 0 &&
+        counts.billing_periods_draft === 0 &&
+        counts.billing_periods_closed === 0 &&
+        counts.billing_line_items === 0 &&
+        counts.rate_schedules === 0
+      );
+    case "edge":
+      return (
+        counts.devices === 0 &&
+        counts.household_devices === 0 &&
+        counts.billing_line_items_nulled === 0
+      );
+  }
+}

--- a/src/lib/entity-descendants.ts
+++ b/src/lib/entity-descendants.ts
@@ -47,61 +47,16 @@ import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export type EntityKind = "organization" | "community" | "microgrid" | "edge";
-
-export type DescendantCounts =
-  | {
-      kind: "organization";
-      communities: number;
-      microgrids: number;
-      edges: number;
-      devices: number;
-      households: number;
-      household_devices: number;
-      household_users: number;
-      billing_periods_draft: number;
-      billing_periods_closed: number;
-      billing_line_items: number;
-      rate_schedules: number;
-      user_roles: number;
-    }
-  | {
-      kind: "community";
-      microgrids: number;
-      edges: number;
-      devices: number;
-      households: number;
-      household_devices: number;
-      household_users: number;
-      billing_periods_draft: number;
-      billing_periods_closed: number;
-      billing_line_items: number;
-      rate_schedules: number;
-    }
-  | {
-      kind: "microgrid";
-      edges: number;
-      devices: number;
-      households: number;
-      household_devices: number;
-      household_users: number;
-      billing_periods_draft: number;
-      billing_periods_closed: number;
-      billing_line_items: number;
-      rate_schedules: number;
-    }
-  | {
-      kind: "edge";
-      devices: number;
-      household_devices: number;
-      /**
-       * Billing line items whose `device_id` will be SET NULL (NOT deleted)
-       * by cascading the edge → device chain. Historical billing rows
-       * survive per schema design (00001_schema.sql:241) — the dialog
-       * surfaces this as a "loses linkage" line, not "destroyed."
-       */
-      billing_line_items_nulled: number;
-    };
+// Types + pure helpers live in a client-safe module so client components
+// (BlastRadiusList, DeleteEntityButton) can import them without pulling
+// `server-only` into the client bundle. Re-export here so existing
+// call sites (routes, log payload) keep working through a single import.
+import type {
+  DescendantCounts,
+  EntityKind,
+} from "@/lib/entity-descendants-types";
+export type { DescendantCounts, EntityKind };
+export { descendantCountsAreEmpty } from "@/lib/entity-descendants-types";
 
 /** Convert a Supabase `count: "exact", head: true` result to a number. */
 function n(count: number | null | undefined): number {
@@ -447,58 +402,7 @@ export async function countEntityDescendants(
   }
 }
 
-/**
- * True iff every descendant field on the given counts object is zero.
- * Used by the dialog body to render a single "no descendants" line
- * instead of a row of zeros (AC-UI-4 empty-entity case).
- */
-export function descendantCountsAreEmpty(counts: DescendantCounts): boolean {
-  switch (counts.kind) {
-    case "organization":
-      return (
-        counts.communities === 0 &&
-        counts.microgrids === 0 &&
-        counts.edges === 0 &&
-        counts.devices === 0 &&
-        counts.households === 0 &&
-        counts.household_devices === 0 &&
-        counts.household_users === 0 &&
-        counts.billing_periods_draft === 0 &&
-        counts.billing_periods_closed === 0 &&
-        counts.billing_line_items === 0 &&
-        counts.rate_schedules === 0 &&
-        counts.user_roles === 0
-      );
-    case "community":
-      return (
-        counts.microgrids === 0 &&
-        counts.edges === 0 &&
-        counts.devices === 0 &&
-        counts.households === 0 &&
-        counts.household_devices === 0 &&
-        counts.household_users === 0 &&
-        counts.billing_periods_draft === 0 &&
-        counts.billing_periods_closed === 0 &&
-        counts.billing_line_items === 0 &&
-        counts.rate_schedules === 0
-      );
-    case "microgrid":
-      return (
-        counts.edges === 0 &&
-        counts.devices === 0 &&
-        counts.households === 0 &&
-        counts.household_devices === 0 &&
-        counts.household_users === 0 &&
-        counts.billing_periods_draft === 0 &&
-        counts.billing_periods_closed === 0 &&
-        counts.billing_line_items === 0 &&
-        counts.rate_schedules === 0
-      );
-    case "edge":
-      return (
-        counts.devices === 0 &&
-        counts.household_devices === 0 &&
-        counts.billing_line_items_nulled === 0
-      );
-  }
-}
+// `descendantCountsAreEmpty` is re-exported from entity-descendants-types.ts
+// (client-safe module). Do NOT duplicate the implementation here — adding
+// a pure helper to a server-only file would defeat the split that lets
+// the UI render without dragging Supabase into the client bundle.

--- a/src/lib/entity-descendants.ts
+++ b/src/lib/entity-descendants.ts
@@ -1,0 +1,504 @@
+import "server-only";
+
+/**
+ * entity-descendants.ts — shared descendant counter for the entity-deletion
+ * flow (#89). Single source of truth used by:
+ *
+ *   - the `GET /api/{organizations|communities|microgrids|edges}/[id]/delete-preview`
+ *     endpoints that feed the blast-radius dialog, and
+ *   - the corresponding DELETE routes' structured log payload (AC-LOG-1).
+ *
+ * Design:
+ *   * Each query uses `count: "exact", head: true` so we count without
+ *     transferring rows. Counts run in parallel via `Promise.all` — one
+ *     "round-trip" per descendant kind is acceptable at pilot scale
+ *     (<200ms aggregate per AC-ROUTE-6 budget). Chose this over a single
+ *     Postgres RPC so the counts honor RLS on the caller's Supabase
+ *     client — no separate privilege surface to audit.
+ *
+ *   * Return type is a discriminated union keyed on `kind`, so call sites
+ *     narrow correctly in TypeScript and the dialog copy can render the
+ *     right labels per entity kind.
+ *
+ *   * For an `edge` delete, `billing_line_items_nulled` is the count of
+ *     rows whose `device_id` points at a device under this edge — these
+ *     rows SURVIVE the cascade (FK is ON DELETE SET NULL per
+ *     00001_schema.sql:241, intentional to preserve historical bills).
+ *     The UI surfaces this as a "loses device linkage" line, NOT a
+ *     destroyed-count. See AC-FK-AUDIT.
+ *
+ *   * For `edge.household_devices`: devices cascade-delete household_devices
+ *     rows per 00001_schema.sql:191, so this count represents meter↔household
+ *     links that will be severed (the households themselves survive since
+ *     they hang off `microgrid_id`, not edge).
+ *
+ *   * Billing periods are split into `billing_periods_draft` and
+ *     `billing_periods_closed` (NOT a single total) so the dialog copy
+ *     can surface the "draft = unfinalized work lost" case distinctly
+ *     per AC-ROUTE-8. Enum values are `'draft'` and `'closed'` — the
+ *     `billing_period_status` enum has no other values (see
+ *     00001_schema.sql:49). Never use the word `'open'`.
+ *
+ *   * `user_roles` counts (org-scoped only) rely on the FK+CASCADE from
+ *     00015_entity_deletion_safeguards.sql; we filter by `scope_type='org'
+ *     AND scope_id=<org_id>` which matches exactly the rows that will be
+ *     cascade-deleted.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type EntityKind = "organization" | "community" | "microgrid" | "edge";
+
+export type DescendantCounts =
+  | {
+      kind: "organization";
+      communities: number;
+      microgrids: number;
+      edges: number;
+      devices: number;
+      households: number;
+      household_devices: number;
+      household_users: number;
+      billing_periods_draft: number;
+      billing_periods_closed: number;
+      billing_line_items: number;
+      rate_schedules: number;
+      user_roles: number;
+    }
+  | {
+      kind: "community";
+      microgrids: number;
+      edges: number;
+      devices: number;
+      households: number;
+      household_devices: number;
+      household_users: number;
+      billing_periods_draft: number;
+      billing_periods_closed: number;
+      billing_line_items: number;
+      rate_schedules: number;
+    }
+  | {
+      kind: "microgrid";
+      edges: number;
+      devices: number;
+      households: number;
+      household_devices: number;
+      household_users: number;
+      billing_periods_draft: number;
+      billing_periods_closed: number;
+      billing_line_items: number;
+      rate_schedules: number;
+    }
+  | {
+      kind: "edge";
+      devices: number;
+      household_devices: number;
+      /**
+       * Billing line items whose `device_id` will be SET NULL (NOT deleted)
+       * by cascading the edge → device chain. Historical billing rows
+       * survive per schema design (00001_schema.sql:241) — the dialog
+       * surfaces this as a "loses linkage" line, not "destroyed."
+       */
+      billing_line_items_nulled: number;
+    };
+
+/** Convert a Supabase `count: "exact", head: true` result to a number. */
+function n(count: number | null | undefined): number {
+  return count ?? 0;
+}
+
+async function countTable(
+  supabase: SupabaseClient,
+  table: string,
+  filter: { column: string; values: string[] }
+): Promise<number> {
+  if (filter.values.length === 0) return 0;
+  const query = supabase.from(table).select("id", { count: "exact", head: true });
+  const { count } = await (filter.values.length === 1
+    ? query.eq(filter.column, filter.values[0])
+    : query.in(filter.column, filter.values));
+  return n(count);
+}
+
+async function countTableWith(
+  supabase: SupabaseClient,
+  table: string,
+  apply: (qb: ReturnType<SupabaseClient["from"]>) => unknown
+): Promise<number> {
+  const qb = supabase.from(table).select("id", { count: "exact", head: true });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const res = (await apply(qb as any)) as { count: number | null };
+  return n(res.count);
+}
+
+// ── Per-entity counters ──────────────────────────────────────────────────
+
+async function countForOrganization(
+  supabase: SupabaseClient,
+  orgId: string
+): Promise<Extract<DescendantCounts, { kind: "organization" }>> {
+  // Resolve the descendant-id trees once; subsequent counts reuse them.
+  const { data: communities } = await supabase
+    .from("communities")
+    .select("id")
+    .eq("org_id", orgId);
+  const communityIds = (communities ?? []).map((r) => r.id as string);
+
+  const { data: microgrids } = communityIds.length
+    ? await supabase.from("microgrids").select("id").in("community_id", communityIds)
+    : { data: [] as { id: string }[] };
+  const microgridIds = (microgrids ?? []).map((r) => r.id as string);
+
+  const { data: edges } = microgridIds.length
+    ? await supabase.from("edges").select("id").in("microgrid_id", microgridIds)
+    : { data: [] as { id: string }[] };
+  const edgeIds = (edges ?? []).map((r) => r.id as string);
+
+  const { data: devices } = edgeIds.length
+    ? await supabase.from("devices").select("id").in("edge_id", edgeIds)
+    : { data: [] as { id: string }[] };
+  const deviceIds = (devices ?? []).map((r) => r.id as string);
+
+  const { data: households } = microgridIds.length
+    ? await supabase.from("households").select("id").in("microgrid_id", microgridIds)
+    : { data: [] as { id: string }[] };
+  const householdIds = (households ?? []).map((r) => r.id as string);
+
+  const { data: billingPeriods } = microgridIds.length
+    ? await supabase
+        .from("billing_periods")
+        .select("id,status")
+        .in("microgrid_id", microgridIds)
+    : { data: [] as { id: string; status: string }[] };
+  const billingPeriodIds = (billingPeriods ?? []).map((r) => r.id as string);
+  const bpDraft = (billingPeriods ?? []).filter((r) => r.status === "draft").length;
+  const bpClosed = (billingPeriods ?? []).filter((r) => r.status === "closed").length;
+
+  const [
+    householdDevicesCount,
+    householdUsersCount,
+    billingLineItemsCount,
+    rateSchedulesCount,
+    userRolesCount,
+  ] = await Promise.all([
+    householdIds.length
+      ? countTable(supabase, "household_devices", {
+          column: "household_id",
+          values: householdIds,
+        })
+      : Promise.resolve(0),
+    householdIds.length
+      ? countTable(supabase, "household_users", {
+          column: "household_id",
+          values: householdIds,
+        })
+      : Promise.resolve(0),
+    billingPeriodIds.length
+      ? countTable(supabase, "billing_line_items", {
+          column: "billing_period_id",
+          values: billingPeriodIds,
+        })
+      : Promise.resolve(0),
+    microgridIds.length
+      ? countTable(supabase, "rate_schedules", {
+          column: "microgrid_id",
+          values: microgridIds,
+        })
+      : Promise.resolve(0),
+    countTableWith(supabase, "user_roles", (qb) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (qb as any).eq("scope_type", "org").eq("scope_id", orgId)
+    ),
+  ]);
+
+  return {
+    kind: "organization",
+    communities: communityIds.length,
+    microgrids: microgridIds.length,
+    edges: edgeIds.length,
+    devices: deviceIds.length,
+    households: householdIds.length,
+    household_devices: householdDevicesCount,
+    household_users: householdUsersCount,
+    billing_periods_draft: bpDraft,
+    billing_periods_closed: bpClosed,
+    billing_line_items: billingLineItemsCount,
+    rate_schedules: rateSchedulesCount,
+    user_roles: userRolesCount,
+  };
+}
+
+async function countForCommunity(
+  supabase: SupabaseClient,
+  communityId: string
+): Promise<Extract<DescendantCounts, { kind: "community" }>> {
+  const { data: microgrids } = await supabase
+    .from("microgrids")
+    .select("id")
+    .eq("community_id", communityId);
+  const microgridIds = (microgrids ?? []).map((r) => r.id as string);
+
+  const { data: edges } = microgridIds.length
+    ? await supabase.from("edges").select("id").in("microgrid_id", microgridIds)
+    : { data: [] as { id: string }[] };
+  const edgeIds = (edges ?? []).map((r) => r.id as string);
+
+  const { data: devices } = edgeIds.length
+    ? await supabase.from("devices").select("id").in("edge_id", edgeIds)
+    : { data: [] as { id: string }[] };
+  const deviceIds = (devices ?? []).map((r) => r.id as string);
+
+  const { data: households } = microgridIds.length
+    ? await supabase.from("households").select("id").in("microgrid_id", microgridIds)
+    : { data: [] as { id: string }[] };
+  const householdIds = (households ?? []).map((r) => r.id as string);
+
+  const { data: billingPeriods } = microgridIds.length
+    ? await supabase
+        .from("billing_periods")
+        .select("id,status")
+        .in("microgrid_id", microgridIds)
+    : { data: [] as { id: string; status: string }[] };
+  const billingPeriodIds = (billingPeriods ?? []).map((r) => r.id as string);
+  const bpDraft = (billingPeriods ?? []).filter((r) => r.status === "draft").length;
+  const bpClosed = (billingPeriods ?? []).filter((r) => r.status === "closed").length;
+
+  const [
+    householdDevicesCount,
+    householdUsersCount,
+    billingLineItemsCount,
+    rateSchedulesCount,
+  ] = await Promise.all([
+    householdIds.length
+      ? countTable(supabase, "household_devices", {
+          column: "household_id",
+          values: householdIds,
+        })
+      : Promise.resolve(0),
+    householdIds.length
+      ? countTable(supabase, "household_users", {
+          column: "household_id",
+          values: householdIds,
+        })
+      : Promise.resolve(0),
+    billingPeriodIds.length
+      ? countTable(supabase, "billing_line_items", {
+          column: "billing_period_id",
+          values: billingPeriodIds,
+        })
+      : Promise.resolve(0),
+    microgridIds.length
+      ? countTable(supabase, "rate_schedules", {
+          column: "microgrid_id",
+          values: microgridIds,
+        })
+      : Promise.resolve(0),
+  ]);
+
+  // For this scope we count edges/devices via the resolved id trees
+  // (Supabase doesn't support cross-table joins in a simple count query).
+  return {
+    kind: "community",
+    microgrids: microgridIds.length,
+    edges: edgeIds.length,
+    devices: deviceIds.length,
+    households: householdIds.length,
+    household_devices: householdDevicesCount,
+    household_users: householdUsersCount,
+    billing_periods_draft: bpDraft,
+    billing_periods_closed: bpClosed,
+    billing_line_items: billingLineItemsCount,
+    rate_schedules: rateSchedulesCount,
+  };
+}
+
+async function countForMicrogrid(
+  supabase: SupabaseClient,
+  microgridId: string
+): Promise<Extract<DescendantCounts, { kind: "microgrid" }>> {
+  const { data: edges } = await supabase
+    .from("edges")
+    .select("id")
+    .eq("microgrid_id", microgridId);
+  const edgeIds = (edges ?? []).map((r) => r.id as string);
+
+  const { data: devices } = edgeIds.length
+    ? await supabase.from("devices").select("id").in("edge_id", edgeIds)
+    : { data: [] as { id: string }[] };
+  const deviceIds = (devices ?? []).map((r) => r.id as string);
+
+  const { data: households } = await supabase
+    .from("households")
+    .select("id")
+    .eq("microgrid_id", microgridId);
+  const householdIds = (households ?? []).map((r) => r.id as string);
+
+  const { data: billingPeriods } = await supabase
+    .from("billing_periods")
+    .select("id,status")
+    .eq("microgrid_id", microgridId);
+  const billingPeriodIds = (billingPeriods ?? []).map((r) => r.id as string);
+  const bpDraft = (billingPeriods ?? []).filter((r) => r.status === "draft").length;
+  const bpClosed = (billingPeriods ?? []).filter((r) => r.status === "closed").length;
+
+  const [
+    householdDevicesCount,
+    householdUsersCount,
+    billingLineItemsCount,
+    rateSchedulesCount,
+  ] = await Promise.all([
+    householdIds.length
+      ? countTable(supabase, "household_devices", {
+          column: "household_id",
+          values: householdIds,
+        })
+      : Promise.resolve(0),
+    householdIds.length
+      ? countTable(supabase, "household_users", {
+          column: "household_id",
+          values: householdIds,
+        })
+      : Promise.resolve(0),
+    billingPeriodIds.length
+      ? countTable(supabase, "billing_line_items", {
+          column: "billing_period_id",
+          values: billingPeriodIds,
+        })
+      : Promise.resolve(0),
+    countTableWith(supabase, "rate_schedules", (qb) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (qb as any).eq("microgrid_id", microgridId)
+    ),
+  ]);
+
+  return {
+    kind: "microgrid",
+    edges: edgeIds.length,
+    devices: deviceIds.length,
+    households: householdIds.length,
+    household_devices: householdDevicesCount,
+    household_users: householdUsersCount,
+    billing_periods_draft: bpDraft,
+    billing_periods_closed: bpClosed,
+    billing_line_items: billingLineItemsCount,
+    rate_schedules: rateSchedulesCount,
+  };
+}
+
+async function countForEdge(
+  supabase: SupabaseClient,
+  edgeId: string
+): Promise<Extract<DescendantCounts, { kind: "edge" }>> {
+  const { data: devices } = await supabase
+    .from("devices")
+    .select("id")
+    .eq("edge_id", edgeId);
+  const deviceIds = (devices ?? []).map((r) => r.id as string);
+
+  const [householdDevicesCount, billingLineItemsNulled] = await Promise.all([
+    deviceIds.length
+      ? countTable(supabase, "household_devices", {
+          column: "device_id",
+          values: deviceIds,
+        })
+      : Promise.resolve(0),
+    deviceIds.length
+      ? countTable(supabase, "billing_line_items", {
+          column: "device_id",
+          values: deviceIds,
+        })
+      : Promise.resolve(0),
+  ]);
+
+  return {
+    kind: "edge",
+    devices: deviceIds.length,
+    household_devices: householdDevicesCount,
+    billing_line_items_nulled: billingLineItemsNulled,
+  };
+}
+
+/**
+ * Count every descendant that would be affected by a CASCADE DELETE of the
+ * given entity, suitable for rendering the blast-radius dialog and for
+ * logging the delete event.
+ *
+ * The Supabase client passed in MUST be the user-bound server client (NOT
+ * service-role). Counts honor RLS — an unauthorized caller sees zeros.
+ * Callers should run a permission check BEFORE this function to avoid
+ * returning misleading zero counts to a legitimate caller who hit a
+ * transient RLS policy regression.
+ */
+export async function countEntityDescendants(
+  supabase: SupabaseClient,
+  kind: EntityKind,
+  id: string
+): Promise<DescendantCounts> {
+  switch (kind) {
+    case "organization":
+      return countForOrganization(supabase, id);
+    case "community":
+      return countForCommunity(supabase, id);
+    case "microgrid":
+      return countForMicrogrid(supabase, id);
+    case "edge":
+      return countForEdge(supabase, id);
+  }
+}
+
+/**
+ * True iff every descendant field on the given counts object is zero.
+ * Used by the dialog body to render a single "no descendants" line
+ * instead of a row of zeros (AC-UI-4 empty-entity case).
+ */
+export function descendantCountsAreEmpty(counts: DescendantCounts): boolean {
+  switch (counts.kind) {
+    case "organization":
+      return (
+        counts.communities === 0 &&
+        counts.microgrids === 0 &&
+        counts.edges === 0 &&
+        counts.devices === 0 &&
+        counts.households === 0 &&
+        counts.household_devices === 0 &&
+        counts.household_users === 0 &&
+        counts.billing_periods_draft === 0 &&
+        counts.billing_periods_closed === 0 &&
+        counts.billing_line_items === 0 &&
+        counts.rate_schedules === 0 &&
+        counts.user_roles === 0
+      );
+    case "community":
+      return (
+        counts.microgrids === 0 &&
+        counts.edges === 0 &&
+        counts.devices === 0 &&
+        counts.households === 0 &&
+        counts.household_devices === 0 &&
+        counts.household_users === 0 &&
+        counts.billing_periods_draft === 0 &&
+        counts.billing_periods_closed === 0 &&
+        counts.billing_line_items === 0 &&
+        counts.rate_schedules === 0
+      );
+    case "microgrid":
+      return (
+        counts.edges === 0 &&
+        counts.devices === 0 &&
+        counts.households === 0 &&
+        counts.household_devices === 0 &&
+        counts.household_users === 0 &&
+        counts.billing_periods_draft === 0 &&
+        counts.billing_periods_closed === 0 &&
+        counts.billing_line_items === 0 &&
+        counts.rate_schedules === 0
+      );
+    case "edge":
+      return (
+        counts.devices === 0 &&
+        counts.household_devices === 0 &&
+        counts.billing_line_items_nulled === 0
+      );
+  }
+}

--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -1278,3 +1278,252 @@ describe("RLS: microgrid_recent_activity VIEW cross-org isolation (#73)", () => 
     expect(resB.error, `super_admin error on B: ${resB.error?.message}`).toBeNull();
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════
+// Entity deletion cascade + permission matrix (#89)
+//
+// Seeds a short-lived org hierarchy (`delorg*`), then exercises the four
+// cascade-safe DELETE RPCs (`fn_entity_delete_*`) through user-bound
+// clients. Each test MUST clean up after itself via the service client so
+// subsequent tests stay isolated.
+// ══════════════════════════════════════════════════════════════════════════
+
+// Stable fixture ids for the dedicated entity-delete scope. Do NOT reuse
+// FIXTURE.orgA/B — those are consumed by the long-lived suite fixtures and
+// must not be deleted mid-run.
+const DELETE_FIXTURE = {
+  org: "cccccccc-0089-4000-8000-000000000001",
+  community: "cccccccc-0089-4000-8001-000000000001",
+  microgrid: "cccccccc-0089-4000-8002-000000000001",
+  edge: "cccccccc-0089-4000-8003-000000000001",
+  device: "cccccccc-0089-4000-8004-000000000001",
+  household: "cccccccc-0089-4000-8005-000000000001",
+  billingPeriod: "cccccccc-0089-4000-8006-000000000001",
+  lineItem: "cccccccc-0089-4000-8007-000000000001",
+};
+
+async function seedEntityDeleteFixture(): Promise<void> {
+  const svc = await serviceClient();
+
+  // Ensure a clean slate even if a prior run didn't tear down.
+  await svc.from("organizations").delete().eq("id", DELETE_FIXTURE.org);
+
+  await svc.from("organizations").insert({
+    id: DELETE_FIXTURE.org,
+    name: "UX6 Delete Test Org",
+  });
+  await svc.from("communities").insert({
+    id: DELETE_FIXTURE.community,
+    org_id: DELETE_FIXTURE.org,
+    name: "UX6 Delete Community",
+  });
+  await svc.from("microgrids").insert({
+    id: DELETE_FIXTURE.microgrid,
+    community_id: DELETE_FIXTURE.community,
+    name: "UX6 Delete Microgrid",
+    currency: "UGX",
+  });
+  await svc.from("edges").insert({
+    id: DELETE_FIXTURE.edge,
+    microgrid_id: DELETE_FIXTURE.microgrid,
+    name: "UX6 Delete Edge",
+    data_source_type: "openems",
+    openems_backend_url: "http://localhost:8075",
+    openems_edge_id: "rls-delete-edge",
+  });
+  await svc.from("devices").insert({
+    id: DELETE_FIXTURE.device,
+    edge_id: DELETE_FIXTURE.edge,
+    name: "UX6 Delete Device",
+    device_type: "consumption_meter",
+    openems_component_id: "rls-delete-meter",
+  });
+  await svc.from("households").insert({
+    id: DELETE_FIXTURE.household,
+    microgrid_id: DELETE_FIXTURE.microgrid,
+    display_name: "UX6 Delete Household",
+  });
+  await svc.from("household_devices").insert({
+    household_id: DELETE_FIXTURE.household,
+    device_id: DELETE_FIXTURE.device,
+    role: "primary_consumption_meter",
+  });
+  await svc.from("billing_periods").insert({
+    id: DELETE_FIXTURE.billingPeriod,
+    microgrid_id: DELETE_FIXTURE.microgrid,
+    start_date: "2026-01-01",
+    end_date: "2026-01-31",
+    status: "draft",
+  });
+  await svc.from("billing_line_items").insert({
+    id: DELETE_FIXTURE.lineItem,
+    billing_period_id: DELETE_FIXTURE.billingPeriod,
+    household_id: DELETE_FIXTURE.household,
+    device_id: DELETE_FIXTURE.device,
+    usage_kwh: 10,
+    total_amount: 2500,
+  });
+}
+
+async function tearDownEntityDeleteFixture(): Promise<void> {
+  const svc = await serviceClient();
+  // Org-level cascade sweeps everything we seeded in one shot.
+  await svc.from("organizations").delete().eq("id", DELETE_FIXTURE.org);
+}
+
+describe("UX6 (#89) entity-deletion cascade + permission matrix", () => {
+  it("userC (no-role) cannot delete an organization — RPC returns 0 rows", async () => {
+    if (skipIfRequested()) return;
+    await seedEntityDeleteFixture();
+    try {
+      const { data, error } = await userC.client.rpc("fn_entity_delete_org", {
+        p_id: DELETE_FIXTURE.org,
+      });
+      // Either RLS returns 0 rows or the call errors — both are acceptable
+      // as "no delete happened." Verify the org still exists.
+      const rowsAffected = error ? 0 : (data as number | null) ?? 0;
+      expect(rowsAffected).toBe(0);
+
+      const svc = await serviceClient();
+      const { data: stillExists } = await svc
+        .from("organizations")
+        .select("id")
+        .eq("id", DELETE_FIXTURE.org)
+        .maybeSingle();
+      expect(stillExists).not.toBeNull();
+    } finally {
+      await tearDownEntityDeleteFixture();
+    }
+  });
+
+  it("userA (org_manager for Org A) cannot delete an organization outside their scope", async () => {
+    if (skipIfRequested()) return;
+    await seedEntityDeleteFixture();
+    try {
+      const { data, error } = await userA.client.rpc("fn_entity_delete_org", {
+        p_id: DELETE_FIXTURE.org,
+      });
+      const rowsAffected = error ? 0 : (data as number | null) ?? 0;
+      expect(rowsAffected).toBe(0);
+    } finally {
+      await tearDownEntityDeleteFixture();
+    }
+  });
+
+  it("userD (super_admin) deletes the org and the full cascade chain empties", async () => {
+    if (skipIfRequested()) return;
+    await seedEntityDeleteFixture();
+
+    // Extra: seed a user_roles row scoped to the org so AC-ROLES-2 is
+    // exercised (the row should vanish alongside the org cascade).
+    const svc = await serviceClient();
+    const { data: extraUserList } = await svc.auth.admin.listUsers({ perPage: 1000 });
+    const extraUser = extraUserList?.users.find(
+      (u) => u.email === testUserEmails[2]
+    );
+    const { data: scopedRoleRow } = await svc
+      .from("user_roles")
+      .insert({
+        user_id: extraUser!.id,
+        role: "org_manager",
+        scope_type: "org",
+        scope_id: DELETE_FIXTURE.org,
+      })
+      .select("id")
+      .single<{ id: string }>();
+
+    try {
+      const { data: rowsDeleted, error } = await userD.client.rpc(
+        "fn_entity_delete_org",
+        { p_id: DELETE_FIXTURE.org }
+      );
+      expect(error).toBeNull();
+      expect(rowsDeleted).toBe(1);
+
+      // Assert the entire cascade chain: every descendant table is empty
+      // for the deleted scope. RLS-less service client for a true view.
+      const tablesToCheck: { table: string; column: string; id: string }[] = [
+        { table: "organizations", column: "id", id: DELETE_FIXTURE.org },
+        { table: "communities", column: "id", id: DELETE_FIXTURE.community },
+        { table: "microgrids", column: "id", id: DELETE_FIXTURE.microgrid },
+        { table: "edges", column: "id", id: DELETE_FIXTURE.edge },
+        { table: "devices", column: "id", id: DELETE_FIXTURE.device },
+        { table: "households", column: "id", id: DELETE_FIXTURE.household },
+        {
+          table: "household_devices",
+          column: "household_id",
+          id: DELETE_FIXTURE.household,
+        },
+        {
+          table: "billing_periods",
+          column: "id",
+          id: DELETE_FIXTURE.billingPeriod,
+        },
+        {
+          table: "billing_line_items",
+          column: "id",
+          id: DELETE_FIXTURE.lineItem,
+        },
+      ];
+      for (const t of tablesToCheck) {
+        const { data } = await svc.from(t.table).select("id").eq(t.column, t.id);
+        expect(
+          (data ?? []).length,
+          `Expected ${t.table} to be empty after org cascade`
+        ).toBe(0);
+      }
+
+      // AC-ROLES-2: user_roles row scoped to the deleted org must also be gone.
+      const { data: remainingRoles } = await svc
+        .from("user_roles")
+        .select("id")
+        .eq("id", scopedRoleRow!.id);
+      expect((remainingRoles ?? []).length).toBe(0);
+    } finally {
+      await tearDownEntityDeleteFixture();
+    }
+  });
+
+  it("AC-ROLES-3: an org_manager can delete their own org without tripping the self-revoke guard", async () => {
+    if (skipIfRequested()) return;
+    await seedEntityDeleteFixture();
+
+    // Seed userB's access to cover our fixture org so the RPC's RLS gate
+    // passes. userB is already an org_manager scoped to orgB (NFE-B); we
+    // add an extra user_roles row scoped to DELETE_FIXTURE.org to match.
+    const svc = await serviceClient();
+    const { data: ownRole } = await svc
+      .from("user_roles")
+      .insert({
+        user_id: userB.userId,
+        role: "org_manager",
+        scope_type: "org",
+        scope_id: DELETE_FIXTURE.org,
+      })
+      .select("id")
+      .single<{ id: string }>();
+
+    try {
+      // Without the trigger bypass, the cascade would hit the self-revoke
+      // guard (OLD.user_id = auth.uid()) and error with 42501.
+      const { data: rowsDeleted, error } = await userB.client.rpc(
+        "fn_entity_delete_org",
+        { p_id: DELETE_FIXTURE.org }
+      );
+      expect(error, `Self-revoke guard triggered: ${error?.message}`).toBeNull();
+      expect(rowsDeleted).toBe(1);
+
+      // userB's scoped role row must also be gone.
+      const { data: remaining } = await svc
+        .from("user_roles")
+        .select("id")
+        .eq("id", ownRole!.id);
+      expect((remaining ?? []).length).toBe(0);
+    } finally {
+      // Cleanup: wipe the temporary role row if anything leaked, and the
+      // fixture org (may already be gone from the delete above).
+      await svc.from("user_roles").delete().eq("id", ownRole!.id);
+      await tearDownEntityDeleteFixture();
+    }
+  });
+});

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -723,6 +723,10 @@ export type Database = {
         }
         Returns: string
       }
+      fn_entity_delete_community: { Args: { p_id: string }; Returns: number }
+      fn_entity_delete_edge: { Args: { p_id: string }; Returns: number }
+      fn_entity_delete_microgrid: { Args: { p_id: string }; Returns: number }
+      fn_entity_delete_org: { Args: { p_id: string }; Returns: number }
       fn_finalize_user_invitation: {
         Args: {
           p_first_name: string

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -623,6 +623,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "user_roles_scope_org_fkey"
+            columns: ["scope_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "user_roles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
@@ -683,7 +690,15 @@ export type Database = {
           scope_type: Database["public"]["Enums"]["role_scope_type"] | null
           user_id: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "user_roles_scope_org_fkey"
+            columns: ["scope_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Functions: {

--- a/supabase/migrations/00015_entity_deletion_safeguards.sql
+++ b/supabase/migrations/00015_entity_deletion_safeguards.sql
@@ -137,3 +137,76 @@ BEGIN
   RETURN OLD;
 END;
 $$;
+
+-- ── 4. RPCs that combine SET LOCAL + DELETE in a single transaction.
+--
+-- The Supabase JS client doesn't expose Postgres transactions — each
+-- `.from(...).delete()` runs in its own implicit transaction, so `SET
+-- LOCAL` would be scoped to a throwaway transaction that never sees the
+-- follow-up DELETE. These RPCs wrap both inside a single function body
+-- so the GUC + DELETE share a transaction without any round-trip.
+--
+-- SECURITY INVOKER (default) — the caller's RLS still applies; these
+-- RPCs are a thin SQL wrapper, NOT a privilege escalation. Permission
+-- checks happen in the route handler before dispatch; cross-org attempts
+-- surface as `result_rows_affected = 0` here (RLS filters) and the route
+-- converts that to 403.
+--
+-- Return type is the number of rows deleted. Routes compare this against
+-- 1 to distinguish "deleted" from "RLS-filtered" / "already gone."
+
+CREATE OR REPLACE FUNCTION fn_entity_delete_org(p_id UUID)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_deleted INT;
+BEGIN
+  SET LOCAL app.entity_cascade_delete = 'on';
+  DELETE FROM organizations WHERE id = p_id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fn_entity_delete_community(p_id UUID)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_deleted INT;
+BEGIN
+  SET LOCAL app.entity_cascade_delete = 'on';
+  DELETE FROM communities WHERE id = p_id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fn_entity_delete_microgrid(p_id UUID)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_deleted INT;
+BEGIN
+  SET LOCAL app.entity_cascade_delete = 'on';
+  DELETE FROM microgrids WHERE id = p_id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fn_entity_delete_edge(p_id UUID)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_deleted INT;
+BEGIN
+  SET LOCAL app.entity_cascade_delete = 'on';
+  DELETE FROM edges WHERE id = p_id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;

--- a/supabase/migrations/00015_entity_deletion_safeguards.sql
+++ b/supabase/migrations/00015_entity_deletion_safeguards.sql
@@ -1,0 +1,139 @@
+-- 00015_entity_deletion_safeguards.sql
+-- Entity deletion semantics (#89).
+--
+-- Two correctness gaps in the pre-existing schema are addressed here:
+--
+-- 1. AC-ROLES-1 — `user_roles.scope_id` is declared as plain `UUID` (no FK)
+--    in 00001_schema.sql:270. When an Organization is deleted (CASCADE being
+--    the PM-decided behavior for #89), the `user_roles` rows that scope
+--    `org_manager` access to that org are left dangling — `scope_id` still
+--    carries the deleted org's UUID. Add a proper FK constraint so the
+--    cascade chain reaches user_roles.
+--
+--    The column today is only ever populated with organization ids (the
+--    `role_scope_type` enum has a single value — `'org'`). That changes when
+--    `microgrid_manager` / `household_*` scopes ship, which will introduce
+--    additional scope types whose FKs must be added separately (see comment
+--    on the constraint below).
+--
+-- 2. AC-ROLES-3 — `fn_user_roles_before_delete_guard` (installed in
+--    00013_invite_user_rpc.sql) raises `42501` on self-revocation. When the
+--    above CASCADE path fires for an `org_manager` deleting *their own* org,
+--    the trigger sees `OLD.user_id = auth.uid()` and rolls the whole delete
+--    back. We introduce a per-transaction GUC (`app.entity_cascade_delete`)
+--    that the DELETE routes flip on via `SET LOCAL` so the guard can tell
+--    "this is a cascade from an entity delete I already authorized" apart
+--    from "someone is trying to mutate user_roles directly via the invite
+--    flow." SET LOCAL scopes to the current transaction only — it cannot
+--    leak between sessions, and `current_setting(name, true)` returns NULL
+--    (rather than erroring) if it was never set, so the invite RPCs and
+--    every other path continue to enforce both guards unchanged.
+--
+--    The bypass flag is ONLY set in the four entity DELETE routes shipped
+--    in #89 (`DELETE /api/{organizations|communities|microgrids|edges}/[id]`).
+--    It must NOT be set anywhere else.
+--
+-- Idempotent / re-run-safe: the ADD CONSTRAINT is preceded by a defensive
+-- DROP IF EXISTS so `supabase db reset` replays cleanly, and the orphan
+-- cleanup deletes zero rows after the first run.
+
+-- ── 1. Clean up any orphan user_roles rows (defensive — production DB
+--    predates the FK and may have dangling scope_ids from manual cleanup).
+DELETE FROM user_roles
+ WHERE scope_type = 'org'
+   AND scope_id IS NOT NULL
+   AND scope_id NOT IN (SELECT id FROM organizations);
+
+-- ── 2. Add the FK with ON DELETE CASCADE.
+--
+-- Note: this constraint assumes `scope_id` only ever references
+-- `organizations.id`. Today that is enforced by the single-value
+-- `role_scope_type` enum. When additional scope types land (e.g.
+-- 'microgrid'), this constraint must be revisited — either converted to a
+-- partial FK (via a dropped-column + check constraint migration) or
+-- replaced with per-scope-type FKs. Re-evaluate at that point.
+ALTER TABLE user_roles DROP CONSTRAINT IF EXISTS user_roles_scope_org_fkey;
+ALTER TABLE user_roles
+  ADD CONSTRAINT user_roles_scope_org_fkey
+  FOREIGN KEY (scope_id)
+  REFERENCES organizations(id)
+  ON DELETE CASCADE
+  DEFERRABLE INITIALLY IMMEDIATE;
+
+-- ── 3. Extend the BEFORE DELETE guard with the cascade-bypass flag.
+--
+-- The replacement below is a strict superset of the original: the first
+-- check short-circuits to RETURN OLD when `app.entity_cascade_delete =
+-- 'on'`, otherwise the logic is byte-for-byte identical to what was
+-- installed in 00013_invite_user_rpc.sql. The original trigger binding
+-- (`trg_user_roles_before_delete_guard`) is preserved — we only rewrite
+-- the function body.
+CREATE OR REPLACE FUNCTION fn_user_roles_before_delete_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_remaining INT;
+  v_session_role TEXT;
+BEGIN
+  -- NEW (AC-ROLES-3): honor the per-transaction cascade bypass. Only the
+  -- four entity-deletion routes in #89 set this GUC via `SET LOCAL` inside
+  -- their transaction wrapper. `current_setting(..., true)` (the trailing
+  -- `true` = missing_ok) returns NULL when unset, so the invite RPCs and
+  -- every other caller fall straight through to the original guards.
+  IF current_setting('app.entity_cascade_delete', true) = 'on' THEN
+    RETURN OLD;
+  END IF;
+
+  -- Bypass guards for DB-superuser cascade paths:
+  --   - `postgres` (local dev, migration tooling, test harness cleanup)
+  --   - `supabase_admin` (Supabase cloud admin operations)
+  -- When auth.users is purged externally (admin console / cleanup script),
+  -- the ON DELETE CASCADE propagates into user_roles and fires this
+  -- trigger. If the purged user happens to be the last super_admin, the
+  -- trigger would block the cleanup, leaving orphan auth rows. Bypass is
+  -- safe: these roles already have full DB access by definition.
+  --
+  -- IMPORTANT: use session_user, NOT current_user. Both fn_finalize_user_invitation
+  -- and fn_change_user_role are SECURITY DEFINER owned by `postgres`, so
+  -- current_user evaluates to 'postgres' inside those function bodies — which
+  -- would silently bypass ALL trigger guards (self-revoke + last-super_admin)
+  -- for any call via those RPCs. session_user returns the original LOGIN role
+  -- (e.g. `authenticated` for normal users) and is NOT changed by SECURITY
+  -- DEFINER. The bypass is only triggered when literally connecting as postgres
+  -- or supabase_admin (migrations, direct admin operations).
+  v_session_role := session_user;
+  IF v_session_role IN ('postgres', 'supabase_admin') THEN
+    RETURN OLD;
+  END IF;
+
+  -- Self-revocation guard. auth.uid() is NULL for service-role callers; we
+  -- intentionally scope this guard to user-bound callers only — the
+  -- service role is an out-of-band admin and can force a revoke if it
+  -- really needs to (e.g. manual cleanup script). Routes MUST NOT use the
+  -- service-role client for user-initiated deletes (documented in the
+  -- route comment).
+  IF auth.uid() IS NOT NULL AND OLD.user_id = auth.uid() THEN
+    RAISE EXCEPTION 'Cannot revoke your own access. Ask another administrator.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Last-super_admin guard. If the row being removed is a super_admin row,
+  -- and it is the last remaining super_admin row in the table, block.
+  -- Counts rows where role='super_admin' excluding the row being deleted.
+  IF OLD.role = 'super_admin' THEN
+    SELECT COUNT(*) INTO v_remaining
+    FROM user_roles
+    WHERE role = 'super_admin'
+      AND id <> OLD.id;
+
+    IF v_remaining = 0 THEN
+      RAISE EXCEPTION 'Cannot revoke the last super admin. Promote another user first.'
+        USING ERRCODE = '40000';
+    END IF;
+  END IF;
+
+  RETURN OLD;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Adds `DELETE` + `GET /delete-preview` routes for Organization / Community / Microgrid / Edge — 4 entities × 2 routes = 8 handlers. Error body shape `{ error: string }` aligned with #79's DELETE.
- Extends `<ConfirmDialog>` with `requireTypedConfirmation` + `body` props (non-breaking); adds `role="alertdialog"` + `aria-describedby` wiring. New `<DeleteEntityButton>`, `<BlastRadiusList>`, `<DeletedSuccessBanner>` components drive the full click → preview → type-to-confirm → redirect-with-banner UX.
- Migration `00015_entity_deletion_safeguards.sql`: adds missing `user_roles.scope_id → organizations(id) ON DELETE CASCADE` FK + orphan cleanup; extends `fn_user_roles_before_delete_guard` with a per-transaction GUC bypass (`app.entity_cascade_delete = 'on'`) so org_manager Org deletes don't self-revoke-rollback; adds 4 `fn_entity_delete_*` SECURITY INVOKER RPCs combining `SET LOCAL` + `DELETE` in one transaction (Supabase JS doesn't expose explicit transactions).
- Structured `console.info` log event `entity.delete` with `actor_user_id`, `actor_role`, `entity_name`, `descendant_counts`, ISO `at` — single JSON line for Vercel log-drain.
- Tests: 4 new RLS integration scenarios (including AC-ROLES-2 cascade to `user_roles` and AC-ROLES-3 self-delete bypass); 27 new route-handler unit tests covering 400/403/404/409/204 + idempotency + log-payload shape; extended `ConfirmDialog` suite covering typed-confirm transitions + a11y attrs; 508/508 tests pass.

## Architecture notes
- **Permission strategy**: cascade at DB level (Postgres default) + blast-radius display + type-to-confirm at UI level. PM-decision: easier to loosen than tighten; UI friction is the real safeguard; PITR + reseed is recovery path.
- **Cascade coverage**: `Descendantcounts.edge` carves out `billing_line_items_nulled` (distinct from destroyed) because `billing_line_items.device_id` is `ON DELETE SET NULL` — preserves historical bills when a meter is replaced.
- **Type-to-confirm**: case-sensitive + `.trim()` against entity name; input focus takes precedence over Cancel when set; dialog shows `as_of` timestamp so 20s typing delay staleness is visible to operator.
- **`microgrids/[id]` layout vs. page**: Delete button is on the microgrid's detail page only (not layout) so it doesn't appear on Setup / Billing / Tenants sub-tabs.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 508/508 passing
- [x] `npm run build`
- [ ] Reviewer: exercise the flow end-to-end — create a test org hierarchy, delete deepest leaf first (edge → microgrid → community → org); verify blast-radius dialog counts match what's on the page, type-to-confirm gates the button, parent page shows green success banner post-redirect.
- [ ] Reviewer: verify cascade chain by deleting an org and confirming `organizations`, `communities`, `microgrids`, `edges`, `devices`, `households`, `household_devices`, `household_users`, `billing_periods`, `billing_line_items`, `rate_schedules`, and `user_roles` (org-scoped) all empty for that org.
- [ ] Reviewer: tail Vercel logs during a delete and verify the `entity.delete` structured log line appears once per successful DELETE.

Closes #89.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)