### PR TITLE
Restore Supabase default grants on public schema

### DIFF
--- a/supabase/migrations/00016_restore_default_grants.sql
+++ b/supabase/migrations/00016_restore_default_grants.sql
@@ -1,0 +1,44 @@
+-- 00016_restore_default_grants.sql
+-- Restore Supabase's standard privilege grants on the `public` schema.
+--
+-- Why this exists:
+--
+-- Supabase normally installs these grants at project init (outside the
+-- `supabase/migrations/` tree). They survive normal operations including
+-- `supabase db reset` and regular migration replays. They do NOT survive
+-- `DROP SCHEMA public CASCADE`, region migrations, or any recovery path
+-- that recreates the `public` schema manually. When that happens, every
+-- table ends up with zero grants for `authenticated` / `anon` /
+-- `service_role`, and RLS policies become irrelevant — the user-bound
+-- Supabase client gets "permission denied" on every query, which
+-- typically surfaces as /no-access redirects or silently-empty queries.
+--
+-- First observed 2026-04-23 after a Path-C cloud migration replay left
+-- `metering-billing-engine.vercel.app` 403ing every authenticated request
+-- despite the `user_roles` rows being present. See
+-- `mbe-docs/docs/learnings.md` and memory `feedback_drop_schema_public.md`.
+--
+-- This migration is idempotent: `GRANT` against an already-granted target
+-- is a no-op, so running it against a fresh Supabase project (where these
+-- grants are already present) causes no side effects.
+--
+-- The `ALTER DEFAULT PRIVILEGES` clause is the future-proofing: any table
+-- added by a future migration (run as `postgres`, which is the default)
+-- automatically inherits the grants without that migration having to
+-- remember.
+
+-- Schema-level usage.
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+-- Existing objects.
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL ROUTINES IN SCHEMA public TO anon, authenticated, service_role;
+
+-- Future objects created by `postgres` (the default migration role).
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON ROUTINES TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- Adds migration `00016_restore_default_grants.sql` that grants standard `anon` / `authenticated` / `service_role` privileges on the `public` schema (GRANT + ALTER DEFAULT PRIVILEGES).
- No-op against a fresh Supabase project (where grants are already present) because `GRANT` is idempotent. Restores grants when they've been lost.

## Why
Supabase installs these grants automatically at project init. They survive normal operations but NOT `DROP SCHEMA public CASCADE`, region migrations, or PITR-style recoveries that recreate `public`. When missing, every user-bound Supabase request fails at the table-level permission layer regardless of RLS. First observed 2026-04-23 when a Path-C cloud migration replay left production blocked on super_admin login despite `user_roles` rows being present — `authenticated` had zero privileges on any public-schema table.

Adding `ALTER DEFAULT PRIVILEGES` ensures future migrations auto-inherit grants on any new table without the ticket author having to remember.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (with `SKIP_RLS_TESTS=1` since local Supabase wasn't running in this worktree)
- [x] `npm run build`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)