### PR TITLE
Fix SidebarNav active state via server/client split (#97)

### DIFF
--- a/src/app/(dashboard)/__tests__/sidebar-nav-links.test.tsx
+++ b/src/app/(dashboard)/__tests__/sidebar-nav-links.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+/**
+ * SidebarNavLinks tests (#97).
+ *
+ * Strategy:
+ *   - Render SidebarNavLinks directly with a fixed entries prop — no server
+ *     parent involvement. The super_admin gate is exercised by including or
+ *     excluding the Organizations entry in the prop.
+ *   - Mock usePathname per test via vi.mock with a module-level getter so
+ *     each test can control the pathname before rendering.
+ *   - Use getByRole("navigation", { name: /primary/i }) for scoped queries
+ *     so tests are immune to other navs on the page.
+ *   - Assertions use getAttribute (no jest-dom required).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import type { SidebarEntry } from "../sidebar-nav-links";
+
+// ─── Module-level pathname state ─────────────────────────────────────────────
+
+let mockPathname = "/";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+// next/link is a server component in Next.js; in jsdom tests we stub it as a
+// plain <a> so RTL can find it via getByRole("link").
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ─── Lazy import after mocks ──────────────────────────────────────────────────
+
+// Import after vi.mock calls so the module picks up the mocked dependencies.
+import { SidebarNavLinks } from "../sidebar-nav-links";
+
+// ─── Fixture entries ──────────────────────────────────────────────────────────
+
+const baseEntries: SidebarEntry[] = [
+  { label: "Dashboard", href: "/", matchPrefix: "/", exact: true },
+  { label: "Communities", href: "/communities", matchPrefix: "/communities" },
+  { label: "Microgrids", href: "/microgrids", matchPrefix: "/microgrids" },
+  {
+    label: "Settings",
+    href: "/settings/profile",
+    matchPrefix: "/settings",
+  },
+];
+
+const entriesWithOrgs: SidebarEntry[] = [
+  { label: "Dashboard", href: "/", matchPrefix: "/", exact: true },
+  {
+    label: "Organizations",
+    href: "/organizations",
+    matchPrefix: "/organizations",
+  },
+  { label: "Communities", href: "/communities", matchPrefix: "/communities" },
+  { label: "Microgrids", href: "/microgrids", matchPrefix: "/microgrids" },
+  {
+    label: "Settings",
+    href: "/settings/profile",
+    matchPrefix: "/settings",
+  },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderNav(entries: SidebarEntry[] = entriesWithOrgs) {
+  render(<SidebarNavLinks entries={entries} />);
+  return within(screen.getByRole("navigation", { name: /primary/i }));
+}
+
+function getLink(nav: ReturnType<typeof renderNav>, name: string) {
+  return nav.getByRole("link", { name });
+}
+
+beforeEach(() => {
+  mockPathname = "/";
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SidebarNavLinks", () => {
+  // (h) nav element carries aria-label="Primary"
+  it("(h) nav has aria-label='Primary'", () => {
+    mockPathname = "/";
+    renderNav();
+    expect(
+      screen.getByRole("navigation", { name: /primary/i })
+    ).toBeDefined();
+  });
+
+  // (a) exact match: pathname="/" → Dashboard active, others not
+  it("(a) pathname='/' → Dashboard has aria-current='page'", () => {
+    mockPathname = "/";
+    const nav = renderNav();
+
+    expect(getLink(nav, "Dashboard").getAttribute("aria-current")).toBe("page");
+    expect(getLink(nav, "Communities").getAttribute("aria-current")).toBeNull();
+    expect(getLink(nav, "Microgrids").getAttribute("aria-current")).toBeNull();
+    expect(getLink(nav, "Settings").getAttribute("aria-current")).toBeNull();
+    expect(getLink(nav, "Organizations").getAttribute("aria-current")).toBeNull();
+  });
+
+  // negative: "/" must NOT trigger prefix entries (Dashboard is exact-only)
+  it("(a-neg) pathname='/' does NOT highlight Communities via prefix", () => {
+    mockPathname = "/";
+    const nav = renderNav();
+    // Communities has matchPrefix="/communities" → must be idle at "/"
+    expect(getLink(nav, "Communities").getAttribute("aria-current")).toBeNull();
+  });
+
+  // (b) direct pathname match
+  it("(b) pathname='/communities' → Communities has aria-current='page'", () => {
+    mockPathname = "/communities";
+    const nav = renderNav();
+
+    expect(getLink(nav, "Communities").getAttribute("aria-current")).toBe("page");
+    expect(getLink(nav, "Dashboard").getAttribute("aria-current")).toBeNull();
+    expect(getLink(nav, "Microgrids").getAttribute("aria-current")).toBeNull();
+  });
+
+  // (c) prefix match via child route
+  it("(c) pathname='/communities/abc-123' → Communities still active", () => {
+    mockPathname = "/communities/abc-123";
+    const nav = renderNav();
+
+    expect(getLink(nav, "Communities").getAttribute("aria-current")).toBe("page");
+    expect(getLink(nav, "Dashboard").getAttribute("aria-current")).toBeNull();
+  });
+
+  // (d) Settings — exact child (/settings/profile) maps to matchPrefix=/settings
+  it("(d) pathname='/settings/profile' → Settings active", () => {
+    mockPathname = "/settings/profile";
+    const nav = renderNav();
+
+    expect(getLink(nav, "Settings").getAttribute("aria-current")).toBe("page");
+    expect(getLink(nav, "Dashboard").getAttribute("aria-current")).toBeNull();
+  });
+
+  // (e) Settings — any /settings/* route keeps it highlighted
+  it("(e) pathname='/settings/users' → Settings active", () => {
+    mockPathname = "/settings/users";
+    const nav = renderNav();
+
+    expect(getLink(nav, "Settings").getAttribute("aria-current")).toBe("page");
+    expect(getLink(nav, "Dashboard").getAttribute("aria-current")).toBeNull();
+  });
+
+  // (f) isSuperAdmin=false → Organizations NOT rendered
+  it("(f) isSuperAdmin=false → Organizations link absent", () => {
+    mockPathname = "/";
+    renderNav(baseEntries); // baseEntries has no Organizations entry
+    expect(
+      screen.queryByRole("link", { name: "Organizations" })
+    ).toBeNull();
+  });
+
+  // (g) isSuperAdmin=true → Organizations rendered
+  it("(g) isSuperAdmin=true → Organizations link present", () => {
+    mockPathname = "/";
+    const nav = renderNav(entriesWithOrgs);
+    expect(getLink(nav, "Organizations")).toBeDefined();
+  });
+
+  // active styling: active link carries bg-accent + text-accent-foreground
+  it("active link carries correct CSS classes", () => {
+    mockPathname = "/microgrids";
+    const nav = renderNav();
+    const link = getLink(nav, "Microgrids");
+    expect(link.className).toContain("bg-accent");
+    expect(link.className).toContain("text-accent-foreground");
+  });
+
+  // idle styling: idle link does NOT carry active class combo
+  it("idle link carries text-muted-foreground", () => {
+    mockPathname = "/microgrids";
+    const nav = renderNav();
+    const link = getLink(nav, "Communities");
+    expect(link.className).toContain("text-muted-foreground");
+    // bg-accent text-accent-foreground is not in a continuous sequence for idle links
+    expect(link.getAttribute("aria-current")).toBeNull();
+  });
+});

--- a/src/app/(dashboard)/sidebar-nav-links.tsx
+++ b/src/app/(dashboard)/sidebar-nav-links.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * SidebarNavLinks — client child of SidebarNav (#97).
+ *
+ * Receives a pre-filtered entries array from the server parent (role-gating
+ * happens server-side in sidebar-nav.tsx) and computes the active state via
+ * usePathname(). Each entry carries a matchPrefix so the visible href and the
+ * active-match target can differ (e.g. Settings links to /settings/profile but
+ * highlights on any /settings/* route).
+ *
+ * Active link: bg-accent text-accent-foreground + aria-current="page"
+ * Idle link:   text-muted-foreground hover:bg-accent hover:text-accent-foreground
+ */
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export type SidebarEntry = {
+  label: string;
+  href: string;
+  matchPrefix: string;
+  exact?: boolean;
+};
+
+export function isActive(pathname: string, entry: SidebarEntry): boolean {
+  if (entry.exact) return pathname === entry.matchPrefix;
+  return (
+    pathname === entry.matchPrefix ||
+    pathname.startsWith(entry.matchPrefix + "/")
+  );
+}
+
+export function SidebarNavLinks({ entries }: { entries: SidebarEntry[] }) {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Primary" className="flex-1 space-y-1 px-3 py-4">
+      {entries.map((entry) => {
+        const active = isActive(pathname, entry);
+        return (
+          <Link
+            key={entry.href}
+            href={entry.href}
+            aria-current={active ? "page" : undefined}
+            className={
+              active
+                ? "flex items-center rounded-md bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
+                : "flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            }
+          >
+            {entry.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/app/(dashboard)/sidebar-nav.tsx
+++ b/src/app/(dashboard)/sidebar-nav.tsx
@@ -1,55 +1,45 @@
-import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+import { SidebarNavLinks } from "./sidebar-nav-links";
+import type { SidebarEntry } from "./sidebar-nav-links";
 
 /**
- * SidebarNav — dashboard sidebar navigation (#76).
+ * SidebarNav — dashboard sidebar navigation (#76, #97).
  *
  * Server component: resolves the user's super_admin status via the auth
- * access module, then renders the "Organizations" entry only for super_admin.
+ * access module, builds a pre-filtered entries array, and delegates
+ * rendering (including active-state via usePathname) to SidebarNavLinks.
  *
- * Entries are server-rendered — there is no client-side role check that a
- * tampered browser could bypass. The route's server component is the
- * authoritative visibility gate.
+ * The Organizations entry is omitted from the entries array when the user is
+ * not a super_admin — role gating stays entirely server-side so a tampered
+ * client cannot reveal hidden links by inspecting the DOM.
+ *
+ * Settings links to /settings/profile (lands the user on a real page) but
+ * uses matchPrefix="/settings" so any /settings/* route keeps it highlighted.
  */
 export async function SidebarNav() {
   const supabase = await createClient();
   const isSuperAdmin = await currentUserIsSuperAdmin(supabase);
 
-  return (
-    <nav className="flex-1 space-y-1 px-3 py-4">
-      <Link
-        href="/"
-        className="flex items-center rounded-md bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
-      >
-        Dashboard
-      </Link>
-      {isSuperAdmin && (
-        <Link
-          href="/organizations"
-          className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-        >
-          Organizations
-        </Link>
-      )}
-      <Link
-        href="/communities"
-        className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      >
-        Communities
-      </Link>
-      <Link
-        href="/microgrids"
-        className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      >
-        Microgrids
-      </Link>
-      <Link
-        href="/settings/profile"
-        className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      >
-        Settings
-      </Link>
-    </nav>
-  );
+  const entries: SidebarEntry[] = [
+    { label: "Dashboard", href: "/", matchPrefix: "/", exact: true },
+    ...(isSuperAdmin
+      ? [
+          {
+            label: "Organizations",
+            href: "/organizations",
+            matchPrefix: "/organizations",
+          } satisfies SidebarEntry,
+        ]
+      : []),
+    { label: "Communities", href: "/communities", matchPrefix: "/communities" },
+    { label: "Microgrids", href: "/microgrids", matchPrefix: "/microgrids" },
+    {
+      label: "Settings",
+      href: "/settings/profile",
+      matchPrefix: "/settings",
+    },
+  ];
+
+  return <SidebarNavLinks entries={entries} />;
 }


### PR DESCRIPTION
## Summary
- Splits `sidebar-nav.tsx` into a server parent (resolves `currentUserIsSuperAdmin`, builds filtered `entries`) and a new client child `sidebar-nav-links.tsx` that calls `usePathname()` and computes the active state.
- Dashboard uses exact match; Organizations / Communities / Microgrids use prefix match; Settings uses `matchPrefix="/settings"` so any `/settings/*` route highlights it regardless of the visible `href="/settings/profile"`.
- False-match safe: prefix matching requires `matchPrefix + "/"`, so `/microgridsomething` doesn't highlight Microgrids.
- Active link gets `aria-current="page"`; `<nav>` gets `aria-label="Primary"` to disambiguate from breadcrumbs and subnavs.
- 11 component tests covering exact match, prefix match, child route, Settings wildcard, super_admin gate, aria-label, and active/idle CSS classes.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (11/11 sidebar tests pass)
- [x] `npm run build`

Closes #97.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)