### PR TITLE
Auto-create user_profiles row on auth.users INSERT (#96)

### DIFF
--- a/src/app/api/users/[id]/profile/__tests__/route.test.ts
+++ b/src/app/api/users/[id]/profile/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+/**
+ * PATCH /api/users/[id]/profile — route handler unit tests (#96).
+ *
+ * Supabase I/O and auth are mocked. Covers:
+ *   - Case 1: self-edit PATCH with a trigger-backfilled (empty) profile row → 200
+ *   - Case 2: missing profile row (trigger failure / data integrity gap) → 500
+ *   - Case 3: cross-user attempt (RLS block, code 42501) → 403
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+// Mutable return values — each test overrides as needed.
+let mockUpdateReturn: { data: unknown; error: unknown } = {
+  data: null,
+  error: null,
+};
+
+// Chain: supabase.from("user_profiles").update(…).eq(…).select("*")
+const mockSelect = vi.fn(() => Promise.resolve(mockUpdateReturn));
+const mockEq = vi.fn(() => ({ select: mockSelect }));
+const mockUpdate = vi.fn(() => ({ eq: mockEq }));
+const mockFrom = vi.fn(() => ({ update: mockUpdate }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const SELF_UUID = "550e8400-e29b-41d4-a716-446655440001";
+const OTHER_UUID = "550e8400-e29b-41d4-a716-446655440002";
+
+function makePatchRequest(
+  id: string,
+  body: Record<string, unknown>
+): NextRequest {
+  return new NextRequest(`http://localhost/api/users/${id}/profile`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/users/[id]/profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateReturn = { data: null, error: null };
+  });
+
+  // ── Case 1: happy path ───────────────────────────────────────────────────
+  // Migration 00017 guarantees a profile row exists (trigger + backfill).
+  // The returned row may have NULL first_name/last_name/phone if it was
+  // created by the trigger before the invite RPC overwrote it, or may have
+  // real values if the PATCH just wrote them. Either way the route returns
+  // the full row from the .select("*").
+  it("returns 200 with updated profile on self-edit (trigger-backfilled row)", async () => {
+    mockUpdateReturn = {
+      data: [
+        {
+          user_id: SELF_UUID,
+          first_name: "Alejandro",
+          last_name: "Malbet",
+          phone: null,
+          created_at: "2026-04-23T00:00:00Z",
+          updated_at: "2026-04-23T00:00:01Z",
+        },
+      ],
+      error: null,
+    };
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(SELF_UUID, { first_name: "Alejandro", last_name: "Malbet" }), {
+      params: Promise.resolve({ id: SELF_UUID }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.profile.first_name).toBe("Alejandro");
+    expect(json.profile.last_name).toBe("Malbet");
+    expect(json.profile.user_id).toBe(SELF_UUID);
+
+    // Confirm the correct table and filter were used.
+    expect(mockFrom).toHaveBeenCalledWith("user_profiles");
+    expect(mockUpdate).toHaveBeenCalledWith({ first_name: "Alejandro", last_name: "Malbet" });
+    expect(mockEq).toHaveBeenCalledWith("user_id", SELF_UUID);
+  });
+
+  // ── Case 2: missing profile row (should not happen post-00017) ───────────
+  // If the trigger somehow failed and no profile row exists, the UPDATE
+  // returns data: [] (empty array — RLS filters the row out OR the row does
+  // not exist). Post-00017, this represents a real bug: return 500.
+  it("returns 500 when profile row is missing (data integrity gap)", async () => {
+    mockUpdateReturn = { data: [], error: null };
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(SELF_UUID, { first_name: "X" }), {
+      params: Promise.resolve({ id: SELF_UUID }),
+    });
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/internal error/i);
+  });
+
+  // ── Case 3: cross-user attempt blocked by RLS ────────────────────────────
+  // Supabase returns a postgres error with code 42501 (insufficient privilege)
+  // when RLS blocks the operation at the policy level. The route converts
+  // this to a 403.
+  it("returns 403 when RLS blocks update of another user's profile (code 42501)", async () => {
+    mockUpdateReturn = {
+      data: null,
+      error: {
+        code: "42501",
+        message: "new row violates row-level security policy for table \"user_profiles\"",
+      },
+    };
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(OTHER_UUID, { first_name: "Hacker" }), {
+      params: Promise.resolve({ id: OTHER_UUID }),
+    });
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Not authorized to update this profile.");
+  });
+
+  // ── Edge: 400 for malformed UUID ─────────────────────────────────────────
+  it("returns 400 for a malformed UUID in the path", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/users/not-a-uuid/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ first_name: "X" }),
+      }),
+      { params: Promise.resolve({ id: "not-a-uuid" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── Edge: 422 when no updatable fields in body ───────────────────────────
+  it("returns 422 when the body contains no updatable fields", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(SELF_UUID, { unrelated_field: "ignored" }), {
+      params: Promise.resolve({ id: SELF_UUID }),
+    });
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toMatch(/no updatable fields/i);
+  });
+});

--- a/src/app/api/users/[id]/profile/route.ts
+++ b/src/app/api/users/[id]/profile/route.ts
@@ -87,29 +87,17 @@ export async function PATCH(
   // RLS SELECT filter may return zero rows even when the UPDATE itself
   // succeeded — but in practice the UPDATE policy is stricter than the
   // SELECT policy, so 0 rows here means "not authorized or no profile row".
-  // Distinguish "no profile row yet" (self-edit path) from "not yours to edit":
-  // if the caller is trying to update their own row and no row exists,
-  // auto-create it. This is the typical first-save path for a freshly
-  // invited user who hasn't filled in a profile yet.
+  //
+  // Migration 00017 adds a backfill + AFTER INSERT trigger that guarantees a
+  // user_profiles row exists for every auth.users row. Reaching this branch
+  // post-migration indicates a genuine data integrity problem (trigger failure,
+  // manual deletion, etc.) — return a generic 500 rather than a misleading
+  // re-invite message. The "not yours to edit" 403 is handled by the RLS
+  // policy error path above (code 42501).
   if (!data || data.length === 0) {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (user?.id === id) {
-      // Profile auto-creation deferred — invite RPC creates the row.
-      // INSERT policy is WITH CHECK (FALSE), so direct inserts are blocked.
-      // Return 403 with a clear message explaining why.
-      return NextResponse.json(
-        {
-          error:
-            "No profile row exists to update. An administrator must (re-)invite you.",
-        },
-        { status: 403 }
-      );
-    }
     return NextResponse.json(
-      { error: "Not authorized to update this profile." },
-      { status: 403 }
+      { error: "Internal error. Please contact an administrator." },
+      { status: 500 }
     );
   }
 

--- a/src/lib/supabase/__tests__/user_directory_view.test.ts
+++ b/src/lib/supabase/__tests__/user_directory_view.test.ts
@@ -80,16 +80,19 @@ beforeAll(async () => {
     }),
   ]);
 
-  // Seed user_profiles rows via service role (RLS INSERT is WITH CHECK
-  // FALSE — direct INSERT bypasses the RLS since service role skips
-  // policy evaluation entirely; this is the only seed path for tests).
+  // Seed user_profiles rows via service role. Migration 00017 adds an AFTER
+  // INSERT trigger on auth.users that auto-creates an empty profile row, so
+  // the rows already exist by the time we get here. Use upsert (ON CONFLICT
+  // DO UPDATE) to overwrite the empty trigger-created rows with test values.
   const users = [A, B, C, D];
   const firstNames = ["Alice", "Bob", "Cara", "Dana"];
   const rows = users.map((u, i) => ({
     user_id: u.userId,
     first_name: firstNames[i],
   }));
-  const { error: pErr } = await svc.from("user_profiles").insert(rows);
+  const { error: pErr } = await svc
+    .from("user_profiles")
+    .upsert(rows, { onConflict: "user_id" });
   if (pErr) throw new Error(`[fixture] user_profiles: ${pErr.message}`);
 }, 60_000);
 

--- a/supabase/migrations/00017_user_profile_auto_create.sql
+++ b/supabase/migrations/00017_user_profile_auto_create.sql
@@ -1,0 +1,81 @@
+-- 00017_user_profile_auto_create.sql
+-- Issue #96: Ensure every auth.users row has a user_profiles row.
+--
+-- Root cause: user_profiles.INSERT policy is WITH CHECK (FALSE), so only the
+-- invite RPC (fn_finalize_user_invitation, 00013) can create profile rows via
+-- its SECURITY DEFINER body. Users seeded via 00003, created from the Supabase
+-- dashboard, or entering via any path other than the invite RPC end up orphaned
+-- — no profile row — which surfaces as a misleading 403 on the Profile settings
+-- page.
+--
+-- Two-part fix:
+--
+--   1. BACKFILL: a one-time INSERT that creates empty profile rows for every
+--      existing auth.users row that lacks one. ON CONFLICT (user_id) DO NOTHING
+--      is safe because user_id is the PRIMARY KEY.
+--
+--   2. TRIGGER: an AFTER INSERT trigger on auth.users that auto-creates an
+--      empty profile row whenever a new auth user appears (via inviteUserByEmail,
+--      createUser, signUp, or any future path).
+--
+-- Interaction with fn_finalize_user_invitation (00013:93-98):
+--   The invite flow is: (1) auth.admin.inviteUserByEmail → auth.users INSERT
+--   → trigger fires → empty user_profiles row created; then (2) the invite RPC
+--   runs and does INSERT ... ON CONFLICT (user_id) DO UPDATE SET first_name=...,
+--   last_name=..., phone=.... The RPC's existing UPSERT semantics overwrite the
+--   empty trigger-created row with the real values. No change to the RPC is
+--   needed.
+--
+-- Idempotent: uses CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS + CREATE
+-- TRIGGER, so supabase db reset (which replays all migrations) is safe.
+
+-- ── 1. Backfill existing orphans ─────────────────────────────────────────────
+
+-- Creates an empty profile row (all nullable fields NULL) for every auth.users
+-- row that does not already have one. The trigger (below) handles new rows going
+-- forward; this handles the historical gap.
+INSERT INTO public.user_profiles (user_id)
+  SELECT id FROM auth.users
+  ON CONFLICT (user_id) DO NOTHING;
+
+-- ── 2. Trigger function ───────────────────────────────────────────────────────
+
+-- SECURITY DEFINER: runs as the function owner (postgres), bypassing the
+-- user_profiles INSERT policy WITH CHECK (FALSE). This mirrors the approach
+-- used by fn_finalize_user_invitation (00013) which also writes user_profiles
+-- under SECURITY DEFINER semantics.
+--
+-- SET search_path = public, pg_temp: guards against search_path injection,
+-- consistent with every other SECURITY DEFINER function in this schema.
+--
+-- ON CONFLICT (user_id) DO NOTHING: makes the trigger safe under concurrent /
+-- out-of-order insert paths. If a profile row somehow exists already (e.g. a
+-- future migration path we haven't thought of), the trigger silently skips.
+--
+-- RETURN NEW: required for AFTER ROW triggers on INSERT — the return value is
+-- ignored by Postgres for AFTER triggers, but must be non-NULL.
+CREATE OR REPLACE FUNCTION fn_create_profile_on_auth_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  INSERT INTO public.user_profiles (user_id)
+    VALUES (NEW.id)
+    ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+-- ── 3. Trigger on auth.users ──────────────────────────────────────────────────
+
+-- DROP + CREATE is idempotent (safe for supabase db reset). We cannot use
+-- CREATE OR REPLACE TRIGGER (Postgres 14 feature not universally available in
+-- Supabase's managed Postgres versions).
+DROP TRIGGER IF EXISTS trg_create_profile_on_auth_user ON auth.users;
+
+CREATE TRIGGER trg_create_profile_on_auth_user
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_create_profile_on_auth_user();


### PR DESCRIPTION
## Summary
- Migration `00017_user_profile_auto_create.sql`: one-time backfill of orphaned `user_profiles` rows + `SECURITY DEFINER` `AFTER INSERT` trigger that auto-creates an empty profile row for every new `auth.users` row (any entry path — invite, dashboard create, signUp). Idempotent.
- Removes misleading 'No profile row exists to update. An administrator must (re-)invite you.' 403 from the profile PATCH route — post-migration that path represents a data-integrity bug, so it's now a generic 500.
- 5-case mocked route handler test for `/api/users/[id]/profile`.
- Fixes `user_directory_view.test.ts` fixture to `upsert` profile rows (trigger now pre-creates them on `auth.users` insert — follow-up `insert` would hit PK conflict).

## Why
Alejandro (and any non-invited user: seeded, Supabase-dashboard-created, future `auth.signUp`) had an `auth.users` row but no `user_profiles` row. The `user_profiles` INSERT policy is `WITH CHECK (FALSE)` (intentionally locked down in #79 — profile lifecycle owned by the invite RPC), so the profile form couldn't self-create. Trigger fixes the gap without loosening the policy.

## AC verification
- Invite-RPC collision: `fn_finalize_user_invitation` already does `ON CONFLICT (user_id) DO UPDATE` — the trigger's empty row is safely overwritten with real name/phone. No RPC change needed.
- Layout permission gate (`user_roles` count only) — unaffected; dead-end path gone after backfill.
- `database.gen.ts` unchanged (trigger/function add no new types).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (513/513 passing, RLS suite included)
- [x] `npm run build`

Closes #96.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)