### PR TITLE
Expose Edge delete via per-row kebab menu in setup listing (#100)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/__tests__/edge-row-actions.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/__tests__/edge-row-actions.test.tsx
@@ -159,6 +159,15 @@ describe("EdgeRowActions", () => {
     expect(screen.getByTestId("edge-form-modal")).toBeDefined();
   });
 
+  // (e) DeleteEntityButton wrapper is hidden (not keyboard-reachable via tab)
+  it("(e) canManage=true: delete wrapper carries hidden attribute (no ghost tab stop)", () => {
+    render(
+      <EdgeRowActions edge={testEdge} microgridId="mg-1" canManage={true} />
+    );
+    const wrapper = screen.getByTestId("delete-entity-wrapper");
+    expect(wrapper.hasAttribute("hidden")).toBe(true);
+  });
+
   // (d) Clicking Delete edge triggers the DeleteEntityButton stub
   it("(d) Clicking Delete edge activates the DeleteEntityButton stub", () => {
     render(

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/__tests__/edge-row-actions.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/__tests__/edge-row-actions.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+/**
+ * EdgeRowActions component tests (#100).
+ *
+ * Strategy:
+ *   - Mock next/navigation (useRouter) and next/link per sidebar-nav-links pattern.
+ *   - Mock DeleteEntityButton to a sentinel div — avoids firing the real
+ *     delete-preview network request.
+ *   - Mock EdgeFormModal so tests don't pull in the full form tree.
+ *   - Open the DropdownMenu using the correct Radix pointer-event sequence
+ *     (pointerdown + click) then assert menu item presence.
+ *
+ * Cases:
+ *   (a) canManage=true → both "Configure…" and "Delete edge" items present after open.
+ *   (b) canManage=false → "Configure…" present, "Delete edge" absent.
+ *   (c) Clicking "Configure…" makes EdgeFormModal open (configureOpen → true).
+ *   (d) Clicking "Delete edge" calls the DeleteEntityButton stub click.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+// ─── Module-level mocks ───────────────────────────────────────────────────────
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// Sentinel: renders a visible button so we can assert presence and simulate clicks.
+const mockDeleteEntityButtonClick = vi.fn();
+vi.mock("@/components/forms/DeleteEntityButton", () => ({
+  DeleteEntityButton: ({
+    entity,
+    id,
+    name,
+  }: {
+    entity: string;
+    id: string;
+    name: string;
+  }) => (
+    <button
+      data-testid="delete-entity-button"
+      data-entity={entity}
+      data-id={id}
+      data-name={name}
+      onClick={mockDeleteEntityButtonClick}
+    >
+      Delete Edge stub
+    </button>
+  ),
+}));
+
+vi.mock("@/components/forms/EdgeForm", () => ({
+  EdgeFormModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="edge-form-modal">EdgeFormModal stub</div> : null,
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { EdgeRowActions } from "../edge-row-actions";
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+const testEdge = {
+  id: "edge-abc",
+  name: "Metering Pi",
+  data_source_type: "openems" as const,
+  openems_edge_id: "edge0",
+  openems_backend_url: "http://openems",
+  role: "metering",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Open the DropdownMenu by dispatching the pointer-event sequence Radix
+ * requires in jsdom (pointerdown → mousedown → click on the trigger).
+ */
+function openMenu() {
+  const trigger = screen.getByRole("button", { name: /edge actions/i });
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+  fireEvent.mouseDown(trigger);
+  fireEvent.click(trigger);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EdgeRowActions", () => {
+  // (a) canManage=true → both items present after opening menu
+  it("(a) canManage=true: Configure… and Delete edge items are present", () => {
+    render(
+      <EdgeRowActions
+        edge={testEdge}
+        microgridId="mg-1"
+        canManage={true}
+      />
+    );
+    openMenu();
+
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByText(/configure/i)).toBeDefined();
+    expect(within(menu).getByText(/delete edge/i)).toBeDefined();
+  });
+
+  // (b) canManage=false → only Configure… present, no Delete edge
+  it("(b) canManage=false: Configure… present, Delete edge absent", () => {
+    render(
+      <EdgeRowActions
+        edge={testEdge}
+        microgridId="mg-1"
+        canManage={false}
+      />
+    );
+    openMenu();
+
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByText(/configure/i)).toBeDefined();
+    expect(within(menu).queryByText(/delete edge/i)).toBeNull();
+  });
+
+  // (c) Clicking Configure… makes EdgeFormModal appear
+  it("(c) Clicking Configure… opens the EdgeFormModal", () => {
+    render(
+      <EdgeRowActions
+        edge={testEdge}
+        microgridId="mg-1"
+        canManage={true}
+      />
+    );
+    openMenu();
+
+    const menu = screen.getByRole("menu");
+    const configureItem = within(menu).getByText(/configure/i);
+    fireEvent.click(configureItem);
+
+    expect(screen.getByTestId("edge-form-modal")).toBeDefined();
+  });
+
+  // (d) Clicking Delete edge triggers the DeleteEntityButton stub
+  it("(d) Clicking Delete edge activates the DeleteEntityButton stub", () => {
+    render(
+      <EdgeRowActions
+        edge={testEdge}
+        microgridId="mg-1"
+        canManage={true}
+      />
+    );
+    openMenu();
+
+    const menu = screen.getByRole("menu");
+    const deleteItem = within(menu).getByText(/delete edge/i);
+    fireEvent.click(deleteItem);
+
+    // triggerDelete() queries the hidden wrapper's button and clicks it.
+    // Verify the stub button received the correct props and was activated.
+    const stub = screen.getByTestId("delete-entity-button");
+    expect(stub.getAttribute("data-entity")).toBe("edge");
+    expect(stub.getAttribute("data-id")).toBe("edge-abc");
+    expect(stub.getAttribute("data-name")).toBe("Metering Pi");
+    expect(mockDeleteEntityButtonClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/edge-row-actions.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/edge-row-actions.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * EdgeRowActions — per-row kebab menu for the Setup > Edges listing.
+ *
+ * Replaces the standalone `EdgesCRUDShell mode="configure-button"` in the
+ * actions column. Wraps the Configure action in a Radix DropdownMenu and
+ * conditionally adds a Delete action (gated on `canManage`, resolved
+ * server-side by the listing page).
+ *
+ * Design: kebab scaffolds future Discover-workstream actions (Rediscover,
+ * Reassign) without further row-shape churn (#100 context note).
+ *
+ * Permission model:
+ *   `canManage` is a UX-only affordance — the Delete item is hidden from
+ *   non-managers. The actual authorization backstop lives in the API route
+ *   (`GET /api/edges/[id]/delete-preview` returns 403 on failure).
+ *
+ * Server-client boundary:
+ *   The listing page resolves `canManage` server-side once and passes it
+ *   here as a prop — no per-row fetch.
+ *
+ * DeleteEntityButton wiring:
+ *   The component renders its own button + ConfirmDialog as a React Fragment.
+ *   We render it outside the DropdownMenu.Portal to avoid z-index/portal
+ *   conflicts and trigger it from the menu item's `onSelect` via an
+ *   imperative ref click on the inner button.
+ */
+
+import * as React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { useRouter } from "next/navigation";
+import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
+import { EdgeFormModal } from "@/components/forms/EdgeForm";
+import type { Edge } from "@/lib/types/domain";
+
+interface EdgeRowActionsProps {
+  edge: Pick<
+    Edge,
+    | "id"
+    | "name"
+    | "data_source_type"
+    | "openems_edge_id"
+    | "openems_backend_url"
+    | "role"
+  >;
+  microgridId: string;
+  canManage: boolean;
+}
+
+export function EdgeRowActions({
+  edge,
+  canManage,
+}: EdgeRowActionsProps) {
+  const router = useRouter();
+  const [configureOpen, setConfigureOpen] = React.useState(false);
+  // Ref on a wrapper div that contains DeleteEntityButton's internal button.
+  // onSelect in the Delete menu item imperatively clicks it so the
+  // DeleteEntityButton's handleOpen fires after the menu closes.
+  const deleteWrapperRef = React.useRef<HTMLDivElement>(null);
+
+  function triggerDelete() {
+    deleteWrapperRef.current?.querySelector("button")?.click();
+  }
+
+  return (
+    <>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Edge actions"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <KebabIcon />
+          </button>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={4}
+            className="z-50 min-w-[160px] rounded-md border border-border bg-card p-1 shadow-elev-2"
+          >
+            {/* Configure — always visible; opens EdgeFormModal in edit mode */}
+            <DropdownMenu.Item
+              onSelect={() => setConfigureOpen(true)}
+              className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-foreground outline-none data-[highlighted]:bg-muted"
+            >
+              Configure…
+            </DropdownMenu.Item>
+
+            {/* Delete — only when canManage */}
+            {canManage && (
+              <>
+                <DropdownMenu.Separator className="my-1 h-px bg-border" />
+                <DropdownMenu.Item
+                  onSelect={triggerDelete}
+                  className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-destructive-fg outline-none data-[highlighted]:bg-destructive-muted"
+                >
+                  Delete edge
+                </DropdownMenu.Item>
+              </>
+            )}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+
+      {/* DeleteEntityButton rendered outside the portal so its ConfirmDialog
+          stacks above the (already-closed) menu without z-index conflicts.
+          Visually hidden wrapper — the button inside is triggered imperatively. */}
+      {canManage && (
+        <div
+          ref={deleteWrapperRef}
+          className="sr-only"
+          data-testid="delete-entity-wrapper"
+        >
+          <DeleteEntityButton
+            entity="edge"
+            id={edge.id}
+            name={edge.name}
+          />
+        </div>
+      )}
+
+      {/* Configure modal — rendered as a sibling so it is not affected by
+          DropdownMenu portal lifecycle. */}
+      <EdgeFormModal
+        mode="edit"
+        edge={edge as Edge}
+        open={configureOpen}
+        onOpenChange={(next) => {
+          setConfigureOpen(next);
+          if (!next) router.refresh();
+        }}
+      />
+    </>
+  );
+}
+
+/** Vertical three-dot (kebab) icon — inline SVG following hierarchy-nav.tsx pattern. */
+function KebabIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+    >
+      <circle cx="8" cy="3" r="1.25" />
+      <circle cx="8" cy="8" r="1.25" />
+      <circle cx="8" cy="13" r="1.25" />
+    </svg>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/edge-row-actions.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/edge-row-actions.tsx
@@ -44,6 +44,7 @@ interface EdgeRowActionsProps {
     | "openems_backend_url"
     | "role"
   >;
+  /** reserved for future Rediscover/Reassign menu items in the Discover workstream */
   microgridId: string;
   canManage: boolean;
 }
@@ -108,11 +109,12 @@ export function EdgeRowActions({
 
       {/* DeleteEntityButton rendered outside the portal so its ConfirmDialog
           stacks above the (already-closed) menu without z-index conflicts.
-          Visually hidden wrapper — the button inside is triggered imperatively. */}
+          Hidden wrapper — display:none removes the button from paint AND tab
+          order. sr-only would leave it keyboard-reachable (ghost tab stop). */}
       {canManage && (
         <div
           ref={deleteWrapperRef}
-          className="sr-only"
+          hidden
           data-testid="delete-entity-wrapper"
         >
           <DeleteEntityButton

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -39,6 +39,16 @@ vi.mock("./edges-crud-shell", () => ({
   EdgesCRUDShell: () => null,
 }));
 
+// Stub EdgeRowActions — client component that uses useRouter + Radix DropdownMenu.
+vi.mock("./edge-row-actions", () => ({
+  EdgeRowActions: () => null,
+}));
+
+// Stub currentUserCanAccessMicrogrid — always returns true for smoke tests.
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true),
+}));
+
 import SetupEdgesPage from "./page";
 
 function buildEdgesQuery(data: unknown) {

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -45,9 +45,12 @@ vi.mock("./edge-row-actions", () => ({
 }));
 
 // Stub currentUserCanAccessMicrogrid — always returns true for smoke tests.
-vi.mock("@/lib/auth/access", () => ({
-  currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true),
-}));
+vi.mock("@/lib/auth/access", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth/access")>(
+    "@/lib/auth/access",
+  );
+  return { ...actual, currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true) };
+});
 
 import SetupEdgesPage from "./page";
 

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
@@ -8,6 +8,8 @@ import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { EdgesCRUDShell } from "./edges-crud-shell";
 import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { EdgeRowActions } from "./edge-row-actions";
 
 // Setup > Edges (D2 / #53, #77).
 // Lists every edge attached to this microgrid. Rows link to edge detail.
@@ -49,6 +51,8 @@ export default async function SetupEdgesPage({
   const { id } = await params;
   const sp = searchParams ? await searchParams : undefined;
   const supabase = await createClient();
+
+  const canManage = await currentUserCanAccessMicrogrid(supabase, id);
 
   const levels = await getHierarchyLevels(supabase, {
     kind: "edges-listing",
@@ -185,11 +189,11 @@ export default async function SetupEdgesPage({
                       )}
                     </td>
                     <td className="px-4 py-3 text-right">
-                      {/* Client shell handles per-row Configure… button */}
-                      <EdgesCRUDShell
+                      {/* Kebab menu: Configure + Delete (gated on canManage) */}
+                      <EdgeRowActions
+                        edge={edge}
                         microgridId={id}
-                        mode="configure-button"
-                        edge={edge as Edge}
+                        canManage={canManage}
                       />
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- Replaces the per-row `Configure…` text button on the Edges & Devices setup listing with a Radix `DropdownMenu` kebab (vertical three-dot). Kebab exposes "Configure…" (always) and "Delete edge" (gated on `canManage`).
- `currentUserCanAccessMicrogrid` resolved once server-side in the listing page; passed as boolean prop to the new `EdgeRowActions` client component — no per-row fetch.
- Reuses `DeleteEntityButton` + `DeletedSuccessBanner` from #89 unchanged; post-delete redirect lands on the listing with the success banner automatically.
- Kebab scaffolds future Discover-workstream actions (Rediscover, Reassign) without a second icon column.

## Review fixes included in this PR
- `DeleteEntityButton` stub wrapper switched from `sr-only` → `hidden` (`display:none`). `sr-only` left the button in the keyboard tab order, creating a ghost tab stop that silently fired delete without going through the menu — a real a11y regression caught in review. `hidden` removes the element from both paint and tab order while preserving the imperative `.click()` path.
- `@/lib/auth/access` mock in `page.test.tsx` now uses `vi.importActual` spread pattern (safer for future test additions).
- Added regression test asserting the hidden wrapper has the `hidden` attribute.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (529 tests pass)
- [x] `npm run build`

Closes #100.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)