### PR TITLE
OpenEMS Backend tab — page, shell, subnav chip, secret-preserve, super_admin gate (#102)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.0",
         "aws4": "^1.13.0",
@@ -2511,6 +2512,40 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.0",
     "aws4": "^1.13.0",

--- a/src/app/(dashboard)/microgrids/[id]/setup/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/layout.tsx
@@ -1,7 +1,13 @@
 import { SetupSubNav } from "./setup-subnav";
+import { createClient } from "@/lib/supabase/server";
+import { deriveOpenemsBackendHealth } from "./openems-backend/health";
+import { timeAgo } from "@/lib/time-ago";
 
 // Setup sub-layout (D2 / #53).
-// Wraps the three Setup sub-routes with a shared tablist sub-nav.
+// Wraps the four Setup sub-routes with a shared tablist sub-nav.
+// OpenEMS Backend tab (added #102) carries a health chip derived from the
+// microgrid's ems_* discovery fields. We resolve it once at the layout so
+// the chip renders even on sibling tabs (e.g. while the user is on Edges).
 export default async function SetupLayout({
   children,
   params,
@@ -10,6 +16,25 @@ export default async function SetupLayout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: mg } = await supabase
+    .from("microgrids")
+    .select(
+      "ems_type, ems_last_discover_at, ems_last_discover_status, ems_last_discover_error"
+    )
+    .eq("id", id)
+    .maybeSingle<{
+      ems_type: "cloud_aws" | "direct_url" | null;
+      ems_last_discover_at: string | null;
+      ems_last_discover_status: string | null;
+      ems_last_discover_error: string | null;
+    }>();
+
+  const health = deriveOpenemsBackendHealth(mg ?? null);
+  const relative = mg?.ems_last_discover_at
+    ? timeAgo(mg.ems_last_discover_at)
+    : null;
 
   return (
     <div className="space-y-4">
@@ -23,7 +48,15 @@ export default async function SetupLayout({
         </p>
       </div>
 
-      <SetupSubNav microgridId={id} />
+      <SetupSubNav
+        microgridId={id}
+        openemsBackendHealth={{
+          status: health,
+          lastDiscoverAt: mg?.ems_last_discover_at ?? null,
+          lastDiscoverError: mg?.ems_last_discover_error ?? null,
+          relativeTime: relative,
+        }}
+      />
 
       <div>{children}</div>
     </div>

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/health.test.ts
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/health.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { deriveOpenemsBackendHealth } from "../health";
+
+const NOW = new Date("2026-04-23T12:00:00Z");
+
+describe("deriveOpenemsBackendHealth()", () => {
+  it("returns not_configured for null row", () => {
+    expect(deriveOpenemsBackendHealth(null, NOW)).toBe("not_configured");
+  });
+
+  it("returns not_configured when ems_type is null", () => {
+    expect(
+      deriveOpenemsBackendHealth(
+        {
+          ems_type: null,
+          ems_last_discover_at: null,
+          ems_last_discover_status: null,
+        },
+        NOW
+      )
+    ).toBe("not_configured");
+  });
+
+  it("returns healthy for success < 24h ago", () => {
+    expect(
+      deriveOpenemsBackendHealth(
+        {
+          ems_type: "cloud_aws",
+          ems_last_discover_at: new Date(
+            NOW.getTime() - 2 * 3600 * 1000
+          ).toISOString(),
+          ems_last_discover_status: "success",
+        },
+        NOW
+      )
+    ).toBe("healthy");
+  });
+
+  it("returns stale for success >= 24h ago", () => {
+    expect(
+      deriveOpenemsBackendHealth(
+        {
+          ems_type: "cloud_aws",
+          ems_last_discover_at: new Date(
+            NOW.getTime() - 48 * 3600 * 1000
+          ).toISOString(),
+          ems_last_discover_status: "success",
+        },
+        NOW
+      )
+    ).toBe("stale");
+  });
+
+  it("returns failing for auth_failed/unreachable/zero_edges/unknown_error", () => {
+    for (const s of [
+      "auth_failed",
+      "unreachable",
+      "zero_edges",
+      "unknown_error",
+    ]) {
+      expect(
+        deriveOpenemsBackendHealth(
+          {
+            ems_type: "cloud_aws",
+            ems_last_discover_at: new Date().toISOString(),
+            ems_last_discover_status: s,
+          },
+          NOW
+        )
+      ).toBe("failing");
+    }
+  });
+
+  it("returns stale as a catch-all for configured-but-unknown status", () => {
+    expect(
+      deriveOpenemsBackendHealth(
+        {
+          ems_type: "cloud_aws",
+          ems_last_discover_at: null,
+          ems_last_discover_status: null,
+        },
+        NOW
+      )
+    ).toBe("stale");
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/openems-backend-shell.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/openems-backend-shell.test.tsx
@@ -1,0 +1,549 @@
+// @vitest-environment jsdom
+/**
+ * OpenemsBackendShell tests (#102).
+ *
+ * Covers the AC-TESTS table:
+ *  1. Empty state (super_admin): two-button row → Cloud/Direct reveal form
+ *  2. Empty state (org_manager): info banner only
+ *  3. Configured state (super_admin): chip, masked secret, Test again,
+ *     Reconfigure
+ *  4. Configured state (org_manager): no Reconfigure, info banner
+ *  5. Reconfigure with draftPeriodsCount=0 → form expands
+ *  6. Reconfigure with draftPeriodsCount>0 → mid-period banner, no form
+ *  7. Save & test success → success banner, form collapses
+ *  8. Save & test zero_edges → warn banner
+ *  9. Save & test auth_failed → destructive banner, form stays
+ * 10. Save & test 409 requires_typed_confirmation → dialog opens; typed
+ *     confirm retries PUT with confirmed_name
+ * 12. Secret-preserve: blank secret field → PUT payload omits
+ *     secretAccessKey
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  within,
+} from "@testing-library/react";
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: mockRefresh }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// Stub Select to a native <select> so jsdom + user interaction works without
+// Radix's portal + pointer-event layer.
+vi.mock("@/components/ui/select", () => {
+  function SelectRoot({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children: React.ReactNode;
+  }) {
+    return (
+      <div data-testid="select-root" data-value={value}>
+        {children}
+        <button
+          type="button"
+          data-testid="select-change"
+          onClick={() => onValueChange?.("us-west-2")}
+        >
+          change
+        </button>
+      </div>
+    );
+  }
+  return {
+    Select: SelectRoot,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectValue: ({ placeholder }: { placeholder?: string }) => (
+      <span>{placeholder}</span>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectItem: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children: React.ReactNode;
+    }) => <div data-value={value}>{children}</div>,
+  };
+});
+
+// Stub Radix Dialog (ConfirmDialog) — our custom dialog uses Radix Portal
+// which jsdom can't render into predictably. Render inline so tests can
+// inspect the typed-input + confirm button.
+vi.mock("@radix-ui/react-dialog", async () => {
+  const React = await import("react");
+  const Root = ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: (o: boolean) => void;
+    children: React.ReactNode;
+  }) => (open ? <>{children}</> : null);
+  const Portal = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  const Overlay = (p: Record<string, unknown>) => <div {...p} />;
+  const Content = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & {
+      onOpenAutoFocus?: (e: Event) => void;
+    }
+  >(({ children, onOpenAutoFocus: _unused, ...rest }, ref) => {
+    void _unused;
+    return (
+      <div ref={ref} data-testid="dialog-content" {...rest}>
+        {children}
+      </div>
+    );
+  });
+  Content.displayName = "DialogContent";
+  const Title = ({ children, ...rest }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h2 {...rest}>{children}</h2>
+  );
+  const Description = ({ children, ...rest }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...rest}>{children}</p>
+  );
+  const Close = ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  );
+  return { Root, Portal, Overlay, Content, Title, Description, Close };
+});
+
+import { OpenemsBackendShell } from "../openems-backend-shell";
+
+const BASE_MG = {
+  id: "mg-abc",
+  name: "Kisakye",
+  ems_type: null,
+  ems_backend_url: null,
+  ems_aws_region: null,
+  ems_aws_access_key_id: null,
+  ems_last_discover_at: null,
+  ems_last_discover_status: null,
+  ems_last_discover_error: null,
+  ems_last_discover_count: null,
+};
+
+const CONFIGURED_CLOUD = {
+  id: "mg-abc",
+  name: "Kisakye",
+  ems_type: "cloud_aws" as const,
+  ems_backend_url: "https://abc.lambda-url.us-east-1.on.aws/",
+  ems_aws_region: "us-east-1",
+  ems_aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+  ems_last_discover_at: "2026-04-23T10:00:00Z",
+  ems_last_discover_status: "success",
+  ems_last_discover_error: null,
+  ems_last_discover_count: 2,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("OpenemsBackendShell — empty state", () => {
+  it("(1) super_admin sees the two-button row; clicking Cloud reveals Cloud form; clicking Direct reveals Direct form", () => {
+    const { rerender } = render(
+      <OpenemsBackendShell
+        microgrid={BASE_MG}
+        health="not_configured"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        isSuperAdmin={true}
+      />
+    );
+
+    const cloudBtn = screen.getByRole("button", { name: /cloud \(aws\)/i });
+    const directBtn = screen.getByRole("button", { name: /direct url/i });
+    expect(cloudBtn).toBeDefined();
+    expect(directBtn).toBeDefined();
+
+    fireEvent.click(cloudBtn);
+    expect(screen.getByLabelText(/lambda function url/i)).toBeDefined();
+    expect(screen.getByLabelText(/access key id/i)).toBeDefined();
+    expect(screen.getByLabelText(/secret access key/i)).toBeDefined();
+
+    // Re-render fresh for Direct assertion (can't toggle between forms without cancel)
+    rerender(
+      <OpenemsBackendShell
+        microgrid={BASE_MG}
+        health="not_configured"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    fireEvent.click(screen.getByRole("button", { name: /direct url/i }));
+    expect(screen.getByLabelText(/backend url/i)).toBeDefined();
+  });
+
+  it("(2) org_manager sees an info banner, NOT the two-button row", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={BASE_MG}
+        health="not_configured"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        isSuperAdmin={false}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /cloud \(aws\)/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /direct url/i })).toBeNull();
+    expect(screen.getByText(/hasn't been connected to OpenEMS/i)).toBeDefined();
+  });
+});
+
+describe("OpenemsBackendShell — configured state", () => {
+  it("(3) super_admin: chip, masked secret (last 4), Test again, Reconfigure visible", () => {
+    const { container } = render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    // Chip
+    expect(container.textContent).toContain("Healthy");
+    // Masked secret last-4
+    expect(container.textContent).toContain("••••••••3ACH");
+    // Test again + Reconfigure buttons
+    expect(screen.getByRole("button", { name: /test again/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /reconfigure/i })).toBeDefined();
+  });
+
+  it("(4) org_manager: no Reconfigure, read-only info banner visible, secret '—'", () => {
+    const { container } = render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        isSuperAdmin={false}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /reconfigure/i })).toBeNull();
+    expect(
+      screen.getByText(/only super admins can update openems credentials/i)
+    ).toBeDefined();
+    // Secret row renders "—" when NULL secretLast4
+    expect(container.textContent).toContain("—");
+  });
+});
+
+describe("OpenemsBackendShell — reconfigure flow", () => {
+  it("(5) draftPeriodsCount=0 expands the form on Reconfigure click", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    // Form inputs should be present
+    expect(screen.getByLabelText(/lambda function url/i)).toBeDefined();
+    expect(screen.getByLabelText(/access key id/i)).toBeDefined();
+  });
+
+  it("(6) draftPeriodsCount>0 renders the mid-period banner and does NOT expand the form", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={1}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    expect(screen.getByText(/there's an open billing period/i)).toBeDefined();
+    // Form is not expanded.
+    expect(screen.queryByLabelText(/lambda function url/i)).toBeNull();
+  });
+});
+
+describe("OpenemsBackendShell — Save & test outcomes", () => {
+  function mockFetch(response: {
+    ok?: boolean;
+    status?: number;
+    body: unknown;
+  }) {
+    const res = {
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      json: () => Promise.resolve(response.body),
+    } as unknown as Response;
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(res);
+  }
+
+  async function openForm() {
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+  }
+
+  async function submitForm() {
+    const btn = screen.getByRole("button", { name: /save & test connection/i });
+    // React's form submit handler is wrapped in act
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    // Flush any microtasks + setTimeout(1500) collapses
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it("(7) Success → success banner renders, form collapses after timer", async () => {
+    vi.useFakeTimers();
+    mockFetch({
+      status: 200,
+      body: {
+        status: "success",
+        message: "Connected.",
+        edgeCount: 3,
+        edges: [],
+      },
+    });
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    await openForm();
+    await submitForm();
+    // Success banner
+    expect(screen.getByText(/connected\. found 3 edges/i)).toBeDefined();
+    // Advance past the 1500ms collapse timer
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+    // Form should be gone (query by the Save button)
+    expect(
+      screen.queryByRole("button", { name: /save & test connection/i })
+    ).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("(8) zero_edges → warn banner, form stays editable, summary still renders", async () => {
+    mockFetch({
+      status: 200,
+      body: {
+        status: "zero_edges",
+        message: "Connected, but zero edges.",
+        edgeCount: 0,
+        edges: [],
+      },
+    });
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    await openForm();
+    await submitForm();
+    expect(screen.getByText(/zero edges discovered/i)).toBeDefined();
+    // Form still rendered
+    expect(
+      screen.getByRole("button", { name: /save & test connection/i })
+    ).toBeDefined();
+  });
+
+  it("(9) auth_failed → destructive banner, form stays open", async () => {
+    mockFetch({
+      status: 200,
+      body: {
+        status: "auth_failed",
+        message: "Authentication failed. Verify credentials.",
+        edgeCount: 0,
+      },
+    });
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    await openForm();
+    await submitForm();
+    // "Authentication failed" appears in both banner title and body — assert the title specifically.
+    expect(
+      screen.getByRole("heading", { name: /authentication failed/i })
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /save & test connection/i })
+    ).toBeDefined();
+  });
+
+  it("(10) 409 requires_typed_confirmation → dialog opens; typing correct name + confirming retries PUT with confirmed_name", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    // First call: 409 with requires_typed_confirmation
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () =>
+        Promise.resolve({
+          error: "Type microgrid name to confirm.",
+          requires_typed_confirmation: { entity_name: "Kisakye" },
+          closed_count: 1,
+          draft_count: 0,
+        }),
+    } as unknown as Response);
+
+    // Second call: success on retry
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          status: "success",
+          message: "OK",
+          edgeCount: 2,
+          edges: [],
+        }),
+    } as unknown as Response);
+
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={1}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    await openForm();
+    await submitForm();
+
+    // Dialog is open with typed-input
+    const dialog = screen.getByTestId("dialog-content");
+    expect(within(dialog).getByText(/confirm backend change/i)).toBeDefined();
+
+    const typedInput = within(dialog).getByLabelText(
+      /type the microgrid name to confirm/i
+    );
+    fireEvent.change(typedInput, { target: { value: "Kisakye" } });
+
+    const confirmBtn = within(dialog).getByRole("button", {
+      name: /save & test/i,
+    });
+    expect(confirmBtn.hasAttribute("disabled")).toBe(false);
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    // Second fetch must include confirmed_name
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(
+      fetchSpy.mock.calls[1][1]?.body as string
+    );
+    expect(secondBody.confirmed_name).toBe("Kisakye");
+  });
+});
+
+describe("OpenemsBackendShell — secret preserve on blank (#102 AC-TEST-PRESERVE)", () => {
+  it("(12) Reconfigure cloud_aws with blank secret → PUT payload OMITS secretAccessKey", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            status: "success",
+            message: "ok",
+            edgeCount: 0,
+            edges: [],
+          }),
+      } as unknown as Response);
+
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    // Don't touch the secret field. Submit.
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save & test connection/i })
+      );
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.type).toBe("cloud_aws");
+    expect("secretAccessKey" in body).toBe(false);
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/health.ts
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/health.ts
@@ -1,0 +1,56 @@
+// Health-derivation helper for the OpenEMS Backend tab (#102).
+//
+// Derives one of four health states from the microgrid's ems_* fields per
+// AC-HEALTH-DERIVATION:
+//
+//   ems_type IS NULL                                                 → not_configured
+//   ems_last_discover_status = 'success' AND < 24h ago               → healthy
+//   ems_last_discover_status = 'success' AND ≥ 24h ago               → stale
+//   ems_last_discover_status IN ('auth_failed','unreachable',
+//                                'zero_edges','unknown_error')       → failing
+//   all other cases                                                  → stale
+//
+// Pure — no DB access. Callers (layout, page) each fetch the fields.
+
+export type OpenemsBackendHealth =
+  | "healthy"
+  | "stale"
+  | "failing"
+  | "not_configured";
+
+export type HealthInput = {
+  ems_type: "cloud_aws" | "direct_url" | null;
+  ems_last_discover_at: string | null;
+  ems_last_discover_status: string | null;
+} | null;
+
+const TWENTY_FOUR_HOURS_MS = 24 * 3600 * 1000;
+
+export function deriveOpenemsBackendHealth(
+  row: HealthInput,
+  now: Date = new Date()
+): OpenemsBackendHealth {
+  if (!row) return "not_configured";
+  if (!row.ems_type) return "not_configured";
+
+  const status = row.ems_last_discover_status;
+
+  if (
+    status === "auth_failed" ||
+    status === "unreachable" ||
+    status === "zero_edges" ||
+    status === "unknown_error"
+  ) {
+    return "failing";
+  }
+
+  if (status === "success") {
+    if (!row.ems_last_discover_at) return "stale";
+    const at = new Date(row.ems_last_discover_at).getTime();
+    const diff = now.getTime() - at;
+    return diff < TWENTY_FOUR_HOURS_MS ? "healthy" : "stale";
+  }
+
+  // Catch-all: configured but no recognized discover status (including null).
+  return "stale";
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
@@ -717,24 +717,22 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
 
       {form}
 
-      {closedPeriodsCount >= 0 && (
-        <ConfirmDialog
-          open={typedConfirmOpen}
-          onOpenChange={(next) => {
-            setTypedConfirmOpen(next);
-            if (!next) setPendingPayload(null);
-          }}
-          tone="neutral"
-          title="Confirm backend change"
-          description={`This microgrid has ${closedPeriodsCount} closed billing period${closedPeriodsCount === 1 ? "" : "s"}. Changing the OpenEMS backend may affect historical invoice verification if edge IDs differ after rediscovery.`}
-          confirmLabel="Save & test"
-          requireTypedConfirmation={{
-            label: "Type the microgrid name to confirm",
-            expected: microgrid.name,
-          }}
-          onConfirm={handleTypedConfirm}
-        />
-      )}
+      <ConfirmDialog
+        open={typedConfirmOpen}
+        onOpenChange={(next) => {
+          setTypedConfirmOpen(next);
+          if (!next) setPendingPayload(null);
+        }}
+        tone="neutral"
+        title="Confirm backend change"
+        description={`This microgrid has ${closedPeriodsCount} closed billing period${closedPeriodsCount === 1 ? "" : "s"}. Changing the OpenEMS backend may affect historical invoice verification if edge IDs differ after rediscovery.`}
+        confirmLabel="Save & test"
+        requireTypedConfirmation={{
+          label: "Type the microgrid name to confirm",
+          expected: microgrid.name,
+        }}
+        onConfirm={handleTypedConfirm}
+      />
     </div>
   );
 }

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
@@ -1,0 +1,786 @@
+"use client";
+
+// OpenemsBackendShell — client shell for the OpenEMS Backend setup tab (#102).
+//
+// Owns:
+//   - mode state (empty | configured | editing)
+//   - form state (type + fields)
+//   - Save & test promise + result banner state
+//   - Test-again promise
+//   - typed-confirm dialog state (closed-period bypass)
+//
+// Data flow:
+//   Server component passes (microgrid, health, counts, secretLast4, isSuperAdmin).
+//   On Save/Test/Dialog-confirm success → router.refresh() so the server
+//   component re-fetches health + counts.
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { StatusChip } from "@/components/ui/status-chip";
+import { Banner } from "@/components/ui/banner";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { LocalDate } from "@/components/format/local-date";
+import type { OpenemsBackendHealth } from "./health";
+
+type MicrogridProps = {
+  id: string;
+  name: string;
+  ems_type: "cloud_aws" | "direct_url" | null;
+  ems_backend_url: string | null;
+  ems_aws_region: string | null;
+  ems_aws_access_key_id: string | null;
+  ems_last_discover_at: string | null;
+  ems_last_discover_status: string | null;
+  ems_last_discover_error: string | null;
+  ems_last_discover_count: number | null;
+};
+
+export type OpenemsBackendShellProps = {
+  microgrid: MicrogridProps;
+  health: OpenemsBackendHealth;
+  draftPeriodsCount: number;
+  closedPeriodsCount: number;
+  secretLast4: string | null;
+  isSuperAdmin: boolean;
+};
+
+type FormType = "cloud_aws" | "direct_url";
+
+type SaveOutcome =
+  | { kind: "success"; edgeCount: number; message: string }
+  | { kind: "zero_edges"; message: string }
+  | { kind: "auth_failed"; message: string }
+  | { kind: "unreachable"; message: string }
+  | { kind: "unknown_error"; message: string }
+  | { kind: "permission_denied"; message: string }
+  | { kind: "generic_error"; message: string };
+
+const AWS_REGIONS = [
+  "us-east-1",
+  "us-west-2",
+  "eu-west-1",
+  "ap-southeast-1",
+] as const;
+
+export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
+  const {
+    microgrid,
+    health,
+    draftPeriodsCount,
+    closedPeriodsCount,
+    secretLast4,
+    isSuperAdmin,
+  } = props;
+
+  const router = useRouter();
+
+  // Mode: "empty" if not configured, else "configured". Editing overlays.
+  // The mode is derived from server-fetched props and never toggled at runtime;
+  // any transition (Save success) flows through router.refresh() which re-
+  // renders the server component. We memoize via useState purely to stabilize
+  // the value across renders of children that might (in a follow-up) rely on
+  // referential equality.
+  const initialMode: "empty" | "configured" =
+    microgrid.ems_type == null ? "empty" : "configured";
+  const [mode] = React.useState<"empty" | "configured">(initialMode);
+  const [isEditing, setIsEditing] = React.useState(false);
+
+  // Form state — initialize from the saved microgrid record when editing.
+  const [formType, setFormType] = React.useState<FormType | null>(
+    microgrid.ems_type
+  );
+  const [backendUrl, setBackendUrl] = React.useState<string>(
+    microgrid.ems_backend_url ?? ""
+  );
+  const [region, setRegion] = React.useState<string>(
+    microgrid.ems_aws_region ?? "us-east-1"
+  );
+  const [accessKeyId, setAccessKeyId] = React.useState<string>(
+    microgrid.ems_aws_access_key_id ?? ""
+  );
+  const [secretAccessKey, setSecretAccessKey] = React.useState<string>("");
+
+  // Mid-period guard banner visibility (derived from draftPeriodsCount +
+  // "user clicked Reconfigure"). Distinct from the form-visible flag so
+  // that dismissing the banner never opens the form; the user must click
+  // Reconfigure again after resolving the draft.
+  const [showMidPeriodBanner, setShowMidPeriodBanner] = React.useState(false);
+
+  // Save & test outcome (null = no submit since last edit).
+  const [outcome, setOutcome] = React.useState<SaveOutcome | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [testingAgain, setTestingAgain] = React.useState(false);
+
+  // Type-to-confirm dialog (closed-period bypass).
+  const [typedConfirmOpen, setTypedConfirmOpen] = React.useState(false);
+  const [pendingPayload, setPendingPayload] =
+    React.useState<Record<string, unknown> | null>(null);
+
+  const putUrl = `/api/microgrids/${microgrid.id}/openems-backend`;
+  const discoverUrl = `/api/microgrids/${microgrid.id}/openems-backend/discover`;
+
+  // ── Reconfigure click flow ─────────────────────────────────────────────
+  function handleReconfigureClick() {
+    setOutcome(null);
+    setShowMidPeriodBanner(false);
+    if (draftPeriodsCount > 0) {
+      setShowMidPeriodBanner(true);
+      return;
+    }
+    // Initialize form from the current config. Secret is intentionally blank.
+    setFormType(microgrid.ems_type);
+    setBackendUrl(microgrid.ems_backend_url ?? "");
+    setRegion(microgrid.ems_aws_region ?? "us-east-1");
+    setAccessKeyId(microgrid.ems_aws_access_key_id ?? "");
+    setSecretAccessKey("");
+    setIsEditing(true);
+  }
+
+  function handleCancel() {
+    setIsEditing(false);
+    setOutcome(null);
+    setShowMidPeriodBanner(false);
+    if (initialMode === "empty") {
+      setFormType(null);
+    }
+  }
+
+  // ── Build PUT payload from form state ──────────────────────────────────
+  function buildPayload(): Record<string, unknown> | null {
+    if (!formType) return null;
+    if (formType === "direct_url") {
+      return { type: "direct_url", backendUrl };
+    }
+    const base: Record<string, unknown> = {
+      type: "cloud_aws",
+      backendUrl,
+      region,
+      accessKeyId,
+    };
+    // Only include secretAccessKey when the user actually typed one — an empty
+    // string signals "preserve the existing secret" to the server (#102
+    // AC-SECRET-PRESERVE, enforced by the PUT handler).
+    if (secretAccessKey && secretAccessKey.length > 0) {
+      base.secretAccessKey = secretAccessKey;
+    }
+    return base;
+  }
+
+  async function submit(payload: Record<string, unknown>) {
+    setSaving(true);
+    setOutcome(null);
+    try {
+      const res = await fetch(putUrl, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = (await res.json()) as Record<string, unknown>;
+
+      if (res.status === 409) {
+        // Branch (a) draft exists, or branch (b) requires_typed_confirmation.
+        if (
+          typeof json.requires_typed_confirmation === "object" &&
+          json.requires_typed_confirmation !== null
+        ) {
+          setPendingPayload(payload);
+          setTypedConfirmOpen(true);
+          return;
+        }
+        // Draft-exists 409 (stale cache — server wins). Render mid-period banner.
+        setShowMidPeriodBanner(true);
+        setIsEditing(false);
+        return;
+      }
+
+      if (res.status === 403) {
+        setOutcome({
+          kind: "permission_denied",
+          message:
+            (typeof json.error === "string"
+              ? json.error
+              : "") ||
+            "You do not have permission to configure this microgrid.",
+        });
+        return;
+      }
+
+      if (res.status === 400) {
+        setOutcome({
+          kind: "generic_error",
+          message:
+            (typeof json.error === "string"
+              ? json.error
+              : "") || "The request was rejected.",
+        });
+        return;
+      }
+
+      if (!res.ok) {
+        setOutcome({
+          kind: "generic_error",
+          message:
+            (typeof json.error === "string"
+              ? json.error
+              : "") || "Something went wrong saving the configuration.",
+        });
+        return;
+      }
+
+      const status = typeof json.status === "string" ? json.status : "unknown";
+      const message = typeof json.message === "string" ? json.message : "";
+      const edgeCount =
+        typeof json.edgeCount === "number" ? json.edgeCount : 0;
+
+      if (status === "success") {
+        setOutcome({ kind: "success", edgeCount, message });
+        // Collapse back to summary after 1.5s.
+        setTimeout(() => {
+          setIsEditing(false);
+          router.refresh();
+        }, 1500);
+        return;
+      }
+      if (status === "zero_edges") {
+        setOutcome({ kind: "zero_edges", message });
+        router.refresh();
+        return;
+      }
+      if (status === "auth_failed") {
+        setOutcome({ kind: "auth_failed", message });
+        return;
+      }
+      if (status === "unreachable") {
+        setOutcome({ kind: "unreachable", message });
+        return;
+      }
+      setOutcome({ kind: "unknown_error", message });
+    } catch {
+      setOutcome({
+        kind: "generic_error",
+        message: "Network error — please try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const payload = buildPayload();
+    if (!payload) return;
+    await submit(payload);
+  }
+
+  async function handleTypedConfirm(): Promise<void> {
+    if (!pendingPayload) return;
+    // The ConfirmDialog's typed-input value lives inside the dialog; we'd
+    // normally pass it back through the onConfirm callback. We use the
+    // expected microgrid name because the dialog only fires onConfirm when
+    // the typed input MATCHES expected — so at this point the typed value
+    // IS the microgrid name.
+    const retry = {
+      ...pendingPayload,
+      confirmed_name: microgrid.name,
+    };
+    const res = await fetch(putUrl, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(retry),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (!res.ok) {
+      const msg =
+        (typeof json.error === "string" && json.error) ||
+        "The request was rejected.";
+      // Dialog stays open on throw.
+      throw new Error(msg);
+    }
+    // Success path — fold back into the main outcome banner.
+    const status = typeof json.status === "string" ? json.status : "unknown";
+    const message = typeof json.message === "string" ? json.message : "";
+    const edgeCount = typeof json.edgeCount === "number" ? json.edgeCount : 0;
+    if (status === "success") {
+      setOutcome({ kind: "success", edgeCount, message });
+      setTimeout(() => {
+        setIsEditing(false);
+        router.refresh();
+      }, 1500);
+    } else if (status === "zero_edges") {
+      setOutcome({ kind: "zero_edges", message });
+      router.refresh();
+    } else if (status === "auth_failed") {
+      setOutcome({ kind: "auth_failed", message });
+    } else if (status === "unreachable") {
+      setOutcome({ kind: "unreachable", message });
+    } else {
+      setOutcome({ kind: "unknown_error", message });
+    }
+    setTypedConfirmOpen(false);
+    setPendingPayload(null);
+  }
+
+  async function handleTestAgain() {
+    setTestingAgain(true);
+    setOutcome(null);
+    try {
+      const res = await fetch(discoverUrl, { method: "POST" });
+      const json = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        const msg =
+          (typeof json.error === "string" && json.error) ||
+          "Test failed. See server logs.";
+        setOutcome({ kind: "generic_error", message: msg });
+        return;
+      }
+      const status = typeof json.status === "string" ? json.status : "unknown";
+      const message = typeof json.message === "string" ? json.message : "";
+      const edgeCount = Array.isArray(json.edges) ? json.edges.length : 0;
+      if (status === "success")
+        setOutcome({ kind: "success", edgeCount, message });
+      else if (status === "zero_edges")
+        setOutcome({ kind: "zero_edges", message });
+      else if (status === "auth_failed")
+        setOutcome({ kind: "auth_failed", message });
+      else if (status === "unreachable")
+        setOutcome({ kind: "unreachable", message });
+      else setOutcome({ kind: "unknown_error", message });
+      router.refresh();
+    } catch {
+      setOutcome({
+        kind: "generic_error",
+        message: "Network error — please try again.",
+      });
+    } finally {
+      setTestingAgain(false);
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  const header = (
+    <div>
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        OpenEMS Backend
+      </p>
+      <h3 className="text-lg font-semibold text-foreground">
+        Connect this microgrid to OpenEMS
+      </h3>
+    </div>
+  );
+
+  // Empty state
+  if (mode === "empty" && !isEditing) {
+    if (!isSuperAdmin) {
+      return (
+        <div className="space-y-4">
+          {header}
+          <Banner tone="info" title="Not connected yet">
+            This microgrid hasn&apos;t been connected to OpenEMS yet. Ask a
+            super admin to configure it.
+          </Banner>
+        </div>
+      );
+    }
+    return (
+      <div className="space-y-4">
+        {header}
+        <div className="mx-auto max-w-[560px] rounded-md border border-border bg-card p-6 shadow-elev-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Connection
+          </p>
+          <h4 className="mt-1 text-lg font-semibold text-foreground">
+            Connect OpenEMS
+          </h4>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Connect this microgrid to its OpenEMS backend. MBE pulls meter
+            data from OpenEMS. Choose how to connect:
+          </p>
+          <div className="mt-4 inline-flex gap-2 rounded-md bg-muted p-1" role="group" aria-label="Connection type">
+            <button
+              type="button"
+              onClick={() => {
+                setFormType("cloud_aws");
+                setIsEditing(true);
+              }}
+              className="rounded-md px-3 py-1.5 text-sm font-medium text-foreground hover:bg-card"
+            >
+              Cloud (AWS)
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setFormType("direct_url");
+                setIsEditing(true);
+              }}
+              className="rounded-md px-3 py-1.5 text-sm font-medium text-foreground hover:bg-card"
+            >
+              Direct URL
+            </button>
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            You can change this later. Changing it requires rediscovering
+            devices.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Configured summary card (also rendered as a read-only header when editing).
+  const summaryCard =
+    microgrid.ems_type != null ? (
+      <div className="rounded-md border border-border bg-card p-5 shadow-elev-1">
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Left column */}
+          <div className="space-y-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Connection type
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                {microgrid.ems_type === "cloud_aws"
+                  ? "Cloud (AWS)"
+                  : "Direct URL"}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {microgrid.ems_type === "cloud_aws"
+                  ? "Lambda function URL"
+                  : "Backend URL"}
+              </p>
+              <p className="mt-1 break-all font-mono text-xs text-foreground">
+                {microgrid.ems_backend_url ?? "—"}
+              </p>
+            </div>
+            {microgrid.ems_type === "cloud_aws" && (
+              <>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Region
+                  </p>
+                  <p className="mt-1 font-mono text-xs text-foreground">
+                    {microgrid.ems_aws_region ?? "—"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Access key ID
+                  </p>
+                  <p className="mt-1 break-all font-mono text-xs text-foreground">
+                    {microgrid.ems_aws_access_key_id ?? "—"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Secret access key
+                  </p>
+                  <p className="mt-1 font-mono text-xs text-foreground">
+                    {secretLast4 ? `••••••••${secretLast4}` : "—"}
+                  </p>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Right column */}
+          <div className="flex flex-col items-start gap-3">
+            <StatusChip kind="openemsBackendHealth" status={health} />
+            {microgrid.ems_last_discover_at ? (
+              <p className="text-xs text-muted-foreground">
+                Last successful discovery:{" "}
+                <LocalDate value={microgrid.ems_last_discover_at} relative />
+                {typeof microgrid.ems_last_discover_count === "number" && (
+                  <> · {microgrid.ems_last_discover_count} edge{microgrid.ems_last_discover_count === 1 ? "" : "s"} found</>
+                )}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No discovery has run yet.
+              </p>
+            )}
+            {isSuperAdmin && (
+              <button
+                type="button"
+                onClick={handleTestAgain}
+                disabled={testingAgain}
+                className="rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {testingAgain ? "Testing…" : "Test again"}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {isSuperAdmin && !isEditing && (
+          <div className="mt-5 flex justify-end">
+            <button
+              type="button"
+              onClick={handleReconfigureClick}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Reconfigure
+            </button>
+          </div>
+        )}
+      </div>
+    ) : null;
+
+  // Form (visible when editing)
+  const form = isEditing && formType ? (
+    <form onSubmit={handleSubmit} className="rounded-md border border-border bg-card p-5 shadow-elev-1 space-y-5">
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {initialMode === "empty" ? "New connection" : "Reconfigure connection"}
+        </p>
+        <h4 className="mt-1 text-lg font-semibold text-foreground">
+          {formType === "cloud_aws" ? "Cloud (AWS)" : "Direct URL"}
+        </h4>
+      </div>
+
+      {formType === "cloud_aws" ? (
+        <>
+          <fieldset className="space-y-3">
+            <legend className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Endpoint
+            </legend>
+            <div>
+              <label htmlFor="lambda-url" className="mb-1 block text-xs font-medium text-foreground">
+                Lambda function URL
+              </label>
+              <Input
+                id="lambda-url"
+                type="url"
+                value={backendUrl}
+                onChange={(e) => setBackendUrl(e.target.value)}
+                placeholder="https://<id>.lambda-url.<region>.on.aws/"
+                required
+                className="font-mono text-xs"
+              />
+            </div>
+            <div>
+              <label htmlFor="aws-region" className="mb-1 block text-xs font-medium text-foreground">
+                AWS region
+              </label>
+              <Select value={region} onValueChange={setRegion}>
+                <SelectTrigger id="aws-region">
+                  <SelectValue placeholder="us-east-1" />
+                </SelectTrigger>
+                <SelectContent>
+                  {AWS_REGIONS.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {r}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </fieldset>
+
+          <fieldset className="space-y-3">
+            <legend className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Credentials
+            </legend>
+            <div>
+              <label htmlFor="access-key-id" className="mb-1 block text-xs font-medium text-foreground">
+                Access key ID
+              </label>
+              <Input
+                id="access-key-id"
+                type="text"
+                value={accessKeyId}
+                onChange={(e) => setAccessKeyId(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+                required
+                className="font-mono text-xs"
+              />
+            </div>
+            <div>
+              <label htmlFor="secret-access-key" className="mb-1 block text-xs font-medium text-foreground">
+                Secret access key
+              </label>
+              <Input
+                id="secret-access-key"
+                type="password"
+                value={secretAccessKey}
+                onChange={(e) => setSecretAccessKey(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+                placeholder={
+                  initialMode === "configured"
+                    ? "Leave blank to keep the current secret"
+                    : ""
+                }
+                className="font-mono text-xs"
+              />
+              {initialMode === "configured" && (
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Leave blank to keep the current secret.
+                </p>
+              )}
+            </div>
+          </fieldset>
+        </>
+      ) : (
+        <div>
+          <label htmlFor="backend-url" className="mb-1 block text-xs font-medium text-foreground">
+            Backend URL
+          </label>
+          <Input
+            id="backend-url"
+            type="url"
+            value={backendUrl}
+            onChange={(e) => setBackendUrl(e.target.value)}
+            placeholder="http://localhost:8082"
+            required
+            className="font-mono text-xs"
+          />
+        </div>
+      )}
+
+      {outcome && (
+        <OutcomeBanner outcome={outcome} />
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="rounded-md px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {saving ? (
+            <>
+              <span aria-hidden="true" className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-primary-foreground border-r-transparent" />
+              Testing connection…
+            </>
+          ) : (
+            "Save & test connection"
+          )}
+        </button>
+      </div>
+    </form>
+  ) : null;
+
+  return (
+    <div className="space-y-4">
+      {header}
+
+      {!isSuperAdmin && mode === "configured" && (
+        <Banner tone="info" title="Read-only view">
+          Only super admins can update OpenEMS credentials. Contact your
+          administrator to request changes.
+        </Banner>
+      )}
+
+      {summaryCard}
+
+      {showMidPeriodBanner && (
+        <Banner
+          tone="warn"
+          title="There's an open billing period"
+          action={
+            <Link
+              href={`/microgrids/${microgrid.id}/billing`}
+              className="text-sm font-medium text-warning-fg underline"
+            >
+              Open billing periods →
+            </Link>
+          }
+        >
+          Close or delete the draft period first — changing the OpenEMS
+          backend requires rediscovering devices and would invalidate
+          readings from the current period.
+        </Banner>
+      )}
+
+      {/* In configured mode, surface Test-again outcome above the card so it
+          doesn't disappear when the form is hidden. */}
+      {!isEditing && outcome && <OutcomeBanner outcome={outcome} />}
+
+      {form}
+
+      {closedPeriodsCount >= 0 && (
+        <ConfirmDialog
+          open={typedConfirmOpen}
+          onOpenChange={(next) => {
+            setTypedConfirmOpen(next);
+            if (!next) setPendingPayload(null);
+          }}
+          tone="neutral"
+          title="Confirm backend change"
+          description={`This microgrid has ${closedPeriodsCount} closed billing period${closedPeriodsCount === 1 ? "" : "s"}. Changing the OpenEMS backend may affect historical invoice verification if edge IDs differ after rediscovery.`}
+          confirmLabel="Save & test"
+          requireTypedConfirmation={{
+            label: "Type the microgrid name to confirm",
+            expected: microgrid.name,
+          }}
+          onConfirm={handleTypedConfirm}
+        />
+      )}
+    </div>
+  );
+}
+
+function OutcomeBanner({ outcome }: { outcome: SaveOutcome }) {
+  if (outcome.kind === "success") {
+    return (
+      <Banner tone="success" title="Connected">
+        Connected. Found {outcome.edgeCount} edge
+        {outcome.edgeCount === 1 ? "" : "s"}.
+      </Banner>
+    );
+  }
+  if (outcome.kind === "zero_edges") {
+    return (
+      <Banner tone="warn" title="Zero edges discovered">
+        {outcome.message || "The OpenEMS Backend returned zero edges."}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "auth_failed") {
+    return (
+      <Banner tone="destructive" title="Authentication failed">
+        {outcome.message ||
+          "Verify your AWS credentials and region (common cause: rotated access key)."}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "unreachable") {
+    return (
+      <Banner tone="destructive" title="Backend unreachable">
+        {outcome.message ||
+          "Could not reach the OpenEMS Backend. Check the URL and that the host is reachable from Vercel."}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "permission_denied") {
+    return (
+      <Banner tone="destructive" title="Permission denied">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  return (
+    <Banner tone="destructive" title="Something went wrong">
+      {outcome.message}
+    </Banner>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/page.tsx
@@ -1,0 +1,121 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import {
+  currentUserCanAccessMicrogrid,
+  currentUserIsSuperAdmin,
+} from "@/lib/auth/access";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
+import { deriveOpenemsBackendHealth } from "./health";
+import { OpenemsBackendShell } from "./openems-backend-shell";
+
+// Setup > OpenEMS Backend (#102).
+//
+// Server component fetches:
+//   1. Microgrid row (name + ems_* columns)
+//   2. Draft billing-period count (mid-period guard)
+//   3. Closed billing-period count (for the type-to-confirm bypass PM copy)
+//   4. Decrypted AWS secret last-4 (super_admin only; fn_get_ems_secret returns
+//      NULL for org_manager → we render "—" in the summary)
+//   5. Permission flags: isSuperAdmin, canAccessMicrogrid
+//
+// The server component passes everything as props to a single client shell
+// that owns mode state (empty / configured / editing), form state, Save
+// promise, and the typed-confirm dialog.
+export default async function OpenemsBackendPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // Permission gate — 404 if the user can't access (don't leak existence).
+  const canAccess = await currentUserCanAccessMicrogrid(supabase, id);
+  if (!canAccess) notFound();
+
+  const isSuperAdmin = await currentUserIsSuperAdmin(supabase);
+
+  const { data: mg, error: mgErr } = await supabase
+    .from("microgrids")
+    .select(
+      "id, name, ems_type, ems_backend_url, ems_aws_region, ems_aws_access_key_id, ems_last_discover_at, ems_last_discover_status, ems_last_discover_error, ems_last_discover_count"
+    )
+    .eq("id", id)
+    .maybeSingle<{
+      id: string;
+      name: string;
+      ems_type: "cloud_aws" | "direct_url" | null;
+      ems_backend_url: string | null;
+      ems_aws_region: string | null;
+      ems_aws_access_key_id: string | null;
+      ems_last_discover_at: string | null;
+      ems_last_discover_status: string | null;
+      ems_last_discover_error: string | null;
+      ems_last_discover_count: number | null;
+    }>();
+
+  if (mgErr || !mg) {
+    notFound();
+  }
+
+  // Count billing periods (draft + closed). `head: true` + `count: 'exact'`
+  // gives us a cheap count-only query per table — two round-trips total,
+  // both indexed on (microgrid_id, status).
+  const [{ count: draftCount }, { count: closedCount }] = await Promise.all([
+    supabase
+      .from("billing_periods")
+      .select("id", { count: "exact", head: true })
+      .eq("microgrid_id", id)
+      .eq("status", "draft"),
+    supabase
+      .from("billing_periods")
+      .select("id", { count: "exact", head: true })
+      .eq("microgrid_id", id)
+      .eq("status", "closed"),
+  ]);
+
+  // Last-4 mask of the decrypted AWS secret. fn_get_ems_secret returns NULL
+  // for non-super_admin (even on own org) per migration 00018 truth table.
+  let secretLast4: string | null = null;
+  if (mg.ems_type === "cloud_aws" && isSuperAdmin) {
+    const { data: secret } = await supabase.rpc("fn_get_ems_secret", {
+      _microgrid_id: id,
+    });
+    if (typeof secret === "string" && secret.length >= 4) {
+      secretLast4 = secret.slice(-4);
+    }
+  }
+
+  const health = deriveOpenemsBackendHealth(mg);
+
+  const levels = await getHierarchyLevels(supabase, {
+    kind: "edges-listing",
+    microgridId: id,
+  });
+
+  return (
+    <div className="space-y-4">
+      <HierarchyNav levels={levels} className="mb-2" />
+      <OpenemsBackendShell
+        microgrid={{
+          id: mg.id,
+          name: mg.name,
+          ems_type: mg.ems_type,
+          ems_backend_url: mg.ems_backend_url,
+          ems_aws_region: mg.ems_aws_region,
+          ems_aws_access_key_id: mg.ems_aws_access_key_id,
+          ems_last_discover_at: mg.ems_last_discover_at,
+          ems_last_discover_status: mg.ems_last_discover_status,
+          ems_last_discover_error: mg.ems_last_discover_error,
+          ems_last_discover_count: mg.ems_last_discover_count,
+        }}
+        health={health}
+        draftPeriodsCount={draftCount ?? 0}
+        closedPeriodsCount={closedCount ?? 0}
+        secretLast4={secretLast4}
+        isSuperAdmin={isSuperAdmin}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx
@@ -2,33 +2,68 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { useRef, type KeyboardEvent } from "react";
+import { StatusChip } from "@/components/ui/status-chip";
+import type { OpenemsBackendHealth } from "./openems-backend/health";
 
-// Setup sub-nav (D2 / #53).
+// Setup sub-nav (D2 / #53, extended #102).
 //
 // Visual language per designer mock `mgm-ia-v1.html` § .setup-subnav:
 //   pill-style container (bg-muted), each tab has its own rounded surface,
-//   active tab raises onto a bg-card surface. This is visually DEMOTED
-//   compared to the top Dashboard/Billing/Setup tabs so it signals
-//   "sub-area, not a primary destination".
+//   active tab raises onto a bg-card surface.
 //
 // A11y contract:
 //   - The nav is `role="tablist"` with `aria-label`.
-//   - Each link is `role="tab"` with `aria-selected` + `aria-controls` pointing at
-//     the content region id (the `children` container in the parent layout —
-//     ties the tab to a panel landmark via its known id).
-//   - ArrowLeft / ArrowRight cycle between tabs and move focus + navigate
-//     (focus mirrors active selection — no parking separate focused tab).
+//   - Each link is `role="tab"` with `aria-selected` + `aria-controls` pointing
+//     at the content region id.
+//   - ArrowLeft / ArrowRight cycle between tabs and move focus + navigate.
 //   - Home / End jump to first / last tab.
+//   - The OpenEMS Backend tab chip is rendered INSIDE the single <a> element
+//     (not a separate focusable surface) so we never nest interactive
+//     descendants. Radix Tooltip on the chip takes tabindex=0 on an inner
+//     span — that's fine because the anchor swallows clicks anyway.
 
 type SubTab = { label: string; segment: string };
 
 const TABS: SubTab[] = [
-  { label: "Edges & Devices", segment: "edges" },
-  { label: "Households",      segment: "households" },
-  { label: "Rate Schedule",   segment: "rates" },
+  { label: "Edges & Devices",  segment: "edges" },
+  { label: "Households",       segment: "households" },
+  { label: "OpenEMS Backend",  segment: "openems-backend" },
+  { label: "Rate Schedule",    segment: "rates" },
 ];
 
-export function SetupSubNav({ microgridId }: { microgridId: string }) {
+export type OpenemsBackendChipData = {
+  status: OpenemsBackendHealth;
+  lastDiscoverAt: string | null;
+  lastDiscoverError: string | null;
+  relativeTime: string | null;
+};
+
+function tooltipFor(data: OpenemsBackendChipData): string | null {
+  switch (data.status) {
+    case "healthy":
+      return data.relativeTime
+        ? `Last successful discovery: ${data.relativeTime}`
+        : "Connection healthy";
+    case "stale":
+      return data.relativeTime
+        ? `Last successful discovery: ${data.relativeTime}. Run 'Test again' to verify.`
+        : "Run 'Test again' to verify the connection.";
+    case "failing":
+      return data.lastDiscoverError
+        ? `Discovery failed: ${data.lastDiscoverError}. Reconfigure or test again.`
+        : "Discovery failed. Reconfigure or test again.";
+    case "not_configured":
+      return "No OpenEMS backend connected yet.";
+  }
+}
+
+export function SetupSubNav({
+  microgridId,
+  openemsBackendHealth,
+}: {
+  microgridId: string;
+  openemsBackendHealth?: OpenemsBackendChipData;
+}) {
   const pathname = usePathname();
   const router = useRouter();
   const base = `/microgrids/${microgridId}/setup`;
@@ -81,6 +116,8 @@ export function SetupSubNav({ microgridId }: { microgridId: string }) {
       {TABS.map((tab, i) => {
         const isActive = i === activeIndex;
         const href = `${base}/${tab.segment}`;
+        const chipData =
+          tab.segment === "openems-backend" ? openemsBackendHealth : undefined;
         return (
           <a
             key={tab.segment}
@@ -92,13 +129,21 @@ export function SetupSubNav({ microgridId }: { microgridId: string }) {
             aria-selected={isActive}
             tabIndex={isActive ? 0 : -1}
             onKeyDown={(e) => onKeyDown(e, i)}
-            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
               isActive
                 ? "bg-card text-foreground font-semibold shadow-elev-1"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
-            {tab.label}
+            <span>{tab.label}</span>
+            {chipData && (
+              <StatusChip
+                kind="openemsBackendHealth"
+                status={chipData.status}
+                size="sm"
+                tooltip={tooltipFor(chipData)}
+              />
+            )}
           </a>
         );
       })}

--- a/src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx
@@ -17,10 +17,10 @@ import type { OpenemsBackendHealth } from "./openems-backend/health";
 //     at the content region id.
 //   - ArrowLeft / ArrowRight cycle between tabs and move focus + navigate.
 //   - Home / End jump to first / last tab.
-//   - The OpenEMS Backend tab chip is rendered INSIDE the single <a> element
-//     (not a separate focusable surface) so we never nest interactive
-//     descendants. Radix Tooltip on the chip takes tabindex=0 on an inner
-//     span — that's fine because the anchor swallows clicks anyway.
+//   - The OpenEMS Backend tab chip is rendered INSIDE the single <a> element.
+//     Radix Tooltip wraps the chip and adds a focusable span (tabindex=0)
+//     inside the anchor. Screen readers follow the anchor as the primary
+//     control; the tooltip surfaces status copy on hover/focus.
 
 type SubTab = { label: string; segment: string };
 

--- a/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
@@ -89,7 +89,14 @@ function makePutRequest(body: unknown): NextRequest {
   });
 }
 
-function mgSelectHandler(row: { id: string; name: string } | null) {
+function mgSelectHandler(
+  row: {
+    id: string;
+    name: string;
+    ems_type?: "cloud_aws" | "direct_url" | null;
+    ems_aws_secret_access_key_encrypted?: string | null;
+  } | null
+) {
   return () => ({
     select: () => ({
       eq: () => ({
@@ -146,7 +153,16 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       return handler(table);
     });
 
-    mockRpc.mockResolvedValue({ data: "\\x01020304" /* bytea hex */, error: null });
+    mockRpc.mockImplementation((fnName: string) => {
+      if (fnName === "fn_get_ems_secret") {
+        return Promise.resolve({
+          data: "DECRYPTED_FAKE_SECRET",
+          error: null,
+        });
+      }
+      // fn_ems_encrypt_secret (default)
+      return Promise.resolve({ data: "\\x01020304", error: null });
+    });
   });
 
   it("returns 400 on malformed body", async () => {
@@ -157,7 +173,13 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 when cloud_aws config is missing secretAccessKey", async () => {
+  it("returns 400 when cloud_aws config is missing secretAccessKey AND no existing ciphertext", async () => {
+    // Route now reads the microgrid row first to check for an existing
+    // ciphertext (#102 secret-preserve). When none exists, blank secret
+    // still yields 400.
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    registerFrom(billingPeriodsHandler([])); // not hit; left here for safety
+
     const { PUT } = await import("../route");
     const res = await PUT(
       makePutRequest({
@@ -387,6 +409,74 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe("zero_edges");
+  });
+
+  // AC-TEST-PRESERVE (#102): "Leave blank to keep the current secret"
+  it("preserve-secret: blank secretAccessKey + existing ciphertext → no re-encrypt, existing secret used for Discover", async () => {
+    registerFrom(
+      mgSelectHandler({
+        id: MG_ID,
+        name: MG_NAME,
+        ems_type: "cloud_aws",
+        // sentinel non-null bytea hex representation
+        ems_aws_secret_access_key_encrypted: "\\x01020304",
+      })
+    );
+    registerFrom(billingPeriodsHandler([]));
+    registerFrom(mgUpdateHandler(null)); // persist config (WITHOUT re-encrypt)
+    registerFrom(edgesSelectHandler([]));
+    registerFrom(mgUpdateHandler(null)); // health
+
+    getEdgesStatusMock.mockResolvedValue([
+      { edgeId: "edge0", online: true },
+    ]);
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "cloud_aws",
+        backendUrl: "https://lambda.example.com/",
+        region: "us-east-1",
+        accessKeyId: "AKIAEXAMPLEKEYID12345",
+        // NO secretAccessKey — preserve branch
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("success");
+
+    // Two RPC calls expected: fn_get_ems_secret (decrypt existing) and
+    // NO fn_ems_encrypt_secret (the preserve branch skips re-encryption).
+    const rpcCalls = mockRpc.mock.calls.map((c) => c[0]);
+    expect(rpcCalls).toContain("fn_get_ems_secret");
+    expect(rpcCalls).not.toContain("fn_ems_encrypt_secret");
+  });
+
+  it("preserve-secret: blank secretAccessKey + NO existing ciphertext → 400", async () => {
+    registerFrom(
+      mgSelectHandler({
+        id: MG_ID,
+        name: MG_NAME,
+        ems_type: null,
+        ems_aws_secret_access_key_encrypted: null,
+      })
+    );
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "cloud_aws",
+        backendUrl: "https://lambda.example.com/",
+        region: "us-east-1",
+        accessKeyId: "AKIAEXAMPLEKEYID12345",
+        // NO secretAccessKey
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("secretAccessKey");
   });
 });
 

--- a/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
@@ -45,6 +45,7 @@ const MG_NAME = "Kisakye";
 let mgRow: { id: string; name: string } | null = { id: MG_ID, name: MG_NAME };
 let periods: { id: string; status: "draft" | "closed" }[] = [];
 let canAccessMicrogridReturn = true;
+let isSuperAdminReturn = true;
 
 const mockFrom = vi.fn();
 const mockRpc = vi.fn();
@@ -69,6 +70,7 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/lib/auth/access", () => ({
   currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
 }));
 
 // Sequenced from() handlers — each test sets up the order of calls.
@@ -144,6 +146,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     fromCallIndex = 0;
     fromHandlers.length = 0;
     canAccessMicrogridReturn = true;
+    isSuperAdminReturn = true;
     mgRow = { id: MG_ID, name: MG_NAME };
     periods = [];
 
@@ -220,6 +223,25 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       { params: Promise.resolve({ id: MG_ID }) }
     );
     expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with super_admin message when org_manager calls PUT (Nit #1 security gate)", async () => {
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    // org_manager can access the microgrid but is not super_admin
+    canAccessMicrogridReturn = true;
+    isSuperAdminReturn = false;
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Only super admins can update OpenEMS backend config.");
   });
 
   it("Branch (a): draft exists → 409 with no write", async () => {

--- a/src/app/api/microgrids/[id]/openems-backend/discover/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/discover/__tests__/route.test.ts
@@ -31,6 +31,12 @@ vi.mock("@/lib/openems/config", () => ({
   getMicrogridEmsConfig: getMicrogridEmsConfigMock,
 }));
 
+let isSuperAdminReturn = true;
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
+}));
+
 const mockFrom = vi.fn();
 const mockGetUser = vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } });
 
@@ -61,6 +67,7 @@ describe("POST /api/microgrids/[id]/openems-backend/discover", () => {
     vi.clearAllMocks();
     handlers = [];
     index = 0;
+    isSuperAdminReturn = true;
     mockFrom.mockImplementation((table: string) => {
       const h = handlers[index++];
       if (!h) throw new Error(`unexpected from(${table}) #${index}`);
@@ -74,6 +81,18 @@ describe("POST /api/microgrids/[id]/openems-backend/discover", () => {
       params: Promise.resolve({ id: "not-a-uuid" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller is not super_admin (Nit #1 security gate)", async () => {
+    isSuperAdminReturn = false;
+
+    const { POST } = await import("../route");
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ id: MG_ID }),
+    });
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Only super admins can run OpenEMS backend discovery.");
   });
 
   it("returns 404 when microgrid is RLS-hidden or missing", async () => {

--- a/src/app/api/microgrids/[id]/openems-backend/discover/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/discover/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { currentUserIsSuperAdmin } from "@/lib/auth/access";
 import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { getMicrogridEmsConfig } from "@/lib/openems/config";
 
@@ -34,6 +35,17 @@ export async function POST(
   }
 
   const supabase = await createClient();
+
+  // Discover mutates ems_last_discover_* health fields and reads the decrypted
+  // secret (fn_get_ems_secret is SECURITY DEFINER, super_admin / service_role
+  // only). Gate here so org_managers cannot trigger a write or observe backend
+  // connectivity status indirectly through error messages.
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      { error: "Only super admins can run OpenEMS backend discovery." },
+      { status: 403 }
+    );
+  }
 
   let emsConfig;
   try {

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { currentUserCanAccessMicrogrid, currentUserIsSuperAdmin } from "@/lib/auth/access";
 import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import type { OpenEmsClientConfig } from "@/lib/openems";
 import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
@@ -162,6 +162,12 @@ export async function PUT(
   if (!(await currentUserCanAccessMicrogrid(supabase, microgridId))) {
     return NextResponse.json(
       { error: "You do not have permission to configure this microgrid." },
+      { status: 403 }
+    );
+  }
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      { error: "Only super admins can update OpenEMS backend config." },
       { status: 403 }
     );
   }

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -97,7 +97,11 @@ export async function PUT(
         ? body.secretAccessKey
         : undefined;
 
-    if (!region || !accessKeyId || !secretAccessKey) {
+    // Region + accessKeyId are always required for cloud_aws.
+    // secretAccessKey required-ness is deferred until after we know whether
+    // an existing ciphertext is preserved (#102 AC-SECRET-PRESERVE). We
+    // resolve that below after reading the microgrid row.
+    if (!region || !accessKeyId) {
       return NextResponse.json(
         {
           error:
@@ -111,11 +115,20 @@ export async function PUT(
   const supabase = await createClient();
 
   // Permission check — 404 on hidden/missing (don't leak existence).
+  // Also read the existing encrypted secret so we can support the
+  // "leave blank to keep the current secret" flow (#102 AC-SECRET-PRESERVE).
   const { data: mgRow, error: mgErr } = await supabase
     .from("microgrids")
-    .select("id, name")
+    .select(
+      "id, name, ems_type, ems_aws_secret_access_key_encrypted"
+    )
     .eq("id", microgridId)
-    .maybeSingle<{ id: string; name: string }>();
+    .maybeSingle<{
+      id: string;
+      name: string;
+      ems_type: "cloud_aws" | "direct_url" | null;
+      ems_aws_secret_access_key_encrypted: string | null;
+    }>();
 
   if (mgErr) {
     return NextResponse.json(
@@ -125,6 +138,26 @@ export async function PUT(
   }
   if (!mgRow) {
     return NextResponse.json({ error: "Microgrid not found." }, { status: 404 });
+  }
+
+  // Secret-preserve gate (cloud_aws only):
+  //   If user submitted blank secretAccessKey AND an existing ciphertext is on
+  //   record, we preserve the existing ciphertext. Otherwise (no ciphertext
+  //   AND blank) we require a secret.
+  const preserveExistingSecret =
+    type === "cloud_aws" &&
+    (!secretAccessKey || secretAccessKey.length === 0) &&
+    mgRow.ems_aws_secret_access_key_encrypted !== null &&
+    mgRow.ems_aws_secret_access_key_encrypted !== undefined;
+
+  if (type === "cloud_aws" && !secretAccessKey && !preserveExistingSecret) {
+    return NextResponse.json(
+      {
+        error:
+          "type='cloud_aws' requires region, accessKeyId, and secretAccessKey",
+      },
+      { status: 400 }
+    );
   }
   if (!(await currentUserCanAccessMicrogrid(supabase, microgridId))) {
     return NextResponse.json(
@@ -197,7 +230,7 @@ export async function PUT(
   // (the RPC is stateless). Discover runs in its own transaction below.
 
   let encryptedSecret: string | null = null;
-  if (type === "cloud_aws" && secretAccessKey) {
+  if (type === "cloud_aws" && secretAccessKey && !preserveExistingSecret) {
     const { data, error } = await supabase.rpc("fn_ems_encrypt_secret", {
       p_plaintext: secretAccessKey,
     });
@@ -212,14 +245,20 @@ export async function PUT(
     encryptedSecret = data as string;
   }
 
+  // Build the UPDATE payload. When preserving the secret we OMIT the
+  // ems_aws_secret_access_key_encrypted column entirely so the existing
+  // ciphertext is left untouched. Omitting the column also prevents a
+  // bytea round-trip encode/decode.
   const updatePayload: Record<string, unknown> = {
     ems_type: type,
     ems_backend_url: backendUrl.trim(),
     ems_aws_region: type === "cloud_aws" ? region : null,
     ems_aws_access_key_id: type === "cloud_aws" ? accessKeyId : null,
-    ems_aws_secret_access_key_encrypted:
-      type === "cloud_aws" ? encryptedSecret : null,
   };
+  if (!preserveExistingSecret) {
+    updatePayload.ems_aws_secret_access_key_encrypted =
+      type === "cloud_aws" ? encryptedSecret : null;
+  }
 
   const { error: updErr } = await supabase
     .from("microgrids")
@@ -252,6 +291,27 @@ export async function PUT(
   // We build the client from the body (not from getMicrogridEmsConfig) so the
   // Discover-after-Save round-trip doesn't depend on RLS for reading the
   // encrypted secret back. This is explicitly the "candidate config" path.
+  //
+  // When preserving the existing secret, decrypt it once via fn_get_ems_secret
+  // (SECURITY DEFINER; returns plaintext for super_admin / service_role).
+  let effectiveSecret: string | undefined = secretAccessKey;
+  if (type === "cloud_aws" && preserveExistingSecret) {
+    const { data: decrypted, error: decryptErr } = await supabase.rpc(
+      "fn_get_ems_secret",
+      { _microgrid_id: microgridId }
+    );
+    if (decryptErr || !decrypted) {
+      return NextResponse.json(
+        {
+          error:
+            "Could not retrieve the existing secret to test the connection. Re-enter the secret access key to proceed.",
+        },
+        { status: 500 }
+      );
+    }
+    effectiveSecret = decrypted as string;
+  }
+
   const candidateConfig: OpenEmsClientConfig =
     type === "cloud_aws"
       ? {
@@ -259,7 +319,7 @@ export async function PUT(
           url: backendUrl.trim(),
           region: region as string,
           accessKeyId: accessKeyId as string,
-          secretAccessKey: secretAccessKey as string,
+          secretAccessKey: effectiveSecret as string,
         }
       : { type: "direct_url", url: backendUrl.trim() };
 

--- a/src/components/format/local-date.tsx
+++ b/src/components/format/local-date.tsx
@@ -11,6 +11,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 import { useLocale } from "./locale-context";
+import { timeAgo } from "@/lib/time-ago";
 
 const cache = new Map<string, Intl.DateTimeFormat>();
 function getDF(locale: string, opts: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
@@ -27,6 +28,13 @@ export interface LocalDateProps extends React.HTMLAttributes<HTMLSpanElement> {
   value: Date | string;
   locale?: string;
   opts?: Intl.DateTimeFormatOptions;
+  /**
+   * Render the value as a relative time string ("2h ago") via `timeAgo()`
+   * instead of the absolute Intl.DateTimeFormat output. Added in #102 for
+   * the "Last successful discovery: <relative>" summary. Mutually
+   * exclusive with `opts` (ignored when `relative` is true).
+   */
+  relative?: boolean;
 }
 
 const DEFAULT_OPTS: Intl.DateTimeFormatOptions = {
@@ -35,13 +43,16 @@ const DEFAULT_OPTS: Intl.DateTimeFormatOptions = {
   day: "numeric",
 };
 
-export function LocalDate({ value, locale, opts, className, ...props }: LocalDateProps) {
+export function LocalDate({ value, locale, opts, relative, className, ...props }: LocalDateProps) {
   const ctx = useLocale();
   const lc = locale ?? ctx.locale;
   const d = value instanceof Date ? value : new Date(value);
+  const text = relative
+    ? timeAgo(d, lc)
+    : getDF(lc, opts ?? DEFAULT_OPTS).format(d);
   return (
     <span className={cn("font-mono tabular-nums", className)} {...props}>
-      {getDF(lc, opts ?? DEFAULT_OPTS).format(d)}
+      {text}
     </span>
   );
 }

--- a/src/components/ui/__tests__/status-chip.test.tsx
+++ b/src/components/ui/__tests__/status-chip.test.tsx
@@ -76,3 +76,68 @@ describe("StatusChip — deviceType kind", () => {
     );
   });
 });
+
+// #102 — OpenEMS Backend health chip (4 states).
+describe("StatusChip — openemsBackendHealth kind", () => {
+  it("renders 'healthy' with success background + dot", () => {
+    const { container } = render(
+      <StatusChip kind="openemsBackendHealth" status="healthy" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-success-muted");
+    // Dot is a first child span with bg-success (per Chip.tsx dotByTone).
+    expect(chip?.querySelector("span")?.className).toContain("bg-success");
+    expect(container.textContent).toContain("Healthy");
+  });
+
+  it("renders 'stale' with warn background + dot", () => {
+    const { container } = render(
+      <StatusChip kind="openemsBackendHealth" status="stale" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-warning-muted");
+    expect(chip?.querySelector("span")?.className).toContain("bg-warning");
+    expect(container.textContent).toContain("Stale");
+  });
+
+  it("renders 'failing' with alert background + dot", () => {
+    const { container } = render(
+      <StatusChip kind="openemsBackendHealth" status="failing" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-destructive-muted");
+    expect(chip?.querySelector("span")?.className).toContain("bg-destructive");
+    expect(container.textContent).toContain("Failing");
+  });
+
+  it("renders 'not_configured' with neutral background + NO dot", () => {
+    const { container } = render(
+      <StatusChip kind="openemsBackendHealth" status="not_configured" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-muted");
+    // No dot child → first child text node is the label, not a dot span.
+    // Asserting no span descendant with a bg-* dot class:
+    const dot = chip?.querySelector(
+      "span.bg-success, span.bg-warning, span.bg-destructive, span.bg-muted-foreground",
+    );
+    expect(dot).toBeNull();
+    expect(container.textContent).toContain("Not connected");
+  });
+
+  it("wraps the chip in a focusable tooltip trigger when `tooltip` is set", () => {
+    const { container } = render(
+      <StatusChip
+        kind="openemsBackendHealth"
+        status="healthy"
+        tooltip="Last successful discovery: 2h ago"
+      />,
+    );
+    // The outer wrapper span is tabIndex=0 (keyboard-focusable).
+    const wrapper = container.querySelector("span[tabindex='0']");
+    expect(wrapper).not.toBeNull();
+    // Chip is inside the wrapper.
+    const chip = wrapper?.querySelector("span");
+    expect(chip?.className).toContain("bg-success-muted");
+  });
+});

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -9,7 +9,9 @@
 // renders the right tone + label + dot + aria-label.
 
 import * as React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { Chip, type ChipProps } from "./chip";
+import { cn } from "@/lib/utils";
 
 type Kind =
   | "billingPeriod"
@@ -18,7 +20,8 @@ type Kind =
   | "deviceType"
   | "household"
   | "householdDeviceRole"
-  | "meterType";
+  | "meterType"
+  | "openemsBackendHealth";
 
 type StatusMap = Record<string, { label: string; tone: ChipProps["tone"]; dot?: boolean }>;
 
@@ -95,28 +98,51 @@ const MAPS: Record<Kind, StatusMap> = {
     PRODUCTION:  { label: "Production",  tone: "success" },
     UNKNOWN:     { label: "Unknown",     tone: "neutral" },
   },
+  // OpenEMS Backend per-microgrid health (#102).
+  //   healthy       — recent (< 24h) successful Discover.
+  //   stale         — last Discover ≥ 24h ago; user should run "Test again".
+  //   failing       — last Discover ended in auth_failed / unreachable /
+  //                   zero_edges / unknown_error.
+  //   not_configured — ems_type IS NULL; no Discover has run. NO dot (chip
+  //                   shouldn't imply any state, just absence).
+  openemsBackendHealth: {
+    healthy:        { label: "Healthy",       tone: "success", dot: true  },
+    stale:          { label: "Stale",         tone: "warn",    dot: true  },
+    failing:        { label: "Failing",       tone: "alert",   dot: true  },
+    not_configured: { label: "Not connected", tone: "neutral" /* no dot */ },
+  },
 };
 
 export interface StatusChipProps extends Omit<ChipProps, "tone" | "children" | "dot"> {
   kind: Kind;
   status: string;
+  /**
+   * Optional tooltip content. When supplied, the chip is wrapped in a
+   * Radix Tooltip (hover + keyboard focus). Added in #102 for the OpenEMS
+   * Backend health chip (tab-label chip) where the long explanation
+   * wouldn't fit inline. The summary-card health chip reads the info from
+   * its surrounding text so callers don't need to duplicate the copy.
+   */
+  tooltip?: React.ReactNode;
 }
 
-export function StatusChip({ kind, status, ...props }: StatusChipProps) {
+export function StatusChip({ kind, status, tooltip, ...props }: StatusChipProps) {
   const map = MAPS[kind];
   const entry = map[status];
-  if (!entry) {
+
+  const chip = !entry ? (
     // Unknown status — fail loudly in dev, fall back to neutral chip.
-    if (process.env.NODE_ENV !== "production") {
-      console.warn(`StatusChip: unknown status "${status}" for kind "${kind}".`);
-    }
-    return (
-      <Chip tone="neutral" aria-label={`${kind}: ${status}`} {...props}>
-        {status}
-      </Chip>
-    );
-  }
-  return (
+    (() => {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`StatusChip: unknown status "${status}" for kind "${kind}".`);
+      }
+      return (
+        <Chip tone="neutral" aria-label={`${kind}: ${status}`} {...props}>
+          {status}
+        </Chip>
+      );
+    })()
+  ) : (
     <Chip
       tone={entry.tone}
       dot={entry.dot}
@@ -125,5 +151,38 @@ export function StatusChip({ kind, status, ...props }: StatusChipProps) {
     >
       {entry.label}
     </Chip>
+  );
+
+  if (!tooltip) return chip;
+
+  // Wrap in Radix Tooltip. Caller is responsible for providing a
+  // TooltipProvider at or near the app root; we inline one here as a
+  // defensive default so single-use sites (the tab chip) don't need to
+  // refactor the layout tree. Radix Providers nest safely.
+  return (
+    <Tooltip.Provider delayDuration={200}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          {/* Wrap in a focusable span so keyboard users get the tooltip.
+              tabIndex=0 makes the chip focusable without turning it into
+              a button (preserves non-interactive semantics). */}
+          <span tabIndex={0} className="inline-flex cursor-default rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            {chip}
+          </span>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            sideOffset={6}
+            className={cn(
+              "z-50 max-w-xs rounded-md bg-foreground px-3 py-2 text-[12px] leading-snug text-background shadow-elev-2",
+              "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out"
+            )}
+          >
+            {tooltip}
+            <Tooltip.Arrow className="fill-foreground" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
   );
 }

--- a/src/lib/__tests__/time-ago.test.ts
+++ b/src/lib/__tests__/time-ago.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { timeAgo } from "../time-ago";
+
+// Stable anchor date for deterministic output.
+const NOW = new Date("2026-04-23T12:00:00.000Z").getTime();
+
+describe("timeAgo()", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function stubNow() {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  }
+
+  it("returns 'just now' under 60 seconds", () => {
+    stubNow();
+    expect(timeAgo(new Date(NOW - 10 * 1000))).toBe("just now");
+    expect(timeAgo(new Date(NOW - 59 * 1000))).toBe("just now");
+  });
+
+  it("formats minutes for 60s–1h (narrow style, past)", () => {
+    stubNow();
+    // 2 minutes ago → narrow format "2m ago" in en
+    const out = timeAgo(new Date(NOW - 2 * 60 * 1000));
+    expect(out).toMatch(/2\s?m/);
+    expect(out.toLowerCase()).toContain("ago");
+  });
+
+  it("formats hours for 1h–24h", () => {
+    stubNow();
+    const out = timeAgo(new Date(NOW - 3 * 3600 * 1000));
+    expect(out).toMatch(/3\s?h/);
+    expect(out.toLowerCase()).toContain("ago");
+  });
+
+  it("formats days for 1d–30d", () => {
+    stubNow();
+    const out = timeAgo(new Date(NOW - 5 * 86400 * 1000));
+    expect(out).toMatch(/5\s?d/);
+    expect(out.toLowerCase()).toContain("ago");
+  });
+
+  it("formats months for 30d–365d", () => {
+    stubNow();
+    // ~2 months
+    const out = timeAgo(new Date(NOW - 60 * 86400 * 1000));
+    expect(out.toLowerCase()).toContain("mo");
+  });
+
+  it("formats years past 365d", () => {
+    stubNow();
+    const out = timeAgo(new Date(NOW - 2 * 365 * 86400 * 1000));
+    // narrow en: "2y ago"
+    expect(out.toLowerCase()).toMatch(/\d\s?y/);
+    expect(out.toLowerCase()).toContain("ago");
+  });
+
+  it("accepts ISO string input", () => {
+    stubNow();
+    const out = timeAgo("2026-04-23T11:58:00.000Z"); // 2m ago
+    expect(out).toMatch(/2\s?m/);
+    expect(out.toLowerCase()).toContain("ago");
+  });
+
+  it("handles future dates", () => {
+    stubNow();
+    const out = timeAgo(new Date(NOW + 3 * 3600 * 1000));
+    // Intl.RelativeTimeFormat with numeric:"auto" will produce an "in"-style
+    // string for future units, e.g. "in 3 hr". We just assert it's not "ago".
+    expect(out.toLowerCase()).not.toContain("ago");
+  });
+});

--- a/src/lib/time-ago.ts
+++ b/src/lib/time-ago.ts
@@ -1,0 +1,67 @@
+// time-ago — locale-aware relative-time formatter.
+//
+// Contract:
+//   - Input: Date or string (ISO-8601 / RFC 2822 / YYYY-MM-DD) + optional locale.
+//   - Output: short relative-time string like "2h ago", "3d ago", "just now",
+//     or "in 5m" for future dates.
+//   - Implementation: Intl.RelativeTimeFormat (CLDR-backed). No date-fns.
+//   - Memoized per locale — RelativeTimeFormat construction is the expensive
+//     part; reuse the instance across calls.
+//
+// Thresholds (seconds → unit):
+//   < 60        → "just now"          (no unit plural)
+//   < 3600      → "Nm ago"            (minutes)
+//   < 86400     → "Nh ago"            (hours)
+//   < 2592000   → "Nd ago"            (days, ≤ 30)
+//   < 31536000  → "Nmo ago"           (months, ≤ 12)
+//   else        → "Ny ago"            (years)
+//
+// We pass `style: "narrow"` to RelativeTimeFormat which produces forms like
+// "2h ago" instead of "2 hours ago" — matches the designer brief.
+
+const cache = new Map<string, Intl.RelativeTimeFormat>();
+
+function getRTF(locale: string): Intl.RelativeTimeFormat {
+  let rtf = cache.get(locale);
+  if (!rtf) {
+    rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto", style: "narrow" });
+    cache.set(locale, rtf);
+  }
+  return rtf;
+}
+
+/**
+ * Returns a short relative-time string for the given date.
+ * Negative deltas (past) render as "Nunit ago"; positive (future) as
+ * "in Nunit" via `numeric: 'auto'`.
+ *
+ * `locale` defaults to "en" so callers inside server-only helpers (no
+ * LocaleContext) can rely on a deterministic output. UI callers pass the
+ * context locale explicitly.
+ */
+export function timeAgo(input: Date | string, locale: string = "en"): string {
+  const d = input instanceof Date ? input : new Date(input);
+  const now = Date.now();
+  const deltaSec = Math.round((d.getTime() - now) / 1000);
+  const abs = Math.abs(deltaSec);
+
+  if (abs < 60) {
+    return "just now";
+  }
+
+  const rtf = getRTF(locale);
+
+  if (abs < 3600) {
+    return rtf.format(Math.round(deltaSec / 60), "minute");
+  }
+  if (abs < 86400) {
+    return rtf.format(Math.round(deltaSec / 3600), "hour");
+  }
+  if (abs < 2592000) {
+    return rtf.format(Math.round(deltaSec / 86400), "day");
+  }
+  if (abs < 31536000) {
+    return rtf.format(Math.round(deltaSec / 2592000), "month");
+  }
+  return rtf.format(Math.round(deltaSec / 31536000), "year");
+}


### PR DESCRIPTION
## Summary
- New Setup sub-tab at `/microgrids/[id]/setup/openems-backend` with empty state (Cloud AWS / Direct URL segmented picker), configured summary (two-column card with masked secret, health chip, "Last successful discovery" timestamp), Reconfigure + Save & test, Test again, and closed-period typed-confirm via reused `<ConfirmDialog requireTypedConfirmation>` from #89.
- Mid-period draft guard via server-loader `draftPeriodsCount` (approach B, no new endpoint) — warning banner replaces form expansion when a draft period exists.
- **Secret-preserve on blank** — PUT handler at `route.ts:147-161` patched to skip re-encryption when an existing ciphertext is on record and the form field is blank. "Leave blank to keep the current secret" is now reachable.
- **Super_admin gate** on PUT + Discover routes (review fix). Previously `currentUserCanAccessMicrogrid` alone, which combined with the `microgrids` RLS policy let `org_manager` bypass the UI and rotate OpenEMS creds for their own org. Now returns 403 `{ error: "Only super admins can update OpenEMS backend config." }`.
- `StatusChip` extended with `openemsBackendHealth` kind + 4 statuses (healthy/stale/failing/not_configured) + optional `tooltip?` prop via `@radix-ui/react-tooltip` (hover + keyboard focus).
- `timeAgo()` helper + `<LocalDate relative>` opt-in prop using `Intl.RelativeTimeFormat`.
- 32 new test cases across route + shell + chip + helpers.

## Permission model
- **super_admin**: sees form, edits, submits PUT
- **org_manager**: sees read-only summary, info banner "Only super admins can update OpenEMS credentials", secret renders as `"—"` (not `••••XXXX`). Cannot trigger Reconfigure or Test again. Route-level 403 if they attempt direct PUT / Discover.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` — 578 passed, 0 failed (pre-existing HouseholdWizard parallel flake unrelated)
- [x] `npm run build`

## Known deferrals
- `setup/layout.tsx` fetches microgrid health on every sub-tab render — candidate for `unstable_cache` if it becomes hot
- RLS policy on `microgrids.ems_*` columns could be tightened to `is_super_admin()` for WRITE at the DB layer for defense-in-depth (today the route gate is the single enforcement point)

Closes #102.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)