### PR TITLE
Add Edge dialog (Discover → multi-select) + gate banner on Edges tab (#103)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/__tests__/edges-crud-shell.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/__tests__/edges-crud-shell.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+//
+// EdgesCRUDShell — add-button gating tests (#103).
+//
+// AddEdgeDialog is mocked so we don't need to stub fetch. The shell renders
+// the gating decision (button visible vs. null) based on emsType + isSuperAdmin.
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+// Sentinel: renders a marker span so we know when the dialog is open.
+vi.mock("@/components/forms/AddEdgeDialog", () => ({
+  AddEdgeDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-edge-dialog-open" /> : null,
+}));
+
+import { EdgesCRUDShell } from "../edges-crud-shell";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EdgesCRUDShell add-button gating", () => {
+  it("(a) renders + Add edge when ems_type is set AND user is super_admin", () => {
+    render(
+      <EdgesCRUDShell
+        mode="add-button"
+        microgridId="mg-1"
+        emsType="direct_url"
+        isSuperAdmin={true}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /\+ Add edge/ })).toBeTruthy();
+  });
+
+  it("(b) renders nothing when ems_type IS NULL (even for super_admin)", () => {
+    const { container } = render(
+      <EdgesCRUDShell
+        mode="add-button"
+        microgridId="mg-1"
+        emsType={null}
+        isSuperAdmin={true}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("(c) renders nothing for non-super-admin (even when ems_type is set)", () => {
+    const { container } = render(
+      <EdgesCRUDShell
+        mode="add-button"
+        microgridId="mg-1"
+        emsType="direct_url"
+        isSuperAdmin={false}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("(d) clicking the button opens the AddEdgeDialog", () => {
+    render(
+      <EdgesCRUDShell
+        mode="add-button"
+        microgridId="mg-1"
+        emsType="direct_url"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add edge/ }));
+    expect(screen.getByTestId("add-edge-dialog-open")).toBeTruthy();
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/edges-crud-shell.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/edges-crud-shell.tsx
@@ -7,8 +7,9 @@
  * into a thin client wrapper so the page's server component can remain async.
  *
  * Two modes:
- *   "add-button"      → renders the "+ Add edge" button (currently disabled,
- *                       pending the Discover-only Add Edge dialog in #103)
+ *   "add-button"      → renders the "+ Add edge" button (gated on ems_type +
+ *                       super_admin). Opens <AddEdgeDialog> on click.
+ *                       Renders nothing when either gate fails.
  *   "configure-button" → renders the "Configure…" link button for a specific edge row
  */
 
@@ -16,39 +17,54 @@ import * as React from "react";
 import { useRouter } from "next/navigation";
 import type { Edge } from "@/lib/types/domain";
 import { EdgeFormModal } from "@/components/forms/EdgeForm";
+import { AddEdgeDialog } from "@/components/forms/AddEdgeDialog";
 
 type AddButtonProps = {
   mode: "add-button";
   microgridId: string;
+  /** Microgrid's ems_type column. NULL means the backend is not configured yet. */
+  emsType: string | null;
+  /** Resolved server-side via currentUserIsSuperAdmin(). */
+  isSuperAdmin: boolean;
   edge?: never;
 };
 
 type ConfigureButtonProps = {
   mode: "configure-button";
   microgridId: string;
+  emsType?: never;
+  isSuperAdmin?: never;
   edge: Edge;
 };
 
 export type EdgesCRUDShellProps = AddButtonProps | ConfigureButtonProps;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- microgridId forwarded to AddEdgeDialog in #103
-export function EdgesCRUDShell({ mode, microgridId, edge }: EdgesCRUDShellProps) {
+export function EdgesCRUDShell(props: EdgesCRUDShellProps) {
   const router = useRouter();
   const [open, setOpen] = React.useState(false);
 
-  if (mode === "add-button") {
-    // TODO #103: Replace this stub with <AddEdgeDialog> once the Discover-only
-    // Add Edge dialog lands. The create branch was removed from EdgeFormModal in
-    // #104; this disabled button keeps the shell compilable until #103 ships.
+  if (props.mode === "add-button") {
+    const { microgridId, emsType, isSuperAdmin } = props;
+    // Both gates must pass. Non-super-admins would hit the Discover route's
+    // 403 gate (#102); not-yet-configured backends would 409. Prefer rendering
+    // nothing to a dead button.
+    if (emsType === null || !isSuperAdmin) return null;
+
     return (
-      <button
-        type="button"
-        disabled
-        title="Add Edge is moving to Discover-only (coming in #103)."
-        className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground opacity-50 cursor-not-allowed"
-      >
-        + Add edge
-      </button>
+      <>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          + Add edge
+        </button>
+        <AddEdgeDialog
+          microgridId={microgridId}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      </>
     );
   }
 
@@ -62,7 +78,7 @@ export function EdgesCRUDShell({ mode, microgridId, edge }: EdgesCRUDShellProps)
         Configure…
       </button>
       <EdgeFormModal
-        edge={edge}
+        edge={props.edge}
         open={open}
         onOpenChange={(next) => {
           setOpen(next);

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -49,15 +49,21 @@ vi.mock("./edge-row-actions", () => ({
   EdgeRowActions: () => null,
 }));
 
-// Stub currentUserCanAccessMicrogrid — always returns true for smoke tests.
+// Stub currentUserCanAccessMicrogrid + currentUserIsSuperAdmin — always
+// returns true for smoke tests.
 vi.mock("@/lib/auth/access", async () => {
   const actual = await vi.importActual<typeof import("@/lib/auth/access")>(
     "@/lib/auth/access",
   );
-  return { ...actual, currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true) };
+  return {
+    ...actual,
+    currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true),
+    currentUserIsSuperAdmin: vi.fn().mockResolvedValue(true),
+  };
 });
 
 import SetupEdgesPage from "./page";
+import * as accessModule from "@/lib/auth/access";
 
 function buildEdgesQuery(data: unknown) {
   return {
@@ -71,21 +77,48 @@ function buildEdgesQuery(data: unknown) {
   };
 }
 
+// Microgrid row fetch (ems_type) — .select().eq().maybeSingle() chain.
+function buildMicrogridRowQuery(emsType: string | null) {
+  return {
+    select: () => ({
+      eq: () => ({
+        maybeSingle: () =>
+          Promise.resolve({ data: { ems_type: emsType }, error: null }),
+      }),
+    }),
+  };
+}
+
+function mockFromDispatcher({
+  edges,
+  emsType = "direct_url",
+}: {
+  edges: unknown;
+  emsType?: string | null;
+}) {
+  return (table: string) => {
+    if (table === "microgrids") return buildMicrogridRowQuery(emsType);
+    return buildEdgesQuery(edges);
+  };
+}
+
 describe("SetupEdgesPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("renders edges with source chip and live online status", async () => {
-    mockFrom.mockImplementation(() =>
-      buildEdgesQuery([
-        {
-          id: "edge-1",
-          name: "Metering Pi",
-          openems_edge_id: "edge0",
-          role: "metering",
-        },
-      ]),
+    mockFrom.mockImplementation(
+      mockFromDispatcher({
+        edges: [
+          {
+            id: "edge-1",
+            name: "Metering Pi",
+            openems_edge_id: "edge0",
+            role: "metering",
+          },
+        ],
+      }),
     );
     getEdgesStatusMock.mockResolvedValue([{ edgeId: "edge0", online: true }]);
 
@@ -102,7 +135,7 @@ describe("SetupEdgesPage", () => {
   });
 
   it("renders the empty state when no edges exist", async () => {
-    mockFrom.mockImplementation(() => buildEdgesQuery([]));
+    mockFrom.mockImplementation(mockFromDispatcher({ edges: [] }));
     getEdgesStatusMock.mockResolvedValue([]);
 
     const jsx = await SetupEdgesPage({
@@ -114,15 +147,17 @@ describe("SetupEdgesPage", () => {
   });
 
   it("falls back to Unknown status when OpenEMS is unreachable", async () => {
-    mockFrom.mockImplementation(() =>
-      buildEdgesQuery([
-        {
-          id: "edge-1",
-          name: "Metering Pi",
-          openems_edge_id: "edge0",
-          role: null,
-        },
-      ]),
+    mockFrom.mockImplementation(
+      mockFromDispatcher({
+        edges: [
+          {
+            id: "edge-1",
+            name: "Metering Pi",
+            openems_edge_id: "edge0",
+            role: null,
+          },
+        ],
+      }),
     );
     getEdgesStatusMock.mockRejectedValue(new Error("network down"));
 
@@ -133,5 +168,59 @@ describe("SetupEdgesPage", () => {
 
     expect(html).toContain("Live edge status unavailable");
     expect(html).toContain("Unknown");
+  });
+
+  // ── Gate banner / button gating (#103) ──────────────────────────────────
+
+  it("shows the super_admin gate banner with a Go-to-Backend link when ems_type IS NULL", async () => {
+    mockFrom.mockImplementation(
+      mockFromDispatcher({ edges: [], emsType: null }),
+    );
+    getEdgesStatusMock.mockResolvedValue([]);
+
+    const jsx = await SetupEdgesPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("OpenEMS backend not configured");
+    expect(html).toContain("Configure the OpenEMS backend");
+    expect(html).toContain("Go to OpenEMS Backend");
+    expect(html).toContain("/microgrids/mg-1/setup/openems-backend");
+  });
+
+  it("shows the org_manager gate banner (no link) when ems_type IS NULL and user is not super_admin", async () => {
+    vi.mocked(accessModule.currentUserIsSuperAdmin).mockResolvedValueOnce(
+      false,
+    );
+    mockFrom.mockImplementation(
+      mockFromDispatcher({ edges: [], emsType: null }),
+    );
+    getEdgesStatusMock.mockResolvedValue([]);
+
+    const jsx = await SetupEdgesPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("OpenEMS backend not configured");
+    expect(html).toContain("Ask a super admin");
+    // org_manager banner should NOT carry the actionable link.
+    expect(html).not.toContain("Go to OpenEMS Backend");
+  });
+
+  it("omits the gate banner when ems_type is configured", async () => {
+    mockFrom.mockImplementation(
+      mockFromDispatcher({ edges: [], emsType: "direct_url" }),
+    );
+    getEdgesStatusMock.mockResolvedValue([]);
+
+    const jsx = await SetupEdgesPage({
+      params: Promise.resolve({ id: "mg-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).not.toContain("OpenEMS backend not configured");
+    expect(html).not.toContain("Ask a super admin");
   });
 });

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Edge } from "@/lib/types/domain";
 import { StatusChip } from "@/components/ui/status-chip";
 import { Chip } from "@/components/ui/chip";
+import { Banner } from "@/components/ui/banner";
 import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { getMicrogridEmsConfig } from "@/lib/openems/config";
 import type { OpenEmsClientConfig } from "@/lib/openems";
@@ -10,7 +11,10 @@ import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { EdgesCRUDShell } from "./edges-crud-shell";
 import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
-import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import {
+  currentUserCanAccessMicrogrid,
+  currentUserIsSuperAdmin,
+} from "@/lib/auth/access";
 import { EdgeRowActions } from "./edge-row-actions";
 
 // Setup > Edges (D2 / #53, #77).
@@ -62,11 +66,20 @@ export default async function SetupEdgesPage({
   const supabase = await createClient();
 
   const canManage = await currentUserCanAccessMicrogrid(supabase, id);
+  const isSuperAdmin = await currentUserIsSuperAdmin(supabase);
 
   const levels = await getHierarchyLevels(supabase, {
     kind: "edges-listing",
     microgridId: id,
   });
+
+  // Fetch ems_type for the gate banner + Add-button gating (#103).
+  const { data: mgRow } = await supabase
+    .from("microgrids")
+    .select("ems_type")
+    .eq("id", id)
+    .maybeSingle<{ ems_type: string | null }>();
+  const emsType: string | null = mgRow?.ems_type ?? null;
 
   const { data: edges, error } = await supabase
     .from("edges")
@@ -117,10 +130,40 @@ export default async function SetupEdgesPage({
           >
             View shared devices →
           </Link>
-          {/* Client shell handles the + Add Edge modal trigger */}
-          <EdgesCRUDShell microgridId={id} mode="add-button" />
+          {/* Client shell handles the + Add Edge modal trigger. Gated on
+              ems_type !== null && isSuperAdmin — see #103 AC-GATE-BUTTON. */}
+          <EdgesCRUDShell
+            microgridId={id}
+            mode="add-button"
+            emsType={emsType}
+            isSuperAdmin={isSuperAdmin}
+          />
         </div>
       </div>
+
+      {/* Gate banner when the OpenEMS Backend is not configured yet (#103). */}
+      {emsType === null &&
+        (isSuperAdmin ? (
+          <Banner
+            tone="warn"
+            title="OpenEMS backend not configured"
+            action={
+              <Link
+                href={`/microgrids/${id}/setup/openems-backend`}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                Go to OpenEMS Backend →
+              </Link>
+            }
+          >
+            Configure the OpenEMS backend for this microgrid before adding
+            edges.
+          </Banner>
+        ) : (
+          <Banner tone="warn" title="OpenEMS backend not configured">
+            Ask a super admin to configure the OpenEMS backend to add edges.
+          </Banner>
+        ))}
 
       {onlineError && (
         <div

--- a/src/components/forms/AddEdgeDialog.tsx
+++ b/src/components/forms/AddEdgeDialog.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+/**
+ * AddEdgeDialog — Discover-driven multi-select Add Edge flow (#103).
+ *
+ * Replaces the disabled `+ Add edge` stub in EdgesCRUDShell. On open, fires
+ * POST /api/microgrids/[id]/openems-backend/discover, then renders the
+ * returned edges in a checkbox list. On submit, POSTs the selected (non-
+ * already-linked) edges to /api/microgrids/[id]/edges/register.
+ *
+ * 5-state machine:
+ *   • discovering — spinner + muted copy; Cancel enabled; primary disabled.
+ *   • list        — scrollable checkbox rows; footer [Add selected (N)].
+ *   • empty       — centered muted copy; footer becomes [Close].
+ *   • error       — destructive block inside body with [Retry]; primary disabled.
+ *   • adding      — dialog locked (Esc/backdrop suppressed); primary shows
+ *                   spinner + "Adding…"; checkboxes + Cancel disabled.
+ *
+ * On register success: dialog closes; router.refresh() repaints the listing.
+ * On register error: stays open, shows inline destructive banner above the
+ * footer, re-enables inputs for retry.
+ *
+ * Role is deliberately NOT sent — the register route defaults it to NULL.
+ * User sets role later via Edit Edge (#104).
+ *
+ * See issue #103 "Pinned during refinement" for the full contract.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { SelectionDialog } from "@/components/ui/selection-dialog";
+import { StatusChip } from "@/components/ui/status-chip";
+import { Chip } from "@/components/ui/chip";
+import { cn } from "@/lib/utils";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+type DiscoveredEdge = {
+  openems_edge_id: string;
+  name: string;
+  /** Per Discover route response shape (#101). */
+  metadata: { online?: boolean } & Record<string, unknown>;
+  alreadyLinked: boolean;
+};
+
+type DiscoverResponse = {
+  status:
+    | "success"
+    | "auth_failed"
+    | "unreachable"
+    | "zero_edges"
+    | "unknown_error";
+  message?: string;
+  error?: string;
+  edges?: DiscoveredEdge[];
+};
+
+type DialogState =
+  | { kind: "discovering" }
+  | { kind: "list"; edges: DiscoveredEdge[] }
+  | { kind: "empty"; message: string }
+  | { kind: "error"; message: string }
+  | { kind: "adding"; edges: DiscoveredEdge[] };
+
+export interface AddEdgeDialogProps {
+  microgridId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function AddEdgeDialog({
+  microgridId,
+  open,
+  onOpenChange,
+}: AddEdgeDialogProps) {
+  const router = useRouter();
+  const [state, setState] = React.useState<DialogState>({ kind: "discovering" });
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [registerError, setRegisterError] = React.useState<string | null>(null);
+
+  const cancelRef = React.useRef<HTMLButtonElement>(null);
+  const primaryRef = React.useRef<HTMLButtonElement>(null);
+  const retryRef = React.useRef<HTMLButtonElement>(null);
+  const firstNewCheckboxRef = React.useRef<HTMLInputElement>(null);
+
+  // ── Discover ──────────────────────────────────────────────────────────
+  const runDiscover = React.useCallback(async () => {
+    setState({ kind: "discovering" });
+    setRegisterError(null);
+    try {
+      const res = await fetch(
+        `/api/microgrids/${microgridId}/openems-backend/discover`,
+        { method: "POST" },
+      );
+      let body: DiscoverResponse | null = null;
+      try {
+        body = (await res.json()) as DiscoverResponse;
+      } catch {
+        body = null;
+      }
+
+      if (!res.ok) {
+        const msg =
+          body?.error || body?.message || "Discover failed. Please retry.";
+        setState({ kind: "error", message: msg });
+        return;
+      }
+
+      if (!body) {
+        setState({ kind: "error", message: "Discover failed. Please retry." });
+        return;
+      }
+
+      if (body.status === "success" && (body.edges?.length ?? 0) > 0) {
+        // Pre-select already-linked rows so they show as "included" visually,
+        // even though we strip them from the submit payload.
+        const preSelected = new Set<string>();
+        for (const e of body.edges ?? []) {
+          if (e.alreadyLinked) preSelected.add(e.openems_edge_id);
+        }
+        setSelected(preSelected);
+        setState({ kind: "list", edges: body.edges ?? [] });
+        return;
+      }
+
+      if (body.status === "zero_edges") {
+        setState({
+          kind: "empty",
+          message:
+            body.message ||
+            "Connected, but no edges are registered on this backend yet. Register an edge in OpenEMS, then return here.",
+        });
+        return;
+      }
+
+      if (
+        body.status === "auth_failed" ||
+        body.status === "unreachable" ||
+        body.status === "unknown_error"
+      ) {
+        setState({
+          kind: "error",
+          message:
+            body.message || body.error || "Discover failed. Please retry.",
+        });
+        return;
+      }
+
+      // Fallback (e.g. success with zero edges, or unknown body shape).
+      setState({
+        kind: "empty",
+        message:
+          body.message ||
+          "Connected, but no edges are registered on this backend yet. Register an edge in OpenEMS, then return here.",
+      });
+    } catch {
+      setState({ kind: "error", message: "Discover failed. Please retry." });
+    }
+  }, [microgridId]);
+
+  // Fire Discover whenever the dialog opens. Reset state + selection on close.
+  React.useEffect(() => {
+    if (open) {
+      runDiscover();
+    } else {
+      setSelected(new Set());
+      setRegisterError(null);
+      setState({ kind: "discovering" });
+    }
+  }, [open, runDiscover]);
+
+  // ── Focus management ─────────────────────────────────────────────────
+  // Focus target per AC-A11Y-FOCUS:
+  //   discovering → Cancel
+  //   list        → first selectable (non-already-linked) checkbox
+  //   empty       → Close (rendered in primary slot)
+  //   error       → Retry button
+  //   adding      → primary button
+  React.useEffect(() => {
+    if (!open) return;
+    // Defer one tick so Radix's own onOpenAutoFocus has already run.
+    const id = window.setTimeout(() => {
+      if (state.kind === "discovering") {
+        cancelRef.current?.focus();
+      } else if (state.kind === "list") {
+        firstNewCheckboxRef.current?.focus();
+      } else if (state.kind === "empty") {
+        primaryRef.current?.focus();
+      } else if (state.kind === "error") {
+        retryRef.current?.focus();
+      } else if (state.kind === "adding") {
+        primaryRef.current?.focus();
+      }
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [open, state.kind]);
+
+  // ── Derived selection state ──────────────────────────────────────────
+  const edges = React.useMemo<DiscoveredEdge[]>(() => {
+    if (state.kind === "list" || state.kind === "adding") return state.edges;
+    return [];
+  }, [state]);
+
+  const newEdges = React.useMemo(
+    () => edges.filter((e) => !e.alreadyLinked),
+    [edges],
+  );
+
+  const newSelectedIds = React.useMemo(
+    () =>
+      newEdges.filter((e) => selected.has(e.openems_edge_id)).map(
+        (e) => e.openems_edge_id,
+      ),
+    [newEdges, selected],
+  );
+
+  const allNewSelected =
+    newEdges.length > 0 && newSelectedIds.length === newEdges.length;
+
+  // ── Handlers ─────────────────────────────────────────────────────────
+  function toggleOne(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAllNew() {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allNewSelected) {
+        for (const e of newEdges) next.delete(e.openems_edge_id);
+      } else {
+        for (const e of newEdges) next.add(e.openems_edge_id);
+      }
+      return next;
+    });
+  }
+
+  async function handleAdd() {
+    if (state.kind !== "list") return;
+    const payload = newEdges
+      .filter((e) => selected.has(e.openems_edge_id))
+      .map((e) => ({
+        openems_edge_id: e.openems_edge_id,
+        name: e.name,
+      }));
+    if (payload.length === 0) return;
+
+    setRegisterError(null);
+    setState({ kind: "adding", edges: state.edges });
+
+    try {
+      const res = await fetch(
+        `/api/microgrids/${microgridId}/edges/register`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ edges: payload }),
+        },
+      );
+      if (!res.ok) {
+        let message = "Registration failed. Please retry.";
+        try {
+          const body = (await res.json()) as { error?: string };
+          if (body?.error) message = body.error;
+        } catch {
+          // keep fallback
+        }
+        // Back to list state, surface error banner above footer.
+        setState({ kind: "list", edges });
+        setRegisterError(message);
+        return;
+      }
+      // Success — close + refresh.
+      onOpenChange(false);
+      router.refresh();
+    } catch {
+      setState({ kind: "list", edges });
+      setRegisterError("Registration failed. Please retry.");
+    }
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────
+  const adding = state.kind === "adding";
+  const newSelectedCount = newSelectedIds.length;
+
+  const body = (
+    <>
+      {state.kind === "discovering" && (
+        <div className="flex h-[240px] items-center justify-center">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Spinner />
+            Discovering edges on this backend…
+          </div>
+        </div>
+      )}
+
+      {state.kind === "empty" && (
+        <div className="flex h-[240px] items-center justify-center px-6 text-center">
+          <p className="text-sm text-muted-foreground">{state.message}</p>
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div className="py-6">
+          <div
+            role="alert"
+            className="rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg"
+          >
+            {state.message}
+          </div>
+          <div className="mt-3 flex justify-end">
+            <button
+              ref={retryRef}
+              type="button"
+              onClick={runDiscover}
+              className="inline-flex h-8 items-center rounded-md border border-border bg-card px-3.5 text-[13px] font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      {(state.kind === "list" || state.kind === "adding") && (
+        <div>
+          <div className="flex items-center justify-between py-2">
+            <p className="text-[12px] text-muted-foreground">
+              {edges.length} edge{edges.length === 1 ? "" : "s"} found
+            </p>
+            {newEdges.length > 0 && (
+              <button
+                type="button"
+                onClick={toggleAllNew}
+                disabled={adding}
+                className="text-[12px] font-medium text-primary hover:underline disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+              >
+                {allNewSelected ? "Deselect all new" : "Select all new"}
+              </button>
+            )}
+          </div>
+          <ul className="divide-y divide-border">
+            {edges.map((edge, idx) => {
+              const isFirstNew =
+                !edge.alreadyLinked &&
+                edges.findIndex((e) => !e.alreadyLinked) === idx;
+              const online = edge.metadata?.online === true;
+              const isChecked = selected.has(edge.openems_edge_id);
+              const idRowDescId = `edge-row-id-${edge.openems_edge_id}`;
+              return (
+                <li
+                  key={edge.openems_edge_id}
+                  className={cn(
+                    "border-b border-border last:border-b-0",
+                    edge.alreadyLinked && "opacity-70",
+                  )}
+                >
+                  <label
+                    className={cn(
+                      "flex items-start gap-3 px-2 py-3 hover:bg-muted",
+                      edge.alreadyLinked
+                        ? "cursor-not-allowed"
+                        : "cursor-pointer",
+                    )}
+                    title={
+                      edge.alreadyLinked
+                        ? "Already registered in this microgrid"
+                        : undefined
+                    }
+                  >
+                    <input
+                      ref={isFirstNew ? firstNewCheckboxRef : undefined}
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border-border text-primary focus-visible:ring-2 focus-visible:ring-ring"
+                      checked={edge.alreadyLinked ? true : isChecked}
+                      disabled={edge.alreadyLinked || adding}
+                      aria-disabled={edge.alreadyLinked ? "true" : undefined}
+                      aria-describedby={idRowDescId}
+                      onChange={() => toggleOne(edge.openems_edge_id)}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">
+                          {edge.name}
+                        </span>
+                        <StatusChip
+                          kind="edge"
+                          status={online ? "online" : "offline"}
+                        />
+                        {edge.alreadyLinked && (
+                          <Chip
+                            tone="neutral"
+                            aria-label="Already linked to this microgrid"
+                          >
+                            Already linked
+                          </Chip>
+                        )}
+                      </div>
+                      <p
+                        id={idRowDescId}
+                        className="mt-0.5 font-mono text-xs text-muted-foreground"
+                      >
+                        {edge.openems_edge_id}
+                      </p>
+                    </div>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+
+          {registerError && (
+            <div
+              role="alert"
+              className="mt-3 rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg"
+            >
+              {registerError}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+
+  // ── Footer ───────────────────────────────────────────────────────────
+  let footer: React.ReactNode = null;
+
+  if (state.kind === "empty") {
+    footer = (
+      <button
+        ref={primaryRef}
+        type="button"
+        onClick={() => onOpenChange(false)}
+        className="inline-flex h-8 items-center rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Close
+      </button>
+    );
+  } else if (state.kind === "error") {
+    footer = (
+      <button
+        ref={cancelRef}
+        type="button"
+        onClick={() => onOpenChange(false)}
+        className="inline-flex h-8 items-center rounded-md px-3.5 text-[13px] font-medium text-foreground hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Cancel
+      </button>
+    );
+  } else {
+    // discovering / list / adding
+    const primaryDisabled =
+      state.kind === "discovering" || newSelectedCount === 0 || adding;
+    footer = (
+      <>
+        <button
+          ref={cancelRef}
+          type="button"
+          onClick={() => onOpenChange(false)}
+          disabled={adding}
+          className="inline-flex h-8 items-center rounded-md px-3.5 text-[13px] font-medium text-foreground hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          Cancel
+        </button>
+        <button
+          ref={primaryRef}
+          type="button"
+          onClick={handleAdd}
+          disabled={primaryDisabled}
+          className="inline-flex h-8 items-center gap-2 rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {adding && <Spinner />}
+          {adding ? "Adding…" : `Add selected (${newSelectedCount})`}
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <SelectionDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && adding) return; // suppressed while submitting
+        onOpenChange(next);
+      }}
+      title="Add edges from OpenEMS"
+      locked={adding}
+      onOpenAutoFocus={(e) => {
+        // Prevent Radix default focus; the focus effect above handles it.
+        e.preventDefault();
+      }}
+      footer={footer}
+    >
+      {body}
+    </SelectionDialog>
+  );
+}
+
+// ── Spinner ──────────────────────────────────────────────────────────────
+
+function Spinner() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3.5 w-3.5 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+    </svg>
+  );
+}

--- a/src/components/forms/__tests__/AddEdgeDialog.test.tsx
+++ b/src/components/forms/__tests__/AddEdgeDialog.test.tsx
@@ -1,0 +1,422 @@
+// @vitest-environment jsdom
+//
+// AddEdgeDialog tests (#103).
+//
+// Strategy:
+//   - vi.stubGlobal("fetch", …) so each test controls Discover + register.
+//   - vi.mock("next/navigation") → stub useRouter.
+//   - Assert via the rendered list / buttons / fetch.mock.calls.
+//
+// Cases:
+//   (a) Discovering state renders spinner + disabled primary.
+//   (b) List state: rows rendered with checkboxes.
+//   (c) Already-linked rows: pre-checked + disabled + tooltip.
+//   (d) [Select all new] selects only non-already-linked rows.
+//   (e) Empty state: Close button + copy.
+//   (f) Error state: Retry button re-fires Discover.
+//   (g) Register payload omits already-linked rows and `role`.
+//   (h) Register error: destructive banner, primary re-enabled, dialog stays open.
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+  within,
+} from "@testing-library/react";
+
+// ── Mocks (hoisted) ──────────────────────────────────────────────────────
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh, push: vi.fn() }),
+}));
+
+// ── Import after mocks ───────────────────────────────────────────────────
+
+import { AddEdgeDialog } from "../AddEdgeDialog";
+
+// ── Fetch helpers ────────────────────────────────────────────────────────
+
+type FetchCall = { input: RequestInfo | URL; init?: RequestInit };
+
+function makeFetch(
+  handlers: Array<
+    (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> | Response
+  >,
+) {
+  const calls: FetchCall[] = [];
+  let idx = 0;
+  const fn = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input, init });
+      const handler = handlers[Math.min(idx, handlers.length - 1)];
+      idx += 1;
+      return handler(input, init);
+    },
+  );
+  vi.stubGlobal("fetch", fn);
+  return { fn, calls };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ── Fixture ──────────────────────────────────────────────────────────────
+
+const FIXTURE_EDGES = [
+  {
+    openems_edge_id: "edge0",
+    name: "edge0",
+    metadata: { online: true },
+    alreadyLinked: false,
+  },
+  {
+    openems_edge_id: "edge1",
+    name: "edge1",
+    metadata: { online: false },
+    alreadyLinked: true,
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AddEdgeDialog", () => {
+  it("(a) discovering state: renders spinner text + primary disabled", async () => {
+    // Fetch never resolves → stays in discovering.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Discovering edges/)).toBeTruthy();
+    });
+    const primary = screen.getByRole("button", { name: /Add selected/ });
+    expect((primary as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("(b) list state: rows render with checkboxes; live count updates", async () => {
+    makeFetch([async () => jsonResponse({ status: "success", edges: FIXTURE_EDGES })]);
+
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 edges found/)).toBeTruthy();
+    });
+
+    const primary = screen.getByRole("button", {
+      name: /Add selected/,
+    }) as HTMLButtonElement;
+    // Nothing selected (non-already-linked) yet.
+    expect(primary.textContent).toMatch(/\(0\)/);
+    expect(primary.disabled).toBe(true);
+
+    // Check the new edge.
+    const checkboxes = screen.getAllByRole("checkbox");
+    // edge0 (new) is first.
+    const newCheckbox = checkboxes[0] as HTMLInputElement;
+    fireEvent.click(newCheckbox);
+
+    await waitFor(() => {
+      const updated = screen.getByRole("button", {
+        name: /Add selected/,
+      }) as HTMLButtonElement;
+      expect(updated.textContent).toMatch(/\(1\)/);
+      expect(updated.disabled).toBe(false);
+    });
+  });
+
+  it("(c) already-linked rows: pre-checked + disabled + carry 'Already linked' chip", async () => {
+    makeFetch([async () => jsonResponse({ status: "success", edges: FIXTURE_EDGES })]);
+
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Already linked/i)).toBeTruthy();
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    // First is edge0 (new, unchecked); second is edge1 (already linked).
+    expect(checkboxes[1].checked).toBe(true);
+    expect(checkboxes[1].disabled).toBe(true);
+    expect(checkboxes[1].getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("(d) [Select all new] selects only non-already-linked rows", async () => {
+    makeFetch([
+      async () =>
+        jsonResponse({
+          status: "success",
+          edges: [
+            ...FIXTURE_EDGES,
+            {
+              openems_edge_id: "edge2",
+              name: "edge2",
+              metadata: { online: true },
+              alreadyLinked: false,
+            },
+          ],
+        }),
+    ]);
+
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const selectAll = await screen.findByRole("button", {
+      name: /Select all new/,
+    });
+    fireEvent.click(selectAll);
+
+    await waitFor(() => {
+      const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+      // edge0 (new) checked, edge1 (linked) still pre-checked, edge2 (new) checked.
+      expect(checkboxes[0].checked).toBe(true);
+      expect(checkboxes[1].checked).toBe(true);
+      expect(checkboxes[2].checked).toBe(true);
+    });
+
+    // Count = 2 (only non-already-linked).
+    const primary = screen.getByRole("button", {
+      name: /Add selected/,
+    }) as HTMLButtonElement;
+    expect(primary.textContent).toMatch(/\(2\)/);
+
+    // Button flips label to "Deselect all new".
+    expect(screen.getByRole("button", { name: /Deselect all new/ })).toBeTruthy();
+  });
+
+  it("(e) empty state: renders muted copy + Close button", async () => {
+    makeFetch([async () => jsonResponse({ status: "zero_edges", edges: [] })]);
+
+    const onOpenChange = vi.fn();
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/no edges are registered/i)).toBeTruthy();
+    });
+    const closeBtn = screen.getByRole("button", { name: /^Close$/ });
+    fireEvent.click(closeBtn);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("(f) error state: Retry re-fires Discover", async () => {
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        call += 1;
+        if (call === 1) {
+          return jsonResponse(
+            { status: "unreachable", message: "Could not reach OpenEMS" },
+            200,
+          );
+        }
+        return jsonResponse({ status: "success", edges: FIXTURE_EDGES });
+      }),
+    );
+
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const retry = await screen.findByRole("button", { name: /Retry/ });
+    fireEvent.click(retry);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 edges found/)).toBeTruthy();
+    });
+  });
+
+  it("(g) register payload omits already-linked rows and `role`", async () => {
+    const { fn } = makeFetch([
+      async () => jsonResponse({ status: "success", edges: FIXTURE_EDGES }),
+      async () => jsonResponse({ inserted: 1, updated: 0, edges: [] }),
+    ]);
+
+    const onOpenChange = vi.fn();
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    // Select edge0 (new).
+    const checkboxes = await screen.findAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
+
+    const addBtn = await screen.findByRole("button", { name: /Add selected \(1\)/ });
+    fireEvent.click(addBtn);
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    // Inspect register call (second call).
+    const registerCall = fn.mock.calls[1];
+    expect(String(registerCall[0])).toContain(
+      "/api/microgrids/mg-1/edges/register",
+    );
+    const init = registerCall[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.edges).toHaveLength(1);
+    expect(body.edges[0].openems_edge_id).toBe("edge0");
+    expect(body.edges[0].name).toBe("edge0");
+    expect("role" in body.edges[0]).toBe(false);
+  });
+
+  it("(h) register error: destructive banner shows; dialog stays open; primary re-enabled", async () => {
+    makeFetch([
+      async () => jsonResponse({ status: "success", edges: FIXTURE_EDGES }),
+      async () =>
+        jsonResponse(
+          { error: "You do not have permission to register edges on this microgrid." },
+          403,
+        ),
+    ]);
+
+    const onOpenChange = vi.fn();
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const checkboxes = await screen.findAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Add selected \(1\)/ }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/do not have permission to register edges/i),
+      ).toBeTruthy();
+    });
+
+    // Dialog should NOT have auto-closed.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    // Primary button is re-enabled and back to "Add selected (1)".
+    const primary = screen.getByRole("button", {
+      name: /Add selected \(1\)/,
+    }) as HTMLButtonElement;
+    expect(primary.disabled).toBe(false);
+  });
+
+  it("(i) adding state: dialog is locked (Escape does not close)", async () => {
+    makeFetch([
+      async () => jsonResponse({ status: "success", edges: FIXTURE_EDGES }),
+      // Register never resolves → stays in adding.
+      () => new Promise<Response>(() => {}),
+    ]);
+
+    const onOpenChange = vi.fn();
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const checkboxes = await screen.findAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Add selected \(1\)/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Adding/ })).toBeTruthy();
+    });
+
+    // Try to close via Escape — locked dialog should suppress it.
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    // Radix fires onOpenChange asynchronously; give it a tick.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("(j) list row exposes the openems_edge_id via aria-describedby on the checkbox", async () => {
+    makeFetch([async () => jsonResponse({ status: "success", edges: FIXTURE_EDGES })]);
+
+    render(
+      <AddEdgeDialog
+        microgridId="mg-1"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 edges found/)).toBeTruthy();
+    });
+    const dialog = screen.getByRole("dialog");
+    const firstCheckbox = within(dialog).getAllByRole("checkbox")[0];
+    const describedBy = firstCheckbox.getAttribute("aria-describedby");
+    expect(describedBy).toBe("edge-row-id-edge0");
+    expect(document.getElementById(describedBy!)?.textContent).toBe("edge0");
+  });
+});

--- a/src/components/ui/__tests__/selection-dialog.test.tsx
+++ b/src/components/ui/__tests__/selection-dialog.test.tsx
@@ -1,0 +1,169 @@
+// SelectionDialog primitive tests (#103).
+//
+// Coverage:
+//   (a) Renders title + body + footer when open=true.
+//   (b) Does NOT render when open=false.
+//   (c) role="dialog" (NOT alertdialog — selection is a task).
+//   (d) aria-labelledby wired to title; aria-describedby includes body id.
+//   (e) Unlocked: Esc fires onOpenChange(false).
+//   (f) locked=true: Esc does NOT fire onOpenChange.
+//   (g) Body region carries aria-live="polite".
+//   (h) onOpenAutoFocus override honored.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { SelectionDialog } from "../selection-dialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SelectionDialog", () => {
+  it("(a) renders title, body, and footer when open", () => {
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Add edges from OpenEMS"
+        footer={<button>Cancel</button>}
+      >
+        <div>Body content</div>
+      </SelectionDialog>,
+    );
+
+    expect(screen.getByText("Add edges from OpenEMS")).toBeTruthy();
+    expect(screen.getByText("Body content")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("(b) renders nothing when open=false", () => {
+    render(
+      <SelectionDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        title="Add edges from OpenEMS"
+        footer={<button>Cancel</button>}
+      >
+        <div data-testid="body">Body content</div>
+      </SelectionDialog>,
+    );
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("(c) uses role='dialog' (not 'alertdialog')", () => {
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Add edges from OpenEMS"
+        footer={<button>Cancel</button>}
+      >
+        <div>Body</div>
+      </SelectionDialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("(d) aria-labelledby wired to title; aria-describedby includes body id", () => {
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Add edges from OpenEMS"
+        description="Choose one or more edges to register."
+        footer={<button>Cancel</button>}
+      >
+        <div>Body</div>
+      </SelectionDialog>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const labelledById = dialog.getAttribute("aria-labelledby");
+    const describedByIds = dialog.getAttribute("aria-describedby") ?? "";
+
+    expect(labelledById).toBeTruthy();
+    expect(document.getElementById(labelledById!)?.textContent).toBe(
+      "Add edges from OpenEMS",
+    );
+    expect(describedByIds).toContain("selection-dialog-body");
+    expect(describedByIds).toContain("selection-dialog-desc");
+  });
+
+  it("(e) unlocked: Escape fires onOpenChange(false)", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Add edges"
+        footer={<button>Cancel</button>}
+      >
+        <div>Body</div>
+      </SelectionDialog>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("(f) locked=true: Escape does NOT fire onOpenChange", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Add edges"
+        locked={true}
+        footer={<button>Cancel</button>}
+      >
+        <div>Body</div>
+      </SelectionDialog>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("(g) body region carries aria-live='polite'", () => {
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Add edges"
+        footer={<button>Cancel</button>}
+      >
+        <div data-testid="inner">Body</div>
+      </SelectionDialog>,
+    );
+
+    const inner = screen.getByTestId("inner");
+    // The body wrapper owns the live region; walk up to find it.
+    const liveRegion = inner.closest("[aria-live]");
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("(h) onOpenAutoFocus override is invoked on open", async () => {
+    const handler = vi.fn((e: Event) => e.preventDefault());
+    render(
+      <SelectionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Add edges"
+        onOpenAutoFocus={handler}
+        footer={<button>Cancel</button>}
+      >
+        <div>Body</div>
+      </SelectionDialog>,
+    );
+
+    await waitFor(() => {
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/ui/selection-dialog.tsx
+++ b/src/components/ui/selection-dialog.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+// SelectionDialog — multi-row selection dialog primitive.
+//
+// Added in #103 for the Add Edge (Discover → multi-select) flow. Sibling to
+// <ConfirmDialog> (decision-shaped). Contract differences from ConfirmDialog:
+//   • role="dialog" (not alertdialog) — selection is a task, not an alert.
+//   • NO tone rail at the top.
+//   • NO cancel-first focus priority — callers own focus via onOpenAutoFocus
+//     or by focusing within `body` once mounted.
+//   • NO typed-confirmation input, NO single onConfirm promise — the caller
+//     owns the state machine (discovering / list / empty / error / adding)
+//     and composes body + footer slots.
+//   • Fixed body dimensions (min-h-[280px] max-h-[70vh] + 560px width) so
+//     the dialog does NOT resize across states. List content scrolls inside.
+//   • `locked` prop disables Esc + backdrop-click dismissal (used during
+//     the in-flight "adding" window to prevent mid-submit dismiss).
+//   • aria-describedby points at a body region with aria-live="polite" so
+//     state transitions are announced to screen readers.
+
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { cn } from "@/lib/utils";
+
+export interface SelectionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Short plain-string title announced to screen readers. */
+  title: string;
+  /** Optional short description; rendered under the title as muted text. */
+  description?: string;
+  /**
+   * When true, Esc and backdrop-click no longer dismiss the dialog. Used
+   * by AddEdgeDialog during the "adding" in-flight state so the user can't
+   * mid-submit dismiss.
+   */
+  locked?: boolean;
+  /** Body content — owns its own scrolling via min-h / max-h clamp. */
+  children: React.ReactNode;
+  /** Right-aligned footer. Caller supplies Cancel + primary action buttons. */
+  footer: React.ReactNode;
+  /**
+   * Optional override for the initial-focus target. When supplied, the
+   * supplied function runs inside Radix Dialog's onOpenAutoFocus; the
+   * caller is expected to call event.preventDefault() and focus whatever
+   * they want imperatively. (Default: Radix default focus behavior.)
+   */
+  onOpenAutoFocus?: (event: Event) => void;
+}
+
+// Stable ids for a11y wiring (aria-labelledby / aria-describedby).
+const TITLE_ID = "selection-dialog-title";
+const DESC_ID = "selection-dialog-desc";
+const BODY_ID = "selection-dialog-body";
+
+export function SelectionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  locked = false,
+  children,
+  footer,
+  onOpenAutoFocus,
+}: SelectionDialogProps) {
+  const describedByIds = [description ? DESC_ID : null, BODY_ID]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55 data-[state=open]:animate-in data-[state=closed]:animate-out" />
+        <Dialog.Content
+          role="dialog"
+          aria-modal
+          aria-labelledby={TITLE_ID}
+          aria-describedby={describedByIds || undefined}
+          onOpenAutoFocus={onOpenAutoFocus}
+          onEscapeKeyDown={(e) => {
+            if (locked) e.preventDefault();
+          }}
+          onPointerDownOutside={(e) => {
+            if (locked) e.preventDefault();
+          }}
+          onInteractOutside={(e) => {
+            if (locked) e.preventDefault();
+          }}
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[560px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+            "overflow-hidden rounded-md border border-border bg-card shadow-elev-3 outline-none",
+          )}
+        >
+          <div className="px-6 pb-2 pt-5">
+            <Dialog.Title
+              id={TITLE_ID}
+              className="text-lg font-semibold tracking-tight text-foreground"
+            >
+              {title}
+            </Dialog.Title>
+            {description && (
+              <Dialog.Description
+                id={DESC_ID}
+                className="mt-1 text-[13px] leading-relaxed text-muted-foreground"
+              >
+                {description}
+              </Dialog.Description>
+            )}
+          </div>
+
+          {/* Body — fixed dimensions, scrolls internally. aria-live="polite"
+              announces state transitions to screen readers (list → empty,
+              list → error, etc.). */}
+          <div
+            id={BODY_ID}
+            aria-live="polite"
+            className="min-h-[280px] max-h-[70vh] overflow-y-auto px-6 pb-2 text-[13px] leading-relaxed text-foreground"
+          >
+            {children}
+          </div>
+
+          <div className="mt-2 flex items-center justify-end gap-2 bg-muted px-6 pb-[18px] pt-[14px]">
+            {footer}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- New `<SelectionDialog>` primitive (`src/components/ui/selection-dialog.tsx`) — thin Radix Dialog wrapper for multi-row selection flows; sibling to `<ConfirmDialog>` (no tone rail, fixed 560×[280–70vh] body, `locked` prop suppresses Esc/backdrop during in-flight mutations).
- New `<AddEdgeDialog>` with 5-state machine (discovering / list / empty / error / adding). Discover response feeds a scrollable checkbox list; already-linked edges render pre-checked + disabled (context-only, never included in register payload). `router.refresh()` on success.
- Edges tab gates `+ Add edge`: hidden when `ems_type IS NULL` OR caller is not super_admin. Role-branched gate banner: super_admin sees warning + `[Go to OpenEMS Backend →]` link; org_manager sees "ask a super admin" copy without a dead link.
- Replaces the `TODO #103` stub button shipped in #104.
- Register payload excludes already-linked rows + omits `role` (Discover returns only `{online: boolean}` per edge — role is set later via Edit Edge).

## Permission model
- super_admin + `ems_type` configured → sees `+ Add edge` button, opens dialog
- super_admin + `ems_type IS NULL` → sees gate banner with link to OpenEMS Backend tab
- org_manager + any state → sees gate banner without link (can view edges but cannot add)

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (617/617 pass)
- [x] `npm run build`
- [ ] Manual: super_admin with configured backend discovers edges, multi-selects new ones, confirms already-linked rows are pre-checked + disabled, clicks Add selected, sees listing refresh with new edges
- [ ] Manual: super_admin with unconfigured backend sees banner + link; button absent
- [ ] Manual: org_manager sees banner without link in both states

## Non-blocking nits (deferred)
- `SelectionDialog` uses module-level IDs; switching to `React.useId()` would protect against future multi-instance mounting
- Discover fetch has no `AbortController` — rapid close/reopen could set state on stale response (low risk at current usage)
- Test file at 422 lines (spec guideline ~200); splittable in a future refactor

Closes #103. Completes the OpenEMS Backend workstream.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)