### PR TITLE
Add 'Known edge IDs' field to OpenEMS Backend tab (#112)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/openems-backend-shell.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/openems-backend-shell.test.tsx
@@ -152,6 +152,7 @@ const BASE_MG = {
   ems_backend_url: null,
   ems_aws_region: null,
   ems_aws_access_key_id: null,
+  ems_known_edge_ids: [] as string[],
   ems_last_discover_at: null,
   ems_last_discover_status: null,
   ems_last_discover_error: null,
@@ -165,6 +166,7 @@ const CONFIGURED_CLOUD = {
   ems_backend_url: "https://abc.lambda-url.us-east-1.on.aws/",
   ems_aws_region: "us-east-1",
   ems_aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+  ems_known_edge_ids: ["edge0", "edge1"],
   ems_last_discover_at: "2026-04-23T10:00:00Z",
   ems_last_discover_status: "success",
   ems_last_discover_error: null,
@@ -367,8 +369,8 @@ describe("OpenemsBackendShell — Save & test outcomes", () => {
     );
     await openForm();
     await submitForm();
-    // Success banner
-    expect(screen.getByText(/connected\. found 3 edges/i)).toBeDefined();
+    // Success banner — message comes from the server response
+    expect(screen.getByText(/connected\./i)).toBeDefined();
     // Advance past the 1500ms collapse timer
     await act(async () => {
       vi.advanceTimersByTime(1600);
@@ -402,7 +404,7 @@ describe("OpenemsBackendShell — Save & test outcomes", () => {
     );
     await openForm();
     await submitForm();
-    expect(screen.getByText(/zero edges discovered/i)).toBeDefined();
+    expect(screen.getByText(/no edges discovered/i)).toBeDefined();
     // Form still rendered
     expect(
       screen.getByRole("button", { name: /save & test connection/i })
@@ -545,5 +547,178 @@ describe("OpenemsBackendShell — secret preserve on blank (#102 AC-TEST-PRESERV
     const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
     expect(body.type).toBe("cloud_aws");
     expect("secretAccessKey" in body).toBe(false);
+  });
+});
+
+describe("OpenemsBackendShell — Known edge IDs (#112)", () => {
+  function mockFetch(response: {
+    ok?: boolean;
+    status?: number;
+    body: unknown;
+  }) {
+    const res = {
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      json: () => Promise.resolve(response.body),
+    } as unknown as Response;
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(res);
+  }
+
+  async function openForm() {
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+  }
+
+  async function submitForm() {
+    const btn = screen.getByRole("button", { name: /save & test connection/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it("Prefill case 1: empty-state (ems_type=null) → field initialized to 'edge0'", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={BASE_MG}
+        health="not_configured"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cloud \(aws\)/i }));
+    const field = screen.getByLabelText(/known edge ids/i) as HTMLInputElement;
+    expect(field.value).toBe("edge0");
+  });
+
+  it("Prefill case 2: reconfigure with populated list → field shows joined list", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    const field = screen.getByLabelText(/known edge ids/i) as HTMLInputElement;
+    expect(field.value).toBe("edge0, edge1");
+  });
+
+  it("Prefill case 3: reconfigure with deliberately empty list → field is empty string", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={{
+          ...CONFIGURED_CLOUD,
+          ems_known_edge_ids: [],
+        }}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    const field = screen.getByLabelText(/known edge ids/i) as HTMLInputElement;
+    expect(field.value).toBe("");
+  });
+
+  it("known_edge_ids is parsed and included in PUT payload as array", async () => {
+    const fetchSpy = mockFetch({
+      ok: true,
+      status: 200,
+      body: { status: "success", message: "Connected.", edgeCount: 2, edges: [] },
+    });
+
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    await openForm();
+
+    // Set edge IDs with extra whitespace and duplicates
+    const field = screen.getByLabelText(/known edge ids/i);
+    fireEvent.change(field, { target: { value: " edge0 , edge1 , edge0 " } });
+
+    await submitForm();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    // Trimmed, deduped
+    expect(body.known_edge_ids).toEqual(["edge0", "edge1"]);
+  });
+
+  it("invalid_edges 400 → destructive banner listing invalid IDs, form stays open", async () => {
+    mockFetch({
+      ok: false,
+      status: 400,
+      body: {
+        error: "Some edge IDs were not found on the backend. Remove or fix them before saving.",
+        invalid_edges: ["edgeX", "edgeY"],
+      },
+    });
+
+    render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    await openForm();
+    await submitForm();
+
+    // Destructive banner with "Edge IDs not found" title
+    expect(screen.getByRole("heading", { name: /edge ids not found/i })).toBeDefined();
+    // Lists the invalid IDs
+    expect(screen.getByText(/edgex, edgey/i)).toBeDefined();
+    // Form stays open
+    expect(screen.getByRole("button", { name: /save & test connection/i })).toBeDefined();
+  });
+
+  it("Configured-state summary card shows Edge IDs line", () => {
+    const { container } = render(
+      <OpenemsBackendShell
+        microgrid={CONFIGURED_CLOUD}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    expect(container.textContent).toContain("Edge IDs");
+    expect(container.textContent).toContain("edge0, edge1");
+  });
+
+  it("Configured-state summary card shows '—' when edge list is empty", () => {
+    const { container } = render(
+      <OpenemsBackendShell
+        microgrid={{ ...CONFIGURED_CLOUD, ems_known_edge_ids: [] }}
+        health="healthy"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4="3ACH"
+        isSuperAdmin={true}
+      />
+    );
+    expect(container.textContent).toContain("Edge IDs");
+    // The — character for empty
+    expect(container.textContent).toContain("—");
   });
 });

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
@@ -38,6 +38,7 @@ type MicrogridProps = {
   ems_backend_url: string | null;
   ems_aws_region: string | null;
   ems_aws_access_key_id: string | null;
+  ems_known_edge_ids: string[];
   ems_last_discover_at: string | null;
   ems_last_discover_status: string | null;
   ems_last_discover_error: string | null;
@@ -62,7 +63,8 @@ type SaveOutcome =
   | { kind: "unreachable"; message: string }
   | { kind: "unknown_error"; message: string }
   | { kind: "permission_denied"; message: string }
-  | { kind: "generic_error"; message: string };
+  | { kind: "generic_error"; message: string }
+  | { kind: "invalid_edges"; message: string; invalidEdges: string[] };
 
 const AWS_REGIONS = [
   "us-east-1",
@@ -109,6 +111,20 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
   );
   const [secretAccessKey, setSecretAccessKey] = React.useState<string>("");
 
+  // Known edge IDs input state.
+  // Prefill logic (3 cases, pinned in #112):
+  //   1. Empty-state form (new microgrid, ems_type == null) → "edge0"
+  //   2. Reconfigure form with a populated list → joined list (e.g. "edge0, edge1")
+  //   3. Reconfigure form with deliberately empty list (ems_type set, list=[]) → ""
+  //      Do NOT re-prefill "edge0" — the user deliberately saved an empty list.
+  const [knownEdgeIds, setKnownEdgeIds] = React.useState<string>(() => {
+    if (initialMode === "empty") return "edge0";
+    if (microgrid.ems_known_edge_ids.length > 0) {
+      return microgrid.ems_known_edge_ids.join(", ");
+    }
+    return "";
+  });
+
   // Mid-period guard banner visibility (derived from draftPeriodsCount +
   // "user clicked Reconfigure"). Distinct from the form-visible flag so
   // that dismissing the banner never opens the form; the user must click
@@ -142,6 +158,8 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
     setRegion(microgrid.ems_aws_region ?? "us-east-1");
     setAccessKeyId(microgrid.ems_aws_access_key_id ?? "");
     setSecretAccessKey("");
+    // Prefill known edge IDs from the saved list (case 2 + 3 above).
+    setKnownEdgeIds(microgrid.ems_known_edge_ids.join(", "));
     setIsEditing(true);
   }
 
@@ -157,14 +175,27 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
   // ── Build PUT payload from form state ──────────────────────────────────
   function buildPayload(): Record<string, unknown> | null {
     if (!formType) return null;
+
+    // Parse known_edge_ids: split on comma, trim, filter empties, dedupe.
+    const seenIds = new Set<string>();
+    const parsedEdgeIds: string[] = [];
+    for (const part of knownEdgeIds.split(",")) {
+      const trimmed = part.trim();
+      if (trimmed && !seenIds.has(trimmed)) {
+        seenIds.add(trimmed);
+        parsedEdgeIds.push(trimmed);
+      }
+    }
+
     if (formType === "direct_url") {
-      return { type: "direct_url", backendUrl };
+      return { type: "direct_url", backendUrl, known_edge_ids: parsedEdgeIds };
     }
     const base: Record<string, unknown> = {
       type: "cloud_aws",
       backendUrl,
       region,
       accessKeyId,
+      known_edge_ids: parsedEdgeIds,
     };
     // Only include secretAccessKey when the user actually typed one — an empty
     // string signals "preserve the existing secret" to the server (#102
@@ -215,6 +246,17 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
       }
 
       if (res.status === 400) {
+        // Check for invalid_edges rejection (step 5 validation in the PUT route).
+        if (Array.isArray(json.invalid_edges) && json.invalid_edges.length > 0) {
+          setOutcome({
+            kind: "invalid_edges",
+            message:
+              (typeof json.error === "string" ? json.error : "") ||
+              "Some edge IDs were not found on the backend.",
+            invalidEdges: json.invalid_edges as string[],
+          });
+          return;
+        }
         setOutcome({
           kind: "generic_error",
           message:
@@ -491,6 +533,16 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
                 </div>
               </>
             )}
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Edge IDs
+              </p>
+              <p className="mt-1 font-mono text-xs text-foreground">
+                {microgrid.ems_known_edge_ids.length > 0
+                  ? microgrid.ems_known_edge_ids.join(", ")
+                  : "—"}
+              </p>
+            </div>
           </div>
 
           {/* Right column */}
@@ -649,6 +701,26 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
         </div>
       )}
 
+      {/* Known edge IDs — shown for both connection types, below credentials (#112) */}
+      <div>
+        <label htmlFor="known-edge-ids" className="mb-1 block text-xs font-medium text-foreground">
+          Known edge IDs
+        </label>
+        <Input
+          id="known-edge-ids"
+          type="text"
+          value={knownEdgeIds}
+          onChange={(e) => setKnownEdgeIds(e.target.value)}
+          placeholder="edge0, edge1, edge2"
+          autoComplete="off"
+          spellCheck={false}
+          className="font-mono text-xs"
+        />
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Comma-separated edge IDs registered on this OpenEMS backend. You can find these in the OpenEMS Backend admin UI under Edges.
+        </p>
+      </div>
+
       {outcome && (
         <OutcomeBanner outcome={outcome} />
       )}
@@ -741,15 +813,22 @@ function OutcomeBanner({ outcome }: { outcome: SaveOutcome }) {
   if (outcome.kind === "success") {
     return (
       <Banner tone="success" title="Connected">
-        Connected. Found {outcome.edgeCount} edge
-        {outcome.edgeCount === 1 ? "" : "s"}.
+        {outcome.message || `Connected. ${outcome.edgeCount} edge${outcome.edgeCount === 1 ? "" : "s"} validated.`}
       </Banner>
     );
   }
   if (outcome.kind === "zero_edges") {
     return (
-      <Banner tone="warn" title="Zero edges discovered">
+      <Banner tone="warn" title="No edges discovered">
         {outcome.message || "The OpenEMS Backend returned zero edges."}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "invalid_edges") {
+    return (
+      <Banner tone="destructive" title="Edge IDs not found">
+        {outcome.message} Remove or fix:{" "}
+        <span className="font-mono">{outcome.invalidEdges.join(", ")}</span>
       </Banner>
     );
   }

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx
@@ -267,6 +267,35 @@ export function OpenemsBackendShell(props: OpenemsBackendShellProps) {
         return;
       }
 
+      if (res.status === 503) {
+        // Step 5 pre-save failure — config was NOT saved. Form stays open.
+        const reason =
+          typeof json.reason === "string" ? json.reason : "unknown_error";
+        if (reason === "auth_failed") {
+          setOutcome({
+            kind: "auth_failed",
+            message:
+              (typeof json.error === "string" ? json.error : "") ||
+              "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).",
+          });
+        } else if (reason === "unreachable") {
+          setOutcome({
+            kind: "unreachable",
+            message:
+              (typeof json.error === "string" ? json.error : "") ||
+              "Could not reach the OpenEMS Backend. Check the URL and that the host is reachable from Vercel.",
+          });
+        } else {
+          setOutcome({
+            kind: "unknown_error",
+            message:
+              (typeof json.error === "string" ? json.error : "") ||
+              "Edge validation failed with an unexpected error. Check server logs.",
+          });
+        }
+        return;
+      }
+
       if (!res.ok) {
         setOutcome({
           kind: "generic_error",

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/page.tsx
@@ -39,7 +39,7 @@ export default async function OpenemsBackendPage({
   const { data: mg, error: mgErr } = await supabase
     .from("microgrids")
     .select(
-      "id, name, ems_type, ems_backend_url, ems_aws_region, ems_aws_access_key_id, ems_last_discover_at, ems_last_discover_status, ems_last_discover_error, ems_last_discover_count"
+      "id, name, ems_type, ems_backend_url, ems_aws_region, ems_aws_access_key_id, ems_known_edge_ids, ems_last_discover_at, ems_last_discover_status, ems_last_discover_error, ems_last_discover_count"
     )
     .eq("id", id)
     .maybeSingle<{
@@ -49,6 +49,7 @@ export default async function OpenemsBackendPage({
       ems_backend_url: string | null;
       ems_aws_region: string | null;
       ems_aws_access_key_id: string | null;
+      ems_known_edge_ids: string[];
       ems_last_discover_at: string | null;
       ems_last_discover_status: string | null;
       ems_last_discover_error: string | null;
@@ -105,6 +106,7 @@ export default async function OpenemsBackendPage({
           ems_backend_url: mg.ems_backend_url,
           ems_aws_region: mg.ems_aws_region,
           ems_aws_access_key_id: mg.ems_aws_access_key_id,
+          ems_known_edge_ids: mg.ems_known_edge_ids ?? [],
           ems_last_discover_at: mg.ems_last_discover_at,
           ems_last_discover_status: mg.ems_last_discover_status,
           ems_last_discover_error: mg.ems_last_discover_error,

--- a/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
@@ -190,10 +190,41 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
         backendUrl: "https://lambda.example.com/",
         region: "us-east-1",
         accessKeyId: "AKIA",
+        known_edge_ids: [],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when known_edge_ids is not an array", async () => {
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        known_edge_ids: "edge0,edge1", // string, not array
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("known_edge_ids must be an array");
+  });
+
+  it("returns 400 when known_edge_ids is missing entirely", async () => {
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        // known_edge_ids intentionally omitted
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("known_edge_ids must be an array");
   });
 
   it("returns 404 when microgrid does not exist", async () => {
@@ -204,6 +235,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -219,6 +251,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -236,6 +269,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -255,6 +289,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -276,6 +311,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -301,6 +337,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0"],
         confirmed_name: MG_NAME,
       }),
       { params: Promise.resolve({ id: MG_ID }) }
@@ -320,6 +357,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [],
         confirmed_name: "WrongName",
       }),
       { params: Promise.resolve({ id: MG_ID }) }
@@ -346,6 +384,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0", "edge1"],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -359,11 +398,9 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     });
   });
 
-  it("auth_failed path: returns 200 + status='auth_failed'", async () => {
+  it("auth_failed path (step 5 edge validation): returns 200 + status='auth_failed'", async () => {
     registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
     registerFrom(billingPeriodsHandler([]));
-    registerFrom(mgUpdateHandler(null));
-    registerFrom(mgUpdateHandler(null)); // health update
 
     const { OpenEmsError } = await import("@/lib/openems");
     getEdgesStatusMock.mockRejectedValue(
@@ -378,6 +415,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
         region: "us-east-1",
         accessKeyId: "AKIAEXAMPLEKEYID12345",
         secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        known_edge_ids: ["edge0"],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -387,11 +425,9 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     expect(json.message).toContain("rotated access key");
   });
 
-  it("unreachable path: returns 200 + status='unreachable'", async () => {
+  it("unreachable path (step 5 edge validation): returns 200 + status='unreachable'", async () => {
     registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
     registerFrom(billingPeriodsHandler([]));
-    registerFrom(mgUpdateHandler(null));
-    registerFrom(mgUpdateHandler(null));
 
     const { OpenEmsError } = await import("@/lib/openems");
     getEdgesStatusMock.mockRejectedValue(
@@ -403,6 +439,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0"],
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
@@ -412,12 +449,13 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     expect(json.message).toContain("Could not reach");
   });
 
-  it("zero_edges path: returns 200 + status='zero_edges'", async () => {
+  it("zero_edges path: empty known_edge_ids → skip RPC, return zero_edges without calling getEdgesStatus", async () => {
     registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
     registerFrom(billingPeriodsHandler([]));
-    registerFrom(mgUpdateHandler(null));
-    registerFrom(mgUpdateHandler(null));
+    registerFrom(mgUpdateHandler(null)); // persist config
+    registerFrom(mgUpdateHandler(null)); // health update
 
+    // getEdgesStatus should NOT be called when known_edge_ids is empty
     getEdgesStatusMock.mockResolvedValue([]);
 
     const { PUT } = await import("../route");
@@ -425,12 +463,16 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       makePutRequest({
         type: "direct_url",
         backendUrl: "http://localhost:8075",
+        known_edge_ids: [], // empty list → skip RPC
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe("zero_edges");
+    expect(json.message).toContain("No edges declared yet");
+    // Verify getEdgesStatus was NOT called (empty list skips the round-trip)
+    expect(getEdgesStatusMock).not.toHaveBeenCalled();
   });
 
   // AC-TEST-PRESERVE (#102): "Leave blank to keep the current secret"
@@ -460,6 +502,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
         backendUrl: "https://lambda.example.com/",
         region: "us-east-1",
         accessKeyId: "AKIAEXAMPLEKEYID12345",
+        known_edge_ids: ["edge0"],
         // NO secretAccessKey — preserve branch
       }),
       { params: Promise.resolve({ id: MG_ID }) }
@@ -492,6 +535,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
         backendUrl: "https://lambda.example.com/",
         region: "us-east-1",
         accessKeyId: "AKIAEXAMPLEKEYID12345",
+        known_edge_ids: [],
         // NO secretAccessKey
       }),
       { params: Promise.resolve({ id: MG_ID }) }
@@ -499,6 +543,116 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toContain("secretAccessKey");
+  });
+
+  // AC-TEST-EDGE-IDS (#112): edge-ID validation tests
+  it("edge-ID validation: one invalid ID → 400 with invalid_edges, row NOT updated", async () => {
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    registerFrom(billingPeriodsHandler([]));
+
+    // Backend returns edge0 but NOT edgeX
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: "edge0", online: true }]);
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0", "edgeX"],
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("not found on the backend");
+    expect(json.invalid_edges).toEqual(["edgeX"]);
+    // No UPDATE should have been called — only mgSelect + billingPeriods
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  it("edge-ID validation: valid mix of online+offline → save succeeds", async () => {
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    registerFrom(billingPeriodsHandler([]));
+    registerFrom(mgUpdateHandler(null)); // persist
+    registerFrom(edgesSelectHandler([]));
+    registerFrom(mgUpdateHandler(null)); // health
+
+    // Both edge0 (online) and edge1 (offline) present in response
+    getEdgesStatusMock.mockResolvedValue([
+      { edgeId: "edge0", online: true },
+      { edgeId: "edge1", online: false },
+    ]);
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0", "edge1"],
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("success");
+    // Message mentions offline count
+    expect(json.message).toContain("offline");
+    expect(json.edges).toHaveLength(2);
+  });
+
+  it("edge-ID validation: all IDs invalid → 400, ems_type stays unchanged", async () => {
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    registerFrom(billingPeriodsHandler([]));
+
+    // Backend returns empty — all IDs unknown
+    getEdgesStatusMock.mockResolvedValue([]);
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edgeA", "edgeB"],
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.invalid_edges).toEqual(["edgeA", "edgeB"]);
+    // No DB write — only 2 from() calls (select + billingPeriods)
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  it("known_edge_ids_count appears in the success log payload (validates log hygiene)", async () => {
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    registerFrom(billingPeriodsHandler([]));
+    registerFrom(mgUpdateHandler(null));
+    registerFrom(edgesSelectHandler([]));
+    registerFrom(mgUpdateHandler(null));
+
+    getEdgesStatusMock.mockResolvedValue([
+      { edgeId: "edge0", online: true },
+    ]);
+
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { PUT } = await import("../route");
+    await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0"],
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+
+    const logCalls = infoSpy.mock.calls.map((c) => JSON.parse(c[0] as string));
+    const saveLog = logCalls.find(
+      (l) => l.event === "openems.save_and_test"
+    );
+    expect(saveLog).toBeDefined();
+    expect(saveLog.known_edge_ids_count).toBe(1);
+    infoSpy.mockRestore();
   });
 });
 

--- a/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
@@ -398,7 +398,7 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     });
   });
 
-  it("auth_failed path (step 5 edge validation): returns 200 + status='auth_failed'", async () => {
+  it("auth_failed path (step 5 edge validation): returns 503 + reason='auth_failed', persist NOT called", async () => {
     registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
     registerFrom(billingPeriodsHandler([]));
 
@@ -419,13 +419,15 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
     const json = await res.json();
-    expect(json.status).toBe("auth_failed");
-    expect(json.message).toContain("rotated access key");
+    expect(json.reason).toBe("auth_failed");
+    expect(json.error).toContain("rotated access key");
+    // No UPDATE should have been called — only mgSelect + billingPeriods (2 from() calls)
+    expect(mockFrom).toHaveBeenCalledTimes(2);
   });
 
-  it("unreachable path (step 5 edge validation): returns 200 + status='unreachable'", async () => {
+  it("unreachable path (step 5 edge validation): returns 503 + reason='unreachable', persist NOT called", async () => {
     registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
     registerFrom(billingPeriodsHandler([]));
 
@@ -443,10 +445,38 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       }),
       { params: Promise.resolve({ id: MG_ID }) }
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
     const json = await res.json();
-    expect(json.status).toBe("unreachable");
-    expect(json.message).toContain("Could not reach");
+    expect(json.reason).toBe("unreachable");
+    expect(json.error).toContain("Could not reach");
+    // No UPDATE should have been called — only mgSelect + billingPeriods (2 from() calls)
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  it("step 5 OPENEMS_AUTH_FAILED → 503 with { error, reason: 'auth_failed' }; persist NOT called", async () => {
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+    registerFrom(billingPeriodsHandler([]));
+
+    const { OpenEmsError } = await import("@/lib/openems");
+    getEdgesStatusMock.mockRejectedValue(
+      new OpenEmsError("auth failed", "OPENEMS_AUTH_FAILED", 401)
+    );
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        type: "direct_url",
+        backendUrl: "http://localhost:8075",
+        known_edge_ids: ["edge0"],
+      }),
+      { params: Promise.resolve({ id: MG_ID }) }
+    );
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json).toMatchObject({ reason: "auth_failed" });
+    expect(typeof json.error).toBe("string");
+    // Persist (microgrids UPDATE) must NOT have been called.
+    expect(mockFrom).toHaveBeenCalledTimes(2);
   });
 
   it("zero_edges path: empty known_edge_ids → skip RPC, return zero_edges without calling getEdgesStatus", async () => {

--- a/src/app/api/microgrids/[id]/openems-backend/discover/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/discover/__tests__/route.test.ts
@@ -134,13 +134,25 @@ describe("POST /api/microgrids/[id]/openems-backend/discover", () => {
     expect(json.error).toContain("OpenEMS Backend not configured");
   });
 
-  it("success path computes alreadyLinked via prefetched Set", async () => {
+  it("success path: reads ems_known_edge_ids, passes to getEdgesStatus, computes alreadyLinked", async () => {
     getMicrogridEmsConfigMock.mockResolvedValue({
       type: "direct_url",
       url: "http://localhost:8075",
     });
 
-    // 1st from call: prefetch existing edges.
+    // 1st from call: read ems_known_edge_ids (#112 separate query).
+    registerFrom(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: { ems_known_edge_ids: ["edge0", "edge1", "edge2"] },
+              error: null,
+            }),
+        }),
+      }),
+    }));
+    // 2nd from call: prefetch existing edges.
     registerFrom(() => ({
       select: () => ({
         eq: () =>
@@ -150,7 +162,7 @@ describe("POST /api/microgrids/[id]/openems-backend/discover", () => {
           }),
       }),
     }));
-    // 2nd from call: health update.
+    // 3rd from call: health update.
     registerFrom(() => ({
       update: () => ({
         eq: () => Promise.resolve({ error: null }),
@@ -181,6 +193,46 @@ describe("POST /api/microgrids/[id]/openems-backend/discover", () => {
       ).map((e) => [e.openems_edge_id, e.alreadyLinked])
     );
     expect(byId).toEqual({ edge0: true, edge1: false, edge2: true });
+
+    // Verify getEdgesStatus was called with the known IDs (NOT [])
+    expect(getEdgesStatusMock).toHaveBeenCalledWith(["edge0", "edge1", "edge2"]);
+  });
+
+  it("empty ems_known_edge_ids → zero_edges without calling getEdgesStatus", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue({
+      type: "direct_url",
+      url: "http://localhost:8075",
+    });
+
+    // 1st from call: read ems_known_edge_ids → empty array.
+    registerFrom(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: { ems_known_edge_ids: [] },
+              error: null,
+            }),
+        }),
+      }),
+    }));
+    // 2nd from call: health update.
+    registerFrom(() => ({
+      update: () => ({
+        eq: () => Promise.resolve({ error: null }),
+      }),
+    }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ id: MG_ID }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("zero_edges");
+    expect(json.message).toContain("No edges declared yet");
+    // getEdgesStatus must NOT be called
+    expect(getEdgesStatusMock).not.toHaveBeenCalled();
   });
 
   it("maps OPENEMS_UNREACHABLE to status='unreachable'", async () => {
@@ -188,7 +240,20 @@ describe("POST /api/microgrids/[id]/openems-backend/discover", () => {
       type: "direct_url",
       url: "http://localhost:8075",
     });
-    // single health-update call only (no edges prefetched since we throw first).
+
+    // 1st from call: read ems_known_edge_ids.
+    registerFrom(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: { ems_known_edge_ids: ["edge0"] },
+              error: null,
+            }),
+        }),
+      }),
+    }));
+    // 2nd from call: health-update call only (no edges prefetched since we throw first).
     registerFrom(() => ({
       update: () => ({
         eq: () => Promise.resolve({ error: null }),

--- a/src/app/api/microgrids/[id]/openems-backend/discover/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/discover/route.ts
@@ -88,7 +88,24 @@ export async function POST(
     );
   }
 
+  // Read ems_known_edge_ids via a separate query — deliberately not extending
+  // getMicrogridEmsConfig so that helper's responsibility stays scoped to
+  // "build a connection config". Catalog data is a separate concern (#112).
+  const { data: mgRow } = await supabase
+    .from("microgrids")
+    .select("ems_known_edge_ids")
+    .eq("id", microgridId)
+    .maybeSingle<{ ems_known_edge_ids: string[] }>();
+
+  const knownEdgeIds: string[] = mgRow?.ems_known_edge_ids ?? [];
+
   // Run Discover.
+  // Pass knownEdgeIds to getEdgesStatus instead of []. getEdgesStatus([])
+  // returns {} on real OpenEMS backends (verified 2026-04-23 against Kisakye);
+  // knownEdgeIds is the correct approach (#112).
+  //
+  // If knownEdgeIds is empty, skip the RPC and return zero_edges immediately
+  // (no edges declared yet — user must configure them via the OpenEMS Backend tab).
   let discoverStatus:
     | "success"
     | "auth_failed"
@@ -103,51 +120,57 @@ export async function POST(
     alreadyLinked: boolean;
   }> = [];
 
-  try {
-    const client = createOpenEmsClient(emsConfig);
-    const statuses = await client.getEdgesStatus([]);
+  if (knownEdgeIds.length === 0) {
+    discoverStatus = "zero_edges";
+    discoverMessage =
+      "No edges declared yet — add some in Reconfigure → Known edge IDs to enable the Add Edge flow.";
+  } else {
+    try {
+      const client = createOpenEmsClient(emsConfig);
+      const statuses = await client.getEdgesStatus(knownEdgeIds);
 
-    if (statuses.length === 0) {
-      discoverStatus = "zero_edges";
-      discoverMessage =
-        "Connected, but the OpenEMS Backend returned zero edges. Check that edges are registered under this backend.";
-    } else {
-      // N+1 avoidance: prefetch existing edge ids once.
-      const prefetched = new Set<string>();
-      const { data: existing } = await supabase
-        .from("edges")
-        .select("openems_edge_id")
-        .eq("microgrid_id", microgridId);
-      for (const e of existing ?? []) {
-        if (e.openems_edge_id) prefetched.add(e.openems_edge_id);
-      }
-
-      discoveredEdges = statuses.map((s) => ({
-        openems_edge_id: s.edgeId,
-        name: s.edgeId,
-        metadata: { online: s.online },
-        alreadyLinked: prefetched.has(s.edgeId),
-      }));
-      discoverMessage = `Connected. ${discoveredEdges.length} edge${discoveredEdges.length === 1 ? "" : "s"} discovered.`;
-    }
-  } catch (err) {
-    if (err instanceof OpenEmsError) {
-      if (err.code === "OPENEMS_AUTH_FAILED") {
-        discoverStatus = "auth_failed";
+      if (statuses.length === 0) {
+        discoverStatus = "zero_edges";
         discoverMessage =
-          "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).";
-      } else if (err.code === "OPENEMS_UNREACHABLE") {
-        discoverStatus = "unreachable";
-        discoverMessage = `Could not reach OpenEMS Backend at ${emsConfig.url}. Check the URL and that the host is reachable from Vercel.`;
+          "Connected, but the OpenEMS Backend returned zero edges. Check that edges are registered under this backend.";
+      } else {
+        // N+1 avoidance: prefetch existing edge ids once.
+        const prefetched = new Set<string>();
+        const { data: existing } = await supabase
+          .from("edges")
+          .select("openems_edge_id")
+          .eq("microgrid_id", microgridId);
+        for (const e of existing ?? []) {
+          if (e.openems_edge_id) prefetched.add(e.openems_edge_id);
+        }
+
+        discoveredEdges = statuses.map((s) => ({
+          openems_edge_id: s.edgeId,
+          name: s.edgeId,
+          metadata: { online: s.online },
+          alreadyLinked: prefetched.has(s.edgeId),
+        }));
+        discoverMessage = `Connected. ${discoveredEdges.length} edge${discoveredEdges.length === 1 ? "" : "s"} discovered.`;
+      }
+    } catch (err) {
+      if (err instanceof OpenEmsError) {
+        if (err.code === "OPENEMS_AUTH_FAILED") {
+          discoverStatus = "auth_failed";
+          discoverMessage =
+            "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).";
+        } else if (err.code === "OPENEMS_UNREACHABLE") {
+          discoverStatus = "unreachable";
+          discoverMessage = `Could not reach OpenEMS Backend at ${emsConfig.url}. Check the URL and that the host is reachable from Vercel.`;
+        } else {
+          discoverStatus = "unknown_error";
+          discoverMessage =
+            "Discover failed with an unexpected error. Check server logs.";
+        }
       } else {
         discoverStatus = "unknown_error";
         discoverMessage =
           "Discover failed with an unexpected error. Check server logs.";
       }
-    } else {
-      discoverStatus = "unknown_error";
-      discoverMessage =
-        "Discover failed with an unexpected error. Check server logs.";
     }
   }
 

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -14,25 +14,34 @@ const UUID_RE =
  * Body shape:
  *   { type: 'cloud_aws' | 'direct_url',
  *     backendUrl: string,
- *     region?, accessKeyId?, secretAccessKey?   // cloud_aws
- *     confirmed_name?: string                   // closed-period bypass
+ *     known_edge_ids: string[],                // edge IDs to validate (#112)
+ *     region?, accessKeyId?, secretAccessKey?  // cloud_aws only
+ *     confirmed_name?: string                  // closed-period bypass
  *   }
  *
- * Mandatory execution order (AC-ROUTE-1, amendments 2026-04-23):
+ * Mandatory execution order (AC-ROUTE-1, amendments 2026-04-23 + #112):
  *
  *   1. Validate body shape → 400 on malformed.
+ *      Accepts known_edge_ids as string[] (non-array → 400).
  *   2. Permission check via currentUserCanAccessMicrogrid. 404 if the
  *      microgrid is hidden/missing (don't leak existence with a 403).
- *   3. Mid-period lock — 3-branch decision tree:
+ *   3. Secret-preserve gate (cloud_aws): if secretAccessKey blank and an
+ *      existing ciphertext is on record, preserve it. Otherwise 400.
+ *   4. Mid-period lock — 3-branch decision tree:
  *        (a) draft exists            → hard 409
  *        (b) closed exists (no draft) → 409 with requires_typed_confirmation
  *                                       unless body.confirmed_name matches
  *        (c) no periods              → free pass
- *   4. Persist the config (first transaction). fn_ems_encrypt_secret encrypts
- *      the AWS secret key if supplied.
- *   5. Run Discover against the newly-saved config (second transaction;
- *      status fields updated regardless of success).
- *   6. Return { status, message, edgeCount?, edges? }.
+ *   5. Edge-ID validation (#112): if known_edge_ids is non-empty, build the
+ *      candidate OpenEmsClientConfig (using effectiveSecret already resolved
+ *      in step 3) and call getEdgesStatus(known_edge_ids). Any ID absent
+ *      from the response → 400 with invalid_edges. No DB write on failure.
+ *   6. Persist the config (first transaction). fn_ems_encrypt_secret encrypts
+ *      the AWS secret key if supplied. Saves ems_known_edge_ids.
+ *   7. Run Discover against the saved config (second transaction; status
+ *      fields updated regardless of success). Passes known_edge_ids to
+ *      getEdgesStatus instead of []; reuses statuses stashed in step 5.
+ *   8. Return { status, message, edgeCount?, edges? }.
  *
  * Error mapping (OpenEmsError):
  *   auth failure  → status='auth_failed'   message with rotated-key hint
@@ -82,6 +91,33 @@ export async function PUT(
       { error: "backendUrl is required" },
       { status: 400 }
     );
+  }
+
+  // Validate known_edge_ids — must be an array of strings.
+  // Server-side sanitize: trim, filter empties, dedupe (preserve first occurrence).
+  if (!Array.isArray(body.known_edge_ids)) {
+    return NextResponse.json(
+      { error: "known_edge_ids must be an array of strings" },
+      { status: 400 }
+    );
+  }
+  for (const el of body.known_edge_ids as unknown[]) {
+    if (typeof el !== "string") {
+      return NextResponse.json(
+        { error: "known_edge_ids must be an array of strings" },
+        { status: 400 }
+      );
+    }
+  }
+  const rawEdgeIds = body.known_edge_ids as string[];
+  const seenEdgeIds = new Set<string>();
+  const known_edge_ids: string[] = [];
+  for (const id of rawEdgeIds) {
+    const trimmed = id.trim();
+    if (trimmed && !seenEdgeIds.has(trimmed)) {
+      seenEdgeIds.add(trimmed);
+      known_edge_ids.push(trimmed);
+    }
   }
 
   let region: string | undefined;
@@ -229,7 +265,117 @@ export async function PUT(
 
   // Branch (c): no periods — fall through.
 
-  // ── Transaction 1: persist config ──────────────────────────────────────
+  // ── Steps 3b + 5 prep: resolve effectiveSecret early so step 5 can reuse ─
+  //
+  // We build the candidate OpenEmsClientConfig here (before the DB write) so
+  // step 5 (edge-ID validation) can use it without a second decrypt round-trip.
+  // effectiveSecret is also reused by step 7 (Discover after save).
+  let effectiveSecret: string | undefined = secretAccessKey;
+  if (type === "cloud_aws" && preserveExistingSecret) {
+    const { data: decrypted, error: decryptErr } = await supabase.rpc(
+      "fn_get_ems_secret",
+      { _microgrid_id: microgridId }
+    );
+    if (decryptErr || !decrypted) {
+      return NextResponse.json(
+        {
+          error:
+            "Could not retrieve the existing secret to test the connection. Re-enter the secret access key to proceed.",
+        },
+        { status: 500 }
+      );
+    }
+    effectiveSecret = decrypted as string;
+  }
+
+  const candidateConfig: OpenEmsClientConfig =
+    type === "cloud_aws"
+      ? {
+          type: "cloud_aws",
+          url: backendUrl.trim(),
+          region: region as string,
+          accessKeyId: accessKeyId as string,
+          secretAccessKey: effectiveSecret as string,
+        }
+      : { type: "direct_url", url: backendUrl.trim() };
+
+  // ── Step 5: Edge-ID validation (#112) ─────────────────────────────────────
+  //
+  // MUST run BEFORE the UPDATE (step 6) so invalid configs are never persisted.
+  // If known_edge_ids is empty, skip the round-trip (empty list is allowed).
+  // Stash statuses for step 7 reuse to avoid a second round-trip.
+  let step5Statuses: Array<{ edgeId: string; online: boolean }> | null = null;
+
+  if (known_edge_ids.length > 0) {
+    try {
+      const client = createOpenEmsClient(candidateConfig);
+      step5Statuses = await client.getEdgesStatus(known_edge_ids);
+      const foundIds = new Set(step5Statuses.map((s) => s.edgeId));
+      const invalidEdges = known_edge_ids.filter((id) => !foundIds.has(id));
+      if (invalidEdges.length > 0) {
+        const {
+          data: { user: actorUser },
+        } = await supabase.auth.getUser();
+        console.info(
+          JSON.stringify({
+            event: "openems.save.invalid_edges",
+            microgrid_id: microgridId,
+            actor_user_id: actorUser?.id ?? null,
+            invalid_edges: invalidEdges,
+            at: new Date().toISOString(),
+          })
+        );
+        return NextResponse.json(
+          {
+            error:
+              "Some edge IDs were not found on the backend. Remove or fix them before saving.",
+            invalid_edges: invalidEdges,
+          },
+          { status: 400 }
+        );
+      }
+    } catch (err) {
+      // Map OpenEmsError to the same outcome kinds as step 7 so the UI banner
+      // reuses existing handling. These are pre-save errors — nothing is persisted.
+      if (err instanceof OpenEmsError) {
+        if (err.code === "OPENEMS_AUTH_FAILED") {
+          return NextResponse.json(
+            {
+              status: "auth_failed",
+              message:
+                "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).",
+            },
+            { status: 200 }
+          );
+        } else if (err.code === "OPENEMS_UNREACHABLE") {
+          return NextResponse.json(
+            {
+              status: "unreachable",
+              message: `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`,
+            },
+            { status: 200 }
+          );
+        } else {
+          return NextResponse.json(
+            {
+              status: "unknown_error",
+              message: "Edge validation failed with an unexpected error. Check server logs.",
+            },
+            { status: 200 }
+          );
+        }
+      }
+      return NextResponse.json(
+        {
+          status: "unknown_error",
+          message: "Edge validation failed with an unexpected error. Check server logs.",
+        },
+        { status: 200 }
+      );
+    }
+  }
+
+  // ── Step 6: Transaction 1 — persist config ─────────────────────────────────
   //
   // We encrypt the AWS secret via a single RPC + a separate UPDATE. This is
   // two DB round-trips but only one committed transaction for the write
@@ -260,6 +406,7 @@ export async function PUT(
     ems_backend_url: backendUrl.trim(),
     ems_aws_region: type === "cloud_aws" ? region : null,
     ems_aws_access_key_id: type === "cloud_aws" ? accessKeyId : null,
+    ems_known_edge_ids: known_edge_ids,
   };
   if (!preserveExistingSecret) {
     updatePayload.ems_aws_secret_access_key_encrypted =
@@ -292,43 +439,17 @@ export async function PUT(
     );
   }
 
-  // ── Transaction 2: Discover — runs against the candidate config directly.
+  // ── Step 7: Transaction 2 — Discover ───────────────────────────────────────
   //
-  // We build the client from the body (not from getMicrogridEmsConfig) so the
-  // Discover-after-Save round-trip doesn't depend on RLS for reading the
-  // encrypted secret back. This is explicitly the "candidate config" path.
+  // Pass known_edge_ids to getEdgesStatus instead of []. getEdgesStatus([])
+  // returns {} on real OpenEMS backends (verified 2026-04-23 against Kisakye);
+  // the known_edge_ids approach is the correct fix (#112).
   //
-  // When preserving the existing secret, decrypt it once via fn_get_ems_secret
-  // (SECURITY DEFINER; returns plaintext for super_admin / service_role).
-  let effectiveSecret: string | undefined = secretAccessKey;
-  if (type === "cloud_aws" && preserveExistingSecret) {
-    const { data: decrypted, error: decryptErr } = await supabase.rpc(
-      "fn_get_ems_secret",
-      { _microgrid_id: microgridId }
-    );
-    if (decryptErr || !decrypted) {
-      return NextResponse.json(
-        {
-          error:
-            "Could not retrieve the existing secret to test the connection. Re-enter the secret access key to proceed.",
-        },
-        { status: 500 }
-      );
-    }
-    effectiveSecret = decrypted as string;
-  }
-
-  const candidateConfig: OpenEmsClientConfig =
-    type === "cloud_aws"
-      ? {
-          type: "cloud_aws",
-          url: backendUrl.trim(),
-          region: region as string,
-          accessKeyId: accessKeyId as string,
-          secretAccessKey: effectiveSecret as string,
-        }
-      : { type: "direct_url", url: backendUrl.trim() };
-
+  // When known_edge_ids is empty, skip the RPC and return zero_edges immediately
+  // (no edges declared yet — user must configure them via Reconfigure).
+  //
+  // If step 5 already fetched statuses (non-empty list path), reuse them to
+  // avoid a second round-trip to the backend.
   let discoverStatus:
     | "success"
     | "auth_failed"
@@ -343,61 +464,66 @@ export async function PUT(
     alreadyLinked: boolean;
   }> = [];
 
-  try {
-    const client = createOpenEmsClient(candidateConfig);
-    // We need all edges; the Backend exposes getEdgesStatus which returns
-    // a map keyed by edge id. For a candidate config we don't know edge IDs
-    // ahead of time — but the JSON-RPC `getEdgesStatus` needs the list of
-    // IDs. Convention on OpenEMS Backend: an empty list is invalid. So we
-    // use `edgeRpc → getEdges` via a side-channel in a follow-up. For
-    // pilot, we ask the Backend for its edges via `getEdges` RPC which is
-    // a documented Cloud extension. If it fails, we fall back to an empty
-    // list and surface zero_edges.
-    //
-    // For now we implement a minimal-viable Discover by invoking
-    // getEdgesStatus([]) which on many backends returns the full catalog.
-    // A proper getEdges method will land alongside #102 UI work.
-    const statuses = await client.getEdgesStatus([]);
-    if (statuses.length === 0) {
-      discoverStatus = "zero_edges";
-      discoverMessage =
-        "Connected, but the OpenEMS Backend returned zero edges. Check that edges are registered under this backend.";
-    } else {
-      const prefetched = new Set<string>();
-      const { data: existing } = await supabase
-        .from("edges")
-        .select("openems_edge_id")
-        .eq("microgrid_id", microgridId);
-      for (const e of existing ?? []) {
-        if (e.openems_edge_id) prefetched.add(e.openems_edge_id);
-      }
-
-      discoveredEdges = statuses.map((s) => ({
-        openems_edge_id: s.edgeId,
-        name: s.edgeId, // Backend doesn't return a display name here; UI may enrich later.
-        metadata: { online: s.online },
-        alreadyLinked: prefetched.has(s.edgeId),
-      }));
-      discoverMessage = `Connected. ${discoveredEdges.length} edge${discoveredEdges.length === 1 ? "" : "s"} discovered.`;
-    }
-  } catch (err) {
-    if (err instanceof OpenEmsError) {
-      if (err.code === "OPENEMS_AUTH_FAILED") {
-        discoverStatus = "auth_failed";
+  if (known_edge_ids.length === 0) {
+    // Empty list — skip the RPC; surface as zero_edges.
+    discoverStatus = "zero_edges";
+    discoverMessage =
+      "Saved. No edges declared yet — add some in Reconfigure → Known edge IDs to enable the Add Edge flow.";
+  } else {
+    try {
+      const client = createOpenEmsClient(candidateConfig);
+      // Reuse statuses from step 5 when available; otherwise re-fetch.
+      const statuses = step5Statuses ?? await client.getEdgesStatus(known_edge_ids);
+      if (statuses.length === 0) {
+        discoverStatus = "zero_edges";
         discoverMessage =
-          "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).";
-      } else if (err.code === "OPENEMS_UNREACHABLE") {
-        discoverStatus = "unreachable";
-        discoverMessage = `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`;
+          "Connected, but the OpenEMS Backend returned zero edges. Check that edges are registered under this backend.";
+      } else {
+        const prefetched = new Set<string>();
+        const { data: existing } = await supabase
+          .from("edges")
+          .select("openems_edge_id")
+          .eq("microgrid_id", microgridId);
+        for (const e of existing ?? []) {
+          if (e.openems_edge_id) prefetched.add(e.openems_edge_id);
+        }
+
+        discoveredEdges = statuses.map((s) => ({
+          openems_edge_id: s.edgeId,
+          name: s.edgeId, // Backend doesn't return a display name here; UI may enrich later.
+          metadata: { online: s.online },
+          alreadyLinked: prefetched.has(s.edgeId),
+        }));
+
+        const onlineCount = statuses.filter((s) => s.online).length;
+        const offlineCount = statuses.length - onlineCount;
+        const validatedCount = statuses.length;
+        const totalCount = known_edge_ids.length;
+        if (offlineCount > 0) {
+          discoverMessage = `Connected. ${validatedCount} of ${totalCount} edge${totalCount === 1 ? "" : "s"} validated — ${offlineCount} offline.`;
+        } else {
+          discoverMessage = `Connected. ${validatedCount} of ${totalCount} edge${totalCount === 1 ? "" : "s"} validated.`;
+        }
+      }
+    } catch (err) {
+      if (err instanceof OpenEmsError) {
+        if (err.code === "OPENEMS_AUTH_FAILED") {
+          discoverStatus = "auth_failed";
+          discoverMessage =
+            "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).";
+        } else if (err.code === "OPENEMS_UNREACHABLE") {
+          discoverStatus = "unreachable";
+          discoverMessage = `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`;
+        } else {
+          discoverStatus = "unknown_error";
+          discoverMessage =
+            "Discover failed with an unexpected error. Check server logs.";
+        }
       } else {
         discoverStatus = "unknown_error";
         discoverMessage =
           "Discover failed with an unexpected error. Check server logs.";
       }
-    } else {
-      discoverStatus = "unknown_error";
-      discoverMessage =
-        "Discover failed with an unexpected error. Check server logs.";
     }
   }
 
@@ -433,6 +559,7 @@ export async function PUT(
           microgrid_id: microgridId,
           actor_user_id: user?.id ?? null,
           ems_type: type,
+          known_edge_ids_count: known_edge_ids.length,
           result_status: discoverStatus,
           edge_count: discoveredEdges.length,
           duration_ms: Date.now() - startedAt,

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -335,42 +335,34 @@ export async function PUT(
         );
       }
     } catch (err) {
-      // Map OpenEmsError to the same outcome kinds as step 7 so the UI banner
-      // reuses existing handling. These are pre-save errors — nothing is persisted.
+      // Step 5 is a pre-save gate — nothing is persisted on OpenEmsError.
+      // Return 503 (not 200) so the client can distinguish pre-save failure
+      // from step 7's post-save health reporting (which stays 200).
       if (err instanceof OpenEmsError) {
+        let reason: "auth_failed" | "unreachable" | "unknown_error";
+        let errorMsg: string;
         if (err.code === "OPENEMS_AUTH_FAILED") {
-          return NextResponse.json(
-            {
-              status: "auth_failed",
-              message:
-                "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).",
-            },
-            { status: 200 }
-          );
+          reason = "auth_failed";
+          errorMsg =
+            "Authentication failed. Verify your AWS credentials and region (common cause: rotated access key).";
         } else if (err.code === "OPENEMS_UNREACHABLE") {
-          return NextResponse.json(
-            {
-              status: "unreachable",
-              message: `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`,
-            },
-            { status: 200 }
-          );
+          reason = "unreachable";
+          errorMsg = `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`;
         } else {
-          return NextResponse.json(
-            {
-              status: "unknown_error",
-              message: "Edge validation failed with an unexpected error. Check server logs.",
-            },
-            { status: 200 }
-          );
+          reason = "unknown_error";
+          errorMsg = "Edge validation failed with an unexpected error. Check server logs.";
         }
+        return NextResponse.json(
+          { error: errorMsg, reason },
+          { status: 503 }
+        );
       }
       return NextResponse.json(
         {
-          status: "unknown_error",
-          message: "Edge validation failed with an unexpected error. Check server logs.",
+          error: "Edge validation failed with an unexpected error. Check server logs.",
+          reason: "unknown_error",
         },
-        { status: 200 }
+        { status: 503 }
       );
     }
   }

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -443,6 +443,7 @@ export type Database = {
           ems_aws_region: string | null
           ems_aws_secret_access_key_encrypted: string | null
           ems_backend_url: string | null
+          ems_known_edge_ids: string[]
           ems_last_discover_at: string | null
           ems_last_discover_count: number | null
           ems_last_discover_error: string | null
@@ -467,6 +468,7 @@ export type Database = {
           ems_aws_region?: string | null
           ems_aws_secret_access_key_encrypted?: string | null
           ems_backend_url?: string | null
+          ems_known_edge_ids?: string[]
           ems_last_discover_at?: string | null
           ems_last_discover_count?: number | null
           ems_last_discover_error?: string | null
@@ -491,6 +493,7 @@ export type Database = {
           ems_aws_region?: string | null
           ems_aws_secret_access_key_encrypted?: string | null
           ems_backend_url?: string | null
+          ems_known_edge_ids?: string[]
           ems_last_discover_at?: string | null
           ems_last_discover_count?: number | null
           ems_last_discover_error?: string | null
@@ -744,6 +747,7 @@ export type Database = {
         }
         Returns: string
       }
+      fn_edge_ids_all_nonempty: { Args: { ids: string[] }; Returns: boolean }
       fn_ems_decrypt_secret: { Args: { p_ciphertext: string }; Returns: string }
       fn_ems_encrypt_secret: { Args: { p_plaintext: string }; Returns: string }
       fn_entity_delete_community: { Args: { p_id: string }; Returns: number }

--- a/supabase/migrations/00019_microgrids_known_edge_ids.sql
+++ b/supabase/migrations/00019_microgrids_known_edge_ids.sql
@@ -37,6 +37,9 @@ AS $$
     END;
 $$;
 
+GRANT EXECUTE ON FUNCTION fn_edge_ids_all_nonempty(TEXT[])
+  TO anon, authenticated, service_role;
+
 ALTER TABLE microgrids
   ADD CONSTRAINT microgrids_ems_known_edge_ids_nonempty_strings
   CHECK (fn_edge_ids_all_nonempty(ems_known_edge_ids));

--- a/supabase/migrations/00019_microgrids_known_edge_ids.sql
+++ b/supabase/migrations/00019_microgrids_known_edge_ids.sql
@@ -1,0 +1,42 @@
+-- Migration 00019: Add ems_known_edge_ids column to microgrids (#112)
+--
+-- Rationale: the B2B REST surface of OpenEMS does not expose a catalog-listing
+-- method — getEdgesStatus([]) returns {} on real backends. The super_admin
+-- knows their edge IDs from the OpenEMS setup script. We store them
+-- explicitly so Save & test can validate each via getEdgesStatus([...ids])
+-- and the Discover route can pass the persisted list instead of [].
+--
+-- NOT NULL DEFAULT '{}': the column always has a value; "not configured" is
+-- still signalled by ems_type IS NULL. No code path should key off
+-- ems_known_edge_ids IS NULL.
+--
+-- Idempotency: all statements are guarded with IF NOT EXISTS / DROP...IF EXISTS
+-- so re-running this migration is safe.
+
+ALTER TABLE microgrids
+  ADD COLUMN IF NOT EXISTS ems_known_edge_ids TEXT[] NOT NULL DEFAULT '{}';
+
+-- Named CHECK constraint: every element must be non-empty after trim.
+-- Pattern mirrors microgrids_ems_backend_url_required in migration 00018
+-- (lines 265-271).
+--
+-- Implementation note: PostgreSQL does not allow subqueries in CHECK
+-- constraints (PG error 0A000). We enforce the invariant via a helper
+-- function (IMMUTABLE, SECURITY INVOKER) instead.
+ALTER TABLE microgrids DROP CONSTRAINT IF EXISTS microgrids_ems_known_edge_ids_nonempty_strings;
+
+CREATE OR REPLACE FUNCTION fn_edge_ids_all_nonempty(ids TEXT[])
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT
+AS $$
+  SELECT
+    CASE WHEN cardinality(ids) = 0 THEN TRUE
+         ELSE '' != ALL(array(SELECT btrim(e) FROM unnest(ids) e))
+    END;
+$$;
+
+ALTER TABLE microgrids
+  ADD CONSTRAINT microgrids_ems_known_edge_ids_nonempty_strings
+  CHECK (fn_edge_ids_all_nonempty(ems_known_edge_ids));


### PR DESCRIPTION
## Summary

Fixes the *"Zero edges discovered"* state observed on `metering-billing-engine.vercel.app` on 2026-04-23. `getEdgesStatus([])` was assumed to return a catalog of all edges on the backend; verified against Kisakye's live stack, it returns `{}` — OpenEMS's B2B REST surface doesn't expose a catalog method. The super_admin now declares the edge IDs explicitly as part of the connection config, and Save & test validates each ID against the backend before persisting.

## Changes

- **Migration 00019**: new column `microgrids.ems_known_edge_ids TEXT[] NOT NULL DEFAULT '{}'`; CHECK constraint `microgrids_ems_known_edge_ids_nonempty_strings` via an immutable helper function `fn_edge_ids_all_nonempty()` (Postgres disallows subqueries in CHECK, so a helper is required). Helper is granted EXECUTE to anon/authenticated/service_role so CHECK evaluation succeeds under the invoker's role.
- **PUT route** adds a 7-step sequence with new step 5 = edge-ID validation via `getEdgesStatus(known_edge_ids)`. Invalid IDs → 400 `{error, invalid_edges: [...]}`, NO persist. Backend unreachable or auth failure during step 5 → **503 `{error, reason}`** so the client distinguishes pre-save failure from post-save health (post-save remains 200 with status field). Accepts offline edges; accepts empty list.
- **Discover route** reads `ems_known_edge_ids` separately and passes it to `getEdgesStatus(ids)` instead of `[]`. Empty list → empty response.
- **OpenEMS Backend tab**: new "Known edge IDs" input in empty + Reconfigure states. Prefills `edge0` for new microgrids; joins existing list on Reconfigure; leaves blank on deliberately-empty reconfig. Configured-state summary shows readonly `EDGE IDS: edge0, edge1`.
- **Log scrubber integration**: save log payload includes `known_edge_ids_count`; new `openems.save.invalid_edges` event on rejection.

## Review fixes included in this PR

- GRANT EXECUTE on `fn_edge_ids_all_nonempty` (missing grant would have failed at runtime for authenticated INSERT/UPDATE; tests running as service_role wouldn't catch it)
- Step 5 returns 503 on pre-save backend errors (was 200 before, which conflated pre-save failure with post-save health)

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` — 632/632 pass
- [x] `npm run build`
- [ ] Manual: super_admin reconfigures Kisakye with `edge0` → "Connected. 1 of 1 edges validated. edge0 online."
- [ ] Manual: Add Edge dialog shows edge0; register succeeds
- [ ] Apply migration 00019 to cloud with `supabase db push` or direct psql

Closes #112.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)