### PR TITLE
Restore device-discovery route for edge detail page (#114)

### DIFF
--- a/src/app/api/edges/[id]/discover-devices/__tests__/route.test.ts
+++ b/src/app/api/edges/[id]/discover-devices/__tests__/route.test.ts
@@ -1,0 +1,347 @@
+/**
+ * GET /api/edges/[id]/discover-devices — unit tests (#114).
+ *
+ * Covers:
+ *   (a) Happy path — super_admin, configured microgrid, edge online, 1 component → 200
+ *   (b) Dedup — existing devices row → alreadyAdded: true
+ *   (c) Bad UUID → 400
+ *   (d) Edge not found → 404
+ *   (e) Cross-microgrid edge (canAccessMicrogrid false) → 404
+ *   (f) org_manager caller → 403
+ *   (g) Microgrid unconfigured → 409 reason: "not_configured"
+ *   (h) OPENEMS_FORBIDDEN from config → 403 reason: "forbidden"
+ *   (i) getEdgesStatus throws OPENEMS_AUTH_FAILED → 503 reason: "auth_failed"
+ *   (j) getEdgesStatus throws OPENEMS_UNREACHABLE → 503 reason: "unreachable"
+ *   (k) getEdgeConfig throws (edge offline) → 200 online: false, devices: []
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const EDGE_DB_ID = "550e8400-e29b-41d4-a716-446655440001";
+const MICROGRID_ID = "550e8400-e29b-41d4-a716-446655440002";
+const OPENEMS_EDGE_ID = "edge0";
+
+// ─── Mock: openems client ───────────────────────────────────────────────────
+const getEdgesStatusMock = vi.fn();
+const getEdgeConfigMock = vi.fn();
+const getMicrogridEmsConfigMock = vi.fn();
+
+vi.mock("@/lib/openems", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/openems")>(
+    "@/lib/openems"
+  );
+  return {
+    ...actual,
+    createOpenEmsClient: () => ({
+      getEdgesStatus: getEdgesStatusMock,
+      getEdgeConfig: getEdgeConfigMock,
+    }),
+  };
+});
+
+vi.mock("@/lib/openems/config", () => ({
+  getMicrogridEmsConfig: getMicrogridEmsConfigMock,
+}));
+
+// ─── Mock: auth ─────────────────────────────────────────────────────────────
+let isSuperAdminReturn = true;
+let canAccessMicrogridReturn = true;
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
+  currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+}));
+
+// ─── Mock: supabase ──────────────────────────────────────────────────────────
+const mockFrom = vi.fn();
+const mockGetUser = vi
+  .fn()
+  .mockResolvedValue({ data: { user: { id: "actor-user-1" } } });
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** from() chain factories registered in call order. */
+let handlers: Array<(table: string) => unknown> = [];
+let callIndex = 0;
+
+function registerFrom(h: (table: string) => unknown) {
+  handlers.push(h);
+}
+
+function makeReq(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/edges/${EDGE_DB_ID}/discover-devices`,
+    { method: "GET" }
+  );
+}
+
+/** Healthy edge row returned by the first from("edges") call. */
+function registerEdgeLookup(found = true) {
+  registerFrom(() => ({
+    select: () => ({
+      eq: () => ({
+        maybeSingle: () =>
+          Promise.resolve({
+            data: found
+              ? {
+                  id: EDGE_DB_ID,
+                  microgrid_id: MICROGRID_ID,
+                  openems_edge_id: OPENEMS_EDGE_ID,
+                }
+              : null,
+            error: null,
+          }),
+      }),
+    }),
+  }));
+}
+
+/** Register the devices dedup query (second from() call after classification). */
+function registerDedupQuery(matchedComponentIds: string[] = []) {
+  registerFrom(() => ({
+    select: () => ({
+      eq: () => ({
+        in: () =>
+          Promise.resolve({
+            data: matchedComponentIds.map((id) => ({
+              openems_component_id: id,
+            })),
+            error: null,
+          }),
+      }),
+    }),
+  }));
+}
+
+/** A minimal valid EdgeConfig with one ElectricityMeter component. */
+const singleComponentConfig = {
+  components: {
+    meter0: {
+      alias: "Main Meter",
+      factoryId: "io.openems.impl.meter.consumption.ConsumptionMeter",
+      properties: {},
+    },
+  },
+  factories: {
+    "io.openems.impl.meter.consumption.ConsumptionMeter": {
+      natureIds: ["io.openems.edge.meter.api.ElectricityMeter"],
+    },
+  },
+};
+
+const defaultEmsConfig = { type: "direct_url" as const, url: "http://localhost:8075" };
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/edges/[id]/discover-devices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = [];
+    callIndex = 0;
+    isSuperAdminReturn = true;
+    canAccessMicrogridReturn = true;
+
+    mockFrom.mockImplementation((table: string) => {
+      const h = handlers[callIndex++];
+      if (!h) throw new Error(`unexpected from(${table}) call #${callIndex}`);
+      return h(table);
+    });
+  });
+
+  // (c) Bad UUID
+  it("(c) returns 400 on bad UUID", async () => {
+    const { GET } = await import("../route");
+    const req = new NextRequest(
+      "http://localhost/api/edges/not-a-uuid/discover-devices",
+      { method: "GET" }
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("UUID");
+  });
+
+  // (d) Edge not found
+  it("(d) returns 404 when edge row is missing / RLS-hidden", async () => {
+    registerEdgeLookup(false);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toContain("Edge not found");
+  });
+
+  // (e) Cross-microgrid edge → 404 (not 403, avoids existence leak)
+  it("(e) returns 404 when currentUserCanAccessMicrogrid is false", async () => {
+    canAccessMicrogridReturn = false;
+    registerEdgeLookup(true);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // (f) org_manager caller → 403
+  it("(f) returns 403 when caller is not super_admin", async () => {
+    isSuperAdminReturn = false;
+    registerEdgeLookup(true);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain("super admin");
+  });
+
+  // (g) Microgrid unconfigured → 409
+  it("(g) returns 409 when getMicrogridEmsConfig returns null (not configured)", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue(null);
+    registerEdgeLookup(true);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("not_configured");
+  });
+
+  // (h) OPENEMS_FORBIDDEN from config → 403
+  it("(h) returns 403 with reason 'forbidden' when getMicrogridEmsConfig throws OPENEMS_FORBIDDEN", async () => {
+    const { OpenEmsError } = await import("@/lib/openems");
+    getMicrogridEmsConfigMock.mockRejectedValue(
+      new OpenEmsError("Forbidden", "OPENEMS_FORBIDDEN", 403)
+    );
+    registerEdgeLookup(true);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.reason).toBe("forbidden");
+  });
+
+  // (i) getEdgesStatus throws OPENEMS_AUTH_FAILED → 503 reason: "auth_failed"
+  it("(i) returns 503 with reason 'auth_failed' when getEdgesStatus throws OPENEMS_AUTH_FAILED", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue(defaultEmsConfig);
+    registerEdgeLookup(true);
+
+    const { OpenEmsError } = await import("@/lib/openems");
+    getEdgesStatusMock.mockRejectedValue(
+      new OpenEmsError("Auth failed", "OPENEMS_AUTH_FAILED", 401)
+    );
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.reason).toBe("auth_failed");
+  });
+
+  // (j) getEdgesStatus throws OPENEMS_UNREACHABLE → 503 reason: "unreachable"
+  it("(j) returns 503 with reason 'unreachable' when getEdgesStatus throws OPENEMS_UNREACHABLE", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue(defaultEmsConfig);
+    registerEdgeLookup(true);
+
+    const { OpenEmsError } = await import("@/lib/openems");
+    getEdgesStatusMock.mockRejectedValue(
+      new OpenEmsError("Unreachable", "OPENEMS_UNREACHABLE", 503)
+    );
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.reason).toBe("unreachable");
+  });
+
+  // (k) getEdgeConfig throws (edge offline) → 200 with online:false, devices:[]
+  it("(k) returns 200 with online:false and empty devices when getEdgeConfig throws (edge offline)", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue(defaultEmsConfig);
+    registerEdgeLookup(true);
+
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: OPENEMS_EDGE_ID, online: false }]);
+    getEdgeConfigMock.mockRejectedValue(new Error("edge offline"));
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.online).toBe(false);
+    expect(json.devices).toHaveLength(0);
+    expect(json.edgeId).toBe(OPENEMS_EDGE_ID);
+  });
+
+  // (a) Happy path
+  it("(a) returns 200 with classified device and alreadyAdded:false", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue(defaultEmsConfig);
+    registerEdgeLookup(true);
+    // dedup query: no existing devices
+    registerDedupQuery([]);
+
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: OPENEMS_EDGE_ID, online: true }]);
+    getEdgeConfigMock.mockResolvedValue(singleComponentConfig);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.edgeId).toBe(OPENEMS_EDGE_ID);
+    expect(json.online).toBe(true);
+    expect(json.devices).toHaveLength(1);
+
+    const device = json.devices[0];
+    expect(device.componentId).toBe("meter0");
+    expect(device.suggestedDeviceType).toBe("consumption_meter");
+    expect(device.alreadyAdded).toBe(false);
+    expect(device.openemsChannelAddress).toBe("meter0/ActiveConsumptionEnergy");
+  });
+
+  // (b) Dedup: existing device → alreadyAdded: true
+  it("(b) marks alreadyAdded:true when a matching devices row exists", async () => {
+    getMicrogridEmsConfigMock.mockResolvedValue(defaultEmsConfig);
+    registerEdgeLookup(true);
+    // dedup query: meter0 already in devices table
+    registerDedupQuery(["meter0"]);
+
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: OPENEMS_EDGE_ID, online: true }]);
+    getEdgeConfigMock.mockResolvedValue(singleComponentConfig);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ id: EDGE_DB_ID }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.devices).toHaveLength(1);
+    expect(json.devices[0].alreadyAdded).toBe(true);
+  });
+});

--- a/src/app/api/edges/[id]/discover-devices/route.ts
+++ b/src/app/api/edges/[id]/discover-devices/route.ts
@@ -1,0 +1,299 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserIsSuperAdmin, currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import { getMicrogridEmsConfig } from "@/lib/openems/config";
+import { classifyDeviceType } from "@/lib/openems/classify";
+import { channelAddressFor } from "@/lib/openems/channel-address";
+import type { DiscoveredDevice, EdgeDiscoveryResponse } from "@/lib/openems/types";
+
+/**
+ * Nature IDs for device types supported by Discover.
+ * Expanded from ElectricityMeter-only to include Ess, Evcs, Inverter
+ * so battery / EV charger / inverter device types are discoverable.
+ */
+const SUPPORTED_NATURE_IDS = [
+  "io.openems.edge.meter.api.ElectricityMeter",
+  "io.openems.edge.ess.api.Ess",
+  "io.openems.edge.evcs.api.Evcs",
+  "io.openems.edge.inverter.api.Inverter",
+];
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * GET /api/edges/[id]/discover-devices
+ *
+ * Restored device-discovery route for the edge detail page (#114).
+ * Replaces the deleted /api/openems/discover?edgeId= route (#101).
+ *
+ * [id] is the edge DB UUID. The route resolves openems_edge_id + microgrid_id
+ * from the DB before calling the OpenEMS backend, so discovery is correctly
+ * scoped to the owning microgrid's configured adapter.
+ *
+ * Edge lookup precedes permission check (matches delete-preview/route.ts pattern)
+ * so a non-existent edge yields 404, not 403 — avoids existence leak.
+ *
+ * Error handling split:
+ *   - getEdgesStatus: not wrapped in catch — errors surface as 503
+ *   - getEdgeConfig: wrapped in .catch(() => null) — offline edge → 200 with
+ *     { online: false, devices: [] }, preserving the old route's lenient behavior
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const startedAt = Date.now();
+  const { id: edgeId } = await params;
+
+  if (!UUID_RE.test(edgeId)) {
+    return NextResponse.json(
+      { error: "Invalid edge id — expected UUID." },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Fetch the edge first so a missing edge yields 404, not 403.
+  // RLS on edges filters cross-org rows; a non-existent or RLS-hidden edge
+  // surfaces as null → 404, avoiding existence leaks for cross-microgrid access.
+  const { data: edge, error: edgeErr } = await supabase
+    .from("edges")
+    .select("id, microgrid_id, openems_edge_id")
+    .eq("id", edgeId)
+    .maybeSingle<{ id: string; microgrid_id: string; openems_edge_id: string }>();
+
+  if (edgeErr) {
+    return NextResponse.json(
+      { error: "Failed to look up edge." },
+      { status: 500 }
+    );
+  }
+  if (!edge) {
+    return NextResponse.json(
+      { error: "Edge not found." },
+      { status: 404 }
+    );
+  }
+
+  // Permission check after existence confirmed.
+  // currentUserCanAccessMicrogrid returns false if the user can't access the
+  // owning microgrid. Since RLS already hides cross-org edges, this primarily
+  // defends against race conditions and explicit cross-microgrid requests.
+  if (!(await currentUserCanAccessMicrogrid(supabase, edge.microgrid_id))) {
+    return NextResponse.json(
+      { error: "Edge not found." },
+      { status: 404 }
+    );
+  }
+
+  // Super-admin gate: getMicrogridEmsConfig throws OPENEMS_FORBIDDEN for
+  // org_managers on cloud_aws (fn_get_ems_secret returns NULL). Gate here
+  // explicitly so the caller gets a clean 403 rather than an opaque backend
+  // config error.
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      { error: "Only super admins can discover devices for this edge." },
+      { status: 403 }
+    );
+  }
+
+  // Resolve per-microgrid OpenEMS config.
+  let emsConfig;
+  try {
+    emsConfig = await getMicrogridEmsConfig(supabase, edge.microgrid_id);
+  } catch (err) {
+    if (err instanceof OpenEmsError) {
+      if (err.code === "OPENEMS_FORBIDDEN") {
+        return NextResponse.json(
+          { error: err.message, reason: "forbidden" },
+          { status: 403 }
+        );
+      }
+      return NextResponse.json(
+        { error: err.message, reason: "unknown_error" },
+        { status: 500 }
+      );
+    }
+    throw err;
+  }
+
+  if (!emsConfig) {
+    console.info(
+      JSON.stringify({
+        event: "openems.discover_devices",
+        microgrid_id: edge.microgrid_id,
+        edge_id: edgeId,
+        openems_edge_id: edge.openems_edge_id,
+        actor_user_id: null,
+        online: false,
+        status: "not_configured",
+        device_count: 0,
+        duration_ms: Date.now() - startedAt,
+        at: new Date().toISOString(),
+      })
+    );
+    return NextResponse.json(
+      {
+        error: "OpenEMS backend is not configured for this microgrid.",
+        reason: "not_configured",
+      },
+      { status: 409 }
+    );
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const openems = createOpenEmsClient(emsConfig);
+  const openemsEdgeId = edge.openems_edge_id;
+
+  let statuses: Array<{ edgeId: string; online: boolean }>;
+
+  // getEdgesStatus is NOT wrapped — auth failures and unreachable backend
+  // should surface as 503 with an actionable reason.
+  try {
+    statuses = await openems.getEdgesStatus([openemsEdgeId]);
+  } catch (err) {
+    let reason: "auth_failed" | "unreachable" | "forbidden" | "unknown_error" =
+      "unknown_error";
+    let message = "Discover failed with an unexpected error. Check server logs.";
+    let httpStatus = 503;
+
+    if (err instanceof OpenEmsError) {
+      if (err.code === "OPENEMS_AUTH_FAILED") {
+        reason = "auth_failed";
+        message = err.message;
+      } else if (err.code === "OPENEMS_UNREACHABLE") {
+        reason = "unreachable";
+        message = err.message;
+      } else if (err.code === "OPENEMS_FORBIDDEN") {
+        reason = "forbidden";
+        message = err.message;
+        httpStatus = 403;
+      } else {
+        reason = "unknown_error";
+        message = err.message;
+      }
+    }
+
+    console.info(
+      JSON.stringify({
+        event: "openems.discover_devices",
+        microgrid_id: edge.microgrid_id,
+        edge_id: edgeId,
+        openems_edge_id: openemsEdgeId,
+        actor_user_id: user?.id ?? null,
+        online: false,
+        status: reason,
+        device_count: 0,
+        duration_ms: Date.now() - startedAt,
+        at: new Date().toISOString(),
+      })
+    );
+
+    return NextResponse.json({ error: message, reason }, { status: httpStatus });
+  }
+
+  const online = statuses.find((s) => s.edgeId === openemsEdgeId)?.online ?? false;
+
+  // getEdgeConfig is lenient — an offline or misconfigured edge should not
+  // crash the discover flow. When null, we return an empty device list.
+  const config = await openems.getEdgeConfig(openemsEdgeId).catch(() => null);
+
+  if (!config) {
+    console.info(
+      JSON.stringify({
+        event: "openems.discover_devices",
+        microgrid_id: edge.microgrid_id,
+        edge_id: edgeId,
+        openems_edge_id: openemsEdgeId,
+        actor_user_id: user?.id ?? null,
+        online: false,
+        status: "edge_offline",
+        device_count: 0,
+        duration_ms: Date.now() - startedAt,
+        at: new Date().toISOString(),
+      })
+    );
+    const response: EdgeDiscoveryResponse = {
+      edgeId: openemsEdgeId,
+      online: false,
+      devices: [],
+    };
+    return NextResponse.json(response);
+  }
+
+  // Classify components whose factory exposes a supported nature.
+  const discovered: DiscoveredDevice[] = [];
+
+  for (const [componentId, component] of Object.entries(config.components)) {
+    const factory = config.factories[component.factoryId];
+    if (!factory) continue;
+
+    const matchedNature = factory.natureIds.find((n) =>
+      SUPPORTED_NATURE_IDS.includes(n)
+    );
+    if (!matchedNature) continue;
+
+    const suggestedDeviceType = classifyDeviceType(component.factoryId, matchedNature);
+    const openemsChannelAddress = channelAddressFor(componentId, suggestedDeviceType);
+
+    discovered.push({
+      componentId,
+      factoryId: component.factoryId,
+      alias: component.alias,
+      nature: matchedNature,
+      openemsChannelAddress,
+      suggestedDeviceType,
+      alreadyAdded: false, // filled in below after dedup check
+    });
+  }
+
+  // Dedup: query devices by (edge_id DB UUID, openems_component_id).
+  // Dedup key is (edge_id, openems_component_id) — UNIQUE constraint
+  // in 00001_schema.sql:144. No channel-address fallback.
+  if (discovered.length > 0) {
+    const { data: existingDevices } = await supabase
+      .from("devices")
+      .select("openems_component_id")
+      .eq("edge_id", edgeId)
+      .in(
+        "openems_component_id",
+        discovered.map((d) => d.componentId)
+      );
+
+    const existingComponentIds = new Set(
+      (existingDevices ?? []).map((d) => d.openems_component_id ?? "")
+    );
+
+    for (const device of discovered) {
+      device.alreadyAdded = existingComponentIds.has(device.componentId);
+    }
+  }
+
+  console.info(
+    JSON.stringify({
+      event: "openems.discover_devices",
+      microgrid_id: edge.microgrid_id,
+      edge_id: edgeId,
+      openems_edge_id: openemsEdgeId,
+      actor_user_id: user?.id ?? null,
+      online,
+      status: "success",
+      device_count: discovered.length,
+      duration_ms: Date.now() - startedAt,
+      at: new Date().toISOString(),
+    })
+  );
+
+  const response: EdgeDiscoveryResponse = {
+    edgeId: openemsEdgeId,
+    online,
+    devices: discovered,
+  };
+  return NextResponse.json(response);
+}

--- a/src/components/DiscoverDevices.tsx
+++ b/src/components/DiscoverDevices.tsx
@@ -5,7 +5,7 @@
  *
  * Rendered on the edge detail page (Setup > Edges > [edgeId]).
  * Responsible for:
- *   1. Triggering GET /api/openems/discover?edgeId=<openemsEdgeId>
+ *   1. Triggering GET /api/edges/<edgeDbId>/discover-devices
  *   2. Rendering each discovered component with:
  *      - factoryId (small) + alias (pre-filled name input)
  *      - suggestedDeviceType chip (StatusChip kind="deviceType")
@@ -55,6 +55,9 @@ type Props = {
   openemsEdgeId: string;
 };
 
+// openemsEdgeId is retained in the Props interface for future display use;
+// the discover fetch now uses edgeDbId directly.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
   const router = useRouter();
 
@@ -79,7 +82,7 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
 
     try {
       const res = await fetch(
-        `/api/openems/discover?edgeId=${encodeURIComponent(openemsEdgeId)}`
+        `/api/edges/${encodeURIComponent(edgeDbId)}/discover-devices`
       );
       const data = await res.json();
 
@@ -106,7 +109,7 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
       setDiscoverError("Could not reach the server. Check your network connection.");
       setPhase("idle");
     }
-  }, [openemsEdgeId]);
+  }, [edgeDbId]);
 
   const handleSave = useCallback(async () => {
     // Only save rows that are not already added and have a billable channel address.


### PR DESCRIPTION
## Summary
- Adds `GET /api/edges/[id]/discover-devices` to replace the `/api/openems/discover` route deleted by #101. Uses the edge's DB UUID (disambiguates across microgrids sharing the same `openems_edge_id`).
- Edge lookup BEFORE permission check — cross-microgrid access returns 404 to avoid existence leak.
- super_admin + `currentUserCanAccessMicrogrid` gate (device discovery uses decrypted AWS secret via `fn_get_ems_secret`).
- Error split: `getEdgesStatus` failures surface as 503 with `reason` (auth_failed / unreachable / unknown_error). `getEdgeConfig` wrapped in `.catch(() => null)` for lenient offline-edge behavior (200 with `online: false, devices: []`).
- Microgrid unconfigured → 409 `reason: "not_configured"`. Config `OPENEMS_FORBIDDEN` → 403.
- Classification + dedup logic lifted verbatim from git history (`afd22ff~1:src/app/api/openems/discover/route.ts`). Supported natures: `ElectricityMeter`, `Ess`, `Evcs`, `Inverter`.
- Response shape unchanged (`{ edgeId, online, devices[] }`) so `DiscoverDevices.tsx` UI works without UI reshaping.
- Client: `DiscoverDevices.tsx` fetch URL updated to new path-param route.
- 11-case route test + existing component test stays passing.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (643/643)
- [x] `npm run build` (route `/api/edges/[id]/discover-devices` appears in route table)
- [ ] Live: navigate to edge detail page → click "Discover devices" → devices populate + can be saved

Closes #114.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)