### PR TITLE
Let user pick which discovered devices to add (#122)

### DIFF
--- a/src/app/api/devices/__tests__/route.test.ts
+++ b/src/app/api/devices/__tests__/route.test.ts
@@ -129,4 +129,35 @@ describe("POST /api/devices", () => {
       expect.objectContaining({ onConflict: "edge_id,openems_component_id" })
     );
   });
+
+  // (f) openemsChannelAddress: null is accepted — non-billable devices registered for observability
+  it("(f) returns 200 when openemsChannelAddress is null (non-billable device)", async () => {
+    const savedRow = {
+      id: "device-uuid-2",
+      name: "Main Battery",
+      device_type: "battery",
+      openems_component_id: "ess0",
+    };
+
+    mockSelect.mockResolvedValueOnce({ data: [savedRow], error: null });
+
+    const { POST } = await import("../route");
+    const req = makeRequest({
+      edgeId: VALID_UUID,
+      devices: [
+        {
+          componentId: "ess0",
+          factoryId: "io.openems.edge.ess.generic.ManagedSymmetricEss",
+          openemsChannelAddress: null,
+          deviceType: "battery",
+          name: "Main Battery",
+        },
+      ],
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ saved: [savedRow] });
+  });
 });

--- a/src/components/DiscoverDevices.tsx
+++ b/src/components/DiscoverDevices.tsx
@@ -6,13 +6,17 @@
  * Rendered on the edge detail page (Setup > Edges > [edgeId]).
  * Responsible for:
  *   1. Triggering GET /api/edges/<edgeDbId>/discover-devices
- *   2. Rendering each discovered component with:
- *      - factoryId (small) + alias (pre-filled name input)
+ *   2. Rendering each discovered component in a unified list with:
+ *      - per-row checkbox (already-added rows: pre-checked + disabled)
+ *      - factoryId (small) + alias (pre-filled name input) for selectable rows
  *      - suggestedDeviceType chip (StatusChip kind="deviceType")
- *      - device_type dropdown (shadcn Select, overridable)
- *      - inline help card below dropdown (from DEVICE_TYPE_HELP)
+ *      - device_type dropdown (shadcn Select, overridable) for selectable rows
+ *      - inline help card below dropdown (from DEVICE_TYPE_HELP) for selectable rows
+ *      - observability-only note for rows with openemsChannelAddress === null
  *      - alreadyAdded → disabled row + "Already added" chip
  *   3. POSTing selected rows to /api/devices (server-side transactional upsert)
+ *      Selected rows with openemsChannelAddress: null are saved for observability
+ *      (no billing channel) — previously these were silently excluded.
  *
  * DeviceManager.tsx is NOT modified — this is a separate component that renders
  * alongside the existing device list on the edge detail page.
@@ -69,6 +73,10 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
   // Per-row editable state (name + deviceType override)
   const [rowState, setRowState] = useState<Record<string, RowState>>({});
 
+  // Per-row selection state (keyed by componentId, true = selected)
+  // Already-added rows are always excluded from this state (their checkbox is disabled).
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+
   // Which row's help card is open (keyed by componentId)
   const [openHelp, setOpenHelp] = useState<string | null>(null);
 
@@ -78,6 +86,7 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
     setSaveError(null);
     setDevices([]);
     setRowState({});
+    setSelected({});
     setOpenHelp(null);
 
     try {
@@ -95,15 +104,21 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
       const discovered: DiscoveredDevice[] = data.devices ?? [];
       setDevices(discovered);
 
-      // Initialise editable row state from discovery results
+      // Initialise editable row state and selection state from discovery results
       const initial: Record<string, RowState> = {};
+      const initialSelected: Record<string, boolean> = {};
       for (const d of discovered) {
         initial[d.componentId] = {
           name: d.alias || d.componentId,
           deviceType: d.suggestedDeviceType,
         };
+        // Auto-select all new (non-already-added) rows by default
+        if (!d.alreadyAdded) {
+          initialSelected[d.componentId] = true;
+        }
       }
       setRowState(initial);
+      setSelected(initialSelected);
       setPhase("ready");
     } catch {
       setDiscoverError("Could not reach the server. Check your network connection.");
@@ -112,10 +127,8 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
   }, [edgeDbId]);
 
   const handleSave = useCallback(async () => {
-    // Only save rows that are not already added and have a billable channel address.
-    // Null-channel rows (battery, inverter, grid_meter, pv_meter) are excluded by default;
-    // force-saving without a channel is deferred to a future ticket.
-    const toSave = devices.filter((d) => !d.alreadyAdded && d.openemsChannelAddress !== null);
+    // Save all selected rows that are not already added (regardless of channel null-ness)
+    const toSave = devices.filter((d) => !d.alreadyAdded && selected[d.componentId]);
     if (toSave.length === 0) return;
 
     setSaveError(null);
@@ -129,7 +142,7 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
           return {
             componentId: d.componentId,
             factoryId: d.factoryId,
-            openemsChannelAddress: d.openemsChannelAddress,
+            openemsChannelAddress: d.openemsChannelAddress, // may be null — server accepts
             deviceType: row?.deviceType ?? d.suggestedDeviceType,
             name: row?.name.trim() || d.alias || d.componentId,
           };
@@ -155,11 +168,12 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
       setPhase("idle");
       setDevices([]);
       setRowState({});
+      setSelected({});
     } catch {
       setSaveError("Network error while saving. Please retry.");
       setPhase("ready");
     }
-  }, [devices, rowState, edgeDbId, router]);
+  }, [devices, rowState, selected, edgeDbId, router]);
 
   const updateRow = useCallback(
     (componentId: string, patch: Partial<RowState>) => {
@@ -171,8 +185,15 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
     []
   );
 
-  // Pending = not already added AND has a billable channel (null-channel rows are excluded from Save)
-  const pendingCount = devices.filter((d) => !d.alreadyAdded && d.openemsChannelAddress !== null).length;
+  const toggleSelected = useCallback((componentId: string) => {
+    setSelected((prev) => ({ ...prev, [componentId]: !prev[componentId] }));
+  }, []);
+
+  // Count = selected rows that are NOT already-added (regardless of channel null-ness)
+  const pendingCount = devices.filter(
+    (d) => !d.alreadyAdded && selected[d.componentId]
+  ).length;
+
   // Derived flags so TypeScript doesn't narrow phase away inside JSX blocks
   const isSaving = phase === "saving";
   const isDiscovering = phase === "discovering";
@@ -229,90 +250,57 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
                 const selectedType = row?.deviceType ?? device.suggestedDeviceType;
                 const helpEntry = DEVICE_TYPE_HELP[selectedType];
                 const isHelpOpen = openHelp === device.componentId;
-
-                if (device.alreadyAdded) {
-                  return (
-                    <div
-                      key={device.componentId}
-                      className="flex items-center justify-between rounded-md border border-border bg-muted px-4 py-3 opacity-60"
-                    >
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <p className="text-sm font-medium text-muted-foreground">
-                            {device.alias || device.componentId}
-                          </p>
-                          <StatusChip
-                            kind="deviceType"
-                            status={device.suggestedDeviceType}
-                            state="disabled"
-                          />
-                        </div>
-                        <p className="font-mono text-xs text-muted-foreground">
-                          {device.componentId}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {device.factoryId}
-                        </p>
-                      </div>
-                      <Chip tone="neutral" state="disabled">
-                        Already added
-                      </Chip>
-                    </div>
-                  );
-                }
-
-                // Null-channel devices: no single auto-billing channel exists for this
-                // device type. Render as muted row with explanatory help text. Excluded
-                // from the Save payload (force-save is a future ticket).
-                if (device.openemsChannelAddress === null) {
-                  return (
-                    <div
-                      key={device.componentId}
-                      className="rounded-md border border-border bg-muted px-4 py-3"
-                    >
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-2">
-                            <p className="text-sm font-medium text-muted-foreground">
-                              {device.alias || device.componentId}
-                            </p>
-                            <StatusChip
-                              kind="deviceType"
-                              status={device.suggestedDeviceType}
-                              state="disabled"
-                            />
-                          </div>
-                          <p className="font-mono text-xs text-muted-foreground">
-                            {device.componentId}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {device.factoryId}
-                          </p>
-                        </div>
-                      </div>
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        No auto-billing channel for this device type; device metadata saved without an auto-query channel.
-                      </p>
-                    </div>
-                  );
-                }
+                const isAlreadyAdded = device.alreadyAdded === true;
+                const isChecked = isAlreadyAdded || !!selected[device.componentId];
+                const hasNullChannel = device.openemsChannelAddress === null;
 
                 return (
                   <div
                     key={device.componentId}
-                    className="rounded-md border border-border bg-card px-4 py-3"
+                    className={[
+                      "rounded-md border border-border px-4 py-3",
+                      isAlreadyAdded ? "bg-muted opacity-60" : "bg-card",
+                    ].join(" ")}
                   >
-                    {/* Row header: alias + chip */}
-                    <div className="mb-2 flex items-start justify-between gap-4">
+                    {/* Row header: checkbox + alias + chip */}
+                    <div className="mb-2 flex items-start gap-3">
+                      {/* Checkbox */}
+                      <div className="mt-0.5 flex-shrink-0">
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          disabled={isAlreadyAdded}
+                          aria-disabled={isAlreadyAdded ? "true" : undefined}
+                          onChange={() => {
+                            if (!isAlreadyAdded) toggleSelected(device.componentId);
+                          }}
+                          className="h-4 w-4 cursor-pointer rounded border-border accent-primary disabled:cursor-not-allowed"
+                        />
+                      </div>
+
+                      {/* Device identity */}
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-foreground">
+                          <span
+                            className={[
+                              "text-sm font-medium",
+                              isAlreadyAdded
+                                ? "text-muted-foreground"
+                                : "text-foreground",
+                            ].join(" ")}
+                          >
                             {device.alias || device.componentId}
                           </span>
                           <StatusChip
                             kind="deviceType"
                             status={device.suggestedDeviceType}
+                            state={isAlreadyAdded ? "disabled" : undefined}
                           />
+                          {isAlreadyAdded && (
+                            <Chip tone="neutral" state="disabled">
+                              Already added
+                            </Chip>
+                          )}
                         </div>
                         <p className="font-mono text-xs text-muted-foreground">
                           {device.componentId}
@@ -323,88 +311,98 @@ export function DiscoverDevices({ edgeDbId, openemsEdgeId }: Props) {
                       </div>
                     </div>
 
-                    {/* Name input */}
-                    <div className="mb-2">
-                      <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                        Device name
-                      </label>
-                      <input
-                        type="text"
-                        value={row?.name ?? ""}
-                        onChange={(e) =>
-                          updateRow(device.componentId, { name: e.target.value })
-                        }
-                        placeholder="Enter device name"
-                        className="w-full rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                      />
-                    </div>
-
-                    {/* Device type dropdown */}
-                    <div className="mb-2">
-                      <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                        Device type
-                      </label>
-                      <Select
-                        value={selectedType}
-                        onValueChange={(val) => {
-                          updateRow(device.componentId, {
-                            deviceType: val as DeviceType,
-                          });
-                          setOpenHelp(device.componentId);
-                        }}
-                      >
-                        <SelectTrigger className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {DEVICE_TYPE_OPTIONS.map((dt) => (
-                            <SelectItem key={dt} value={dt}>
-                              {DEVICE_TYPE_HELP[dt].label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    {/* Inline help card (below dropdown, not a tooltip, not a side panel) */}
-                    <div className="mt-1">
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setOpenHelp(isHelpOpen ? null : device.componentId)
-                        }
-                        className="text-xs text-muted-foreground underline hover:text-foreground hover:no-underline"
-                      >
-                        {isHelpOpen ? "Hide help" : "What is this?"}
-                      </button>
-                      {isHelpOpen && helpEntry && (
-                        <div className="mt-2 rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
-                          <p className="font-medium text-foreground">
-                            {helpEntry.label}
+                    {/* Selectable row controls (not shown for already-added) */}
+                    {!isAlreadyAdded && (
+                      <>
+                        {/* Observability-only note for null-channel devices */}
+                        {hasNullChannel && (
+                          <p className="mb-2 text-xs text-muted-foreground">
+                            No auto-billing channel for this device type — this device will be registered for observability but won&apos;t contribute to household billing.
                           </p>
-                          <p className="mt-0.5">{helpEntry.description}</p>
+                        )}
+
+                        {/* Name input */}
+                        <div className="mb-2">
+                          <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                            Device name
+                          </label>
+                          <input
+                            type="text"
+                            value={row?.name ?? ""}
+                            onChange={(e) =>
+                              updateRow(device.componentId, { name: e.target.value })
+                            }
+                            placeholder="Enter device name"
+                            className="w-full rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                          />
                         </div>
-                      )}
-                    </div>
+
+                        {/* Device type dropdown */}
+                        <div className="mb-2">
+                          <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                            Device type
+                          </label>
+                          <Select
+                            value={selectedType}
+                            onValueChange={(val) => {
+                              updateRow(device.componentId, {
+                                deviceType: val as DeviceType,
+                              });
+                              setOpenHelp(device.componentId);
+                            }}
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {DEVICE_TYPE_OPTIONS.map((dt) => (
+                                <SelectItem key={dt} value={dt}>
+                                  {DEVICE_TYPE_HELP[dt].label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+
+                        {/* Inline help card (below dropdown, not a tooltip, not a side panel) */}
+                        <div className="mt-1">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setOpenHelp(isHelpOpen ? null : device.componentId)
+                            }
+                            className="text-xs text-muted-foreground underline hover:text-foreground hover:no-underline"
+                          >
+                            {isHelpOpen ? "Hide help" : "What is this?"}
+                          </button>
+                          {isHelpOpen && helpEntry && (
+                            <div className="mt-2 rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+                              <p className="font-medium text-foreground">
+                                {helpEntry.label}
+                              </p>
+                              <p className="mt-0.5">{helpEntry.description}</p>
+                            </div>
+                          )}
+                        </div>
+                      </>
+                    )}
                   </div>
                 );
               })}
 
               {/* Save bar */}
-              {pendingCount > 0 && (
-                <div className="flex items-center justify-end gap-3 pt-1">
-                  <span className="text-sm text-muted-foreground">
-                    {pendingCount} device{pendingCount !== 1 ? "s" : ""} to add
-                  </span>
-                  <button
-                    onClick={handleSave}
-                    disabled={isSaving}
-                    className="rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-                  >
-                    {isSaving ? "Saving…" : "Save devices"}
-                  </button>
-                </div>
-              )}
+              <div className="flex items-center justify-end gap-3 pt-1">
+                <span className="text-sm text-muted-foreground">
+                  {pendingCount} device{pendingCount !== 1 ? "s" : ""} selected
+                </span>
+                <button
+                  onClick={handleSave}
+                  disabled={isSaving || pendingCount === 0}
+                  className="rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  {isSaving ? "Adding…" : `Add ${pendingCount} device${pendingCount !== 1 ? "s" : ""}`}
+                </button>
+              </div>
             </div>
           )}
         </>

--- a/src/components/__tests__/DiscoverDevices.test.tsx
+++ b/src/components/__tests__/DiscoverDevices.test.tsx
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 /**
- * DiscoverDevices component tests (F #57, #68).
+ * DiscoverDevices component tests (F #57, #68, #122).
  *
  * Covers:
  *   (a) suggested device_type renders in the dropdown
  *   (b) dropdown override propagates to the save payload
  *   (c) Save calls POST /api/devices with the correct payload shape
  *   (d) 'Already added' chip renders as disabled for a component matching an existing device row
- *   (e) null-channel rows render muted with help text and are excluded from Save payload (#68)
+ *   (e) null-channel rows: observability note shown; rows are selectable and included in save (#122)
+ *   (f) checkbox selection state — tick/untick updates pending count and save payload
+ *   (g) mixed billable + non-billable + already-added renders all in one list
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -110,7 +112,7 @@ describe("DiscoverDevices", () => {
   // (b) Dropdown override propagates to the save payload
   // ──────────────────────────────────────────────────────────────────────────
   describe("(b) dropdown override propagates to save payload", () => {
-    it("sends the overridden device_type when the user changes the dropdown", async () => {
+    it("sends the suggested device_type when the user saves without changing the dropdown", async () => {
       const devices = [makeDevice("meter0", "consumption_meter")];
 
       // First call: discover
@@ -128,14 +130,11 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
-      await waitFor(() => screen.getByText("Save devices"));
+      // Wait for Add button to appear (auto-selected by default)
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
 
-      // Simulate changing the select value by dispatching a custom event
-      // (Radix Select is hard to drive via fireEvent.change; we test the
-      // payload shape by inspecting the fetch call arguments after save).
-      // For the purpose of this test, we click Save without changing the dropdown
-      // and verify the suggested type is sent.
-      fireEvent.click(screen.getByRole("button", { name: /save devices/i }));
+      // Click Add without changing the dropdown
+      fireEvent.click(screen.getByRole("button", { name: /add 1 device/i }));
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -172,13 +171,13 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
-      await waitFor(() => screen.getByText("Save devices"));
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
 
       // Update the name input
       const input = screen.getByPlaceholderText("Enter device name") as HTMLInputElement;
       fireEvent.change(input, { target: { value: "Solar PV meter" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /save devices/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add 1 device/i }));
 
       await waitFor(() => {
         const [url, init] = fetchMock.mock.calls[1];
@@ -219,8 +218,8 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
-      await waitFor(() => screen.getByText("Save devices"));
-      fireEvent.click(screen.getByRole("button", { name: /save devices/i }));
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add 1 device/i }));
 
       await waitFor(() => {
         const [, init] = fetchMock.mock.calls[1];
@@ -254,9 +253,9 @@ describe("DiscoverDevices", () => {
       });
     });
 
-    it("disabled rows do not show a Save button", async () => {
+    it("already-added rows have a pre-checked disabled checkbox", async () => {
       const devices = [
-        makeDevice("meter0", "grid_meter", true), // already added — no Save for this
+        makeDevice("meter0", "grid_meter", true), // already added
       ];
 
       fetchMock.mockResolvedValueOnce({
@@ -267,9 +266,11 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
-      await waitFor(() => {
-        expect(screen.queryByRole("button", { name: /save devices/i })).toBeNull();
-      });
+      await waitFor(() => screen.getByText("Already added"));
+
+      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+      expect(checkbox.disabled).toBe(true);
     });
 
     it("renders disabled row with opacity class for already-added device", async () => {
@@ -289,13 +290,32 @@ describe("DiscoverDevices", () => {
       const disabledRow = container.querySelector(".opacity-60");
       expect(disabledRow).not.toBeNull();
     });
+
+    it("Add button shows 0 count (disabled) when only already-added devices present", async () => {
+      const devices = [
+        makeDevice("meter0", "grid_meter", true), // already added — not counted in Add
+      ];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => screen.getByText("Already added"));
+
+      const addBtn = screen.getByRole("button", { name: /add 0 devices/i }) as HTMLButtonElement;
+      expect(addBtn.disabled).toBe(true);
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // (e) null-channel rows — muted rendering + excluded from Save (#68)
+  // (e) null-channel rows — observability note shown; rows are selectable (#122)
   // ──────────────────────────────────────────────────────────────────────────
   describe("(e) null-channel rows (battery, inverter, grid_meter, pv_meter)", () => {
-    it("renders muted row with help text when openemsChannelAddress is null", async () => {
+    it("renders observability note when openemsChannelAddress is null", async () => {
       const devices = [makeDevice("ess0", "battery", false, null)];
 
       fetchMock.mockResolvedValueOnce({
@@ -313,20 +333,15 @@ describe("DiscoverDevices", () => {
       });
     });
 
-    it("excludes null-channel device from the POST /api/devices payload on bulk save", async () => {
-      // One null-channel device (battery) + one billable device (consumption_meter)
-      const devices = [
-        makeDevice("ess0", "battery", false, null),
-        makeDevice("meter0", "consumption_meter", false, "meter0/ActiveConsumptionEnergy"),
-      ];
+    it("null-channel device is auto-selected and included in POST payload", async () => {
+      // One null-channel device (battery)
+      const devices = [makeDevice("ess0", "battery", false, null)];
 
-      // First call: discover
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => mockDiscoverResponse(devices),
       } as Response);
 
-      // Second call: save
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ saved: [{ id: "new-uuid" }] }),
@@ -335,8 +350,9 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
-      await waitFor(() => screen.getByText("Save devices"));
-      fireEvent.click(screen.getByRole("button", { name: /save devices/i }));
+      // Add button is enabled (null-channel row auto-selected)
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add 1 device/i }));
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -344,13 +360,50 @@ describe("DiscoverDevices", () => {
         expect(url).toBe("/api/devices");
 
         const body = JSON.parse(init?.body as string);
-        // Only meter0 (consumption_meter) should be in the payload — ess0 has no channel
+        // ess0 (null-channel) is in the payload with openemsChannelAddress: null
         expect(body.devices).toHaveLength(1);
-        expect(body.devices[0].componentId).toBe("meter0");
+        expect(body.devices[0].componentId).toBe("ess0");
+        expect(body.devices[0].openemsChannelAddress).toBeNull();
       });
     });
 
-    it("does not show Save button when all new rows have null channel", async () => {
+    it("includes both billable and null-channel devices in POST payload by default", async () => {
+      const devices = [
+        makeDevice("ess0", "battery", false, null),
+        makeDevice("meter0", "consumption_meter", false, "meter0/ActiveConsumptionEnergy"),
+      ];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ saved: [{ id: "new-uuid-1" }, { id: "new-uuid-2" }] }),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => screen.getByRole("button", { name: /add 2 devices/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add 2 devices/i }));
+
+      await waitFor(() => {
+        const [, init] = fetchMock.mock.calls[1];
+        const body = JSON.parse(init?.body as string);
+        // Both devices are in the payload
+        expect(body.devices).toHaveLength(2);
+        const ids = body.devices.map((d: { componentId: string }) => d.componentId);
+        expect(ids).toContain("ess0");
+        expect(ids).toContain("meter0");
+        // null-channel device sends openemsChannelAddress: null
+        const battery = body.devices.find((d: { componentId: string }) => d.componentId === "ess0");
+        expect(battery.openemsChannelAddress).toBeNull();
+      });
+    });
+
+    it("unchecking a null-channel row removes it from the Add count", async () => {
       const devices = [makeDevice("ess0", "battery", false, null)];
 
       fetchMock.mockResolvedValueOnce({
@@ -361,11 +414,130 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
+      // Initially auto-selected → Add 1 device
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
+
+      // Uncheck the row
+      const checkboxes = screen.getAllByRole("checkbox");
+      const enabledCheckbox = checkboxes.find(
+        (cb) => !(cb as HTMLInputElement).disabled
+      ) as HTMLInputElement;
+      fireEvent.click(enabledCheckbox);
+
+      // Count drops to 0 → button disabled
       await waitFor(() => {
-        expect(
-          screen.getByText(/No auto-billing channel for this device type/i)
-        ).toBeDefined();
-        expect(screen.queryByRole("button", { name: /save devices/i })).toBeNull();
+        const addBtn = screen.getByRole("button", { name: /add 0 devices/i }) as HTMLButtonElement;
+        expect(addBtn.disabled).toBe(true);
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (f) Checkbox selection state — tick/untick updates count + save payload
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(f) checkbox selection state", () => {
+    it("unchecking a billable row removes it from the save payload", async () => {
+      const devices = [
+        makeDevice("meter0", "consumption_meter"),
+        makeDevice("meter1", "consumption_meter"),
+      ];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ saved: [{ id: "new-uuid" }] }),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      // Both auto-selected by default → Add 2 devices
+      await waitFor(() => screen.getByRole("button", { name: /add 2 devices/i }));
+
+      // Uncheck the first enabled checkbox (meter0)
+      const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+      fireEvent.click(checkboxes[0]);
+
+      // Count drops to 1
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
+
+      fireEvent.click(screen.getByRole("button", { name: /add 1 device/i }));
+
+      await waitFor(() => {
+        const [, init] = fetchMock.mock.calls[1];
+        const body = JSON.parse(init?.body as string);
+        // Only the checked device should be in the payload
+        expect(body.devices).toHaveLength(1);
+      });
+    });
+
+    it("device-type dropdown override is preserved across re-renders (row state stable)", async () => {
+      const devices = [
+        makeDevice("meter0", "other", false, null),
+      ];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ saved: [{ id: "new-uuid" }] }),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
+
+      // Uncheck then re-check to trigger re-render
+      const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+      const enabledCheckbox = checkboxes.find((cb) => !cb.disabled) as HTMLInputElement;
+      fireEvent.click(enabledCheckbox); // uncheck
+      fireEvent.click(enabledCheckbox); // re-check
+
+      // The dropdown for "other" still shows the original suggestion
+      await waitFor(() => {
+        // "Other" label appears (from the Select trigger showing current value)
+        const otherLabels = screen.getAllByText("Other");
+        expect(otherLabels.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // (g) Mixed billable + non-billable + already-added → unified list
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("(g) mixed device types render in one unified list", () => {
+    it("renders all device types in a single list with appropriate states", async () => {
+      const devices = [
+        makeDevice("meter0", "consumption_meter", true),  // already added
+        makeDevice("ess0", "battery", false, null),       // null-channel, selectable
+        makeDevice("meter1", "pv_meter", false, null),    // null-channel, selectable
+        makeDevice("meter2", "consumption_meter"),         // billable, selectable
+      ];
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDiscoverResponse(devices),
+      } as Response);
+
+      render(<DiscoverDevices {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
+
+      await waitFor(() => {
+        // Already-added chip present
+        expect(screen.getByText("Already added")).toBeDefined();
+        // Observability note for null-channel devices (two devices → two notes)
+        const notes = screen.getAllByText(/No auto-billing channel for this device type/i);
+        expect(notes.length).toBe(2);
+        // Add button counts 3 new devices (ess0 + meter1 + meter2)
+        expect(screen.getByRole("button", { name: /add 3 devices/i })).toBeDefined();
       });
     });
   });
@@ -425,19 +597,19 @@ describe("DiscoverDevices", () => {
       render(<DiscoverDevices {...defaultProps} />);
       fireEvent.click(screen.getByRole("button", { name: /discover devices/i }));
 
-      await waitFor(() => screen.getByText("Save devices"));
+      await waitFor(() => screen.getByRole("button", { name: /add 1 device/i }));
 
       // Change name before save
       const input = screen.getByPlaceholderText("Enter device name") as HTMLInputElement;
       fireEvent.change(input, { target: { value: "My Meter" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /save devices/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add 1 device/i }));
 
       await waitFor(() => {
         // Error message is shown
         expect(screen.getByText(/Not authorized/i)).toBeDefined();
-        // User selections are preserved — Save button still visible
-        expect(screen.getByRole("button", { name: /save devices/i })).toBeDefined();
+        // User selections are preserved — Add button still visible
+        expect(screen.getByRole("button", { name: /add 1 device/i })).toBeDefined();
         // Name input still has the value
         const inputAfter = screen.getByPlaceholderText("Enter device name") as HTMLInputElement;
         expect(inputAfter.value).toBe("My Meter");


### PR DESCRIPTION
## Summary
- Collapses DiscoverDevices' 3 render branches (already-added / null-channel / billable) into 1 unified list with per-row checkboxes.
- Non-billable types (grid meter / PV meter / battery / inverter / other) are now selectable. Saved with `openemsChannelAddress: null` for observability; excluded from billing queries by default.
- Replaces misleading *"saved without an auto-query channel"* copy with an informational note: *"No auto-billing channel for this device type — this device will be registered for observability but won't contribute to household billing."*
- Save bar always visible (rather than appearing only when `pendingCount > 0`); button label is **"Add N devices"** and is disabled at N=0. Minor UX improvement so users see the target button state instead of wondering where the action went.
- Auto-selects all new (not-already-added) rows on discovery — user unchecks any they don't want. Already-added rows remain disabled + pre-checked.
- `POST /api/devices` already accepts null `openemsChannelAddress`; added test confirming that path.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` — 649/649 pass (includes 7 new DiscoverDevices tests + 1 new route test)
- [x] `npm run build`
- [ ] Manual: discover on edge1 (grid + PV East/West + Consumption) → all 4 appear with checkboxes → optionally uncheck some → click "Add N devices" → confirm only checked rows land in the device list below

Closes #122.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)