### PR TITLE
Community Payment tab — sub-nav, empty/configured states, Save & test (#119)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/__tests__/community-subnav.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/__tests__/community-subnav.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+/**
+ * CommunitySubNav tests (#119 AC-NAV-*).
+ *
+ * Covers:
+ *   - Renders Overview + Payment tabs
+ *   - Active-tab derivation via usePathname (longest-prefix match on /payment)
+ *   - Payment tab chip renders when paymentHealth prop supplied
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+let mockPathname = "/communities/comm-abc";
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { CommunitySubNav } from "../community-subnav";
+
+describe("CommunitySubNav", () => {
+  it("renders Overview + Payment tabs", () => {
+    mockPathname = "/communities/comm-abc";
+    render(<CommunitySubNav communityId="comm-abc" />);
+    expect(screen.getByRole("tab", { name: /overview/i })).toBeDefined();
+    expect(screen.getByRole("tab", { name: /payment/i })).toBeDefined();
+  });
+
+  it("marks Overview active on /communities/[id]", () => {
+    mockPathname = "/communities/comm-abc";
+    render(<CommunitySubNav communityId="comm-abc" />);
+    const overviewTab = screen.getByRole("tab", { name: /overview/i });
+    expect(overviewTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("marks Payment active on /communities/[id]/payment", () => {
+    mockPathname = "/communities/comm-abc/payment";
+    render(<CommunitySubNav communityId="comm-abc" />);
+    const paymentTab = screen.getByRole("tab", { name: /payment/i });
+    expect(paymentTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("renders the payment health chip on the Payment tab when supplied", () => {
+    mockPathname = "/communities/comm-abc";
+    const { container } = render(
+      <CommunitySubNav
+        communityId="comm-abc"
+        paymentHealth={{
+          status: "healthy",
+          lastConfiguredAt: "2026-04-23T10:00:00Z",
+          relativeTime: "2h ago",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain("Healthy");
+  });
+
+  it("chip is NOT rendered when paymentHealth is undefined", () => {
+    mockPathname = "/communities/comm-abc";
+    const { container } = render(<CommunitySubNav communityId="comm-abc" />);
+    expect(container.textContent).not.toContain("Healthy");
+    expect(container.textContent).not.toContain("Stale");
+    expect(container.textContent).not.toContain("Not connected");
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/community-subnav.tsx
+++ b/src/app/(dashboard)/communities/[id]/community-subnav.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useRef, type KeyboardEvent } from "react";
+import { StatusChip } from "@/components/ui/status-chip";
+import type { PaymentHealth } from "./payment/health";
+
+// Community sub-nav (#119).
+//
+// Sibling to `src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx`;
+// intentionally NOT a refactor of that component — the OpenEMS chip wiring
+// there is load-bearing and the two sub-navs live at different URL scopes.
+//
+// Visual language matches SetupSubNav (pill-style container `bg-muted`,
+// active tab raises onto `bg-card shadow-elev-1`).
+//
+// A11y contract (mirrors SetupSubNav):
+//   - role="tablist" + aria-label
+//   - each link is role="tab" + aria-selected
+//   - ArrowLeft/Right cycle; Home/End jump to first/last
+//   - The Payment tab chip is rendered INSIDE the anchor; Radix Tooltip
+//     wraps the chip and adds a focusable span (tabindex=0). Screen readers
+//     follow the anchor as the primary control.
+
+type SubTab = { label: string; segment: string };
+
+const TABS: SubTab[] = [
+  { label: "Overview", segment: "" },
+  { label: "Payment", segment: "payment" },
+];
+
+export type PaymentChipData = {
+  status: PaymentHealth;
+  lastConfiguredAt: string | null;
+  relativeTime: string | null;
+};
+
+function tooltipFor(data: PaymentChipData): string | null {
+  switch (data.status) {
+    case "healthy":
+      return data.relativeTime
+        ? `Last successful save: ${data.relativeTime}`
+        : "Connection healthy";
+    case "stale":
+      return data.relativeTime
+        ? `Last save: ${data.relativeTime}. Run Save & test again to verify.`
+        : "Run Save & test again to verify.";
+    case "failing":
+      // Reserved for #121; derivePaymentHealth never returns this today.
+      return "Payment provider is failing. Reconfigure or test again.";
+    case "not_configured":
+      return "No payment provider connected yet.";
+  }
+}
+
+export function CommunitySubNav({
+  communityId,
+  paymentHealth,
+}: {
+  communityId: string;
+  paymentHealth?: PaymentChipData;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const base = `/communities/${communityId}`;
+  const tabRefs = useRef<Array<HTMLAnchorElement | null>>([]);
+
+  // Active-tab resolution:
+  //   - Payment tab wins when pathname starts with `${base}/payment`
+  //   - Otherwise Overview (default / exact-match).
+  const activeIndex = (() => {
+    for (let i = 0; i < TABS.length; i++) {
+      const t = TABS[i];
+      if (t.segment === "") continue;
+      if (pathname.startsWith(`${base}/${t.segment}`)) return i;
+    }
+    return 0;
+  })();
+
+  function hrefFor(tab: SubTab): string {
+    return tab.segment === "" ? base : `${base}/${tab.segment}`;
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLAnchorElement>, current: number) {
+    const last = TABS.length - 1;
+    let next = current;
+    switch (e.key) {
+      case "ArrowRight":
+        next = current === last ? 0 : current + 1;
+        break;
+      case "ArrowLeft":
+        next = current === 0 ? last : current - 1;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = last;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const el = tabRefs.current[next];
+    el?.focus();
+    router.push(hrefFor(TABS[next]));
+  }
+
+  return (
+    <nav
+      role="tablist"
+      aria-label="Community sections"
+      className="inline-flex w-fit gap-1 rounded-lg bg-muted p-1"
+    >
+      {TABS.map((tab, i) => {
+        const isActive = i === activeIndex;
+        const chipData = tab.segment === "payment" ? paymentHealth : undefined;
+        return (
+          <a
+            key={tab.segment || "overview"}
+            ref={(el) => {
+              tabRefs.current[i] = el;
+            }}
+            href={hrefFor(tab)}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onKeyDown={(e) => onKeyDown(e, i)}
+            className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              isActive
+                ? "bg-card text-foreground font-semibold shadow-elev-1"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <span>{tab.label}</span>
+            {chipData && (
+              <StatusChip
+                kind="paymentHealth"
+                status={chipData.status}
+                size="sm"
+                tooltip={tooltipFor(chipData)}
+              />
+            )}
+          </a>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/layout.tsx
+++ b/src/app/(dashboard)/communities/[id]/layout.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+import { CommunitySubNav, type PaymentChipData } from "./community-subnav";
+import { derivePaymentHealth } from "./payment/health";
+import { timeAgo } from "@/lib/time-ago";
+
+/**
+ * /communities/[id] — shared layout (#119).
+ *
+ * Wraps both the Overview page (`/communities/[id]`) and the Payment page
+ * (`/communities/[id]/payment`) with a sub-nav that surfaces the payment
+ * health chip. Overview page's existing content keeps rendering as children.
+ *
+ * The layout fetches just enough for the sub-nav (community id/name +
+ * payment_* fields for the chip). Each child page does its own richer fetch
+ * for its specific data — cheap duplicate reads, simpler reasoning.
+ */
+export default async function CommunityLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // Permission gate — 404 if the user can't access (don't leak existence).
+  const canAccess = await currentUserCanAccessCommunity(supabase, id);
+  if (!canAccess) notFound();
+
+  const { data: community } = await supabase
+    .from("communities")
+    .select(
+      "id, name, payment_provider, payment_last_configured_at",
+    )
+    .eq("id", id)
+    .maybeSingle<{
+      id: string;
+      name: string;
+      payment_provider: "pesapal" | null;
+      payment_last_configured_at: string | null;
+    }>();
+
+  if (!community) notFound();
+
+  const health = derivePaymentHealth({
+    payment_provider: community.payment_provider,
+    payment_last_configured_at: community.payment_last_configured_at,
+  });
+
+  const relativeTime = community.payment_last_configured_at
+    ? timeAgo(community.payment_last_configured_at)
+    : null;
+
+  const chipData: PaymentChipData = {
+    status: health,
+    lastConfiguredAt: community.payment_last_configured_at,
+    relativeTime,
+  };
+
+  return (
+    <div>
+      <div className="mb-4">
+        <CommunitySubNav communityId={community.id} paymentHealth={chipData} />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/payment/__tests__/health.test.ts
+++ b/src/app/(dashboard)/communities/[id]/payment/__tests__/health.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { derivePaymentHealth } from "../health";
+
+const NOW = new Date("2026-04-23T12:00:00Z");
+
+describe("derivePaymentHealth()", () => {
+  it("returns not_configured for null row", () => {
+    expect(derivePaymentHealth(null, NOW)).toBe("not_configured");
+  });
+
+  it("returns not_configured when payment_provider is null", () => {
+    expect(
+      derivePaymentHealth(
+        {
+          payment_provider: null,
+          payment_last_configured_at: null,
+        },
+        NOW,
+      ),
+    ).toBe("not_configured");
+  });
+
+  it("returns healthy for save < 24h ago", () => {
+    expect(
+      derivePaymentHealth(
+        {
+          payment_provider: "pesapal",
+          payment_last_configured_at: new Date(
+            NOW.getTime() - 2 * 3600 * 1000,
+          ).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe("healthy");
+  });
+
+  it("returns healthy at the boundary (just under 24h)", () => {
+    expect(
+      derivePaymentHealth(
+        {
+          payment_provider: "pesapal",
+          payment_last_configured_at: new Date(
+            NOW.getTime() - (24 * 3600 * 1000 - 1),
+          ).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe("healthy");
+  });
+
+  it("returns stale for save >= 24h ago", () => {
+    expect(
+      derivePaymentHealth(
+        {
+          payment_provider: "pesapal",
+          payment_last_configured_at: new Date(
+            NOW.getTime() - 48 * 3600 * 1000,
+          ).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe("stale");
+  });
+
+  it("returns stale when payment_provider set but payment_last_configured_at is null (defensive)", () => {
+    expect(
+      derivePaymentHealth(
+        {
+          payment_provider: "pesapal",
+          payment_last_configured_at: null,
+        },
+        NOW,
+      ),
+    ).toBe("stale");
+  });
+
+  it("never returns failing today — reserved for #121", () => {
+    // Exercise a range of inputs and assert the helper NEVER emits "failing".
+    const inputs = [
+      { payment_provider: null, payment_last_configured_at: null },
+      {
+        payment_provider: "pesapal" as const,
+        payment_last_configured_at: new Date().toISOString(),
+      },
+      {
+        payment_provider: "pesapal" as const,
+        payment_last_configured_at: new Date(
+          NOW.getTime() - 365 * 24 * 3600 * 1000,
+        ).toISOString(),
+      },
+      {
+        payment_provider: "pesapal" as const,
+        payment_last_configured_at: "not-a-date",
+      },
+    ];
+    for (const row of inputs) {
+      expect(derivePaymentHealth(row, NOW)).not.toBe("failing");
+    }
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/payment/__tests__/payment-shell.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/__tests__/payment-shell.test.tsx
@@ -1,0 +1,342 @@
+// @vitest-environment jsdom
+/**
+ * PaymentShell tests (#119).
+ *
+ * Covers:
+ *  1. Empty state (super_admin): "Connect Pesapal" card + coming-soon footnote
+ *  2. Empty state (org_manager): info banner, no form
+ *  3. Configured state (super_admin): chip, masked secret, Test again,
+ *     Reconfigure buttons visible
+ *  4. Configured state (org_manager): no Reconfigure/Test again, read-only
+ *     banner, secret renders "—"
+ *  5. Reconfigure form opens with existing consumer_key + blank secret +
+ *     sandbox toggle initialized from stored value
+ *  6. Save & test success → success banner, form collapses
+ *  7. Save & test auth_failed → destructive banner, form stays open
+ *  8. Save & test unreachable → destructive banner
+ *  9. Secret-preserve: blank secret field → PUT payload omits
+ *     `secret_access_key`
+ * 10. Sandbox checkbox round-trips through Reconfigure
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: mockRefresh }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { PaymentShell } from "../payment-shell";
+
+const BASE_COMMUNITY = {
+  id: "comm-abc",
+  name: "Kisakye",
+  payment_provider: null,
+  payment_last_configured_at: null,
+  config: { consumer_key: "", base_url: "", sandbox: false },
+} as const;
+
+const CONFIGURED_COMMUNITY = {
+  id: "comm-abc",
+  name: "Kisakye",
+  payment_provider: "pesapal" as const,
+  payment_last_configured_at: "2026-04-23T10:00:00Z",
+  config: {
+    consumer_key: "ck_live_example",
+    base_url: "https://pay.pesapal.com/v3",
+    sandbox: false,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Empty state ─────────────────────────────────────────────────────────
+
+describe("PaymentShell — empty state", () => {
+  it("(1) super_admin sees Connect Pesapal card + coming-soon footnote", () => {
+    render(
+      <PaymentShell
+        community={BASE_COMMUNITY}
+        health="not_configured"
+        secretLast4={null}
+        isSuperAdmin={true}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /connect pesapal/i }),
+    ).toBeDefined();
+    expect(screen.getByText(/more providers/i)).toBeDefined();
+  });
+
+  it("(2) org_manager sees info banner, no Connect button", () => {
+    render(
+      <PaymentShell
+        community={BASE_COMMUNITY}
+        health="not_configured"
+        secretLast4={null}
+        isSuperAdmin={false}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /connect pesapal/i }),
+    ).toBeNull();
+    expect(screen.getByText(/not configured yet/i)).toBeDefined();
+  });
+});
+
+// ─── Configured state ────────────────────────────────────────────────────
+
+describe("PaymentShell — configured state", () => {
+  it("(3) super_admin: chip, masked secret, Test again + Reconfigure visible", () => {
+    const { container } = render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    expect(container.textContent).toContain("Healthy");
+    expect(container.textContent).toContain("••••••••9xYZ");
+    expect(screen.getByRole("button", { name: /test again/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /reconfigure/i })).toBeDefined();
+  });
+
+  it("(4) org_manager: read-only banner, no Reconfigure/Test, secret '—'", () => {
+    const { container } = render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4={null}
+        isSuperAdmin={false}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /reconfigure/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /test again/i })).toBeNull();
+    expect(
+      screen.getByText(/only super admins can update payment credentials/i),
+    ).toBeDefined();
+    expect(container.textContent).toContain("—");
+  });
+});
+
+// ─── Reconfigure flow ────────────────────────────────────────────────────
+
+describe("PaymentShell — reconfigure flow", () => {
+  it("(5) Reconfigure opens form with existing consumer_key + blank secret + sandbox toggle from store", () => {
+    render(
+      <PaymentShell
+        community={{ ...CONFIGURED_COMMUNITY, config: { ...CONFIGURED_COMMUNITY.config, sandbox: true } }}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+
+    const keyInput = screen.getByLabelText(/consumer key/i) as HTMLInputElement;
+    const secretInput = screen.getByLabelText(
+      /consumer secret/i,
+    ) as HTMLInputElement;
+    const sandboxCb = screen.getByLabelText(
+      /use sandbox environment/i,
+    ) as HTMLInputElement;
+
+    expect(keyInput.value).toBe("ck_live_example");
+    expect(secretInput.value).toBe("");
+    expect(sandboxCb.checked).toBe(true);
+  });
+});
+
+// ─── Save & test outcomes ────────────────────────────────────────────────
+
+function mockFetch(response: { status?: number; body: unknown }) {
+  const res = {
+    ok: (response.status ?? 200) >= 200 && (response.status ?? 200) < 300,
+    status: response.status ?? 200,
+    json: () => Promise.resolve(response.body),
+  } as unknown as Response;
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(res);
+}
+
+async function submitForm() {
+  const btn = screen.getByRole("button", {
+    name: /save & test connection/i,
+  });
+  await act(async () => {
+    fireEvent.click(btn);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("PaymentShell — Save & test outcomes", () => {
+  it("(6) success → success banner + refresh after timer", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = mockFetch({
+      status: 200,
+      body: {
+        status: "success",
+        message: "Connected. Pesapal authentication succeeded.",
+      },
+    });
+    render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    // Re-enter a secret so we hit the non-preserve path.
+    fireEvent.change(screen.getByLabelText(/consumer secret/i), {
+      target: { value: "cs_live_replacement" },
+    });
+    await submitForm();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/connected\./i)).toBeDefined();
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+    expect(mockRefresh).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("(7) auth_failed → destructive banner, form stays open", async () => {
+    mockFetch({
+      status: 503,
+      body: {
+        error: "Authentication failed.",
+        reason: "auth_failed",
+      },
+    });
+    render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    fireEvent.change(screen.getByLabelText(/consumer secret/i), {
+      target: { value: "cs_wrong" },
+    });
+    await submitForm();
+    // Destructive banner title ("Authentication failed") renders as an h3.
+    expect(
+      screen.getByRole("heading", { name: /authentication failed/i }),
+    ).toBeDefined();
+    // Form still open — secret input still in DOM.
+    expect(screen.getByLabelText(/consumer secret/i)).toBeDefined();
+  });
+
+  it("(8) unreachable → destructive banner", async () => {
+    mockFetch({
+      status: 503,
+      body: { error: "Could not reach Pesapal.", reason: "unreachable" },
+    });
+    render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    fireEvent.change(screen.getByLabelText(/consumer secret/i), {
+      target: { value: "cs" },
+    });
+    await submitForm();
+    expect(screen.getByText(/pesapal unreachable/i)).toBeDefined();
+  });
+});
+
+// ─── Secret-preserve ─────────────────────────────────────────────────────
+
+describe("PaymentShell — secret-preserve", () => {
+  it("(9) blank secret on Reconfigure → PUT body omits secret_access_key", async () => {
+    const fetchSpy = mockFetch({
+      status: 200,
+      body: { status: "success", message: "Connected." },
+    });
+    render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    // Leave the secret input blank.
+    await submitForm();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect("secret_access_key" in body).toBe(false);
+    expect(body.config.consumer_key).toBe("ck_live_example");
+  });
+});
+
+// ─── Sandbox round-trip ──────────────────────────────────────────────────
+
+describe("PaymentShell — sandbox toggle", () => {
+  it("(10) sandbox toggle in form reflects store and flips on user click", async () => {
+    const fetchSpy = mockFetch({
+      status: 200,
+      body: { status: "success", message: "Connected." },
+    });
+    render(
+      <PaymentShell
+        community={{
+          ...CONFIGURED_COMMUNITY,
+          config: { ...CONFIGURED_COMMUNITY.config, sandbox: false },
+        }}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+    const cb = screen.getByLabelText(
+      /use sandbox environment/i,
+    ) as HTMLInputElement;
+    expect(cb.checked).toBe(false);
+    fireEvent.click(cb);
+    expect(cb.checked).toBe(true);
+    fireEvent.change(screen.getByLabelText(/consumer secret/i), {
+      target: { value: "cs_live_rotated" },
+    });
+    await submitForm();
+    const body = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body));
+    expect(body.config.sandbox).toBe(true);
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/payment/health.ts
+++ b/src/app/(dashboard)/communities/[id]/payment/health.ts
@@ -1,0 +1,46 @@
+// Health-derivation helper for the community Payment tab (#119).
+//
+// Derives a PaymentHealth state from the community's payment_* fields. This
+// helper is PURE — no DB access. The layout + page each fetch the row and
+// hand the result to this function.
+//
+// State table (AC-HEALTH-1):
+//
+//   payment_provider IS NULL                          → not_configured
+//   payment_last_configured_at < 24h ago              → healthy
+//   payment_last_configured_at >= 24h ago (or null)   → stale
+//
+// Note: the `failing` state is RESERVED for #121 (IPN registration +
+// webhook failure tracking). `derivePaymentHealth` never returns `failing`
+// today — migration 00020 has no `payment_last_status` column to source it
+// from. The `failing` entry still lives in `StatusChip MAPS.paymentHealth`
+// (Designer locked the tone table in #117 so the MAPS are stable across
+// the deferred IPN rollout).
+
+export type PaymentHealth =
+  | "healthy"
+  | "stale"
+  | "failing"
+  | "not_configured";
+
+export type PaymentHealthInput = {
+  payment_provider: "pesapal" | null;
+  payment_last_configured_at: string | null;
+} | null;
+
+const TWENTY_FOUR_HOURS_MS = 24 * 3600 * 1000;
+
+export function derivePaymentHealth(
+  row: PaymentHealthInput,
+  now: Date = new Date(),
+): PaymentHealth {
+  if (!row) return "not_configured";
+  if (!row.payment_provider) return "not_configured";
+
+  if (!row.payment_last_configured_at) return "stale";
+
+  const at = new Date(row.payment_last_configured_at).getTime();
+  if (Number.isNaN(at)) return "stale";
+  const diff = now.getTime() - at;
+  return diff < TWENTY_FOUR_HOURS_MS ? "healthy" : "stale";
+}

--- a/src/app/(dashboard)/communities/[id]/payment/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/page.tsx
@@ -1,0 +1,103 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import {
+  currentUserCanAccessCommunity,
+  currentUserIsSuperAdmin,
+} from "@/lib/auth/access";
+import { derivePaymentHealth } from "./health";
+import { PaymentShell } from "./payment-shell";
+
+/**
+ * /communities/[id]/payment — Payment configuration (#119).
+ *
+ * Server component fetches:
+ *   1. Community row (name + payment_* columns).
+ *   2. Permission flags (canAccessCommunity, isSuperAdmin).
+ *   3. Decrypted secret last-4 — super_admin only. We call
+ *      fn_get_community_payment_secret which returns NULL for org_manager
+ *      (even on their own community), then compute `secret.slice(-4)`
+ *      SERVER-SIDE. The plaintext secret NEVER crosses to the client.
+ *
+ * The server component passes everything as props to `<PaymentShell>` which
+ * owns mode state (empty / configured / editing), form state, and the
+ * Save & test promise.
+ */
+export default async function PaymentPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // Permission gate — 404 if hidden (don't leak existence).
+  const canAccess = await currentUserCanAccessCommunity(supabase, id);
+  if (!canAccess) notFound();
+
+  const isSuperAdmin = await currentUserIsSuperAdmin(supabase);
+
+  const { data: community, error: commErr } = await supabase
+    .from("communities")
+    .select(
+      "id, name, payment_provider, payment_provider_config, payment_last_configured_at",
+    )
+    .eq("id", id)
+    .maybeSingle<{
+      id: string;
+      name: string;
+      payment_provider: "pesapal" | null;
+      payment_provider_config: unknown;
+      payment_last_configured_at: string | null;
+    }>();
+
+  if (commErr || !community) notFound();
+
+  // Mirrors openems-backend/page.tsx:81-89. `fn_get_community_payment_secret`
+  // returns NULL for non-super_admin per migration 00020 truth table, so the
+  // secretLast4 prop is NULL for org_manager (UI renders "—").
+  let secretLast4: string | null = null;
+  if (community.payment_provider === "pesapal" && isSuperAdmin) {
+    const { data: secret } = await supabase.rpc(
+      "fn_get_community_payment_secret",
+      { _community_id: id },
+    );
+    if (typeof secret === "string" && secret.length >= 4) {
+      secretLast4 = secret.slice(-4);
+    }
+  }
+
+  // Normalize the stored config into the shape the shell expects.
+  const cfgObj =
+    community.payment_provider_config &&
+    typeof community.payment_provider_config === "object"
+      ? (community.payment_provider_config as Record<string, unknown>)
+      : {};
+  const normalizedConfig = {
+    consumer_key:
+      typeof cfgObj.consumer_key === "string" ? cfgObj.consumer_key : "",
+    base_url: typeof cfgObj.base_url === "string" ? cfgObj.base_url : "",
+    sandbox: typeof cfgObj.sandbox === "boolean" ? cfgObj.sandbox : false,
+  };
+
+  const health = derivePaymentHealth({
+    payment_provider: community.payment_provider,
+    payment_last_configured_at: community.payment_last_configured_at,
+  });
+
+  return (
+    <div className="space-y-4">
+      <PaymentShell
+        community={{
+          id: community.id,
+          name: community.name,
+          payment_provider: community.payment_provider,
+          payment_last_configured_at: community.payment_last_configured_at,
+          config: normalizedConfig,
+        }}
+        health={health}
+        secretLast4={secretLast4}
+        isSuperAdmin={isSuperAdmin}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/payment/payment-shell.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/payment-shell.tsx
@@ -1,0 +1,558 @@
+"use client";
+
+// PaymentShell — client shell for the community Payment tab (#119).
+//
+// Owns:
+//   - mode state (empty | configured | editing)
+//   - form state (consumer_key + consumer_secret + sandbox toggle)
+//   - Save & test promise + result banner state
+//
+// Data flow:
+//   Server component passes (community, health, secretLast4, isSuperAdmin).
+//   On Save/Test success → router.refresh() so the layout + page re-fetch
+//   health + last-configured timestamp.
+//
+// Mirrors `openems-backend-shell.tsx` pattern; SKIPS the mid-period guard
+// and typed-confirm dialog branches per #119 refinement-locked decision E.
+//
+// Secret handling: the server NEVER ships the plaintext secret to the
+// client. The reconfigure form's secret input initializes blank with a
+// helper "Leave blank to keep the current secret"; submitting a blank
+// secret triggers the PUT route's secret-preserve gate.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { StatusChip } from "@/components/ui/status-chip";
+import { Banner } from "@/components/ui/banner";
+import { Input } from "@/components/ui/input";
+import { LocalDate } from "@/components/format/local-date";
+import type { PaymentHealth } from "./health";
+
+type CommunityProps = {
+  id: string;
+  name: string;
+  payment_provider: "pesapal" | null;
+  payment_last_configured_at: string | null;
+  config: {
+    consumer_key: string;
+    base_url: string;
+    sandbox: boolean;
+  };
+};
+
+export type PaymentShellProps = {
+  community: CommunityProps;
+  health: PaymentHealth;
+  secretLast4: string | null;
+  isSuperAdmin: boolean;
+};
+
+type SaveOutcome =
+  | { kind: "success"; message: string }
+  | { kind: "auth_failed"; message: string }
+  | { kind: "unreachable"; message: string }
+  | { kind: "invalid_config"; message: string }
+  | { kind: "permission_denied"; message: string }
+  | { kind: "generic_error"; message: string };
+
+export function PaymentShell(props: PaymentShellProps) {
+  const { community, health, secretLast4, isSuperAdmin } = props;
+  const router = useRouter();
+
+  const initialMode: "empty" | "configured" =
+    community.payment_provider == null ? "empty" : "configured";
+  const [mode] = React.useState<"empty" | "configured">(initialMode);
+  const [isEditing, setIsEditing] = React.useState(false);
+
+  const [consumerKey, setConsumerKey] = React.useState<string>(
+    community.config.consumer_key,
+  );
+  const [consumerSecret, setConsumerSecret] = React.useState<string>("");
+  const [sandbox, setSandbox] = React.useState<boolean>(
+    community.config.sandbox,
+  );
+
+  const [outcome, setOutcome] = React.useState<SaveOutcome | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [testingAgain, setTestingAgain] = React.useState(false);
+
+  const putUrl = `/api/communities/${community.id}/payment`;
+
+  // ── Connect / Reconfigure click flow ───────────────────────────────────
+  function handleConnectClick() {
+    setOutcome(null);
+    setConsumerKey("");
+    setConsumerSecret("");
+    setSandbox(false);
+    setIsEditing(true);
+  }
+
+  function handleReconfigureClick() {
+    setOutcome(null);
+    setConsumerKey(community.config.consumer_key);
+    setConsumerSecret(""); // Always blank on Reconfigure — secret-preserve.
+    setSandbox(community.config.sandbox);
+    setIsEditing(true);
+  }
+
+  function handleCancel() {
+    setIsEditing(false);
+    setOutcome(null);
+  }
+
+  // ── Build PUT payload from form state ──────────────────────────────────
+  function buildPayload(options: { preserveSecret: boolean }): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      provider: "pesapal",
+      config: {
+        consumer_key: consumerKey,
+        sandbox,
+      },
+    };
+    if (!options.preserveSecret && consumerSecret.length > 0) {
+      payload.secret_access_key = consumerSecret;
+    }
+    return payload;
+  }
+
+  async function submit(payload: Record<string, unknown>, kind: "save" | "test") {
+    if (kind === "save") setSaving(true);
+    else setTestingAgain(true);
+    setOutcome(null);
+    try {
+      const res = await fetch(putUrl, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = (await res.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+
+      if (res.status === 403) {
+        setOutcome({
+          kind: "permission_denied",
+          message:
+            (typeof json.error === "string" && json.error) ||
+            "You do not have permission to update this payment configuration.",
+        });
+        return;
+      }
+      if (res.status === 400) {
+        setOutcome({
+          kind: "invalid_config",
+          message:
+            (typeof json.error === "string" && json.error) ||
+            "The request was rejected.",
+        });
+        return;
+      }
+      if (res.status === 503) {
+        const reason =
+          typeof json.reason === "string" ? json.reason : "unknown_error";
+        if (reason === "auth_failed") {
+          setOutcome({
+            kind: "auth_failed",
+            message:
+              (typeof json.error === "string" && json.error) ||
+              "Authentication failed. Verify the consumer key and consumer secret on your Pesapal dashboard.",
+          });
+        } else if (reason === "unreachable") {
+          setOutcome({
+            kind: "unreachable",
+            message:
+              (typeof json.error === "string" && json.error) ||
+              "Could not reach Pesapal. Check your network and try again.",
+          });
+        } else {
+          setOutcome({
+            kind: "generic_error",
+            message:
+              (typeof json.error === "string" && json.error) ||
+              "Pesapal returned an unexpected error. Check server logs.",
+          });
+        }
+        return;
+      }
+      if (!res.ok) {
+        setOutcome({
+          kind: "generic_error",
+          message:
+            (typeof json.error === "string" && json.error) ||
+            "Something went wrong saving the configuration.",
+        });
+        return;
+      }
+
+      const message = typeof json.message === "string" ? json.message : "";
+      setOutcome({ kind: "success", message: message || "Connected." });
+
+      if (kind === "save") {
+        // Collapse back to summary after 1.5s.
+        setTimeout(() => {
+          setIsEditing(false);
+          router.refresh();
+        }, 1500);
+      } else {
+        router.refresh();
+      }
+    } catch {
+      setOutcome({
+        kind: "generic_error",
+        message: "Network error — please try again.",
+      });
+    } finally {
+      if (kind === "save") setSaving(false);
+      else setTestingAgain(false);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const payload = buildPayload({ preserveSecret: false });
+    await submit(payload, "save");
+  }
+
+  async function handleTestAgain() {
+    // "Test again" reuses the stored config by sending the same-shape payload
+    // with an empty secret → triggers the server's secret-preserve path + a
+    // fresh auth validation against Pesapal.
+    const payload = {
+      provider: "pesapal",
+      config: {
+        consumer_key: community.config.consumer_key,
+        sandbox: community.config.sandbox,
+      },
+    };
+    await submit(payload, "test");
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  const header = (
+    <div>
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        Payment
+      </p>
+      <h3 className="text-lg font-semibold text-foreground">
+        Connect this community to a payment provider
+      </h3>
+    </div>
+  );
+
+  // Empty state
+  if (mode === "empty" && !isEditing) {
+    if (!isSuperAdmin) {
+      return (
+        <div className="space-y-4">
+          {header}
+          <Banner tone="info" title="Not configured yet">
+            This community hasn&apos;t been connected to a payment provider yet.
+            Ask a super admin to configure it.
+          </Banner>
+        </div>
+      );
+    }
+    return (
+      <div className="space-y-4">
+        {header}
+        <div className="mx-auto max-w-[560px] rounded-md border border-border bg-card p-6 shadow-elev-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Provider
+          </p>
+          <h4 className="mt-1 text-lg font-semibold text-foreground">
+            Connect Pesapal
+          </h4>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Pesapal handles mobile-money and card collection for households in
+            Uganda and Kenya. MBE generates one payment link per billing line
+            item and records the redirect URL.
+          </p>
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={handleConnectClick}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Connect Pesapal
+            </button>
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            More providers (Stripe, Flutterwave, M-Pesa direct) coming soon.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Summary card (configured)
+  const summaryCard =
+    community.payment_provider != null ? (
+      <div className="rounded-md border border-border bg-card p-5 shadow-elev-1">
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Left column */}
+          <div className="space-y-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Provider
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                Pesapal
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Environment
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                {community.config.sandbox ? "Sandbox" : "Live"}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Consumer key
+              </p>
+              <p className="mt-1 break-all font-mono text-xs text-foreground">
+                {community.config.consumer_key || "—"}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Consumer secret
+              </p>
+              <p className="mt-1 font-mono text-xs text-foreground">
+                {secretLast4 ? `••••••••${secretLast4}` : "—"}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Base URL
+              </p>
+              <p className="mt-1 break-all font-mono text-xs text-foreground">
+                {community.config.base_url || "—"}
+              </p>
+            </div>
+          </div>
+
+          {/* Right column */}
+          <div className="flex flex-col items-start gap-3">
+            <StatusChip kind="paymentHealth" status={health} />
+            {community.payment_last_configured_at ? (
+              <p className="text-xs text-muted-foreground">
+                Last test:{" "}
+                <LocalDate
+                  value={community.payment_last_configured_at}
+                  relative
+                />
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No Save & test has run yet.
+              </p>
+            )}
+            {isSuperAdmin && (
+              <button
+                type="button"
+                onClick={handleTestAgain}
+                disabled={testingAgain}
+                className="rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {testingAgain ? "Testing…" : "Test again"}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {isSuperAdmin && !isEditing && (
+          <div className="mt-5 flex justify-end">
+            <button
+              type="button"
+              onClick={handleReconfigureClick}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Reconfigure
+            </button>
+          </div>
+        )}
+      </div>
+    ) : null;
+
+  // Form (visible when editing)
+  const form = isEditing ? (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-md border border-border bg-card p-5 shadow-elev-1 space-y-5"
+    >
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {initialMode === "empty" ? "New connection" : "Reconfigure connection"}
+        </p>
+        <h4 className="mt-1 text-lg font-semibold text-foreground">Pesapal</h4>
+      </div>
+
+      <fieldset className="space-y-3">
+        <legend className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Credentials
+        </legend>
+        <div>
+          <label
+            htmlFor="pesapal-consumer-key"
+            className="mb-1 block text-xs font-medium text-foreground"
+          >
+            Consumer key
+          </label>
+          <Input
+            id="pesapal-consumer-key"
+            type="text"
+            value={consumerKey}
+            onChange={(e) => setConsumerKey(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            required
+            className="font-mono text-xs"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="pesapal-consumer-secret"
+            className="mb-1 block text-xs font-medium text-foreground"
+          >
+            Consumer secret
+          </label>
+          <Input
+            id="pesapal-consumer-secret"
+            type="password"
+            value={consumerSecret}
+            onChange={(e) => setConsumerSecret(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={
+              initialMode === "configured"
+                ? "Leave blank to keep the current secret"
+                : ""
+            }
+            className="font-mono text-xs"
+          />
+          {initialMode === "configured" && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Leave blank to keep the current secret.
+            </p>
+          )}
+        </div>
+      </fieldset>
+
+      <div>
+        <label className="inline-flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            checked={sandbox}
+            onChange={(e) => setSandbox(e.target.checked)}
+            className="h-4 w-4 rounded border-border text-primary focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="text-xs text-foreground">
+            Use sandbox environment
+          </span>
+        </label>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          When enabled, MBE talks to Pesapal&apos;s test environment at{" "}
+          <span className="font-mono">cybqa.pesapal.com</span>. Leave unchecked
+          for live collections.
+        </p>
+      </div>
+
+      {outcome && <OutcomeBanner outcome={outcome} />}
+
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="rounded-md px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          aria-busy={saving}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {saving ? (
+            <>
+              <span
+                aria-hidden="true"
+                className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-primary-foreground border-r-transparent"
+              />
+              Testing connection…
+            </>
+          ) : (
+            "Save & test connection"
+          )}
+        </button>
+      </div>
+    </form>
+  ) : null;
+
+  return (
+    <div className="space-y-4">
+      {header}
+
+      {!isSuperAdmin && mode === "configured" && (
+        <Banner tone="info" title="Read-only view">
+          Only super admins can update Payment credentials. Contact your
+          administrator to request changes.
+        </Banner>
+      )}
+
+      {summaryCard}
+
+      {/* In configured mode, surface Test-again outcome above the card so it
+          doesn't disappear when the form is hidden. */}
+      {!isEditing && outcome && <OutcomeBanner outcome={outcome} />}
+
+      {form}
+    </div>
+  );
+}
+
+function OutcomeBanner({ outcome }: { outcome: SaveOutcome }) {
+  if (outcome.kind === "success") {
+    return (
+      <Banner tone="success" title="Connected">
+        {outcome.message || "Connected. Pesapal authentication succeeded."}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "auth_failed") {
+    return (
+      <Banner tone="destructive" title="Authentication failed">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "unreachable") {
+    return (
+      <Banner tone="destructive" title="Pesapal unreachable">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "invalid_config") {
+    return (
+      <Banner tone="warn" title="Invalid configuration">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "permission_denied") {
+    return (
+      <Banner tone="destructive" title="Permission denied">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  return (
+    <Banner tone="destructive" title="Something went wrong">
+      {outcome.message}
+    </Banner>
+  );
+}

--- a/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
@@ -266,6 +266,47 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
     expect(body.reason).toBe("not_found");
   });
 
+  // ─── (9) IPN not registered (post-#119 deferred-IPN state) ───────────────
+  //
+  // A community configured with empty ipn_id is "configured for auth" but
+  // not yet "ready for link generation". The PesapalProvider constructor
+  // throws PESAPAL_NO_IPN; the route maps it to 409 reason: "invalid_config"
+  // with a distinct message so the UI can render the Designer §8 gate copy.
+  //
+  // Since this test mocks `getPaymentProviderClient`, we simulate the
+  // constructor-time throw by having the factory's generatePaymentLink mock
+  // raise PESAPAL_NO_IPN. End-to-end coverage (real factory + real provider
+  // constructor) is out of scope for this route test — the library-side
+  // validation is covered by parsePesapalConfig + PesapalProvider unit tests.
+  it("(9) returns 409 invalid_config when config has empty ipn_id (deferred-IPN state)", async () => {
+    const { PesapalError } = await import("@/lib/payments/pesapal/errors");
+    generatePaymentLinkMock.mockRejectedValueOnce(
+      new PesapalError(
+        "Pesapal config missing ipn_id — register an IPN via Pesapal first",
+        "PESAPAL_NO_IPN",
+        400,
+      ),
+    );
+    getCommunityPaymentConfigMock.mockResolvedValueOnce({
+      ...GOOD_CONFIG,
+      config: {
+        consumer_key: GOOD_CONFIG.config.consumer_key,
+        base_url: GOOD_CONFIG.config.base_url,
+        // ipn_id intentionally omitted — parsePesapalConfig now accepts this
+        // shape and returns a PesapalConfig without ipn_id.
+      },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ lineItemId: LINE_ITEM_ID }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.reason).toBe("invalid_config");
+    expect(String(body.error)).toMatch(/IPN/i);
+  });
+
   // ─── (8) Log scrubber strips secret + token + URL ─────────────────────────
   it("(8) log payload never contains secret, session token, or redirect URL", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});

--- a/src/app/api/billing-line-items/[lineItemId]/url/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/route.ts
@@ -226,10 +226,14 @@ export async function POST(
   // 6. Pesapal rejects reused `id` — fresh per click.
   const orderId = `INV-${lineItemId}-${Date.now()}`;
 
-  // 7. Dispatch through the factory.
-  const client = getPaymentProviderClient(paymentConfig);
+  // 7. Dispatch through the factory. The PesapalProvider constructor itself
+  //    throws PESAPAL_NO_IPN when the persisted config lacks ipn_id (a
+  //    per-#119 deferred-IPN state). Wrap both the constructor and the
+  //    generatePaymentLink call under a single try so every Pesapal-layer
+  //    error lands in the same mapPaymentError branch.
   let result: GeneratePaymentLinkResult;
   try {
+    const client = getPaymentProviderClient(paymentConfig);
     result = await client.generatePaymentLink({
       lineItemId,
       orderId,
@@ -314,7 +318,16 @@ function mapPaymentError(err: unknown): MappedError {
     case "PESAPAL_UNREACHABLE":
       return { message: err.message, reason: "unreachable", httpStatus: 503 };
     case "PESAPAL_NO_IPN":
-      return { message: err.message, reason: "invalid_config", httpStatus: 503 };
+      // Per #119 AC-LIB-2: community has a provider configured but no IPN
+      // registered yet — a user-caused not-ready state distinct from the
+      // malformed/invalid (503) case. 409 signals "config exists but link
+      // generation is gated on IPN registration (ships with #121)".
+      return {
+        message:
+          "Payment provider is configured but no IPN has been registered yet. A super admin must complete IPN registration before links can be generated.",
+        reason: "invalid_config",
+        httpStatus: 409,
+      };
     case "PESAPAL_INVALID_CONFIG":
       return { message: err.message, reason: "invalid_config", httpStatus: 503 };
     case "PESAPAL_MISSING_CONTACT":

--- a/src/app/api/communities/[id]/payment/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/payment/__tests__/route.test.ts
@@ -1,0 +1,365 @@
+/**
+ * PUT /api/communities/[id]/payment — unit tests (#119 AC-ROUTE-*).
+ *
+ * Supabase + auth helpers + PesapalClient are mocked. Covers:
+ *   (1) Happy path (new config) → 200, encrypts secret, writes all 4 columns
+ *   (2) Happy path (reconfigure w/ blank secret) → secret-preserve skips encrypt
+ *   (3) Permission: non-super_admin (org_manager) → 403
+ *   (4) Permission: cannot access org → 403
+ *   (5) RLS-hidden / missing community → 404
+ *   (6) Pesapal auth fail → 503 { reason: "auth_failed" }, no DB write
+ *   (7) Pesapal unreachable → 503 { reason: "unreachable" }, no DB write
+ *   (8) Malformed body → 400
+ *   (9) First-configuration with blank secret → 400
+ *  (10) base_url is server-derived from sandbox (NOT taken from body)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const COMMUNITY_ID = "550e8400-e29b-41d4-a716-446655440010";
+const ORG_ID = "550e8400-e29b-41d4-a716-446655440020";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const getAccessTokenMock = vi.fn();
+
+vi.mock("@/lib/payments/pesapal/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/payments/pesapal/client")
+  >("@/lib/payments/pesapal/client");
+  class PesapalClientMock {
+    constructor(public cfg: unknown) {}
+    getAccessToken = getAccessTokenMock;
+  }
+  return {
+    ...actual,
+    PesapalClient: PesapalClientMock,
+  };
+});
+
+let canAccessOrgReturn = true;
+let isSuperAdminReturn = true;
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessOrg: async () => canAccessOrgReturn,
+  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
+}));
+
+// ─── Supabase mock — sequenced from() handlers, shared mockRpc ─────────────
+//
+// Route's from() sequence (success path):
+//   1. communities.select(... payment_provider_secret_encrypted).eq(id).maybeSingle()
+//   2. communities.select(payment_provider_config).eq(id).maybeSingle()     ← pre-update read
+//   3. communities.update(payload).eq(id)
+//
+// Plus: mockRpc is used for fn_get_community_payment_secret (preserve path)
+// and fn_ems_encrypt_secret.
+
+let communitySelectResp: { data: unknown; error: unknown } = {
+  data: {
+    id: COMMUNITY_ID,
+    org_id: ORG_ID,
+    payment_provider_secret_encrypted: null,
+  },
+  error: null,
+};
+let existingCfgSelectResp: { data: unknown; error: unknown } = {
+  data: { payment_provider_config: null },
+  error: null,
+};
+let updateError: unknown = null;
+let updatePayloadCapture: Record<string, unknown> | null = null;
+let fromCallIndex = 0;
+
+const mockFrom = vi.fn();
+const mockRpc = vi.fn();
+const mockGetUser = vi
+  .fn()
+  .mockResolvedValue({ data: { user: { id: "actor-user-1" } } });
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: mockFrom,
+    rpc: mockRpc,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+function makePutRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/communities/${COMMUNITY_ID}/payment`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe("PUT /api/communities/[id]/payment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallIndex = 0;
+    canAccessOrgReturn = true;
+    isSuperAdminReturn = true;
+    communitySelectResp = {
+      data: {
+        id: COMMUNITY_ID,
+        org_id: ORG_ID,
+        payment_provider_secret_encrypted: null,
+      },
+      error: null,
+    };
+    existingCfgSelectResp = {
+      data: { payment_provider_config: null },
+      error: null,
+    };
+    updateError = null;
+    updatePayloadCapture = null;
+
+    mockFrom.mockImplementation(() => {
+      const idx = fromCallIndex++;
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => {
+              if (idx === 0) return Promise.resolve(communitySelectResp);
+              return Promise.resolve(existingCfgSelectResp);
+            },
+          }),
+        }),
+        update: (payload: Record<string, unknown>) => {
+          updatePayloadCapture = payload;
+          return {
+            eq: () => Promise.resolve({ error: updateError }),
+          };
+        },
+      };
+    });
+
+    mockRpc.mockImplementation((name: string) => {
+      if (name === "fn_get_community_payment_secret") {
+        return Promise.resolve({ data: "DECRYPTED_SECRET_VALUE_X", error: null });
+      }
+      if (name === "fn_ems_encrypt_secret") {
+        return Promise.resolve({ data: "\\x0a0b0c0d", error: null });
+      }
+      return Promise.resolve({ data: null, error: { message: "unexpected rpc" } });
+    });
+
+    getAccessTokenMock.mockResolvedValue("fake-token");
+  });
+
+  // ─── (1) Happy path ────────────────────────────────────────────────────
+  it("(1) happy path writes all 4 columns and returns 200 success", async () => {
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("success");
+    expect(getAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(updatePayloadCapture).toBeTruthy();
+    const payload = updatePayloadCapture!;
+    expect(payload.payment_provider).toBe("pesapal");
+    expect(payload.payment_provider_config).toMatchObject({
+      consumer_key: "ck_live_abc",
+      base_url: "https://pay.pesapal.com/v3",
+      sandbox: false,
+    });
+    expect(payload.payment_provider_secret_encrypted).toBe("\\x0a0b0c0d");
+    expect(payload.payment_last_configured_at).toEqual(expect.any(String));
+  });
+
+  // ─── (2) Reconfigure with blank secret preserves ciphertext ────────────
+  it("(2) secret-preserve: blank secret + existing ciphertext → no re-encrypt, column omitted", async () => {
+    communitySelectResp = {
+      data: {
+        id: COMMUNITY_ID,
+        org_id: ORG_ID,
+        payment_provider_secret_encrypted: "\\xdeadbeef",
+      },
+      error: null,
+    };
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: true },
+        // no secret_access_key
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(200);
+    // fn_get_community_payment_secret is the preserve-path decrypt.
+    const rpcNames = mockRpc.mock.calls.map((c) => c[0]);
+    expect(rpcNames).toContain("fn_get_community_payment_secret");
+    expect(rpcNames).not.toContain("fn_ems_encrypt_secret");
+    expect(updatePayloadCapture).toBeTruthy();
+    expect(
+      "payment_provider_secret_encrypted" in (updatePayloadCapture as object),
+    ).toBe(false);
+    // Server derived base_url from sandbox=true.
+    expect(
+      (
+        updatePayloadCapture!.payment_provider_config as Record<
+          string,
+          unknown
+        >
+      ).base_url,
+    ).toBe("https://cybqa.pesapal.com/pesapalv3");
+  });
+
+  // ─── (3) org_manager → 403 ─────────────────────────────────────────────
+  it("(3) non-super_admin → 403 before any DB write", async () => {
+    isSuperAdminReturn = false;
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(403);
+    expect(getAccessTokenMock).not.toHaveBeenCalled();
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  // ─── (4) cross-org → 403 ───────────────────────────────────────────────
+  it("(4) currentUserCanAccessOrg=false → 403", async () => {
+    canAccessOrgReturn = false;
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(403);
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  // ─── (5) RLS-hidden / missing community → 404 ─────────────────────────
+  it("(5) community not found / RLS-hidden → 404", async () => {
+    communitySelectResp = { data: null, error: null };
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // ─── (6) Pesapal auth fail → 503 no write ─────────────────────────────
+  it("(6) Pesapal auth failure → 503 auth_failed, no DB persist", async () => {
+    const { PesapalError } = await import("@/lib/payments/pesapal/errors");
+    getAccessTokenMock.mockRejectedValueOnce(
+      new PesapalError("auth nope", "PESAPAL_AUTH_FAILED", 401),
+    );
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.reason).toBe("auth_failed");
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  // ─── (7) Pesapal unreachable → 503 no write ───────────────────────────
+  it("(7) Pesapal unreachable → 503 unreachable, no DB persist", async () => {
+    const { PesapalError } = await import("@/lib/payments/pesapal/errors");
+    getAccessTokenMock.mockRejectedValueOnce(
+      new PesapalError("net down", "PESAPAL_UNREACHABLE", 503),
+    );
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.reason).toBe("unreachable");
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  // ─── (8) Malformed body → 400 ─────────────────────────────────────────
+  it("(8) malformed body → 400", async () => {
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({ provider: "not-a-provider" }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ─── (9) First configure with blank secret → 400 ──────────────────────
+  it("(9) first configuration with blank secret → 400", async () => {
+    // default communitySelectResp has payment_provider_secret_encrypted: null
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        // no secret
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect(getAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  // ─── (10) base_url is server-derived from sandbox ─────────────────────
+  it("(10) base_url is server-derived (sandbox=true → cybqa host)", async () => {
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        // Body sends bogus base_url — should be IGNORED by the server.
+        config: {
+          consumer_key: "ck_live_abc",
+          sandbox: true,
+          base_url: "https://evil.example.com/",
+        } as unknown as Record<string, unknown>,
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(200);
+    const stored = (updatePayloadCapture!.payment_provider_config as Record<
+      string,
+      unknown
+    >).base_url;
+    expect(stored).toBe("https://cybqa.pesapal.com/pesapalv3");
+  });
+});

--- a/src/app/api/communities/[id]/payment/route.ts
+++ b/src/app/api/communities/[id]/payment/route.ts
@@ -1,0 +1,381 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  currentUserCanAccessOrg,
+  currentUserIsSuperAdmin,
+} from "@/lib/auth/access";
+import { PesapalClient } from "@/lib/payments/pesapal/client";
+import { PesapalError } from "@/lib/payments/pesapal/errors";
+import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
+
+/**
+ * PUT /api/communities/[id]/payment — Save & test payment-provider config (#119).
+ *
+ * Body shape (super_admin only):
+ *   {
+ *     provider: 'pesapal',
+ *     config: { consumer_key: string, sandbox: boolean },
+ *     secret_access_key?: string,
+ *   }
+ *
+ * Note: `base_url` is NOT accepted from the body. The server derives it
+ * from the `sandbox` boolean so the JSONB stays canonical and typo'd URLs
+ * can never reach the DB.
+ *
+ * Execution order (AC-ROUTE-1..6 in #119):
+ *
+ *   1. UUID check on [id] → 400 on malformed.
+ *   2. JSON parse + manual shape validation → 400 on malformed body.
+ *   3. Resolve the community's org_id (and existing payment_*_encrypted column)
+ *      with a single row read. RLS hidden or missing → 404 (don't leak).
+ *   4. Permission gate: currentUserCanAccessOrg(org_id) AND
+ *      currentUserIsSuperAdmin. Either missing → 403. super_admin gate is the
+ *      primary rule; org access is defense-in-depth.
+ *   5. Secret-preserve gate: if the body's secret_access_key is blank/absent
+ *      AND an existing payment_provider_secret_encrypted row is non-NULL,
+ *      preserve it. Otherwise require a non-empty secret → 400.
+ *   6. Decrypt the preserved secret via fn_get_community_payment_secret so we
+ *      can run a live auth test against Pesapal with it.
+ *   7. Save & test: call PesapalClient.getAccessToken() with the effective
+ *      credentials. On failure → 503 { reason } with no DB write.
+ *   8. On success: atomic UPDATE of all 4 columns
+ *      (payment_provider, payment_provider_config JSONB,
+ *      payment_provider_secret_encrypted BYTEA via fn_ems_encrypt_secret,
+ *      payment_last_configured_at = now()).
+ *   9. Log payment.save_test with scrubbed secret + token.
+ *
+ * Response:
+ *   200 → { status: 'success', message: string }
+ *   4xx/5xx → { error, reason? }
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const PESAPAL_BASE_URL_PROD = "https://pay.pesapal.com/v3";
+const PESAPAL_BASE_URL_SANDBOX = "https://cybqa.pesapal.com/pesapalv3";
+
+type ParsedBody = {
+  provider: "pesapal";
+  consumer_key: string;
+  sandbox: boolean;
+  secret_access_key: string | undefined;
+};
+
+function parseBody(raw: unknown): ParsedBody | { error: string } {
+  if (!raw || typeof raw !== "object") {
+    return { error: "Request body must be an object" };
+  }
+  const body = raw as Record<string, unknown>;
+  if (body.provider !== "pesapal") {
+    return { error: "provider must be 'pesapal'" };
+  }
+  if (!body.config || typeof body.config !== "object") {
+    return { error: "config is required and must be an object" };
+  }
+  const cfg = body.config as Record<string, unknown>;
+  const consumer_key =
+    typeof cfg.consumer_key === "string" ? cfg.consumer_key.trim() : "";
+  if (!consumer_key) {
+    return { error: "config.consumer_key must be a non-empty string" };
+  }
+  if (typeof cfg.sandbox !== "boolean") {
+    return { error: "config.sandbox must be a boolean" };
+  }
+  let secret_access_key: string | undefined;
+  if (body.secret_access_key !== undefined) {
+    if (typeof body.secret_access_key !== "string") {
+      return { error: "secret_access_key, when provided, must be a string" };
+    }
+    secret_access_key = body.secret_access_key;
+  }
+  return {
+    provider: "pesapal",
+    consumer_key,
+    sandbox: cfg.sandbox,
+    secret_access_key,
+  };
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const startedAt = Date.now();
+  const { id: communityId } = await params;
+
+  if (!UUID_RE.test(communityId)) {
+    return NextResponse.json(
+      { error: "Invalid community id — expected UUID" },
+      { status: 400 },
+    );
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = parseBody(rawBody);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  // Row read: we need org_id for the permission check + the existing
+  // ciphertext for the secret-preserve gate.
+  const { data: community, error: commErr } = await supabase
+    .from("communities")
+    .select("id, org_id, payment_provider_secret_encrypted")
+    .eq("id", communityId)
+    .maybeSingle<{
+      id: string;
+      org_id: string;
+      payment_provider_secret_encrypted: string | null;
+    }>();
+
+  if (commErr) {
+    return NextResponse.json(
+      { error: `Failed to read community: ${commErr.message}` },
+      { status: 500 },
+    );
+  }
+  // RLS-hidden or missing row → 404 (don't leak existence via 403).
+  if (!community) {
+    return NextResponse.json({ error: "Community not found." }, { status: 404 });
+  }
+
+  // Permission — super_admin gate is the primary rule; org access
+  // is defense-in-depth (super_admins always pass currentUserCanAccessOrg).
+  if (!(await currentUserCanAccessOrg(supabase, community.org_id))) {
+    return NextResponse.json(
+      { error: "You do not have permission to configure this community." },
+      { status: 403 },
+    );
+  }
+  if (!(await currentUserIsSuperAdmin(supabase))) {
+    return NextResponse.json(
+      {
+        error:
+          "Only super admins can update Payment credentials.",
+      },
+      { status: 403 },
+    );
+  }
+
+  // Secret-preserve gate. If blank/absent + existing ciphertext → preserve.
+  const submittedSecret = parsed.secret_access_key ?? "";
+  const preserveExistingSecret =
+    submittedSecret.length === 0 &&
+    community.payment_provider_secret_encrypted !== null &&
+    community.payment_provider_secret_encrypted !== undefined;
+
+  if (submittedSecret.length === 0 && !preserveExistingSecret) {
+    return NextResponse.json(
+      {
+        error:
+          "A consumer secret is required for the first Pesapal configuration.",
+      },
+      { status: 400 },
+    );
+  }
+
+  // Resolve the effective plaintext secret for the Save & test step.
+  let effectiveSecret = submittedSecret;
+  if (preserveExistingSecret) {
+    const { data: decrypted, error: decryptErr } = await supabase.rpc(
+      "fn_get_community_payment_secret",
+      { _community_id: communityId },
+    );
+    if (decryptErr || !decrypted) {
+      return NextResponse.json(
+        {
+          error:
+            "Could not retrieve the existing secret to test the connection. Re-enter the consumer secret to proceed.",
+        },
+        { status: 500 },
+      );
+    }
+    effectiveSecret = decrypted as string;
+  }
+
+  // Server-derived base_url from sandbox toggle.
+  const base_url = parsed.sandbox
+    ? PESAPAL_BASE_URL_SANDBOX
+    : PESAPAL_BASE_URL_PROD;
+
+  // Save & test — call Pesapal auth BEFORE any persist.
+  try {
+    const client = new PesapalClient({
+      consumerKey: parsed.consumer_key,
+      consumerSecret: effectiveSecret,
+      baseUrl: base_url,
+    });
+    await client.getAccessToken();
+  } catch (err) {
+    let reason: "auth_failed" | "unreachable" | "unknown_error" =
+      "unknown_error";
+    let message = "Could not validate the Pesapal credentials.";
+    if (err instanceof PesapalError) {
+      if (err.code === "PESAPAL_AUTH_FAILED") {
+        reason = "auth_failed";
+        message =
+          "Authentication failed. Verify the consumer key and consumer secret on your Pesapal dashboard.";
+      } else if (err.code === "PESAPAL_UNREACHABLE") {
+        reason = "unreachable";
+        message =
+          "Could not reach Pesapal. Check your network and try again.";
+      } else {
+        message =
+          "Pesapal returned an unexpected error. Check server logs and try again.";
+      }
+    }
+
+    logSaveTest({
+      communityId,
+      provider: parsed.provider,
+      status: reason,
+      durationMs: Date.now() - startedAt,
+      sensitive: [effectiveSecret],
+      supabase,
+    });
+
+    return NextResponse.json({ error: message, reason }, { status: 503 });
+  }
+
+  // Pesapal validated the creds → persist.
+  // 1. Encrypt the (possibly reused) plaintext secret.
+  let encryptedSecret: string | null = null;
+  if (!preserveExistingSecret) {
+    const { data: enc, error: encErr } = await supabase.rpc(
+      "fn_ems_encrypt_secret",
+      { p_plaintext: effectiveSecret },
+    );
+    if (encErr || !enc) {
+      return NextResponse.json(
+        {
+          error: `Failed to encrypt secret: ${encErr?.message ?? "no data"}`,
+        },
+        { status: 500 },
+      );
+    }
+    encryptedSecret = enc as string;
+  }
+
+  // 2. Build the atomic UPDATE payload. Preserve existing ipn_id if present
+  //    on the current row (IPN registration UX ships with #121; until then
+  //    the column may carry a stale ipn_id from pre-#119 configs). Read the
+  //    existing config first to avoid dropping the field.
+  const { data: existingCfg } = await supabase
+    .from("communities")
+    .select("payment_provider_config")
+    .eq("id", communityId)
+    .maybeSingle<{ payment_provider_config: unknown }>();
+
+  const existingIpnId =
+    existingCfg &&
+    existingCfg.payment_provider_config &&
+    typeof existingCfg.payment_provider_config === "object" &&
+    typeof (
+      existingCfg.payment_provider_config as Record<string, unknown>
+    ).ipn_id === "string"
+      ? ((existingCfg.payment_provider_config as Record<string, unknown>)
+          .ipn_id as string)
+      : undefined;
+
+  const newConfig: Record<string, unknown> = {
+    consumer_key: parsed.consumer_key,
+    base_url,
+    sandbox: parsed.sandbox,
+  };
+  if (existingIpnId) newConfig.ipn_id = existingIpnId;
+
+  const updatePayload: Record<string, unknown> = {
+    payment_provider: parsed.provider,
+    payment_provider_config: newConfig,
+    payment_last_configured_at: new Date().toISOString(),
+  };
+  if (!preserveExistingSecret) {
+    updatePayload.payment_provider_secret_encrypted = encryptedSecret;
+  }
+
+  const { error: updErr } = await supabase
+    .from("communities")
+    .update(updatePayload)
+    .eq("id", communityId);
+
+  if (updErr) {
+    if (
+      updErr.code === "42501" ||
+      updErr.message.includes("row-level security")
+    ) {
+      return NextResponse.json(
+        { error: "You do not have permission to configure this community." },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json(
+      {
+        error: scrubSecretValues(
+          `Failed to persist config: ${updErr.message}`,
+          { extra: [effectiveSecret] },
+        ),
+      },
+      { status: 500 },
+    );
+  }
+
+  logSaveTest({
+    communityId,
+    provider: parsed.provider,
+    status: "success",
+    durationMs: Date.now() - startedAt,
+    sensitive: [effectiveSecret],
+    supabase,
+  });
+
+  return NextResponse.json(
+    {
+      status: "success",
+      message: "Connected. Pesapal authentication succeeded.",
+    },
+    { status: 200 },
+  );
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function logSaveTest(args: {
+  communityId: string;
+  provider: string;
+  status: string;
+  durationMs: number;
+  sensitive: string[];
+  supabase: Awaited<ReturnType<typeof createClient>>;
+}): Promise<void> {
+  let actorUserId: string | null = null;
+  try {
+    const {
+      data: { user },
+    } = await args.supabase.auth.getUser();
+    actorUserId = user?.id ?? null;
+  } catch {
+    actorUserId = null;
+  }
+  const payload = {
+    event: "payment.save_test",
+    community_id: args.communityId,
+    actor_user_id: actorUserId,
+    provider: args.provider,
+    status: args.status,
+    duration_ms: args.durationMs,
+    at: new Date().toISOString(),
+  };
+  const scrubbed = scrubSecretValues(payload, {
+    extra: args.sensitive.filter(Boolean),
+  });
+  console.info(JSON.stringify(scrubbed));
+}

--- a/src/components/ui/__tests__/status-chip.test.tsx
+++ b/src/components/ui/__tests__/status-chip.test.tsx
@@ -141,3 +141,49 @@ describe("StatusChip — openemsBackendHealth kind", () => {
     expect(chip?.className).toContain("bg-success-muted");
   });
 });
+
+// #119 — Community Payment-provider health chip (4 states).
+describe("StatusChip — paymentHealth kind", () => {
+  it("renders 'healthy' with success background + dot", () => {
+    const { container } = render(
+      <StatusChip kind="paymentHealth" status="healthy" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-success-muted");
+    expect(chip?.querySelector("span")?.className).toContain("bg-success");
+    expect(container.textContent).toContain("Healthy");
+  });
+
+  it("renders 'stale' with warn background + dot", () => {
+    const { container } = render(
+      <StatusChip kind="paymentHealth" status="stale" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-warning-muted");
+    expect(chip?.querySelector("span")?.className).toContain("bg-warning");
+    expect(container.textContent).toContain("Stale");
+  });
+
+  it("renders 'failing' with alert background + dot (reserved; not emitted by derivePaymentHealth today)", () => {
+    const { container } = render(
+      <StatusChip kind="paymentHealth" status="failing" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-destructive-muted");
+    expect(chip?.querySelector("span")?.className).toContain("bg-destructive");
+    expect(container.textContent).toContain("Failing");
+  });
+
+  it("renders 'not_configured' with neutral background + NO dot", () => {
+    const { container } = render(
+      <StatusChip kind="paymentHealth" status="not_configured" />,
+    );
+    const chip = container.querySelector("span");
+    expect(chip?.className).toContain("bg-muted");
+    const dot = chip?.querySelector(
+      "span.bg-success, span.bg-warning, span.bg-destructive, span.bg-muted-foreground",
+    );
+    expect(dot).toBeNull();
+    expect(container.textContent).toContain("Not connected");
+  });
+});

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -21,7 +21,8 @@ type Kind =
   | "household"
   | "householdDeviceRole"
   | "meterType"
-  | "openemsBackendHealth";
+  | "openemsBackendHealth"
+  | "paymentHealth";
 
 type StatusMap = Record<string, { label: string; tone: ChipProps["tone"]; dot?: boolean }>;
 
@@ -106,6 +107,21 @@ const MAPS: Record<Kind, StatusMap> = {
   //   not_configured — ems_type IS NULL; no Discover has run. NO dot (chip
   //                   shouldn't imply any state, just absence).
   openemsBackendHealth: {
+    healthy:        { label: "Healthy",       tone: "success", dot: true  },
+    stale:          { label: "Stale",         tone: "warn",    dot: true  },
+    failing:        { label: "Failing",       tone: "alert",   dot: true  },
+    not_configured: { label: "Not connected", tone: "neutral" /* no dot */ },
+  },
+  // Community Payment-provider health (#119).
+  //   healthy        — payment_last_configured_at is recent (< 24h).
+  //   stale          — configured but last Save & test was ≥ 24h ago; user
+  //                    should "Test again".
+  //   failing        — RESERVED for #121 (IPN webhook failure tracking).
+  //                    `derivePaymentHealth` never emits this today, but the
+  //                    MAPS entry stays pinned so Designer §3's tone table
+  //                    remains stable across the deferred-IPN rollout.
+  //   not_configured — payment_provider IS NULL (no dot — just absence).
+  paymentHealth: {
     healthy:        { label: "Healthy",       tone: "success", dot: true  },
     stale:          { label: "Stale",         tone: "warn",    dot: true  },
     failing:        { label: "Failing",       tone: "alert",   dot: true  },

--- a/src/lib/payments/config.ts
+++ b/src/lib/payments/config.ts
@@ -95,8 +95,21 @@ export async function getCommunityPaymentConfig(
   );
 }
 
-/** Validate the JSONB shape for Pesapal. Throws `PAYMENT_INVALID_CONFIG` on any issue. */
-function parsePesapalConfig(raw: unknown): PesapalConfig {
+/**
+ * Validate the JSONB shape for Pesapal.
+ *
+ * Required fields: `consumer_key`, `base_url`.
+ *
+ * `ipn_id` is **optional** (#119 contract amendment — IPN registration UX
+ * ships with #121). A configured community without ipn_id is "ready for auth
+ * validation" but not yet "ready to generate links" — the strict check lives
+ * further downstream in `PesapalProvider` / `submitOrder`, which throws
+ * `PESAPAL_NO_IPN` when a link is actually requested.
+ *
+ * Throws `PAYMENT_INVALID_CONFIG` only when the shape itself is wrong or the
+ * truly-required fields are missing.
+ */
+export function parsePesapalConfig(raw: unknown): PesapalConfig {
   if (!raw || typeof raw !== "object") {
     throw new PaymentError(
       "payment_provider_config is missing or not an object",
@@ -107,13 +120,17 @@ function parsePesapalConfig(raw: unknown): PesapalConfig {
   const obj = raw as Record<string, unknown>;
   const consumer_key = typeof obj.consumer_key === "string" ? obj.consumer_key : "";
   const base_url = typeof obj.base_url === "string" ? obj.base_url : "";
-  const ipn_id = typeof obj.ipn_id === "string" ? obj.ipn_id : "";
-  if (!consumer_key || !base_url || !ipn_id) {
+  if (!consumer_key || !base_url) {
     throw new PaymentError(
-      "payment_provider_config is missing required fields (consumer_key, base_url, ipn_id)",
+      "payment_provider_config is missing required fields (consumer_key, base_url)",
       "PAYMENT_INVALID_CONFIG",
       500,
     );
   }
-  return { consumer_key, base_url, ipn_id };
+  const ipn_id_raw = typeof obj.ipn_id === "string" ? obj.ipn_id : "";
+  const sandbox = typeof obj.sandbox === "boolean" ? obj.sandbox : undefined;
+  const parsed: PesapalConfig = { consumer_key, base_url };
+  if (ipn_id_raw) parsed.ipn_id = ipn_id_raw;
+  if (sandbox !== undefined) parsed.sandbox = sandbox;
+  return parsed;
 }

--- a/src/lib/payments/pesapal/types.ts
+++ b/src/lib/payments/pesapal/types.ts
@@ -73,9 +73,24 @@ export interface SubmitOrderResponse {
  * `communities.payment_provider_config`. `consumer_secret` is stored separately
  * in `payment_provider_secret_encrypted` (envelope-encrypted BYTEA) and
  * surfaced via `fn_get_community_payment_secret`.
+ *
+ * `ipn_id` is **optional** today (#119 contract amendment): Save & test
+ * persists a config with no IPN registered yet — IPN registration UX lands
+ * with #121. `submitOrder` remains strict; the PesapalProvider constructor
+ * throws PESAPAL_NO_IPN at link-generation time when ipn_id is missing,
+ * which surfaces as a clean 409/503 to the user rather than a silent crash.
  */
 export interface PesapalConfig {
   consumer_key: string;
   base_url: string;
-  ipn_id: string;
+  ipn_id?: string;
+  /**
+   * Persisted reflection of the Sandbox toggle in the config UI. Server
+   * derives `base_url` from this boolean on write, but we also persist the
+   * flag so the Reconfigure form can round-trip the toggle state without
+   * string-matching the URL. Optional for backward compatibility with rows
+   * written before #119 (there shouldn't be any in production, but tests
+   * and fixtures may omit it).
+   */
+  sandbox?: boolean;
 }


### PR DESCRIPTION
## Summary
- **Library loosening**: `PesapalConfig.ipn_id` made optional in `types.ts`; `parsePesapalConfig` accepts undefined/empty; `submitOrder` stays strict and surfaces a clean 409 `invalid_config` (with IPN-specific message) at link-generation time when missing. New test case in line-item URL route asserts this path.
- **PUT route** `/api/communities/[id]/payment`:
  - super_admin route-layer gate (defense-in-depth alongside `currentUserCanAccessOrg`)
  - Server-derived `base_url` from sandbox toggle (NOT client-supplied — body-supplied URL is ignored)
  - Pre-persist Pesapal `getAccessToken()` validation; on `auth_failed` / `unreachable` → 503 with `reason`, NO write
  - Atomic UPDATE of all 4 payment columns on success; secret-preserve on blank
  - Scrubbed `payment.save_test` log
- **Community sub-nav + layout**: new sibling `<CommunitySubNav>` (NOT a refactor of `<SetupSubNav>`); shared `layout.tsx` wraps Overview (`/communities/[id]`) and Payment (`/communities/[id]/payment`).
- **Payment page + shell**:
  - Server loader computes `secretLast4 = secret?.slice(-4)` server-side; plaintext NEVER crosses to the client
  - State machine: empty / configured-summary / reconfigure-form / save-loading / save-success / save-error
  - Empty state: single "Connect Pesapal" card + "Coming soon" footnote (provider-abstraction signal)
  - Configured: 2-column summary card (provider chip / masked secret last-4 / last-configured timestamp / sandbox indicator | health chip / Test again / Reconfigure)
  - Reconfigure form: Consumer Key + Consumer Secret (blank with "Leave blank to keep" helper) + Sandbox toggle
  - Org_manager: read-only summary + info banner ("Only super admins can update Payment credentials")
- **Health chip**: `<StatusChip kind="paymentHealth">` extends MAPS with 4 statuses (`healthy` / `stale` / `failing` / `not_configured`); only 3 are emitted today (`failing` reserved for #121).

## Out of scope (deliberate)
- Mid-period guard — refinement skipped (provider rotation doesn't break in-flight Pesapal orders per PM)
- IPN registration UX — #121
- `failing` health state derivation — #121

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` — 713 pass
- [x] `npm run build`
- [ ] Manual: super_admin on Kisakye community → Payment tab → Connect Pesapal → enter Consumer Key + Secret + sandbox → Save & test → success banner → form collapses
- [ ] Manual: org_manager → sees read-only summary + info banner

## Known nits (non-blocking)
- Two reads of `communities` in PUT route (could be one); TOCTOU window is negligible (super_admin-only writes)
- `ipn_id` preserved across sandbox→live swap (Pesapal IPN is environment-specific) — flagged for #121
- Consumer Secret input lacks `required` on first configure (server returns 400 → flows to error banner; UX could be tightened)

Closes #119.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)