### PR TITLE
Eager-resolve actorUserId; make logPaymentEvent synchronous (#126)

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
@@ -157,11 +157,19 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
 
   // ─── (1) Happy path ───────────────────────────────────────────────────────
   it("(1) returns 200 with redirectUrl/orderTrackingId/merchantReference on success", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
     const { POST } = await import("../route");
     const res = await POST(makeReq(), {
       params: Promise.resolve({ lineItemId: LINE_ITEM_ID }),
     });
     expect(res.status).toBe(200);
+
+    // Log emits synchronously before the response is consumed.
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('"payment.generate_link"'));
+    // Eager resolution: auth.getUser() called exactly once per request.
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+
     const body = await res.json();
     expect(body).toEqual({
       redirectUrl: GOOD_RESULT.redirectUrl,
@@ -173,6 +181,8 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
     const call = generatePaymentLinkMock.mock.calls[0][0];
     expect(call.orderId).toMatch(new RegExp(`^INV-${LINE_ITEM_ID}-\\d+$`));
     expect(call.currency).toBe("UGX");
+
+    infoSpy.mockRestore();
   });
 
   // ─── (2) Not configured ────────────────────────────────────────────────────

--- a/src/app/api/billing-line-items/[lineItemId]/url/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/route.ts
@@ -132,6 +132,17 @@ export async function POST(
   const microgridId = period.microgrid_id;
   const communityId = microgrid.community_id;
 
+  // Eager-resolve the authenticated user once so logPaymentEvent is synchronous.
+  let actorUserId: string | null = null;
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    actorUserId = user?.id ?? null;
+  } catch {
+    actorUserId = null;
+  }
+
   // 2. Permission gate. org_manager + super_admin both allowed; secret access
   //    is filtered by fn_get_community_payment_secret (org_manager → null →
   //    PAYMENT_FORBIDDEN below).
@@ -152,12 +163,11 @@ export async function POST(
       communityId,
       microgridId,
       lineItemId,
-      actorUserId: null,
+      actorUserId,
       provider: null,
       status: mapped.reason,
       durationMs: Date.now() - startedAt,
       sensitive: [],
-      supabase,
     });
     return NextResponse.json(
       { error: mapped.message, reason: mapped.reason },
@@ -170,12 +180,11 @@ export async function POST(
       communityId,
       microgridId,
       lineItemId,
-      actorUserId: null,
+      actorUserId,
       provider: null,
       status: "not_configured",
       durationMs: Date.now() - startedAt,
       sensitive: [],
-      supabase,
     });
     return NextResponse.json(
       {
@@ -196,12 +205,11 @@ export async function POST(
       communityId,
       microgridId,
       lineItemId,
-      actorUserId: null,
+      actorUserId,
       provider: paymentConfig.provider,
       status: mapped.reason,
       durationMs: Date.now() - startedAt,
       sensitive: [paymentConfig.secret],
-      supabase,
     });
     return NextResponse.json(
       { error: mapped.message, reason: mapped.reason },
@@ -245,12 +253,11 @@ export async function POST(
       communityId,
       microgridId,
       lineItemId,
-      actorUserId: null,
+      actorUserId,
       provider: paymentConfig.provider,
       status: mapped.reason,
       durationMs: Date.now() - startedAt,
       sensitive: [paymentConfig.secret],
-      supabase,
     });
     return NextResponse.json(
       { error: mapped.message, reason: mapped.reason },
@@ -262,12 +269,11 @@ export async function POST(
     communityId,
     microgridId,
     lineItemId,
-    actorUserId: null,
+    actorUserId,
     provider: paymentConfig.provider,
     status: "success",
     durationMs: Date.now() - startedAt,
     sensitive: [paymentConfig.secret, result.redirectUrl, result.providerOrderId],
-    supabase,
   });
 
   return NextResponse.json({
@@ -333,7 +339,7 @@ function mapPaymentError(err: unknown): MappedError {
   }
 }
 
-async function logPaymentEvent(args: {
+function logPaymentEvent(args: {
   communityId: string;
   microgridId: string;
   lineItemId: string;
@@ -342,26 +348,13 @@ async function logPaymentEvent(args: {
   status: string;
   durationMs: number;
   sensitive: string[];
-  supabase: Awaited<ReturnType<typeof createClient>>;
-}): Promise<void> {
-  let actor = args.actorUserId;
-  if (!actor) {
-    try {
-      const {
-        data: { user },
-      } = await args.supabase.auth.getUser();
-      actor = user?.id ?? null;
-    } catch {
-      actor = null;
-    }
-  }
-
+}): void {
   const payload = {
     event: "payment.generate_link",
     community_id: args.communityId,
     microgrid_id: args.microgridId,
     line_item_id: args.lineItemId,
-    actor_user_id: actor,
+    actor_user_id: args.actorUserId,
     provider: args.provider,
     status: args.status,
     duration_ms: args.durationMs,


### PR DESCRIPTION
## Summary
Audit-trail reliability fix for the merged #115 generate-link route:
- `logPaymentEvent` was `async`-but-unawaited at all 5 callsites — logs could be dropped on serverless fast-exit.
- Every callsite passed `actorUserId: null`, so the lazy `auth.getUser()` branch fired up to 5× per request.
- **Fix**: resolve `actorUserId` once at route entry (try/catch fallback to `null`), pass into a now-synchronous `logPaymentEvent`. One `auth.getUser()` per request, zero fire-and-forget risk.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` — 676 pass; new assertions in Case 1: `infoSpy` called with `"payment.generate_link"` before response is consumed; `mockGetUser` called exactly once
- [x] `npm run build`

Closes #126.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)