### PR TITLE
Allow Add Community + Add Microgrid from global listings via parent picker (#132)

### DIFF
--- a/src/app/(dashboard)/communities/page.test.tsx
+++ b/src/app/(dashboard)/communities/page.test.tsx
@@ -7,11 +7,12 @@
 //   - Assert:
 //     (a) Row renders with community name, city/country, and microgrid count.
 //     (b) Empty state renders when the query returns zero rows.
+//     (c) Add button renders in single-org context (#76 original behaviour).
+//     (d) Add button renders in multi-org context (#132: picker mode).
 //
 // Note: after #76 (UX4a), the listing query selects `*, microgrids(count)` so
-// row rendering receives the full Community row shape. Empty-state copy
-// diverges per access: org_manager (1 accessible org) sees an add CTA;
-// anonymous / 0-org view sees "add from the organization detail page".
+// row rendering receives the full Community row shape. After #132 the gate is
+// lifted — Add renders for any non-zero accessibleOrgs count.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -53,6 +54,7 @@ const mockFrom = vi.fn((table: string) => {
 
 // Mutable test-scoped state so each test can control what the DB returns.
 let communitiesData: unknown = [];
+// orgsData now includes `name` (fetched as `id, name` after #132).
 let orgsData: unknown = [];
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -118,7 +120,7 @@ describe("CommunitiesPage", () => {
 
   it("renders a row with name, city/country, and microgrid count", async () => {
     communitiesData = [COMMUNITY_WITH_DATA];
-    orgsData = [{ id: "org-1" }];
+    orgsData = [{ id: "org-1", name: "EnergyIoT Uganda" }];
 
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
@@ -132,7 +134,7 @@ describe("CommunitiesPage", () => {
 
   it("renders multiple rows when multiple communities are returned", async () => {
     communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
-    orgsData = [{ id: "org-1" }];
+    orgsData = [{ id: "org-1", name: "EnergyIoT Uganda" }];
 
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
@@ -142,6 +144,31 @@ describe("CommunitiesPage", () => {
     expect(html).toContain("1 microgrid");
   });
 
+  it("renders Add Community button in single-org context (locked mode)", async () => {
+    communitiesData = [COMMUNITY_WITH_DATA];
+    orgsData = [{ id: "org-1", name: "EnergyIoT Uganda" }];
+
+    const jsx = await CommunitiesPage();
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // AddEntityButton renders a <button> with the default label.
+    expect(html).toContain("+ Add Community");
+  });
+
+  it("renders Add Community button in multi-org context (picker mode, #132)", async () => {
+    communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
+    orgsData = [
+      { id: "org-1", name: "EnergyIoT Uganda" },
+      { id: "org-2", name: "Field Energy Kenya" },
+    ];
+
+    const jsx = await CommunitiesPage();
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Add button must render even when multiple orgs are accessible.
+    expect(html).toContain("+ Add Community");
+  });
+
   it("renders empty state when query returns zero rows", async () => {
     communitiesData = [];
     orgsData = [];
@@ -149,8 +176,7 @@ describe("CommunitiesPage", () => {
     const jsx = await CommunitiesPage();
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
-    // After #76, empty state splits by access. For zero-org view it directs
-    // the user to the organization detail page.
+    // Zero-org view: directs user to the organization detail page.
     expect(html).toMatch(/No communities/);
     expect(html).not.toContain("Kisakye");
   });

--- a/src/app/(dashboard)/communities/page.tsx
+++ b/src/app/(dashboard)/communities/page.tsx
@@ -9,6 +9,8 @@ type CommunityRow = Community & {
   microgrids: { count: number }[];
 };
 
+type OrgRow = { id: string; name: string };
+
 export default async function CommunitiesPage() {
   const supabase = await createClient();
 
@@ -21,17 +23,23 @@ export default async function CommunitiesPage() {
         .returns<CommunityRow[]>(),
       supabase
         .from("organizations")
-        .select("id")
+        .select("id, name")
         .order("name")
-        .returns<{ id: string }[]>(),
+        .returns<OrgRow[]>(),
       getHierarchyLevels(supabase, { kind: "communities" }),
     ]);
 
-  // If the user can see exactly one org (the org_manager case), we can offer
-  // "+ Add Community" inline. Super_admin typically creates via the org
-  // detail page; we still allow inline add when there's only one org in view.
-  const singleAccessibleOrgId =
-    accessibleOrgs && accessibleOrgs.length === 1 ? accessibleOrgs[0].id : null;
+  // Resolve which AddEntityButton variant to use:
+  //   - Single accessible org → locked mode (parentOrgId)
+  //   - Multiple accessible orgs → picker mode (availableOrgs)
+  //   - Zero accessible orgs → no button
+  const orgs = accessibleOrgs ?? [];
+  const addButton =
+    orgs.length === 1 ? (
+      <AddEntityButton entity="community" parentOrgId={orgs[0].id} />
+    ) : orgs.length > 1 ? (
+      <AddEntityButton entity="community" availableOrgs={orgs} />
+    ) : null;
 
   if (error) {
     return (
@@ -51,16 +59,24 @@ export default async function CommunitiesPage() {
           </h1>
         </div>
         <div className="rounded-md border border-border bg-card p-8 text-center">
-          {singleAccessibleOrgId ? (
+          {addButton ? (
             <>
               <p className="mb-4 text-muted-foreground">
                 No communities yet.
               </p>
-              <AddEntityButton
-                entity="community"
-                parentOrgId={singleAccessibleOrgId}
-                label="+ Add the first Community"
-              />
+              {orgs.length === 1 ? (
+                <AddEntityButton
+                  entity="community"
+                  parentOrgId={orgs[0].id}
+                  label="+ Add the first Community"
+                />
+              ) : (
+                <AddEntityButton
+                  entity="community"
+                  availableOrgs={orgs}
+                  label="+ Add the first Community"
+                />
+              )}
             </>
           ) : (
             <p className="text-muted-foreground">
@@ -77,12 +93,7 @@ export default async function CommunitiesPage() {
       <HierarchyNav levels={levels} className="mb-4" />
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">Communities</h1>
-        {singleAccessibleOrgId && (
-          <AddEntityButton
-            entity="community"
-            parentOrgId={singleAccessibleOrgId}
-          />
-        )}
+        {addButton}
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {communities.map((community) => {

--- a/src/app/(dashboard)/microgrids/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/page.test.tsx
@@ -1,0 +1,188 @@
+// MicrogridsPage server-component test (node environment).
+//
+// Strategy:
+//   - Mock @/lib/supabase/server with a table-aware builder that supports
+//     .eq() filtering, .single(), .maybeSingle(), .returns(), .order(), and
+//     head:true count queries.
+//   - Call MicrogridsPage() directly (async server component).
+//   - Render the returned JSX with react-dom/server renderToStaticMarkup.
+//   - Assert:
+//     (a) Rows render with microgrid name.
+//     (b) Add button renders in single-community URL context (locked mode).
+//     (c) Add button renders in multi-community scope (picker mode, #132).
+//     (d) Empty state shows CTA when communities accessible.
+//     (e) Empty state shows fallback when zero communities accessible.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+// ─── Supabase mock ─────────────────────────────────────────────────────────────
+//
+// Mirrors the pattern in src/lib/__tests__/hierarchy.test.ts:
+// each table has its data rows; .eq() filters, .single()/.maybeSingle() return
+// the first matching row, .returns() returns all matching rows.
+// households always returns count=0 (head:true shape).
+
+type Tables = Record<string, Record<string, unknown>[]>;
+
+let tables: Tables = {};
+
+function makeBuilder(tableName: string) {
+  const _eqs: [string, unknown][] = [];
+  let _head = false;
+
+  const proxy: Record<string, unknown> = {
+    select(_cols: string, opts?: { count?: string; head?: boolean }) {
+      if (opts?.head) _head = true;
+      return proxy;
+    },
+    eq(col: string, val: unknown) {
+      _eqs.push([col, val]);
+      return proxy;
+    },
+    order() {
+      return proxy;
+    },
+    returns() {
+      let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+      for (const [col, val] of _eqs) {
+        rows = rows.filter((r) => r[col] === val);
+      }
+      return Promise.resolve({ data: rows, error: null });
+    },
+    single() {
+      let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+      for (const [col, val] of _eqs) {
+        rows = rows.filter((r) => r[col] === val);
+      }
+      return Promise.resolve({ data: rows[0] ?? null, error: null });
+    },
+    maybeSingle() {
+      let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+      for (const [col, val] of _eqs) {
+        rows = rows.filter((r) => r[col] === val);
+      }
+      return Promise.resolve({ data: rows[0] ?? null, error: null });
+    },
+    then(resolve: (v: { count: number }) => unknown) {
+      // head:true count query awaited directly.
+      if (_head) {
+        return Promise.resolve({ count: 0 }).then(resolve);
+      }
+      // Should not normally be reached.
+      return Promise.resolve({ data: null, error: null }).then(resolve);
+    },
+  };
+  return proxy;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: (tableName: string) => makeBuilder(tableName),
+    auth: {
+      getUser: async () => ({ data: { user: null }, error: null }),
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => {}, push: () => {}, replace: () => {} }),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MG_1 = {
+  id: "mg-1",
+  community_id: "c-1",
+  name: "Kisakye MG-1",
+  currency: "UGX",
+  address_line1: null,
+  address_line2: null,
+  address_city: "Kampala",
+  address_region: null,
+  address_country: "Uganda",
+  address_postal_code: null,
+  lat: null,
+  lng: null,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const ORG_ROW = { id: "o-1", name: "EnergyIoT Uganda" };
+
+const COMMUNITY_ROWS = [
+  { id: "c-1", name: "Kisakye", org_id: "o-1", organizations: { name: "EnergyIoT Uganda" } },
+  { id: "c-2", name: "Gulu", org_id: "o-1", organizations: { name: "EnergyIoT Uganda" } },
+];
+
+// ─── Import page (after mocks) ────────────────────────────────────────────────
+
+import MicrogridsPage from "./page";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("MicrogridsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tables = {
+      organizations: [ORG_ROW],
+      communities: [],
+      microgrids: [],
+      households: [],
+    };
+  });
+
+  it("renders a microgrid row with name", async () => {
+    tables.microgrids = [MG_1];
+    tables.communities = [COMMUNITY_ROWS[0]];
+
+    const jsx = await MicrogridsPage({ searchParams: Promise.resolve({}) });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("Kisakye MG-1");
+    expect(html).toContain("/microgrids/mg-1");
+  });
+
+  it("renders Add Microgrid button in single-community URL context (locked mode)", async () => {
+    tables.microgrids = [MG_1];
+    tables.communities = [COMMUNITY_ROWS[0]];
+
+    const jsx = await MicrogridsPage({
+      searchParams: Promise.resolve({ community: "c-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("+ Add Microgrid");
+  });
+
+  it("renders Add Microgrid button in multi-community scope (picker mode, #132)", async () => {
+    tables.microgrids = [MG_1];
+    tables.communities = COMMUNITY_ROWS;
+
+    const jsx = await MicrogridsPage({ searchParams: Promise.resolve({}) });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("+ Add Microgrid");
+  });
+
+  it("renders empty-state CTA when communities are accessible (#132)", async () => {
+    tables.microgrids = [];
+    tables.communities = COMMUNITY_ROWS;
+
+    const jsx = await MicrogridsPage({ searchParams: Promise.resolve({}) });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No microgrids");
+    expect(html).toContain("+ Add the first Microgrid");
+  });
+
+  it("renders fallback message when no communities accessible", async () => {
+    tables.microgrids = [];
+    tables.communities = [];
+
+    const jsx = await MicrogridsPage({ searchParams: Promise.resolve({}) });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("No microgrids visible");
+  });
+});

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -3,9 +3,17 @@ import type { Microgrid } from "@/lib/types/domain";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { AddEntityButton } from "@/components/forms/AddEntityButton";
+import type { CommunityOption } from "@/components/forms/AddEntityButton";
 
 type MicrogridWithHouseholdCount = Microgrid & {
   household_count: number;
+};
+
+type CommunityWithOrgRow = {
+  id: string;
+  name: string;
+  org_id: string;
+  organizations: { name: string };
 };
 
 export default async function MicrogridsPage({
@@ -17,29 +25,108 @@ export default async function MicrogridsPage({
   const supabase = await createClient();
 
   // Resolve breadcrumb levels in parallel with data fetch.
-  const [levelsResult, communityResult, microgridsResult] = await Promise.all([
-    getHierarchyLevels(supabase, {
-      kind: "microgrids",
-      communityId,
-    }),
-    communityId
-      ? supabase
-          .from("communities")
-          .select("name")
-          .eq("id", communityId)
-          .maybeSingle()
-      : Promise.resolve({ data: null, error: null }),
-    (() => {
-      let query = supabase.from("microgrids").select("*");
-      if (communityId) query = query.eq("community_id", communityId);
-      return query.returns<Microgrid[]>();
-    })(),
-  ]);
+  const [levelsResult, communityResult, microgridsResult, communitiesResult] =
+    await Promise.all([
+      getHierarchyLevels(supabase, {
+        kind: "microgrids",
+        communityId,
+      }),
+      communityId
+        ? supabase
+            .from("communities")
+            .select("name")
+            .eq("id", communityId)
+            .maybeSingle()
+        : Promise.resolve({ data: null, error: null }),
+      (() => {
+        let query = supabase.from("microgrids").select("*");
+        if (communityId) query = query.eq("community_id", communityId);
+        return query.returns<Microgrid[]>();
+      })(),
+      // Fetch all accessible communities for the Add button parent picker.
+      // RLS scopes this naturally — only communities the user can access are returned.
+      supabase
+        .from("communities")
+        .select("id, name, org_id, organizations!inner(name)")
+        .order("name")
+        .returns<CommunityWithOrgRow[]>(),
+    ]);
 
   const levels = levelsResult;
   const communityName = communityResult.data?.name ?? null;
   const communityNotFound = communityId != null && !communityResult.data;
   const { data: microgrids, error } = microgridsResult;
+
+  // Map accessible communities to the CommunityOption shape.
+  const accessibleCommunities: CommunityOption[] = (
+    communitiesResult.data ?? []
+  ).map((c) => ({
+    id: c.id,
+    name: c.name,
+    org_name: c.organizations.name,
+  }));
+
+  // Resolve which AddEntityButton variant to use:
+  //   - In a single-community URL context (?community=...) → locked mode
+  //   - Single accessible community → locked mode
+  //   - Multiple accessible communities → picker mode
+  //   - Zero accessible communities → no button
+  const addButton = (() => {
+    if (communityId) {
+      return (
+        <AddEntityButton entity="microgrid" parentCommunityId={communityId} />
+      );
+    }
+    if (accessibleCommunities.length === 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          parentCommunityId={accessibleCommunities[0].id}
+        />
+      );
+    }
+    if (accessibleCommunities.length > 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          availableCommunities={accessibleCommunities}
+        />
+      );
+    }
+    return null;
+  })();
+
+  // CTA button for empty state (same logic but with label override).
+  const addButtonCta = (() => {
+    if (communityId) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          parentCommunityId={communityId}
+          label="+ Add the first Microgrid"
+        />
+      );
+    }
+    if (accessibleCommunities.length === 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          parentCommunityId={accessibleCommunities[0].id}
+          label="+ Add the first Microgrid"
+        />
+      );
+    }
+    if (accessibleCommunities.length > 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          availableCommunities={accessibleCommunities}
+          label="+ Add the first Microgrid"
+        />
+      );
+    }
+    return null;
+  })();
 
   const heading = communityName
     ? `${communityName} · Microgrids`
@@ -73,24 +160,15 @@ export default async function MicrogridsPage({
         <HierarchyNav levels={levels} className="mb-4" />
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
-          {communityId && (
-            <AddEntityButton
-              entity="microgrid"
-              parentCommunityId={communityId}
-            />
-          )}
+          {addButton}
         </div>
         <div className="rounded-md border border-border bg-card p-8 text-center">
-          {communityId ? (
+          {addButtonCta ? (
             <>
               <p className="mb-4 text-muted-foreground">
-                No microgrids in this community yet.
+                No microgrids{communityId ? " in this community" : ""} yet.
               </p>
-              <AddEntityButton
-                entity="microgrid"
-                parentCommunityId={communityId}
-                label="+ Add the first Microgrid"
-              />
+              {addButtonCta}
             </>
           ) : (
             <p className="text-muted-foreground">
@@ -120,12 +198,7 @@ export default async function MicrogridsPage({
       <HierarchyNav levels={levels} className="mb-4" />
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
-        {communityId && (
-          <AddEntityButton
-            entity="microgrid"
-            parentCommunityId={communityId}
-          />
-        )}
+        {addButton}
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {microgridsWithCounts.map((mg) => {

--- a/src/components/forms/AddEntityButton.tsx
+++ b/src/components/forms/AddEntityButton.tsx
@@ -6,10 +6,23 @@
  * Renders a button; when clicked, opens the shared EntityForm in create mode.
  * Parent (server component) supplies the entity kind and any parent IDs.
  * Label defaults to "+ Add {Entity}" but can be overridden (empty-state CTA).
+ *
+ * Multi-parent picker mode (#132):
+ *   - entity="community": pass either `parentOrgId` (locked single-parent) OR
+ *     `availableOrgs` (renders a parent-picker select in the form).
+ *   - entity="microgrid": pass either `parentCommunityId` OR
+ *     `availableCommunities` (picker). When communities span multiple orgs,
+ *     include `org_name` on each item so the form can disambiguate labels.
  */
 
 import * as React from "react";
 import { EntityForm } from "./EntityForm";
+
+/** Items for the organization picker (community creation). */
+export type OrgOption = { id: string; name: string };
+
+/** Items for the community picker (microgrid creation). */
+export type CommunityOption = { id: string; name: string; org_name?: string };
 
 type Props =
   | {
@@ -20,14 +33,36 @@ type Props =
     }
   | {
       entity: "community";
+      /** Single-parent locked mode — picker is hidden. */
       parentOrgId: string;
+      availableOrgs?: never;
+      label?: string;
+      className?: string;
+      variant?: "primary" | "secondary";
+    }
+  | {
+      entity: "community";
+      /** Multi-parent picker mode — user selects the org in the form. */
+      availableOrgs: OrgOption[];
+      parentOrgId?: never;
       label?: string;
       className?: string;
       variant?: "primary" | "secondary";
     }
   | {
       entity: "microgrid";
+      /** Single-parent locked mode — picker is hidden. */
       parentCommunityId: string;
+      availableCommunities?: never;
+      label?: string;
+      className?: string;
+      variant?: "primary" | "secondary";
+    }
+  | {
+      entity: "microgrid";
+      /** Multi-parent picker mode — user selects the community in the form. */
+      availableCommunities: CommunityOption[];
+      parentCommunityId?: never;
       label?: string;
       className?: string;
       variant?: "primary" | "secondary";
@@ -66,7 +101,7 @@ export function AddEntityButton(props: Props) {
           onOpenChange={setOpen}
         />
       )}
-      {props.entity === "community" && (
+      {props.entity === "community" && props.parentOrgId != null && (
         <EntityForm
           entity="community"
           mode="create"
@@ -75,11 +110,29 @@ export function AddEntityButton(props: Props) {
           onOpenChange={setOpen}
         />
       )}
-      {props.entity === "microgrid" && (
+      {props.entity === "community" && props.availableOrgs != null && (
+        <EntityForm
+          entity="community"
+          mode="create"
+          availableOrgs={props.availableOrgs}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+      {props.entity === "microgrid" && props.parentCommunityId != null && (
         <EntityForm
           entity="microgrid"
           mode="create"
           parentCommunityId={props.parentCommunityId}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+      {props.entity === "microgrid" && props.availableCommunities != null && (
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          availableCommunities={props.availableCommunities}
           open={open}
           onOpenChange={setOpen}
         />

--- a/src/components/forms/EntityForm.tsx
+++ b/src/components/forms/EntityForm.tsx
@@ -48,6 +48,7 @@ import type {
   Community,
   Microgrid,
 } from "@/lib/types/domain";
+import type { OrgOption, CommunityOption } from "./AddEntityButton";
 
 // ── Props (discriminated union) ──────────────────────────────────────────
 
@@ -67,14 +68,34 @@ export type EntityFormProps = CommonModalProps &
     | {
         entity: "community";
         mode: "create" | "edit";
+        /** Single-parent locked mode. */
         parentOrgId: string;
+        availableOrgs?: never;
         initialValues?: Partial<Community> & { id?: string };
+      }
+    | {
+        entity: "community";
+        mode: "create";
+        /** Multi-parent picker mode. Only valid for create. */
+        availableOrgs: OrgOption[];
+        parentOrgId?: never;
+        initialValues?: never;
       }
     | {
         entity: "microgrid";
         mode: "create" | "edit";
+        /** Single-parent locked mode. */
         parentCommunityId: string;
+        availableCommunities?: never;
         initialValues?: Partial<Microgrid> & { id?: string };
+      }
+    | {
+        entity: "microgrid";
+        mode: "create";
+        /** Multi-parent picker mode. Only valid for create. */
+        availableCommunities: CommunityOption[];
+        parentCommunityId?: never;
+        initialValues?: never;
       }
   );
 
@@ -86,6 +107,10 @@ type FormState = AddressValues & {
   currency?: string;
   lat?: string; // kept as string for input binding
   lng?: string;
+  /** Selected org ID when in community picker mode. */
+  selectedOrgId?: string;
+  /** Selected community ID when in microgrid picker mode. */
+  selectedCommunityId?: string;
 };
 
 type FieldErrors = Partial<Record<string, string>>;
@@ -147,11 +172,13 @@ function buildCreatePayload(
   }
 
   if (props.entity === "community") {
-    payload.org_id = props.parentOrgId;
+    // parentOrgId is set in locked mode; selectedOrgId is used in picker mode.
+    payload.org_id = props.parentOrgId ?? state.selectedOrgId;
     payload.geography_notes = state.geography_notes?.trim() ?? "";
   }
   if (props.entity === "microgrid") {
-    payload.community_id = props.parentCommunityId;
+    // parentCommunityId is set in locked mode; selectedCommunityId is used in picker mode.
+    payload.community_id = props.parentCommunityId ?? state.selectedCommunityId;
     payload.currency = state.currency ?? "UGX";
     payload.lat = state.lat?.trim() ? state.lat.trim() : null;
     payload.lng = state.lng?.trim() ? state.lng.trim() : null;
@@ -285,12 +312,20 @@ export function EntityForm(props: EntityFormProps) {
       if (!(state.address_country ?? "").trim())
         errs.address_country = "Country is required.";
     }
+    if (props.entity === "community" && "availableOrgs" in props && props.availableOrgs) {
+      if (!state.selectedOrgId)
+        errs.selectedOrgId = "Organization is required.";
+    }
     if (props.entity === "microgrid") {
       if (!(state.currency ?? "").trim())
         errs.currency = "Currency is required.";
+      if ("availableCommunities" in props && props.availableCommunities) {
+        if (!state.selectedCommunityId)
+          errs.selectedCommunityId = "Community is required.";
+      }
     }
     return errs;
-  }, [state, props.entity]);
+  }, [state, props]);
 
   const handleSubmit = React.useCallback(
     async (e: React.FormEvent) => {
@@ -396,6 +431,93 @@ export function EntityForm(props: EntityFormProps) {
                 {topError}
               </Banner>
             )}
+
+            {/* Parent picker — community create in multi-org scope */}
+            {props.entity === "community" &&
+              "availableOrgs" in props &&
+              props.availableOrgs && (
+                <div>
+                  <label
+                    htmlFor="entity-parent-org"
+                    className="mb-1 block text-xs font-medium text-muted-foreground"
+                  >
+                    Organization
+                    <span aria-hidden="true" className="ml-0.5 text-destructive-fg">
+                      *
+                    </span>
+                    <span className="sr-only"> (required)</span>
+                  </label>
+                  <Select
+                    value={state.selectedOrgId ?? ""}
+                    onValueChange={(v) => updateField("selectedOrgId", v)}
+                    disabled={submitting}
+                  >
+                    <SelectTrigger id="entity-parent-org" className="w-full">
+                      <SelectValue placeholder="Select an organization…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[...props.availableOrgs]
+                        .sort((a, b) => a.name.localeCompare(b.name))
+                        .map((org) => (
+                          <SelectItem key={org.id} value={org.id}>
+                            {org.name}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                  {fieldErrors.selectedOrgId && (
+                    <p role="alert" className="mt-1 text-xs text-destructive-fg">
+                      {fieldErrors.selectedOrgId}
+                    </p>
+                  )}
+                </div>
+              )}
+
+            {/* Parent picker — microgrid create in multi-community scope */}
+            {props.entity === "microgrid" &&
+              "availableCommunities" in props &&
+              props.availableCommunities && (
+                <div>
+                  <label
+                    htmlFor="entity-parent-community"
+                    className="mb-1 block text-xs font-medium text-muted-foreground"
+                  >
+                    Community
+                    <span aria-hidden="true" className="ml-0.5 text-destructive-fg">
+                      *
+                    </span>
+                    <span className="sr-only"> (required)</span>
+                  </label>
+                  <Select
+                    value={state.selectedCommunityId ?? ""}
+                    onValueChange={(v) => updateField("selectedCommunityId", v)}
+                    disabled={submitting}
+                  >
+                    <SelectTrigger id="entity-parent-community" className="w-full">
+                      <SelectValue placeholder="Select a community…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[...props.availableCommunities]
+                        .sort((a, b) => {
+                          const orgCmp = (a.org_name ?? "").localeCompare(b.org_name ?? "");
+                          return orgCmp !== 0 ? orgCmp : a.name.localeCompare(b.name);
+                        })
+                        .map((community) => (
+                          <SelectItem key={community.id} value={community.id}>
+                            {community.org_name
+                              ? `${community.name} (${community.org_name})`
+                              : community.name}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                  {fieldErrors.selectedCommunityId && (
+                    <p role="alert" className="mt-1 text-xs text-destructive-fg">
+                      {fieldErrors.selectedCommunityId}
+                    </p>
+                  )}
+                </div>
+              )}
 
             {/* Name */}
             <div>

--- a/src/components/forms/__tests__/AddEntityButton.test.tsx
+++ b/src/components/forms/__tests__/AddEntityButton.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/**
+ * AddEntityButton tests (#132).
+ *
+ * Covers:
+ *   - community locked mode: button renders; EntityForm receives parentOrgId.
+ *   - community picker mode: button renders; EntityForm receives availableOrgs.
+ *   - microgrid locked mode: button renders; EntityForm receives parentCommunityId.
+ *   - microgrid picker mode: button renders; EntityForm receives availableCommunities.
+ *   - organization: button renders (no parent).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { AddEntityButton } from "../AddEntityButton";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AddEntityButton", () => {
+  describe("entity=organization", () => {
+    it("renders the Add Organization button", () => {
+      render(<AddEntityButton entity="organization" />);
+      expect(screen.getByRole("button", { name: /\+ Add Organization/i })).toBeTruthy();
+    });
+  });
+
+  describe("entity=community — locked mode (single parentOrgId)", () => {
+    it("renders the Add Community button", () => {
+      render(<AddEntityButton entity="community" parentOrgId="org-1" />);
+      expect(screen.getByRole("button", { name: /\+ Add Community/i })).toBeTruthy();
+    });
+
+    it("clicking opens the form dialog", async () => {
+      render(<AddEntityButton entity="community" parentOrgId="org-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /\+ Add Community/i }));
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeTruthy();
+      });
+      // Should NOT render the org picker in locked mode.
+      expect(screen.queryByLabelText(/^Organization/i)).toBeNull();
+    });
+  });
+
+  describe("entity=community — picker mode (availableOrgs)", () => {
+    const orgs = [
+      { id: "org-a", name: "Alpha Energy" },
+      { id: "org-b", name: "Beta Power" },
+    ];
+
+    it("renders the Add Community button", () => {
+      render(<AddEntityButton entity="community" availableOrgs={orgs} />);
+      expect(screen.getByRole("button", { name: /\+ Add Community/i })).toBeTruthy();
+    });
+
+    it("clicking opens the form with an Organization picker", async () => {
+      render(<AddEntityButton entity="community" availableOrgs={orgs} />);
+      fireEvent.click(screen.getByRole("button", { name: /\+ Add Community/i }));
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeTruthy();
+        expect(screen.getByLabelText(/^Organization/i)).toBeTruthy();
+      });
+    });
+
+    it("supports a custom label", () => {
+      render(
+        <AddEntityButton
+          entity="community"
+          availableOrgs={orgs}
+          label="+ Add the first Community"
+        />
+      );
+      expect(screen.getByRole("button", { name: /Add the first Community/i })).toBeTruthy();
+    });
+  });
+
+  describe("entity=microgrid — locked mode (single parentCommunityId)", () => {
+    it("renders the Add Microgrid button", () => {
+      render(<AddEntityButton entity="microgrid" parentCommunityId="c-1" />);
+      expect(screen.getByRole("button", { name: /\+ Add Microgrid/i })).toBeTruthy();
+    });
+
+    it("clicking opens the form dialog without community picker", async () => {
+      render(<AddEntityButton entity="microgrid" parentCommunityId="c-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /\+ Add Microgrid/i }));
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeTruthy();
+      });
+      // Should NOT render the community picker in locked mode.
+      expect(screen.queryByLabelText(/^Community/i)).toBeNull();
+    });
+  });
+
+  describe("entity=microgrid — picker mode (availableCommunities)", () => {
+    const communities = [
+      { id: "c-a", name: "Kisakye", org_name: "EnergyIoT Uganda" },
+      { id: "c-b", name: "Gulu", org_name: "EnergyIoT Uganda" },
+    ];
+
+    it("renders the Add Microgrid button", () => {
+      render(
+        <AddEntityButton entity="microgrid" availableCommunities={communities} />
+      );
+      expect(screen.getByRole("button", { name: /\+ Add Microgrid/i })).toBeTruthy();
+    });
+
+    it("clicking opens the form with a Community picker", async () => {
+      render(
+        <AddEntityButton entity="microgrid" availableCommunities={communities} />
+      );
+      fireEvent.click(screen.getByRole("button", { name: /\+ Add Microgrid/i }));
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeTruthy();
+        expect(screen.getByLabelText(/^Community/i)).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/components/forms/__tests__/EntityForm.test.tsx
+++ b/src/components/forms/__tests__/EntityForm.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 /**
- * EntityForm tests (#76).
+ * EntityForm tests (#76 + #132).
  *
  * Covers:
  *   - Organization: create POSTs to /api/organizations with all fields.
- *   - Community: create includes injected parentOrgId.
- *   - Microgrid: create includes parentCommunityId + currency default.
+ *   - Community: create includes injected parentOrgId (locked mode).
+ *   - Community picker mode (#132): org select required; payload uses selectedOrgId.
+ *   - Microgrid: create includes parentCommunityId + currency default (locked mode).
+ *   - Microgrid picker mode (#132): community select required; payload uses selectedCommunityId.
  *   - Edit mode (microgrid): PATCH payload contains ONLY dirty fields;
  *     untouched fields (name, currency) are NOT sent when only address_city
  *     changes.
@@ -365,6 +367,126 @@ describe("EntityForm", () => {
         name: "Kisakye MG-2",
         address_city: "Entebbe",
       });
+    });
+  });
+
+  // ── Community — picker mode (#132) ───────────────────────────────────────
+  describe("community: picker mode (availableOrgs)", () => {
+    const orgs = [
+      { id: "org-a", name: "Alpha Energy" },
+      { id: "org-b", name: "Beta Power" },
+    ];
+
+    it("renders an Organization select when availableOrgs is provided", () => {
+      render(
+        <EntityForm
+          entity="community"
+          mode="create"
+          availableOrgs={orgs}
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+      expect(screen.getByLabelText(/^Organization/i)).toBeTruthy();
+    });
+
+    it("shows a validation error when submitted without selecting an org", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ community: { id: "c1" } }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="community"
+          mode="create"
+          availableOrgs={orgs}
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Test Community" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        const alerts = screen.getAllByRole("alert");
+        const orgErr = alerts.find((a) =>
+          /organization is required/i.test(a.textContent ?? "")
+        );
+        expect(orgErr).toBeDefined();
+      });
+      // fetch must NOT have been called — client validation stopped submission.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Microgrid — picker mode (#132) ───────────────────────────────────────
+  describe("microgrid: picker mode (availableCommunities)", () => {
+    const communities = [
+      { id: "c-a", name: "Kisakye", org_name: "EnergyIoT Uganda" },
+      { id: "c-b", name: "Gulu", org_name: "EnergyIoT Uganda" },
+    ];
+
+    it("renders a Community select when availableCommunities is provided", () => {
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          availableCommunities={communities}
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+      expect(screen.getByLabelText(/^Community/i)).toBeTruthy();
+    });
+
+    it("shows validation error when submitted without selecting a community", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ microgrid: { id: "m1" } }),
+      } as Response);
+
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          availableCommunities={communities}
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/^Name/i), {
+        target: { value: "Test MG" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      await waitFor(() => {
+        const alerts = screen.getAllByRole("alert");
+        const commErr = alerts.find((a) =>
+          /community is required/i.test(a.textContent ?? "")
+        );
+        expect(commErr).toBeDefined();
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT render the community picker in locked (parentCommunityId) mode", () => {
+      render(
+        <EntityForm
+          entity="microgrid"
+          mode="create"
+          parentCommunityId="c-a"
+          open={true}
+          onOpenChange={() => {}}
+        />
+      );
+      expect(screen.queryByLabelText(/^Community/i)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extends `AddEntityButton` + `EntityForm` discriminated unions: each `community` / `microgrid` variant now has a **locked** mode (existing — single parent passed in) and a **picker** mode (`availableOrgs` / `availableCommunities` passed in instead). TypeScript `never` guards make the modes mutually exclusive.
- When in picker mode, `EntityForm` renders a required shadcn `<Select>` at the top — labels as `"Community (Org)"` when communities span multiple orgs (disambiguates).
- **Communities listing**: now fetches `id, name` from `organizations` via RLS; always renders Add button (locked at 1 org, picker at >1, hidden at 0).
- **Microgrids listing**: fetches accessible communities with `organizations!inner(name)` join; resolves Add button variant per scope (URL `?community=` → locked; multi → picker; none → hidden).
- Drops the `singleAccessibleOrgId` / single-community gates that hid the Add button for super_admins / multi-org users.
- 818 tests pass (new AddEntityButton tests, extended EntityForm + listing tests).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (818/818)
- [x] `npm run build`
- [ ] Manual: super_admin on `/communities` (multi-org context) sees Add Community → opens form with org picker
- [ ] Manual: super_admin on `/microgrids` (no `?community=` filter) sees Add Microgrid → opens form with community picker (labeled `"Community (Org)"`)

Closes #132.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)