### PR TITLE
Thread ?org= filter through Communities + Microgrids listings (#134)

### DIFF
--- a/src/app/(dashboard)/communities/page.test.tsx
+++ b/src/app/(dashboard)/communities/page.test.tsx
@@ -9,35 +9,49 @@
 //     (b) Empty state renders when the query returns zero rows.
 //     (c) Add button renders in single-org context (#76 original behaviour).
 //     (d) Add button renders in multi-org context (#132: picker mode).
-//
-// Note: after #76 (UX4a), the listing query selects `*, microgrids(count)` so
-// row rendering receives the full Community row shape. After #132 the gate is
-// lifted — Add renders for any non-zero accessibleOrgs count.
+//     (e) ?org=X → only X's communities queried + rendered (#134).
+//     (f) ?org=X-invalid → banner + unfiltered list (#134).
+//     (g) ?org=X → AddEntityButton locked with parentOrgId=X (#134).
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
 
 // ─── Supabase mock ───────────────────────────────────────────────────────────
+//
+// We need a builder that supports .eq() so we can assert the org filter was
+// applied (and to actually filter fixture data in tests).
 
 type MockBuilder = {
   select: (...args: unknown[]) => MockBuilder;
   order: (...args: unknown[]) => MockBuilder;
+  eq: (col: string, val: unknown) => MockBuilder;
   returns: <T>() => Promise<{ data: T | null; error: null }>;
   _data: unknown;
+  _eqs: [string, unknown][];
 };
 
 function makeMockBuilder(data: unknown): MockBuilder {
   const builder: MockBuilder = {
     _data: data,
+    _eqs: [],
     select() {
       return builder;
     },
     order() {
       return builder;
     },
+    eq(col: string, val: unknown) {
+      builder._eqs.push([col, val]);
+      return builder;
+    },
     returns<T>() {
-      return Promise.resolve({ data: builder._data as T, error: null });
+      // Apply any .eq() filters before returning.
+      let rows = (builder._data as Record<string, unknown>[]) ?? [];
+      for (const [col, val] of builder._eqs) {
+        rows = rows.filter((r) => r[col] === val);
+      }
+      return Promise.resolve({ data: rows as T, error: null });
     },
   };
   return builder;
@@ -92,7 +106,7 @@ const COMMUNITY_WITH_DATA = {
 
 const COMMUNITY_NO_LOCATION = {
   id: "comm-2",
-  org_id: "org-1",
+  org_id: "org-2",
   name: "Test Community",
   address_line1: null,
   address_line2: null,
@@ -122,7 +136,7 @@ describe("CommunitiesPage", () => {
     communitiesData = [COMMUNITY_WITH_DATA];
     orgsData = [{ id: "org-1", name: "EnergyIoT Uganda" }];
 
-    const jsx = await CommunitiesPage();
+    const jsx = await CommunitiesPage({});
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     expect(html).toContain("Kisakye");
@@ -136,7 +150,7 @@ describe("CommunitiesPage", () => {
     communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
     orgsData = [{ id: "org-1", name: "EnergyIoT Uganda" }];
 
-    const jsx = await CommunitiesPage();
+    const jsx = await CommunitiesPage({});
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     expect(html).toContain("Kisakye");
@@ -148,7 +162,7 @@ describe("CommunitiesPage", () => {
     communitiesData = [COMMUNITY_WITH_DATA];
     orgsData = [{ id: "org-1", name: "EnergyIoT Uganda" }];
 
-    const jsx = await CommunitiesPage();
+    const jsx = await CommunitiesPage({});
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     // AddEntityButton renders a <button> with the default label.
@@ -162,7 +176,7 @@ describe("CommunitiesPage", () => {
       { id: "org-2", name: "Field Energy Kenya" },
     ];
 
-    const jsx = await CommunitiesPage();
+    const jsx = await CommunitiesPage({});
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     // Add button must render even when multiple orgs are accessible.
@@ -173,7 +187,7 @@ describe("CommunitiesPage", () => {
     communitiesData = [];
     orgsData = [];
 
-    const jsx = await CommunitiesPage();
+    const jsx = await CommunitiesPage({});
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     // Zero-org view: directs user to the organization detail page.
@@ -185,9 +199,80 @@ describe("CommunitiesPage", () => {
     communitiesData = null;
     orgsData = null;
 
-    const jsx = await CommunitiesPage();
+    const jsx = await CommunitiesPage({});
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     expect(html).toMatch(/No communities/);
+  });
+
+  // ── #134: ?org= filter ────────────────────────────────────────────────────
+
+  it("?org=X: only shows communities whose org_id matches (#134)", async () => {
+    communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
+    orgsData = [
+      { id: "org-1", name: "EnergyIoT Uganda" },
+      { id: "org-2", name: "Field Energy Kenya" },
+    ];
+
+    const jsx = await CommunitiesPage({
+      searchParams: Promise.resolve({ org: "org-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // org-1 community renders, org-2 community does not.
+    expect(html).toContain("Kisakye");
+    expect(html).not.toContain("Test Community");
+  });
+
+  it("?org=X: AddEntityButton receives parentOrgId=X (locked mode) (#134)", async () => {
+    communitiesData = [COMMUNITY_WITH_DATA];
+    orgsData = [
+      { id: "org-1", name: "EnergyIoT Uganda" },
+      { id: "org-2", name: "Field Energy Kenya" },
+    ];
+
+    const jsx = await CommunitiesPage({
+      searchParams: Promise.resolve({ org: "org-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // The Add button must still render (locked mode is functional).
+    expect(html).toContain("+ Add Community");
+    // Should NOT render picker (no "availableOrgs" path is taken).
+    // We can't directly inspect props in SSR output, but the button renders.
+  });
+
+  it("?org=invalid: shows warning banner and unfiltered list (#134)", async () => {
+    communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
+    orgsData = [
+      { id: "org-1", name: "EnergyIoT Uganda" },
+      { id: "org-2", name: "Field Energy Kenya" },
+    ];
+
+    const jsx = await CommunitiesPage({
+      searchParams: Promise.resolve({ org: "org-does-not-exist" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Warning banner present.
+    expect(html).toContain("Invalid or inaccessible organization filter");
+    // Both communities render (unfiltered).
+    expect(html).toContain("Kisakye");
+    expect(html).toContain("Test Community");
+  });
+
+  it("no ?org=: preserves current behaviour (all communities render) (#134)", async () => {
+    communitiesData = [COMMUNITY_WITH_DATA, COMMUNITY_NO_LOCATION];
+    orgsData = [
+      { id: "org-1", name: "EnergyIoT Uganda" },
+      { id: "org-2", name: "Field Energy Kenya" },
+    ];
+
+    const jsx = await CommunitiesPage({});
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("Kisakye");
+    expect(html).toContain("Test Community");
+    expect(html).not.toContain("Invalid or inaccessible organization filter");
   });
 });

--- a/src/app/(dashboard)/communities/page.tsx
+++ b/src/app/(dashboard)/communities/page.tsx
@@ -11,35 +11,67 @@ type CommunityRow = Community & {
 
 type OrgRow = { id: string; name: string };
 
-export default async function CommunitiesPage() {
+export default async function CommunitiesPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ org?: string }>;
+}) {
+  const { org: orgId } = (await searchParams) ?? {};
   const supabase = await createClient();
 
-  const [{ data: communities, error }, { data: accessibleOrgs }, levels] =
-    await Promise.all([
-      supabase
-        .from("communities")
-        .select("*, microgrids(count)")
-        .order("name")
-        .returns<CommunityRow[]>(),
-      supabase
-        .from("organizations")
-        .select("id, name")
-        .order("name")
-        .returns<OrgRow[]>(),
-      getHierarchyLevels(supabase, { kind: "communities" }),
-    ]);
+  const [{ data: accessibleOrgs }, levels] = await Promise.all([
+    supabase
+      .from("organizations")
+      .select("id, name")
+      .order("name")
+      .returns<OrgRow[]>(),
+    getHierarchyLevels(supabase, { kind: "communities", orgId }),
+  ]);
 
-  // Resolve which AddEntityButton variant to use:
-  //   - Single accessible org → locked mode (parentOrgId)
-  //   - Multiple accessible orgs → picker mode (availableOrgs)
-  //   - Zero accessible orgs → no button
   const orgs = accessibleOrgs ?? [];
-  const addButton =
-    orgs.length === 1 ? (
-      <AddEntityButton entity="community" parentOrgId={orgs[0].id} />
-    ) : orgs.length > 1 ? (
-      <AddEntityButton entity="community" availableOrgs={orgs} />
-    ) : null;
+
+  // Validate the ?org= param: must be a UUID the user can actually access.
+  const orgValid =
+    orgId != null && orgs.some((o) => o.id === orgId);
+  const orgInvalid = orgId != null && !orgValid;
+
+  // Build the communities query — apply org filter when valid.
+  const communitiesQuery = (() => {
+    let q = supabase
+      .from("communities")
+      .select("*, microgrids(count)")
+      .order("name");
+    if (orgValid) {
+      q = q.eq("org_id", orgId!);
+    }
+    return q.returns<CommunityRow[]>();
+  })();
+
+  const { data: communities, error } = await communitiesQuery;
+
+  // Resolve AddEntityButton variant:
+  //   - ?org=X valid → locked mode with that org (even in multi-org context)
+  //   - single accessible org (no filter) → locked mode
+  //   - multiple accessible orgs (no filter) → picker mode
+  //   - zero accessible orgs → no button
+  const addButton = (() => {
+    if (orgValid) {
+      return <AddEntityButton entity="community" parentOrgId={orgId!} />;
+    }
+    if (orgs.length === 1) {
+      return <AddEntityButton entity="community" parentOrgId={orgs[0].id} />;
+    }
+    if (orgs.length > 1) {
+      return <AddEntityButton entity="community" availableOrgs={orgs} />;
+    }
+    return null;
+  })();
+
+  const invalidBanner = orgInvalid ? (
+    <div className="mb-4 rounded-md bg-warning-muted p-3 text-sm text-warning-fg">
+      Invalid or inaccessible organization filter — showing all.
+    </div>
+  ) : null;
 
   if (error) {
     return (
@@ -53,6 +85,7 @@ export default async function CommunitiesPage() {
     return (
       <div>
         <HierarchyNav levels={levels} className="mb-4" />
+        {invalidBanner}
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-2xl font-semibold text-foreground">
             Communities
@@ -64,7 +97,13 @@ export default async function CommunitiesPage() {
               <p className="mb-4 text-muted-foreground">
                 No communities yet.
               </p>
-              {orgs.length === 1 ? (
+              {orgValid ? (
+                <AddEntityButton
+                  entity="community"
+                  parentOrgId={orgId!}
+                  label="+ Add the first Community"
+                />
+              ) : orgs.length === 1 ? (
                 <AddEntityButton
                   entity="community"
                   parentOrgId={orgs[0].id}
@@ -91,6 +130,7 @@ export default async function CommunitiesPage() {
   return (
     <div>
       <HierarchyNav levels={levels} className="mb-4" />
+      {invalidBanner}
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">Communities</h1>
         {addButton}

--- a/src/app/(dashboard)/microgrids/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/page.test.tsx
@@ -12,6 +12,10 @@
 //     (c) Add button renders in multi-community scope (picker mode, #132).
 //     (d) Empty state shows CTA when communities accessible.
 //     (e) Empty state shows fallback when zero communities accessible.
+//     (f) ?org=X filters microgrids to that org's communities (#134).
+//     (g) ?community=Y + ?org=X → community wins; banner renders (#134).
+//     (h) ?org=invalid → banner + unfiltered (#134).
+//     (i) accessibleCommunities filtered to org when ?org=X (#134).
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -23,6 +27,11 @@ import React from "react";
 // each table has its data rows; .eq() filters, .single()/.maybeSingle() return
 // the first matching row, .returns() returns all matching rows.
 // households always returns count=0 (head:true shape).
+//
+// For the microgrids org-filter path the page calls:
+//   supabase.from("microgrids").select("*, communities!inner(org_id)").eq("communities.org_id", orgId)
+// The mock handles "communities.org_id" by looking at the joined community row
+// embedded as `communities` on each microgrid row.
 
 type Tables = Record<string, Record<string, unknown>[]>;
 
@@ -47,7 +56,16 @@ function makeBuilder(tableName: string) {
     returns() {
       let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
       for (const [col, val] of _eqs) {
-        rows = rows.filter((r) => r[col] === val);
+        if (col.includes(".")) {
+          // Dotted col like "communities.org_id" — resolve via embedded join row.
+          const [joinTable, joinCol] = col.split(".");
+          rows = rows.filter((r) => {
+            const joined = r[joinTable] as Record<string, unknown> | undefined;
+            return joined?.[joinCol] === val;
+          });
+        } else {
+          rows = rows.filter((r) => r[col] === val);
+        }
       }
       return Promise.resolve({ data: rows, error: null });
     },
@@ -65,7 +83,8 @@ function makeBuilder(tableName: string) {
       }
       return Promise.resolve({ data: rows[0] ?? null, error: null });
     },
-    then(resolve: (v: { count: number }) => unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    then(resolve: (v: any) => unknown) {
       // head:true count query awaited directly.
       if (_head) {
         return Promise.resolve({ count: 0 }).then(resolve);
@@ -92,6 +111,10 @@ vi.mock("next/navigation", () => ({
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
+const ORG_ROW = { id: "o-1", name: "EnergyIoT Uganda" };
+const ORG_ROW_2 = { id: "o-2", name: "Field Energy Kenya" };
+
+// MG rows include embedded `communities` join data for the org-filter path.
 const MG_1 = {
   id: "mg-1",
   community_id: "c-1",
@@ -106,13 +129,29 @@ const MG_1 = {
   lat: null,
   lng: null,
   created_at: "2026-01-01T00:00:00Z",
+  communities: { org_id: "o-1" },
 };
 
-const ORG_ROW = { id: "o-1", name: "EnergyIoT Uganda" };
+const MG_2 = {
+  id: "mg-2",
+  community_id: "c-2",
+  name: "Gulu MG-1",
+  currency: "UGX",
+  address_line1: null,
+  address_line2: null,
+  address_city: "Gulu",
+  address_region: null,
+  address_country: "Uganda",
+  address_postal_code: null,
+  lat: null,
+  lng: null,
+  created_at: "2026-01-01T00:00:00Z",
+  communities: { org_id: "o-2" },
+};
 
 const COMMUNITY_ROWS = [
   { id: "c-1", name: "Kisakye", org_id: "o-1", organizations: { name: "EnergyIoT Uganda" } },
-  { id: "c-2", name: "Gulu", org_id: "o-1", organizations: { name: "EnergyIoT Uganda" } },
+  { id: "c-2", name: "Gulu", org_id: "o-2", organizations: { name: "Field Energy Kenya" } },
 ];
 
 // ─── Import page (after mocks) ────────────────────────────────────────────────
@@ -125,7 +164,7 @@ describe("MicrogridsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     tables = {
-      organizations: [ORG_ROW],
+      organizations: [ORG_ROW, ORG_ROW_2],
       communities: [],
       microgrids: [],
       households: [],
@@ -184,5 +223,65 @@ describe("MicrogridsPage", () => {
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
     expect(html).toContain("No microgrids visible");
+  });
+
+  // ── #134: ?org= filter ────────────────────────────────────────────────────
+
+  it("?org=X: only shows microgrids whose community belongs to org X (#134)", async () => {
+    tables.microgrids = [MG_1, MG_2];
+    tables.communities = COMMUNITY_ROWS;
+
+    const jsx = await MicrogridsPage({
+      searchParams: Promise.resolve({ org: "o-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    expect(html).toContain("Kisakye MG-1");
+    expect(html).not.toContain("Gulu MG-1");
+  });
+
+  it("?community=Y + ?org=X: community wins; both-filters banner renders (#134)", async () => {
+    tables.microgrids = [MG_1, MG_2];
+    tables.communities = COMMUNITY_ROWS;
+
+    const jsx = await MicrogridsPage({
+      searchParams: Promise.resolve({ community: "c-1", org: "o-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Community filter wins — only c-1's microgrids.
+    expect(html).toContain("Kisakye MG-1");
+    // Banner rendered.
+    expect(html).toContain("Community filter applied — org filter ignored");
+  });
+
+  it("?org=invalid: shows warning banner and unfiltered list (#134)", async () => {
+    tables.microgrids = [MG_1, MG_2];
+    tables.communities = COMMUNITY_ROWS;
+
+    const jsx = await MicrogridsPage({
+      searchParams: Promise.resolve({ org: "org-does-not-exist" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Warning banner present.
+    expect(html).toContain("Invalid or inaccessible organization filter");
+    // Both microgrids render (unfiltered).
+    expect(html).toContain("Kisakye MG-1");
+    expect(html).toContain("Gulu MG-1");
+  });
+
+  it("?org=X valid: accessibleCommunities narrowed to org's communities (#134)", async () => {
+    // Only one community in org o-1 → Add button should be in locked mode.
+    tables.microgrids = [MG_1];
+    tables.communities = COMMUNITY_ROWS; // both, but only c-1 belongs to o-1.
+
+    const jsx = await MicrogridsPage({
+      searchParams: Promise.resolve({ org: "o-1" }),
+    });
+    const html = renderToStaticMarkup(jsx as React.ReactElement);
+
+    // Add button renders (locked mode for single community in org).
+    expect(html).toContain("+ Add Microgrid");
   });
 });

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -19,46 +19,20 @@ type CommunityWithOrgRow = {
 export default async function MicrogridsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ community?: string }>;
+  searchParams: Promise<{ community?: string; org?: string }>;
 }) {
-  const { community: communityId } = await searchParams;
+  const { community: communityId, org: orgId } = await searchParams;
   const supabase = await createClient();
 
-  // Resolve breadcrumb levels in parallel with data fetch.
-  const [levelsResult, communityResult, microgridsResult, communitiesResult] =
-    await Promise.all([
-      getHierarchyLevels(supabase, {
-        kind: "microgrids",
-        communityId,
-      }),
-      communityId
-        ? supabase
-            .from("communities")
-            .select("name")
-            .eq("id", communityId)
-            .maybeSingle()
-        : Promise.resolve({ data: null, error: null }),
-      (() => {
-        let query = supabase.from("microgrids").select("*");
-        if (communityId) query = query.eq("community_id", communityId);
-        return query.returns<Microgrid[]>();
-      })(),
-      // Fetch all accessible communities for the Add button parent picker.
-      // RLS scopes this naturally — only communities the user can access are returned.
-      supabase
-        .from("communities")
-        .select("id, name, org_id, organizations!inner(name)")
-        .order("name")
-        .returns<CommunityWithOrgRow[]>(),
-    ]);
+  // Fetch accessible communities for nav + add-button picker.
+  // RLS scopes this naturally — only communities the user can access are returned.
+  const communitiesResult = await supabase
+    .from("communities")
+    .select("id, name, org_id, organizations!inner(name)")
+    .order("name")
+    .returns<CommunityWithOrgRow[]>();
 
-  const levels = levelsResult;
-  const communityName = communityResult.data?.name ?? null;
-  const communityNotFound = communityId != null && !communityResult.data;
-  const { data: microgrids, error } = microgridsResult;
-
-  // Map accessible communities to the CommunityOption shape.
-  const accessibleCommunities: CommunityOption[] = (
+  const allAccessibleCommunities: CommunityOption[] = (
     communitiesResult.data ?? []
   ).map((c) => ({
     id: c.id,
@@ -66,8 +40,76 @@ export default async function MicrogridsPage({
     org_name: c.organizations.name,
   }));
 
+  // Validate the ?org= param.
+  const accessibleOrgIds = new Set(
+    (communitiesResult.data ?? []).map((c) => c.org_id),
+  );
+  const orgValid = orgId != null && accessibleOrgIds.has(orgId);
+  const orgInvalid = orgId != null && !orgValid;
+
+  // When ?org=X valid, narrow the community picker to that org's communities.
+  const accessibleCommunities: CommunityOption[] = orgValid
+    ? allAccessibleCommunities.filter((c) => {
+        const row = (communitiesResult.data ?? []).find((r) => r.id === c.id);
+        return row?.org_id === orgId;
+      })
+    : allAccessibleCommunities;
+
+  // Resolve breadcrumb levels in parallel with data fetch.
+  const [levelsResult, communityResult, microgridsResult] = await Promise.all([
+    getHierarchyLevels(supabase, {
+      kind: "microgrids",
+      communityId,
+      orgId: communityId ? undefined : orgId,
+    }),
+    communityId
+      ? supabase
+          .from("communities")
+          .select("name")
+          .eq("id", communityId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    (() => {
+      let query = supabase.from("microgrids").select("*");
+      if (communityId) {
+        // Community filter is narrower — it wins.
+        query = query.eq("community_id", communityId);
+      } else if (orgValid) {
+        // Org filter: join via communities to filter by org_id.
+        // PostgREST syntax: select from the embedded communities resource.
+        query = supabase
+          .from("microgrids")
+          .select("*, communities!inner(org_id)")
+          .eq("communities.org_id", orgId!);
+      }
+      return query.returns<Microgrid[]>();
+    })(),
+  ]);
+
+  const levels = levelsResult;
+  const communityName = communityResult.data?.name ?? null;
+  const communityNotFound = communityId != null && !communityResult.data;
+  const { data: microgrids, error } = microgridsResult;
+
+  // Banner: both filters present → community wins.
+  const bothFiltersBanner =
+    communityId && orgValid ? (
+      <div className="mb-4 rounded-md bg-warning-muted p-3 text-sm text-warning-fg">
+        Community filter applied — org filter ignored.
+      </div>
+    ) : null;
+
+  // Banner: invalid ?org= param.
+  const invalidOrgBanner = orgInvalid ? (
+    <div className="mb-4 rounded-md bg-warning-muted p-3 text-sm text-warning-fg">
+      Invalid or inaccessible organization filter — showing all.
+    </div>
+  ) : null;
+
   // Resolve which AddEntityButton variant to use:
   //   - In a single-community URL context (?community=...) → locked mode
+  //   - ?org=X valid + exactly 1 community in that org → locked mode
+  //   - ?org=X valid + multiple communities in that org → picker (narrower list)
   //   - Single accessible community → locked mode
   //   - Multiple accessible communities → picker mode
   //   - Zero accessible communities → no button
@@ -75,6 +117,22 @@ export default async function MicrogridsPage({
     if (communityId) {
       return (
         <AddEntityButton entity="microgrid" parentCommunityId={communityId} />
+      );
+    }
+    if (orgValid && accessibleCommunities.length === 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          parentCommunityId={accessibleCommunities[0].id}
+        />
+      );
+    }
+    if (orgValid && accessibleCommunities.length > 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          availableCommunities={accessibleCommunities}
+        />
       );
     }
     if (accessibleCommunities.length === 1) {
@@ -103,6 +161,24 @@ export default async function MicrogridsPage({
         <AddEntityButton
           entity="microgrid"
           parentCommunityId={communityId}
+          label="+ Add the first Microgrid"
+        />
+      );
+    }
+    if (orgValid && accessibleCommunities.length === 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          parentCommunityId={accessibleCommunities[0].id}
+          label="+ Add the first Microgrid"
+        />
+      );
+    }
+    if (orgValid && accessibleCommunities.length > 1) {
+      return (
+        <AddEntityButton
+          entity="microgrid"
+          availableCommunities={accessibleCommunities}
           label="+ Add the first Microgrid"
         />
       );
@@ -158,6 +234,8 @@ export default async function MicrogridsPage({
     return (
       <div>
         <HierarchyNav levels={levels} className="mb-4" />
+        {bothFiltersBanner}
+        {invalidOrgBanner}
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
           {addButton}
@@ -196,6 +274,8 @@ export default async function MicrogridsPage({
   return (
     <div>
       <HierarchyNav levels={levels} className="mb-4" />
+      {bothFiltersBanner}
+      {invalidOrgBanner}
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
         {addButton}

--- a/src/lib/__tests__/hierarchy.test.ts
+++ b/src/lib/__tests__/hierarchy.test.ts
@@ -316,9 +316,12 @@ describe("getHierarchyLevels — href contracts", () => {
     households: [HH_1],
   });
 
-  it("Organization href is /", async () => {
+  it("Organization href is /communities for the communities listing scope (#134)", async () => {
+    // The communities listing scope passes currentListingPath="/communities" to
+    // fetchOrgLevel so the org breadcrumb navigates back to the unfiltered listing,
+    // not the dashboard root.
     const levels = await getHierarchyLevels(supabase, { kind: "communities" });
-    expect(levels[0].href).toBe("/");
+    expect(levels[0].href).toBe("/communities");
   });
 
   it("Community href points to /communities/<id>", async () => {
@@ -442,5 +445,91 @@ describe("getHierarchyLevels — listing scopes", () => {
     expect(levels[3].count).toBe(0);
     expect(levels[3].label).toBe("Edges");
     expect(levels[3].active).toBe(true);
+  });
+});
+
+// ── #134: currentListingPath + orgId threading ─────────────────────────────────
+
+describe("getHierarchyLevels — #134: listing-path sibling hrefs + orgId threading", () => {
+  const ORG_B = { id: "org-b", name: "Second Org" };
+
+  const multiOrgSupabase = makeMockSupabase({
+    organizations: [ORG_A, ORG_B],
+    communities: [COMMUNITY_K],
+    microgrids: [MICROGRID_1],
+    edges: [],
+    households: [],
+  });
+
+  it("communities scope: sibling hrefs use /communities?org=<id>", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "communities",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel!.siblings).toBeDefined();
+    const siblingHref = orgLevel!.siblings![0].href;
+    // Must point to the communities listing, not the dashboard root.
+    expect(siblingHref).toBe("/communities?org=org-b");
+  });
+
+  it("communities scope: org href points to /communities (clear filter)", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "communities",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel!.href).toBe("/communities");
+  });
+
+  it("microgrids scope: sibling hrefs use /microgrids?org=<id>", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "microgrids",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel!.siblings).toBeDefined();
+    const siblingHref = orgLevel!.siblings![0].href;
+    expect(siblingHref).toBe("/microgrids?org=org-b");
+  });
+
+  it("communities scope: orgId param controls current label (not first-alphabetical)", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "communities",
+      orgId: "org-b",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    // "Second Org" (org-b) should be the current label.
+    expect(orgLevel!.label).toBe("Second Org");
+    // Sibling should be ORG_A.
+    expect(orgLevel!.siblings![0].label).toBe("Nearly Free Energy");
+  });
+
+  it("microgrids scope: orgId param controls current label", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "microgrids",
+      orgId: "org-b",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel!.label).toBe("Second Org");
+  });
+
+  it("communities scope: invalid orgId falls back to first-alphabetical", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "communities",
+      orgId: "org-does-not-exist",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    // Falls back to first alphabetically: ORG_A = "Nearly Free Energy".
+    expect(orgLevel!.label).toBe("Nearly Free Energy");
+  });
+
+  it("non-listing scopes (microgrid detail) still use /?org=<id> format", async () => {
+    const levels = await getHierarchyLevels(multiOrgSupabase, {
+      kind: "microgrid",
+      microgridId: "mg-1",
+    });
+    const orgLevel = levels.find((l) => l.kind === "Organization");
+    expect(orgLevel!.siblings).toBeDefined();
+    const siblingHref = orgLevel!.siblings![0].href;
+    // Detail pages use the original dashboard-root format.
+    expect(siblingHref).toBe("/?org=org-b");
   });
 });

--- a/src/lib/hierarchy.ts
+++ b/src/lib/hierarchy.ts
@@ -16,9 +16,9 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { HierarchyLevel } from "@/components/ui/hierarchy-nav";
 
 export type HierarchyScope =
-  | { kind: "communities" }
+  | { kind: "communities"; orgId?: string }
   | { kind: "community"; communityId: string }
-  | { kind: "microgrids"; communityId?: string }
+  | { kind: "microgrids"; communityId?: string; orgId?: string }
   | { kind: "microgrid"; microgridId: string }
   | { kind: "edge"; microgridId: string; edgeId: string }
   | { kind: "edges-listing"; microgridId: string }
@@ -29,10 +29,19 @@ type SiblingRow = { id: string; name: string | null };
 
 // ── Internal fetch helpers ─────────────────────────────────────────────────────
 
-/** Fetch the single accessible org + sibling orgs for a switcher. */
+/** Fetch the single accessible org + sibling orgs for a switcher.
+ *
+ * @param currentOrgId  — org to highlight as "current" in the nav label.
+ *                        Falls back to first-alphabetical if not found.
+ * @param currentListingPath — when set, sibling href becomes
+ *                        `${currentListingPath}?org=<id>` instead of `/?org=<id>`.
+ *                        Pass this from listing pages so the switcher stays on
+ *                        the current listing rather than navigating to the dashboard.
+ */
 async function fetchOrgLevel(
   supabase: SupabaseClient,
   currentOrgId?: string,
+  currentListingPath?: string,
 ): Promise<HierarchyLevel> {
   const { data: orgs } = await supabase
     .from("organizations")
@@ -56,17 +65,24 @@ async function fetchOrgLevel(
     (currentOrgId ? orgList.find((o) => o.id === currentOrgId) : undefined) ??
     orgList[0];
 
+  const siblingHref = (id: string) =>
+    currentListingPath ? `${currentListingPath}?org=${id}` : `/?org=${id}`;
+
+  // Org-level href: when on a listing page, the current-org link should stay
+  // on the listing (without a filter) so the user can navigate "up" to all orgs.
+  const orgHref = currentListingPath ?? "/";
+
   return {
     kind: "Organization",
     label: current?.name ?? "Organization",
     count: orgList.length,
-    href: "/",
+    href: orgHref,
     active: false,
     siblings:
       orgList.length > 1
         ? orgList
             .filter((o) => o.id !== current?.id)
-            .map((o) => ({ label: o.name ?? o.id, href: `/?org=${o.id}` }))
+            .map((o) => ({ label: o.name ?? o.id, href: siblingHref(o.id) }))
         : undefined,
   };
 }
@@ -282,7 +298,7 @@ export async function getHierarchyLevels(
 ): Promise<HierarchyLevel[]> {
   switch (scope.kind) {
     case "communities": {
-      const orgLevel = await fetchOrgLevel(supabase);
+      const orgLevel = await fetchOrgLevel(supabase, scope.orgId, "/communities");
       return [orgLevel];
     }
 
@@ -307,24 +323,24 @@ export async function getHierarchyLevels(
     }
 
     case "microgrids": {
-      let orgId: string | undefined;
+      let resolvedOrgId: string | undefined = scope.orgId;
       let communityLevel: HierarchyLevel | undefined;
 
       if (scope.communityId) {
-        // Resolve community → org chain.
+        // Resolve community → org chain (community-scoped view takes precedence).
         const { data: community } = await supabase
           .from("communities")
           .select("id, name, org_id")
           .eq("id", scope.communityId)
           .single<{ id: string; name: string; org_id: string }>();
 
-        orgId = community?.org_id;
+        resolvedOrgId = community?.org_id;
 
         const cl = await fetchCommunityLevel(supabase, scope.communityId, false);
         if (cl) communityLevel = cl;
       }
 
-      const orgLevel = await fetchOrgLevel(supabase, orgId);
+      const orgLevel = await fetchOrgLevel(supabase, resolvedOrgId, "/microgrids");
 
       // Empty-state: 0 orgs — return just org placeholder.
       if (orgLevel.count === 0) return [orgLevel];


### PR DESCRIPTION
## Summary
- `/communities?org=X` filters the query with `.eq("org_id", X)` and auto-locks the Add button to that org (picker unnecessary when filter is active)
- `/microgrids?org=X` filters via `communities!inner(org_id)` join; `?community=` wins when both present with a banner noting the precedence
- `fetchOrgLevel` accepts a `currentListingPath` param so sibling dropdown hrefs point to `/communities?org=<id>` / `/microgrids?org=<id>` instead of `/?org=<id>` (which was the actual bug — selecting a sibling org dropped you on the dashboard)
- Current org in HierarchyNav matches URL selection (was: first alphabetically)
- Invalid `?org=` → inline warning banner, unfiltered list, no redirect (preserves bookmarks)
- `accessibleCommunities` for Add Microgrid picker is narrowed to the filtered org's communities when `?org=` is active

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (833 pass)
- [x] `npm run build`
- [ ] Manual: `/communities?org=<NFE-id>` → only Kisakye shows, not empty
- [ ] Manual: switch to `Alejandro's test org` via the HierarchyNav dropdown → URL becomes `/communities?org=<alejandro-id>`, list empties (no communities under that org yet)
- [ ] Manual: remove `?org=` → all accessible show

Closes #134.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)