### PR TITLE
EmptyState primitive + 8 priority surfaces (#139)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/__tests__/page.test.tsx
@@ -173,8 +173,8 @@ describe("CommunityDetailPage", () => {
     expect(notFoundMock).toHaveBeenCalled();
   });
 
-  // 3. Empty-microgrids community → "No microgrids yet" placeholder.
-  it("renders 'No microgrids yet' placeholder when microgrids array is empty", async () => {
+  // 3. Empty-microgrids community → EmptyState with "Add the first microgrid" (#139 P2).
+  it("renders EmptyState 'Add the first microgrid' when microgrids array is empty", async () => {
     communityData = {
       ...BASE_COMMUNITY,
       microgrids: [],
@@ -186,7 +186,8 @@ describe("CommunityDetailPage", () => {
     });
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
-    expect(html).toContain("No microgrids yet");
+    expect(html).toContain("Add the first microgrid");
+    expect(html).toContain("A microgrid is the physical installation");
     // Stats show zeros
     expect(html).toContain("0");
   });

--- a/src/app/(dashboard)/communities/[id]/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/page.tsx
@@ -7,6 +7,8 @@ import { EditEntityButton } from "@/components/forms/EditEntityButton";
 import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
 import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+import { EmptyState } from "@/components/ui/empty-state";
+import { AddEntityButton } from "@/components/forms/AddEntityButton";
 import type { Community } from "@/lib/types/domain";
 
 /**
@@ -186,7 +188,29 @@ export default async function CommunityDetailPage({
           Microgrids in this community
         </h2>
         {microgrids.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No microgrids yet.</p>
+          <EmptyState
+            eyebrow="Microgrids"
+            title="Add the first microgrid"
+            body={
+              <>
+                A microgrid is the physical installation that meters and bills
+                electricity in this community. Most start with one.
+              </>
+            }
+            cta={
+              canEdit ? (
+                <AddEntityButton
+                  entity="microgrid"
+                  parentCommunityId={community.id}
+                />
+              ) : undefined
+            }
+            footnote={
+              !canEdit
+                ? "Ask a super admin to add the first microgrid."
+                : undefined
+            }
+          />
         ) : (
           <ul className="space-y-1">
             {microgrids.map((mg) => (

--- a/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/page.tsx
@@ -3,6 +3,7 @@ import type { BillingPeriod } from "@/lib/types/domain";
 import { BillingPeriodList } from "@/components/BillingPeriodList";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 export default async function BillingPage({
   params,
@@ -12,10 +13,13 @@ export default async function BillingPage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const levels = await getHierarchyLevels(supabase, {
-    kind: "microgrid",
-    microgridId: id,
-  });
+  const [canManage, levels] = await Promise.all([
+    currentUserCanAccessMicrogrid(supabase, id),
+    getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: id,
+    }),
+  ]);
 
   // Step 1: Fetch periods
   const { data: periods, error } = await supabase
@@ -74,6 +78,7 @@ export default async function BillingPage({
         periods={periods ?? []}
         summaries={summaries}
         currency={microgridResult.data?.currency ?? "UGX"}
+        canManage={canManage}
       />
     </>
   );

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
@@ -10,7 +10,7 @@ import { EdgeDetailConfigureButton } from "./edge-detail-configure-button";
 import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
 import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 import { EmptyState } from "@/components/ui/empty-state";
-import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import { createOpenEmsClient } from "@/lib/openems";
 import { getMicrogridEmsConfig } from "@/lib/openems/config";
 import type { OpenEmsClientConfig } from "@/lib/openems";
 

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
@@ -9,12 +9,32 @@ import { DiscoverDevices } from "@/components/DiscoverDevices";
 import { EdgeDetailConfigureButton } from "./edge-detail-configure-button";
 import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
 import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { EmptyState } from "@/components/ui/empty-state";
+import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
+import { getMicrogridEmsConfig } from "@/lib/openems/config";
+import type { OpenEmsClientConfig } from "@/lib/openems";
 
 // Setup > Edges > [edgeId] — edge detail (D2 / #53, #77).
 // Lists devices on this edge. For each device, shows the linked household
 // (via household_devices) if any.
 //
 // #77 adds: "Configure…" button in the header (via client shell component).
+// #139 adds: edge-online fetch for the empty-state tone (warn if offline).
+
+async function fetchEdgeOnlineStatus(
+  emsConfig: OpenEmsClientConfig | null,
+  openemsEdgeId: string | null,
+): Promise<boolean> {
+  if (!emsConfig || !openemsEdgeId) return false;
+  try {
+    const client = createOpenEmsClient(emsConfig);
+    const statuses = await client.getEdgesStatus([openemsEdgeId]);
+    return statuses.find((s) => s.edgeId === openemsEdgeId)?.online === true;
+  } catch (err) {
+    void err; // treat fetch error as offline
+    return false;
+  }
+}
 
 type DeviceRow = Pick<
   Device,
@@ -50,6 +70,16 @@ export default async function EdgeDetailPage({
   }
 
   const canManage = await currentUserCanAccessMicrogrid(supabase, id);
+
+  // Fetch edge online status for the devices empty-state tone (#139 P6).
+  // Treat emsConfig fetch failure or missing openems_edge_id as offline.
+  let emsConfig: OpenEmsClientConfig | null = null;
+  try {
+    emsConfig = await getMicrogridEmsConfig(supabase, id);
+  } catch {
+    emsConfig = null;
+  }
+  const edgeOnline = await fetchEdgeOnlineStatus(emsConfig, edge.openems_edge_id ?? null);
 
   const { data: devices, error: devicesError } = await supabase
     .from("devices")
@@ -131,9 +161,37 @@ export default async function EdgeDetailPage({
       )}
 
       {(!devices || devices.length === 0) ? (
-        <p className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-          No devices configured on this edge.
-        </p>
+        edgeOnline ? (
+          <EmptyState
+            eyebrow="Devices"
+            title="Run discovery to see meters"
+            body={
+              <>
+                MBE pulls meters from this edge&apos;s OpenEMS backend. Make
+                sure the edge is online, then click Discover.
+              </>
+            }
+            footnote={
+              canManage
+                ? "The Discover devices card is above this section."
+                : "Ask a super admin to run discovery on this edge."
+            }
+          />
+        ) : (
+          <EmptyState
+            tone="warn"
+            eyebrow="Devices"
+            title="Edge is offline — can't discover yet"
+            body={
+              <>
+                MBE pulls meters from this edge&apos;s OpenEMS backend. Bring{" "}
+                <span className="font-medium text-foreground">{edge.name}</span>{" "}
+                online, then run discovery.
+              </>
+            }
+            footnote="Tip: check the edge hardware and confirm it's reporting to OpenEMS Backend."
+          />
+        )
       ) : (
         <div className="overflow-hidden rounded-lg border border-border bg-card">
           <table className="w-full text-left text-sm">

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/edge-empty-state.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/edge-empty-state.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * EdgeEmptyState — client wrapper for the edges listing empty state (#139 P4).
+ *
+ * Handles local dialog state for the "Add edge" CTA. The edges listing page
+ * is a server component; this thin client shell owns the AddEdgeDialog open
+ * state so the CTA can be interactive.
+ *
+ * Tone is always neutral (§G in the refinement): the top-of-page <Banner>
+ * already owns the warn signal when emsType === null. Duplicating with another
+ * warn tone creates double-warning noise.
+ *
+ * CTA gating:
+ *   - canManage && emsType !== null → show + Add edge button
+ *   - emsType === null → show secondary link to OpenEMS backend config +
+ *     neutral footnote (banner already warns)
+ *   - !canManage → footnote only
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { EmptyState } from "@/components/ui/empty-state";
+import { AddEdgeDialog } from "@/components/forms/AddEdgeDialog";
+
+type Props = {
+  microgridId: string;
+  canManage: boolean;
+  emsType: string | null;
+};
+
+export function EdgeEmptyState({ microgridId, canManage, emsType }: Props) {
+  const [open, setOpen] = React.useState(false);
+  const blockedOnBackend = emsType === null;
+
+  return (
+    <>
+      <EmptyState
+        eyebrow="Edges"
+        title="Add the first edge"
+        body={
+          <>
+            An edge connects this microgrid to its meters — typically an
+            OpenEMS instance running on a gateway device at your site.
+          </>
+        }
+        cta={
+          canManage && !blockedOnBackend ? (
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              + Add edge
+            </button>
+          ) : undefined
+        }
+        secondary={
+          blockedOnBackend ? (
+            <Link
+              href={`/microgrids/${microgridId}/setup/openems-backend`}
+              className="text-sm font-medium text-foreground underline hover:opacity-80"
+            >
+              Configure OpenEMS backend →
+            </Link>
+          ) : undefined
+        }
+        footnote={
+          blockedOnBackend
+            ? "Configure the OpenEMS backend first, then add an edge."
+            : !canManage
+              ? "Ask a super admin to add the first edge."
+              : undefined
+        }
+      />
+      {canManage && !blockedOnBackend && (
+        <AddEdgeDialog
+          microgridId={microgridId}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -7,9 +7,9 @@
 //   - Mock @/lib/openems/config so we bypass the microgrid config fetch.
 //   - Call SetupEdgesPage() directly and serialize returned JSX to HTML.
 
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import type React from "react";
 
 const mockFrom = vi.fn();
 
@@ -47,10 +47,7 @@ vi.mock("./edges-crud-shell", () => ({
 // Stub EdgeEmptyState — client component (uses useState + AddEdgeDialog which
 // uses useRouter — both unavailable in server-component renderToStaticMarkup tests).
 vi.mock("./edge-empty-state", () => ({
-  EdgeEmptyState: () => {
-    const React = require("react");
-    return React.createElement("p", null, "No edges configured");
-  },
+  EdgeEmptyState: () => React.createElement("p", null, "No edges configured"),
 }));
 
 // Stub EdgeRowActions — client component that uses useRouter + Radix DropdownMenu.

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.test.tsx
@@ -44,6 +44,15 @@ vi.mock("./edges-crud-shell", () => ({
   EdgesCRUDShell: () => null,
 }));
 
+// Stub EdgeEmptyState — client component (uses useState + AddEdgeDialog which
+// uses useRouter — both unavailable in server-component renderToStaticMarkup tests).
+vi.mock("./edge-empty-state", () => ({
+  EdgeEmptyState: () => {
+    const React = require("react");
+    return React.createElement("p", null, "No edges configured");
+  },
+}));
+
 // Stub EdgeRowActions — client component that uses useRouter + Radix DropdownMenu.
 vi.mock("./edge-row-actions", () => ({
   EdgeRowActions: () => null,

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/page.tsx
@@ -10,6 +10,7 @@ import type { OpenEmsClientConfig } from "@/lib/openems";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { EdgesCRUDShell } from "./edges-crud-shell";
+import { EdgeEmptyState } from "./edge-empty-state";
 import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 import {
   currentUserCanAccessMicrogrid,
@@ -175,10 +176,11 @@ export default async function SetupEdgesPage({
       )}
 
       {!edges || edges.length === 0 ? (
-        <p className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-          No edges configured yet. Add an edge to link this microgrid to a
-          metering source.
-        </p>
+        <EdgeEmptyState
+          microgridId={id}
+          canManage={canManage}
+          emsType={emsType}
+        />
       ) : (
         <div className="overflow-hidden rounded-lg border border-border bg-card">
           <table className="w-full text-left text-sm">

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
@@ -39,6 +39,15 @@ vi.mock("next/link", () => ({
   },
 }));
 
+// ── Auth access mock ──────────────────────────────────────────────────────────
+// Stub so currentUserCanAccessMicrogrid doesn't hit Supabase auth.getUser.
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: vi.fn().mockResolvedValue(true),
+  currentUserIsSuperAdmin: vi.fn().mockResolvedValue(true),
+  currentUserCanAccessCommunity: vi.fn().mockResolvedValue(true),
+  currentUserCanAccessOrg: vi.fn().mockResolvedValue(true),
+}));
+
 // ── Supabase mock ────────────────────────────────────────────────────────────
 
 const mockFrom = vi.fn();
@@ -115,6 +124,28 @@ function buildLineItemsQuery(data: unknown) {
   return chain;
 }
 
+/**
+ * Builds a generic flexible query chain that handles the various query
+ * patterns for edges, household_devices, devices (new in #139).
+ * Returns { data: [], error: null } for .select().eq() chains and
+ * { count: 0, error: null } for count queries.
+ */
+function buildFlexQuery(data: unknown[] = [], count = 0) {
+  const chain: Record<string, unknown> = {};
+  const resolve = () => Promise.resolve({ data, count, error: null });
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.in = () => chain;
+  chain.not = () => resolve;
+  chain.returns = () => Promise.resolve({ data, error: null });
+  chain.maybeSingle = () => Promise.resolve({ data: data[0] ?? null, error: null });
+  chain.single = () => Promise.resolve({ data: data[0] ?? null, error: null });
+  // Make chain itself thenable so await on it works (direct .eq() returns promise)
+  (chain as unknown as Promise<unknown>).then = (resolve2: unknown, reject: unknown) =>
+    Promise.resolve({ data, count, error: null }).then(resolve2 as never, reject as never);
+  return chain;
+}
+
 // ── Import page (after mocks) ─────────────────────────────────────────────────
 
 import HouseholdDetailPage from "./page";
@@ -149,7 +180,8 @@ describe("HouseholdDetailPage", () => {
           },
         ]);
       }
-      return buildCountQuery(0);
+      // edges, household_devices, devices queries for P7 hasMetersAvailable
+      return buildFlexQuery([]);
     });
 
     const jsx = await HouseholdDetailPage({
@@ -183,8 +215,8 @@ describe("HouseholdDetailPage", () => {
     expect(html).toContain("2026-03-31");
   });
 
-  // (b) Empty devices: 0 household_devices
-  it("renders empty devices state when no devices are linked", async () => {
+  // (b) Empty devices: 0 household_devices → EmptyState with warn tone (#139 P7)
+  it("renders EmptyState 'Link this household to its meter' when no devices are linked", async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === "households") {
         return buildHouseholdQuery({
@@ -198,7 +230,8 @@ describe("HouseholdDetailPage", () => {
       if (table === "billing_line_items") {
         return buildLineItemsQuery([]);
       }
-      return buildCountQuery(0);
+      // edges, household_devices, devices queries for P7 hasMetersAvailable
+      return buildFlexQuery([]);
     });
 
     const jsx = await HouseholdDetailPage({
@@ -206,7 +239,8 @@ describe("HouseholdDetailPage", () => {
     });
     const html = renderToStaticMarkup(jsx as React.ReactElement);
 
-    expect(html).toContain("No devices linked to this household yet");
+    expect(html).toContain("Link this household to its meter");
+    expect(html).toContain("primary meter get billed");
     // Billing empty state should still appear (0 line items)
     expect(html).toContain("No billing history");
   });
@@ -228,7 +262,7 @@ describe("HouseholdDetailPage", () => {
       if (table === "billing_line_items") {
         return buildLineItemsQuery([]);
       }
-      return buildCountQuery(0);
+      return buildFlexQuery([]);
     });
 
     const jsx = await HouseholdDetailPage({
@@ -250,7 +284,7 @@ describe("HouseholdDetailPage", () => {
           code: "PGRST116",
         });
       }
-      return buildCountQuery(0);
+      return buildFlexQuery([]);
     });
 
     await expect(
@@ -288,7 +322,7 @@ describe("HouseholdDetailPage", () => {
       if (table === "billing_line_items") {
         return buildLineItemsQuery([]);
       }
-      return buildCountQuery(0);
+      return buildFlexQuery([]);
     });
 
     const jsx = await HouseholdDetailPage({

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
@@ -4,6 +4,8 @@ import { createClient } from "@/lib/supabase/server";
 import { StatusChip } from "@/components/ui/status-chip";
 import { Currency } from "@/components/format/currency";
 import { Kwh } from "@/components/format/kwh";
+import { EmptyState } from "@/components/ui/empty-state";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 // Setup > Households > [householdId] — Household detail page (D3 / #54).
 //
@@ -101,6 +103,37 @@ export default async function HouseholdDetailPage({
     (li) => li.billing_periods?.status === "closed",
   );
 
+  // Resolve role + available unlinked consumption meters for P7 empty state (#139).
+  const canManage = await currentUserCanAccessMicrogrid(supabase, microgridId);
+
+  // Count unlinked consumption meters on this microgrid (sequential queries kept
+  // simple to avoid dynamic .not("id","in",...) edge cases with empty arrays).
+  const [edgesResult, assignedResult] = await Promise.all([
+    supabase.from("edges").select("id").eq("microgrid_id", microgridId),
+    supabase
+      .from("household_devices")
+      .select("device_id")
+      .eq("role", "primary_consumption_meter"),
+  ]);
+  const microgridEdgeIds = (edgesResult.data ?? []).map((e) => e.id);
+  const assignedDeviceIds = (assignedResult.data ?? []).map((r) => r.device_id);
+
+  let hasMetersAvailable = false;
+  if (microgridEdgeIds.length > 0) {
+    let metersQuery = supabase
+      .from("devices")
+      .select("id", { count: "exact", head: true })
+      .in("edge_id", microgridEdgeIds)
+      .eq("device_type", "consumption_meter");
+
+    if (assignedDeviceIds.length > 0) {
+      metersQuery = metersQuery.not("id", "in", `(${assignedDeviceIds.join(",")})`);
+    }
+
+    const { count } = await metersQuery;
+    hasMetersAvailable = (count ?? 0) > 0;
+  }
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
@@ -163,9 +196,35 @@ export default async function HouseholdDetailPage({
           Linked devices
         </h4>
         {devices.length === 0 ? (
-          <p className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-            No devices linked to this household yet
-          </p>
+          <EmptyState
+            tone="warn"
+            eyebrow="Linked devices"
+            title="Link this household to its meter"
+            body={
+              <>
+                Pick a device from this microgrid&apos;s edges and mark it the
+                primary consumption meter. Only households with a primary meter
+                get billed.
+              </>
+            }
+            secondary={
+              canManage ? (
+                <Link
+                  href={`/microgrids/${microgridId}/setup/households`}
+                  className="text-sm font-medium text-foreground underline hover:opacity-80"
+                >
+                  Go to Households listing →
+                </Link>
+              ) : undefined
+            }
+            footnote={
+              !canManage
+                ? `Ask a super admin to link a meter to ${household.display_name ?? "this household"}.`
+                : hasMetersAvailable
+                  ? "Go to Setup › Households and pick this household's primary meter from the row dropdown. A dedicated Link Device dialog is coming soon."
+                  : "No unlinked consumption meters on this microgrid yet — run device discovery on an edge first."
+            }
+          />
         ) : (
           <div className="overflow-hidden rounded-lg border border-border bg-card">
             <table className="w-full text-left text-sm">

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/households-section.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/households-section.tsx
@@ -25,6 +25,7 @@ type Props = {
   devices: Device[];
   primaryDeviceAssignments: Record<string, string>;
   availableMeters: AvailableMeter[];
+  canManage?: boolean;
 };
 
 export function HouseholdsSection({
@@ -33,6 +34,7 @@ export function HouseholdsSection({
   devices,
   primaryDeviceAssignments,
   availableMeters,
+  canManage = false,
 }: Props) {
   const [wizardOpen, setWizardOpen] = React.useState(false);
 
@@ -69,6 +71,8 @@ export function HouseholdsSection({
         households={households}
         devices={devices}
         primaryDeviceAssignments={primaryDeviceAssignments}
+        canManage={canManage}
+        onAdd={() => setWizardOpen(true)}
       />
     </div>
   );

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
@@ -3,6 +3,7 @@ import type { Device, Household } from "@/lib/types/domain";
 import { HouseholdsSection } from "./households-section";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 import type { AvailableMeter } from "@/components/forms/HouseholdWizard";
 
 // Setup > Households (D2 / #53, upgraded in UX2 / #74).
@@ -19,10 +20,13 @@ export default async function SetupHouseholdsPage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const levels = await getHierarchyLevels(supabase, {
-    kind: "households-listing",
-    microgridId: id,
-  });
+  const [canManage, levels] = await Promise.all([
+    currentUserCanAccessMicrogrid(supabase, id),
+    getHierarchyLevels(supabase, {
+      kind: "households-listing",
+      microgridId: id,
+    }),
+  ]);
 
   const [
     { data: households, error: householdsError },
@@ -117,6 +121,7 @@ export default async function SetupHouseholdsPage({
         devices={devices ?? []}
         primaryDeviceAssignments={primaryDeviceAssignments}
         availableMeters={availableMeters}
+        canManage={canManage}
       />
     </>
   );

--- a/src/app/(dashboard)/microgrids/[id]/setup/rates/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/rates/page.tsx
@@ -3,6 +3,7 @@ import type { RateSchedule } from "@/lib/types/domain";
 import { TierEditor } from "@/components/TierEditor";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 
 export default async function RatesPage({
   params,
@@ -12,10 +13,13 @@ export default async function RatesPage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const levels = await getHierarchyLevels(supabase, {
-    kind: "microgrid",
-    microgridId: id,
-  });
+  const [canManage, levels] = await Promise.all([
+    currentUserCanAccessMicrogrid(supabase, id),
+    getHierarchyLevels(supabase, {
+      kind: "microgrid",
+      microgridId: id,
+    }),
+  ]);
 
   const [{ data: schedule, error: scheduleError }, { data: microgrid, error: microgridError }] =
     await Promise.all([
@@ -57,6 +61,7 @@ export default async function RatesPage({
         microgridId={id}
         currency={microgrid.currency}
         initialSchedule={schedule}
+        canManage={canManage}
       />
     </>
   );

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -5,6 +5,8 @@ import { EditEntityButton } from "@/components/forms/EditEntityButton";
 import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
 import { DeletedSuccessBanner } from "@/components/entity-deletion/DeletedSuccessBanner";
 import { currentUserIsSuperAdmin } from "@/lib/auth/access";
+import { EmptyState } from "@/components/ui/empty-state";
+import { AddEntityButton } from "@/components/forms/AddEntityButton";
 import type { Organization } from "@/lib/types/domain";
 
 /**
@@ -92,9 +94,27 @@ export default async function OrganizationDetailPage({
           Communities
         </h2>
         {!communities || communities.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No communities in this organization yet.
-          </p>
+          <EmptyState
+            eyebrow="Communities"
+            title="Add the first community"
+            body={
+              <>
+                A community is a site where your microgrid(s) live — a
+                neighborhood, building complex, or co-op. One organization can
+                have many.
+              </>
+            }
+            cta={
+              isSuperAdmin ? (
+                <AddEntityButton entity="community" parentOrgId={org.id} />
+              ) : undefined
+            }
+            footnote={
+              !isSuperAdmin
+                ? "Ask a super admin to add the first community."
+                : undefined
+            }
+          />
         ) : (
           <ul className="space-y-1">
             {communities.map((c) => {

--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -11,6 +11,7 @@ import { Kwh } from "@/components/format/kwh";
 import { LocalDate } from "@/components/format/local-date";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { PeriodPicker, type PeriodOption } from "@/components/ui/period-picker";
+import { EmptyState } from "@/components/ui/empty-state";
 
 function toPeriodOption(
   period: BillingPeriod,
@@ -43,11 +44,14 @@ export function BillingPeriodList({
   periods,
   summaries,
   currency,
+  canManage = false,
 }: {
   microgridId: string;
   periods: BillingPeriod[];
   summaries: Record<string, { totalKwh: number; totalAmount: number } | undefined>;
   currency: string;
+  /** Whether the current user can manage billing periods. Defaults to false. */
+  canManage?: boolean;
 }) {
   const router = useRouter();
   const supabase = createClient();
@@ -196,9 +200,35 @@ export function BillingPeriodList({
       )}
 
       {periods.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No billing periods yet. Create a new period to get started.
-        </p>
+        <EmptyState
+          eyebrow="Billing periods"
+          title="Create the first billing period"
+          body={
+            <>
+              A billing period defines the start and end dates you&apos;re
+              invoicing for — typically one calendar month. When you close it,
+              MBE snapshots meter readings and generates line items for every
+              household.
+            </>
+          }
+          cta={
+            canManage ? (
+              <button
+                type="button"
+                onClick={() => setShowCreateForm(true)}
+                className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+              >
+                + Create period
+              </button>
+            ) : undefined
+          }
+          footnote={
+            !canManage
+              ? "Ask a super admin to create the first billing period."
+              : "You'll be able to edit the date range up until you Close the period."
+          }
+          className="border-0 shadow-none bg-transparent p-0"
+        />
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">

--- a/src/components/HouseholdTable.tsx
+++ b/src/components/HouseholdTable.tsx
@@ -6,18 +6,25 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { Device, Household } from "@/lib/types/domain";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export function HouseholdTable({
   microgridId,
   households,
   devices,
   primaryDeviceAssignments,
+  canManage = false,
+  onAdd,
 }: {
   microgridId: string;
   households: Household[];
   devices: Device[];
   /** Map of household_id → device_id for primary_consumption_meter rows */
   primaryDeviceAssignments: Record<string, string>;
+  /** Whether the current user can manage households. Defaults to false. */
+  canManage?: boolean;
+  /** Called when the user clicks the "Add household" CTA in the empty state. */
+  onAdd?: () => void;
 }) {
   const router = useRouter();
   const supabase = createClient();
@@ -284,9 +291,33 @@ export function HouseholdTable({
       )}
 
       {households.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No households yet. Add a household to get started.
-        </p>
+        <EmptyState
+          eyebrow="Households"
+          title="Add the first household"
+          body={
+            <>
+              Households are the customers on this microgrid. Each gets their
+              own bill. Add them now; link their meter later.
+            </>
+          }
+          cta={
+            canManage && onAdd ? (
+              <button
+                type="button"
+                onClick={onAdd}
+                className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+              >
+                + Add household
+              </button>
+            ) : undefined
+          }
+          footnote={
+            !canManage
+              ? "Ask a super admin to add households for this microgrid."
+              : undefined
+          }
+          className="border-0 shadow-none bg-transparent p-0"
+        />
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">

--- a/src/components/TierEditor.tsx
+++ b/src/components/TierEditor.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Banner } from "@/components/ui/banner";
 import { Input } from "@/components/ui/input";
 import { Currency } from "@/components/format/currency";
+import { EmptyState } from "@/components/ui/empty-state";
 import { calculateTieredCost } from "@/lib/billing/calculations";
 
 const SAMPLE_USAGE_KWH = 100;
@@ -15,10 +16,13 @@ export function TierEditor({
   microgridId,
   currency,
   initialSchedule,
+  canManage = false,
 }: {
   microgridId: string;
   currency: string;
   initialSchedule: RateSchedule | null;
+  /** Whether the current user can manage the rate schedule. Defaults to false. */
+  canManage?: boolean;
 }) {
   const router = useRouter();
 
@@ -266,9 +270,37 @@ export function TierEditor({
         )}
 
         {tiers.length === 0 ? (
-          <p className="mb-6 text-sm text-muted-foreground">
-            No tiers configured. Add a tier to define the rate schedule.
-          </p>
+          <div className="mb-6">
+            <EmptyState
+              tone="warn"
+              eyebrow="Rate schedule"
+              title="Set up the rate schedule"
+              body={
+                <>
+                  Tiers define the kWh price bands — e.g. the first 50 kWh at
+                  one rate, the next 100 at a higher rate. Without tiers, bills
+                  come out zero.
+                </>
+              }
+              cta={
+                canManage ? (
+                  <button
+                    type="button"
+                    onClick={addTier}
+                    className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+                  >
+                    + Add first tier
+                  </button>
+                ) : undefined
+              }
+              footnote={
+                !canManage
+                  ? "Ask a super admin to configure the rate schedule for this microgrid."
+                  : undefined
+              }
+              className="border-0 shadow-none bg-transparent p-0"
+            />
+          </div>
         ) : (
           <div className="mb-6 overflow-x-auto">
             <table className="w-full text-left text-sm">

--- a/src/components/__tests__/billing-period-list.test.tsx
+++ b/src/components/__tests__/billing-period-list.test.tsx
@@ -128,3 +128,86 @@ describe("BillingPeriodList", () => {
     );
   });
 });
+
+// ─── EmptyState (#139 P9) ─────────────────────────────────────────────────────
+
+describe("BillingPeriodList — EmptyState (#139)", () => {
+  it("shows EmptyState title and body when periods is empty", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+    expect(screen.getByText("Create the first billing period")).toBeTruthy();
+    expect(screen.getByText(/A billing period defines the start and end dates/)).toBeTruthy();
+  });
+
+  it("shows '+ Create period' CTA when canManage=true and periods empty", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+    expect(screen.getByRole("button", { name: /Create period/i })).toBeTruthy();
+  });
+
+  it("hides CTA and shows role-locked footnote when canManage=false", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+          canManage={false}
+        />
+      </Wrapper>
+    );
+    expect(screen.queryByRole("button", { name: /Create period/i })).toBeNull();
+    expect(
+      screen.getByText(/Ask a super admin to create the first billing period/)
+    ).toBeTruthy();
+  });
+
+  it("shows canManage=true footnote about editing date range", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+    expect(
+      screen.getByText(/You'll be able to edit the date range/)
+    ).toBeTruthy();
+  });
+
+  it("does NOT show EmptyState when periods are present", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[PERIOD_1, PERIOD_2]}
+          summaries={SUMMARIES}
+          currency="UGX"
+        />
+      </Wrapper>
+    );
+    expect(screen.queryByText("Create the first billing period")).toBeNull();
+  });
+});

--- a/src/components/__tests__/household-table.test.tsx
+++ b/src/components/__tests__/household-table.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+/**
+ * HouseholdTable EmptyState tests (#139 P5).
+ *
+ * Covers:
+ *   (a) EmptyState renders with correct eyebrow + title + body when households empty
+ *   (b) CTA visible when canManage=true + onAdd provided; hidden when canManage=false
+ *   (c) Footnote visible in role-locked state (canManage=false)
+ *   (d) Non-empty rendering is unchanged (CSS regression check)
+ *   (e) border-0 override classes present (no cards-in-cards nesting)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { Device, Household } from "@/lib/types/domain";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/",
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+// Mock Supabase client
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: () => ({
+      delete: () => ({
+        eq: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      }),
+      update: () => ({
+        eq: () => Promise.resolve({ error: null }),
+      }),
+      insert: () => Promise.resolve({ error: null }),
+    }),
+  }),
+}));
+
+import { HouseholdTable } from "../HouseholdTable";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MICROGRID_ID = "mg-test-1";
+
+const HOUSEHOLD: Household = {
+  id: "hh-1",
+  microgrid_id: MICROGRID_ID,
+  display_name: "Household Alpha",
+  primary_phone: null,
+  primary_email: null,
+  address_line1: null,
+  address_line2: null,
+  unit_label: null,
+  created_at: "2026-01-01T00:00:00Z",
+} as Household;
+
+const DEVICE: Device = {
+  id: "dev-1",
+  edge_id: "edge-1",
+  name: "Meter 1",
+  device_type: "consumption_meter",
+  openems_component_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  config: {},
+} as Device;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("HouseholdTable — EmptyState (#139 P5)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("(a) renders EmptyState with correct title, body when households empty", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[]}
+        devices={[]}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+        onAdd={() => {}}
+      />
+    );
+    // title
+    expect(screen.getByText("Add the first household")).toBeTruthy();
+    // body
+    expect(screen.getByText(/Households are the customers on this microgrid/)).toBeTruthy();
+  });
+
+  it("(b) CTA '+ Add household' visible when canManage=true (EmptyState CTA)", () => {
+    const onAdd = vi.fn();
+    const { container } = render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[]}
+        devices={[]}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+        onAdd={onAdd}
+      />
+    );
+    // The EmptyState CTA is inside role="region"; find it there
+    const region = container.querySelector("[role='region']");
+    const cta = region?.querySelector("button");
+    expect(cta).not.toBeNull();
+    expect(cta?.textContent).toContain("Add household");
+    fireEvent.click(cta!);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("(b) EmptyState has no button inside region when canManage=false", () => {
+    const { container } = render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[]}
+        devices={[]}
+        primaryDeviceAssignments={{}}
+        canManage={false}
+      />
+    );
+    const region = container.querySelector("[role='region']");
+    const ctaInRegion = region?.querySelector("button");
+    expect(ctaInRegion).toBeNull();
+  });
+
+  it("(c) footnote visible in role-locked state (canManage=false)", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[]}
+        devices={[]}
+        primaryDeviceAssignments={{}}
+        canManage={false}
+      />
+    );
+    expect(
+      screen.getByText(/Ask a super admin to add households for this microgrid/)
+    ).toBeTruthy();
+  });
+
+  it("(d) non-empty: renders household row without EmptyState", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD]}
+        devices={[DEVICE]}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+        onAdd={() => {}}
+      />
+    );
+    expect(screen.queryByText("Add the first household")).toBeNull();
+    expect(screen.getByText("Household Alpha")).toBeTruthy();
+  });
+
+  it("(e) EmptyState rendered with border-0 override (no cards-in-cards)", () => {
+    const { container } = render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[]}
+        devices={[]}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+        onAdd={() => {}}
+      />
+    );
+    const region = container.querySelector("[role='region']");
+    expect(region?.className).toContain("border-0");
+    expect(region?.className).toContain("shadow-none");
+    expect(region?.className).toContain("p-0");
+  });
+});

--- a/src/components/__tests__/tier-editor.test.tsx
+++ b/src/components/__tests__/tier-editor.test.tsx
@@ -197,3 +197,61 @@ describe("TierEditor", () => {
     expect(screen.getByText(/Example: 100 kWh/)).toBeTruthy();
   });
 });
+
+// ─── EmptyState (#139 P8) ─────────────────────────────────────────────────────
+
+describe("TierEditor — EmptyState (#139)", () => {
+  it("shows EmptyState with title and body when tiers is empty", () => {
+    renderEditor(null);
+    expect(screen.getByText("Set up the rate schedule")).toBeTruthy();
+    expect(screen.getByText(/Tiers define the kWh price bands/)).toBeTruthy();
+  });
+
+  it("shows warn-toned empty state (has border-warning) when tiers empty", () => {
+    const { container } = renderEditor(null);
+    const region = container.querySelector("[role='region']");
+    // border-warning is present from tone="warn"; note: border-l-4 may be merged-out
+    // by the border-0 card-suppression override (tailwind-merge resolves last wins).
+    // The primitive itself is tested for border-l-4 in empty-state.test.tsx.
+    // Here we just verify the warn class is applied and the region is present.
+    expect(region?.className).toContain("border-warning");
+  });
+
+  it("shows '+ Add first tier' CTA when canManage=true and tiers empty", () => {
+    render(
+      <LocaleProvider locale="en-UG" currency="UGX">
+        <TierEditor
+          microgridId={MICROGRID_ID}
+          currency="UGX"
+          initialSchedule={null}
+          canManage={true}
+        />
+      </LocaleProvider>
+    );
+    expect(screen.getByRole("button", { name: /Add first tier/i })).toBeTruthy();
+  });
+
+  it("hides CTA and shows footnote when canManage=false and tiers empty", () => {
+    render(
+      <LocaleProvider locale="en-UG" currency="UGX">
+        <TierEditor
+          microgridId={MICROGRID_ID}
+          currency="UGX"
+          initialSchedule={null}
+          canManage={false}
+        />
+      </LocaleProvider>
+    );
+    expect(
+      screen.queryByRole("button", { name: /Add first tier/i })
+    ).toBeNull();
+    expect(
+      screen.getByText(/Ask a super admin to configure the rate schedule/)
+    ).toBeTruthy();
+  });
+
+  it("does NOT show EmptyState when tiers are present", () => {
+    renderEditor(INITIAL_SCHEDULE);
+    expect(screen.queryByText("Set up the rate schedule")).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/empty-state.test.tsx
+++ b/src/components/ui/__tests__/empty-state.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+/**
+ * EmptyState primitive tests (#139).
+ *
+ * Covers:
+ *   (a) Renders title as <h3> with id wired to aria-labelledby on region wrapper
+ *   (b) role="region" present on the wrapper
+ *   (c) All slot props render: eyebrow above title, body below title,
+ *       cta/secondary row below body, footnote at bottom
+ *   (d) tone="warn" adds border-l-4 border-warning; tone="neutral" adds border-border
+ *   (e) icon renders with aria-hidden="true"
+ *   (f) Role-locked variant (no cta, only footnote): CTA row NOT rendered; footnote renders
+ *   (g) Custom id prop propagates to the wrapper and to the title's id
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EmptyState } from "../empty-state";
+
+// ─── (a) + (b) ───────────────────────────────────────────────────────────────
+
+describe("EmptyState — structure", () => {
+  it("(a) renders title as <h3> and wires aria-labelledby", () => {
+    const { container } = render(
+      <EmptyState title="Add the first community" body="A community is a site." />,
+    );
+    const h3 = container.querySelector("h3");
+    expect(h3).not.toBeNull();
+    expect(h3?.textContent).toBe("Add the first community");
+
+    const region = container.querySelector("[role='region']");
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute("aria-labelledby")).toBe(h3?.id);
+  });
+
+  it("(b) wraps the card in role='region'", () => {
+    render(<EmptyState title="Add the first edge" body="An edge connects." />);
+    const region = screen.getByRole("region");
+    expect(region).not.toBeNull();
+  });
+});
+
+// ─── (c) slot props ──────────────────────────────────────────────────────────
+
+describe("EmptyState — slot props", () => {
+  it("(c) renders eyebrow above the title", () => {
+    const { container } = render(
+      <EmptyState eyebrow="Communities" title="Add the first community" body="A community is a site." />,
+    );
+    const eyebrow = container.querySelector("p.uppercase");
+    expect(eyebrow?.textContent).toBe("Communities");
+    const h3 = container.querySelector("h3");
+    // eyebrow should appear before h3 in the DOM
+    const eyebrowPos = Array.from(container.querySelectorAll("*")).indexOf(eyebrow!);
+    const h3Pos = Array.from(container.querySelectorAll("*")).indexOf(h3!);
+    expect(eyebrowPos).toBeLessThan(h3Pos);
+  });
+
+  it("(c) renders body text below the title", () => {
+    render(
+      <EmptyState title="Add the first community" body="A community is a place." />,
+    );
+    expect(screen.getByText("A community is a place.")).toBeTruthy();
+  });
+
+  it("(c) renders cta and secondary in the same flex row", () => {
+    const { container } = render(
+      <EmptyState
+        title="Add edge"
+        body="An edge."
+        cta={<button>+ Add edge</button>}
+        secondary={<a href="/setup">Configure →</a>}
+      />,
+    );
+    const ctaRow = container.querySelector(".mt-4.flex");
+    expect(ctaRow).not.toBeNull();
+    expect(ctaRow?.querySelector("button")?.textContent).toBe("+ Add edge");
+    expect(ctaRow?.querySelector("a")?.textContent).toBe("Configure →");
+  });
+
+  it("(c) renders footnote at the bottom", () => {
+    render(
+      <EmptyState
+        title="Add edge"
+        body="An edge."
+        footnote="Ask a super admin to add edges."
+      />,
+    );
+    expect(screen.getByText("Ask a super admin to add edges.")).toBeTruthy();
+  });
+});
+
+// ─── (d) tone ────────────────────────────────────────────────────────────────
+
+describe("EmptyState — tone", () => {
+  it("(d) tone='warn' adds border-l-4 and border-warning classes", () => {
+    const { container } = render(
+      <EmptyState tone="warn" title="Edge offline" body="Can't discover." />,
+    );
+    const region = container.querySelector("[role='region']");
+    expect(region?.className).toContain("border-l-4");
+    expect(region?.className).toContain("border-warning");
+  });
+
+  it("(d) tone='neutral' (default) adds border-border class", () => {
+    const { container } = render(
+      <EmptyState title="Add the first community" body="A community is a site." />,
+    );
+    const region = container.querySelector("[role='region']");
+    expect(region?.className).toContain("border-border");
+    expect(region?.className).not.toContain("border-warning");
+  });
+
+  it("(d) explicit tone='neutral' adds border-border class", () => {
+    const { container } = render(
+      <EmptyState tone="neutral" title="Add the first community" body="A community is a site." />,
+    );
+    const region = container.querySelector("[role='region']");
+    expect(region?.className).toContain("border-border");
+    expect(region?.className).not.toContain("border-warning");
+  });
+});
+
+// ─── (e) icon ────────────────────────────────────────────────────────────────
+
+describe("EmptyState — icon", () => {
+  it("(e) icon renders with aria-hidden='true' wrapper", () => {
+    const { container } = render(
+      <EmptyState
+        title="Add edge"
+        body="An edge."
+        icon={<span data-testid="icon-glyph">⚡</span>}
+      />,
+    );
+    const iconWrapper = container.querySelector("[aria-hidden='true']");
+    expect(iconWrapper).not.toBeNull();
+    expect(iconWrapper?.querySelector("[data-testid='icon-glyph']")).not.toBeNull();
+  });
+
+  it("(e) no icon slot = no aria-hidden wrapper", () => {
+    const { container } = render(
+      <EmptyState title="Add edge" body="An edge." />,
+    );
+    const iconWrapper = container.querySelector("[aria-hidden='true']");
+    expect(iconWrapper).toBeNull();
+  });
+});
+
+// ─── (f) role-locked variant ──────────────────────────────────────────────────
+
+describe("EmptyState — role-locked variant", () => {
+  it("(f) CTA row NOT rendered when no cta and no secondary", () => {
+    const { container } = render(
+      <EmptyState
+        title="Add edge"
+        body="An edge."
+        footnote="Ask a super admin to add edges."
+      />,
+    );
+    // The CTA row has both mt-4 and flex classes — it should not appear
+    const ctaRow = container.querySelector(".mt-4.flex.flex-wrap");
+    expect(ctaRow).toBeNull();
+  });
+
+  it("(f) footnote renders without cta", () => {
+    render(
+      <EmptyState
+        title="Add edge"
+        body="An edge."
+        footnote="Ask a super admin to add edges."
+      />,
+    );
+    expect(screen.getByText("Ask a super admin to add edges.")).toBeTruthy();
+  });
+});
+
+// ─── (g) custom id ────────────────────────────────────────────────────────────
+
+describe("EmptyState — custom id", () => {
+  it("(g) custom id propagates to wrapper element", () => {
+    const { container } = render(
+      <EmptyState id="empty-households" title="Add household" body="A household." />,
+    );
+    const region = container.querySelector("[role='region']");
+    expect(region?.id).toBe("empty-households");
+  });
+
+  it("(g) title id uses custom id as prefix", () => {
+    const { container } = render(
+      <EmptyState id="empty-households" title="Add household" body="A household." />,
+    );
+    const h3 = container.querySelector("h3");
+    expect(h3?.id).toBe("empty-households-title");
+    const region = container.querySelector("[role='region']");
+    expect(region?.getAttribute("aria-labelledby")).toBe("empty-households-title");
+  });
+});
+
+// ─── className merge ──────────────────────────────────────────────────────────
+
+describe("EmptyState — className merge", () => {
+  it("merges custom className with base classes", () => {
+    const { container } = render(
+      <EmptyState
+        title="Rate schedule"
+        body="Tiers define price bands."
+        className="border-0 shadow-none bg-transparent p-0"
+      />,
+    );
+    const region = container.querySelector("[role='region']");
+    expect(region?.className).toContain("border-0");
+    expect(region?.className).toContain("shadow-none");
+    expect(region?.className).toContain("p-0");
+  });
+});

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,129 @@
+// EmptyState — reusable empty-state primitive for list/section surfaces (#139).
+//
+// The "gold standard" we're rhyming with:
+//   - microgrids/[id]/setup/openems-backend/openems-backend-shell.tsx  (lines 465–507)
+//   - communities/[id]/payment/payment-shell.tsx                       (lines 256–286)
+//
+// Shared shape (pinned by designer per #137):
+//   max-w-[560px] · mx-auto · rounded-md · border border-border · bg-card ·
+//   p-6 · shadow-elev-1
+//
+// Typography mirrors the shell empties:
+//   - Eyebrow:  text-[10px] font-semibold uppercase tracking-wide text-muted-foreground
+//   - Title:    text-lg font-semibold text-foreground
+//   - Body:     text-sm text-muted-foreground  (mt-2)
+//   - CTA row:  mt-4
+//   - Footnote: text-xs text-muted-foreground  (mt-4)
+//
+// Escape hatches (stay bespoke; DO NOT convert to this primitive):
+//   - openems-backend empty-state: needs the segmented "Cloud (AWS) / Direct URL"
+//     toggle. Unique shape.
+//   - payment empty-state: single provider Connect Pesapal button + provider
+//     roadmap footnote. Close enough; PM chose to leave it.
+//
+// Role-aware:
+//   When `cta` is null/undefined, callers can pass a `footnote` string instead
+//   (e.g. "Ask a super admin to add edges."). This mirrors the openems-backend
+//   non-super-admin branch that renders a <Banner tone="info"> instead of a form.
+//   Callers wanting that banner shape should keep using <Banner>; this primitive
+//   is the card shape.
+//
+// A11y:
+//   - role="region" + aria-labelledby linking to the title — this is a
+//     discrete landmark for keyboard users navigating sections.
+//   - Title renders as <h3>. Callers place this under a section <h2>.
+//   - If the parent surface just transitioned from populated → empty (e.g. user
+//     deleted the last tier), the parent should announce via a separate
+//     aria-live region; this component is static once mounted.
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type EmptyStateTone = "neutral" | "warn";
+
+export interface EmptyStateProps {
+  /** Short category above the title — e.g. "Communities", "Rate schedule".
+   *  Should match the surrounding section's <h2>. */
+  eyebrow?: string;
+  /** Imperative title — "Add the first community", not "No communities". */
+  title: string;
+  /** One or two sentences explaining what this entity IS (operator-voice). */
+  body: React.ReactNode;
+  /** Primary CTA — typically <AddEntityButton> or <Link>-styled button.
+   *  Omit for role-locked views; pass `footnote` instead. */
+  cta?: React.ReactNode;
+  /** Secondary action — typically a <Link> to documentation or a sibling page. */
+  secondary?: React.ReactNode;
+  /** Small italic/muted footnote rendered below the CTA row.
+   *  Use for caveats ("You can change this later") or role-locked help-text. */
+  footnote?: React.ReactNode;
+  /** neutral (default) = card shape. warn = inject a left border-warning accent,
+   *  used when something upstream is blocking (e.g. "Edge offline, can't
+   *  discover yet"). */
+  tone?: EmptyStateTone;
+  /** Optional decorative icon slot (left of title). aria-hidden enforced.
+   *  Keep simple — lucide-react 20px glyph. No illustrations (PM §5). */
+  icon?: React.ReactNode;
+  className?: string;
+  /** HTML id for the card — useful for deep-linking and aria-describedby. */
+  id?: string;
+}
+
+export function EmptyState({
+  eyebrow,
+  title,
+  body,
+  cta,
+  secondary,
+  footnote,
+  tone = "neutral",
+  icon,
+  className,
+  id,
+}: EmptyStateProps) {
+  const reactId = React.useId();
+  const titleId = `${id ?? reactId}-title`;
+
+  return (
+    <div
+      id={id}
+      role="region"
+      aria-labelledby={titleId}
+      className={cn(
+        "mx-auto max-w-[560px] rounded-md border bg-card p-6 shadow-elev-1",
+        tone === "warn" ? "border-warning border-l-4" : "border-border",
+        className,
+      )}
+    >
+      {eyebrow && (
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {eyebrow}
+        </p>
+      )}
+
+      <div className="mt-1 flex items-start gap-3">
+        {icon && (
+          <span aria-hidden="true" className="mt-0.5 text-muted-foreground">
+            {icon}
+          </span>
+        )}
+        <h3 id={titleId} className="text-lg font-semibold text-foreground">
+          {title}
+        </h3>
+      </div>
+
+      <div className="mt-2 text-sm text-muted-foreground">{body}</div>
+
+      {(cta || secondary) && (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          {cta}
+          {secondary}
+        </div>
+      )}
+
+      {footnote && (
+        <p className="mt-4 text-xs text-muted-foreground">{footnote}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces 8 dead-end `<p>No X yet.</p>` empty-state surfaces with a reusable primitive that invites the user to add the child entity.

**New primitive** (`src/components/ui/empty-state.tsx`):
- Props: `eyebrow`, `title`, `body`, `cta`, `secondary`, `footnote`, `tone` (neutral/warn), `icon`, `className`, `id`
- Layout: `mx-auto max-w-[560px] rounded-md border bg-card p-6 shadow-elev-1`; warn tone adds `border-l-4 border-warning`
- A11y: `role="region"` + `aria-labelledby` → `<h3>`

**Applied to 8 surfaces** (per PM audit #137 + Designer mockups at `mbe-docs/design/mocks/empty-states-2026-04-24/`):

| # | Surface | Tone | CTA |
|---|---|---|---|
| P1 | Org → Communities | neutral | `<AddEntityButton entity="community">` |
| P2 | Community → Microgrids | neutral | `<AddEntityButton entity="microgrid">` |
| P4 | Microgrid Setup → Edges | neutral (top Banner owns warn) | `<AddEdgeDialog>` |
| P5 | Microgrid Setup → Households | neutral | `+ Add household` (opens HouseholdWizard) |
| P6 | Edge detail → Devices | warn (offline) / neutral (online) | — (DiscoverDevices card above) |
| P7 | Household detail → Linked device | warn | — (Link Device flow deferred; `secondary` link to Households listing) |
| P8 | Microgrid Setup → Rate Schedule | warn | `+ Add first tier` |
| P9 | Microgrid Billing → Periods | neutral | `+ Create period` |

**Role thread-through**: `canManage` prop added to `HouseholdTable`, `TierEditor`, `BillingPeriodList`; `currentUserCanAccessMicrogrid` resolved on 4 server pages.

**Out of scope (bespoke, unchanged)**: OpenEMS Backend shell (#102), Payment shell (#119), `microgrids/[id]` top-of-page no-edges Banner.

## Copy tweaks (user-approved, currency/hardware-agnostic)

- P4 body: *"typically an OpenEMS instance running on a gateway device at your site."* (no Pi/Modbus hardware specifics)
- P8 body: *"Tiers define the kWh price bands — e.g. the first 50 kWh at one rate, the next 100 at a higher rate. Without tiers, bills come out zero."* (no UGX-scale numeric examples)

## Review fixes / deviations

- P4: tone **neutral** (not warn per mockup) to avoid double-warn with the top Banner
- P8 + P5 + P9: cards-in-cards override (`border-0 shadow-none bg-transparent p-0`) since they sit inside existing `bg-card` wrappers
- P6: edge-online fetch added to the detail page (reused `fetchEdgeOnlineMap` pattern)
- P7: **Link Device flow deferred** — no primary CTA this round; secondary link to Households listing. Follow-up ticket noted for a dedicated Link Device dialog.
- EdgeEmptyState extracted to `"use client"` file to manage dialog state inside a server-component page

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (870/870 pass)
- [x] `npm run build`

Closes #139.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)