### PR TITLE
Add revalidatePath to POST /organizations, /communities, /microgrids (#141)

### DIFF
--- a/src/app/api/communities/__tests__/route.test.ts
+++ b/src/app/api/communities/__tests__/route.test.ts
@@ -11,6 +11,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
+const mockRevalidatePath = vi.fn();
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
 let canAccessOrgReturn = true;
 let canAccessCommunityReturn = true;
 
@@ -119,6 +122,13 @@ describe("POST /api/communities", () => {
 
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({ org_id: VALID_ORG, name: "C1" })
+    );
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/communities", "layout");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/microgrids", "layout");
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      `/organizations/${VALID_ORG}`,
+      "layout"
     );
   });
 });

--- a/src/app/api/communities/route.ts
+++ b/src/app/api/communities/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserCanAccessOrg } from "@/lib/auth/access";
 
@@ -81,6 +82,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 500 }
     );
   }
+
+  revalidatePath("/communities", "layout");
+  revalidatePath("/microgrids", "layout");
+  revalidatePath(`/organizations/${orgId}`, "layout");
 
   return NextResponse.json({ community: data }, { status: 201 });
 }

--- a/src/app/api/microgrids/__tests__/route.test.ts
+++ b/src/app/api/microgrids/__tests__/route.test.ts
@@ -14,6 +14,9 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ───────────────────────────────────────────────────────────────
 
+const mockRevalidatePath = vi.fn();
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
 let canAccessCommunityReturn = true;
 let canAccessMicrogridReturn = true;
 
@@ -174,6 +177,12 @@ describe("POST /api/microgrids", () => {
         name: "New MG",
         currency: "USD",
       })
+    );
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/microgrids", "layout");
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      `/communities/${VALID_COMMUNITY}`,
+      "layout"
     );
   });
 });

--- a/src/app/api/microgrids/route.ts
+++ b/src/app/api/microgrids/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserCanAccessCommunity } from "@/lib/auth/access";
 import { validateCurrency } from "@/lib/validation/currency";
@@ -114,6 +115,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 500 }
     );
   }
+
+  revalidatePath("/microgrids", "layout");
+  revalidatePath(`/communities/${communityId}`, "layout");
 
   return NextResponse.json({ microgrid: data }, { status: 201 });
 }

--- a/src/app/api/organizations/__tests__/route.test.ts
+++ b/src/app/api/organizations/__tests__/route.test.ts
@@ -14,6 +14,9 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ───────────────────────────────────────────────────────────────
 
+const mockRevalidatePath = vi.fn();
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
 let isSuperAdminReturn = true;
 const mockInsert = vi.fn();
 const mockUpdate = vi.fn();
@@ -145,6 +148,8 @@ describe("POST /api/organizations", () => {
     expect(res.status).toBe(201);
     const json = await res.json();
     expect(json.organization.id).toBe("o1");
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/organizations", "layout");
   });
 });
 

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserIsSuperAdmin } from "@/lib/auth/access";
 
@@ -91,6 +92,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 500 }
     );
   }
+
+  revalidatePath("/organizations", "layout");
 
   return NextResponse.json({ organization: data }, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- Three POST routes (`/api/organizations`, `/api/communities`, `/api/microgrids`) were missing `revalidatePath` calls — Next.js served stale page cache after creates, manifesting as listings that didn't show freshly-created entities and the "Invalid or inaccessible organization filter" banner on `/microgrids?org=<newly-created-org-id>` (because cached `accessibleOrgIds` set excluded the new org).
- Mirrors the existing PATCH/DELETE pattern from `/api/{...}/[id]/route.ts`.
- Tests assert `revalidatePath` is called with expected paths on each POST happy path.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` — 870/870
- [x] `npm run build`
- [ ] Manual: create a community → navigate to `/microgrids?org=<that-org>` → no stale banner; new community's org validates correctly

Closes #141.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)