### PR TITLE
Household Edit dialog: kill inline create + per-row select; add kebab menu (#145)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/households/households-section.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/households-section.tsx
@@ -77,6 +77,7 @@ export function HouseholdsSection({
         primaryDeviceAssignments={primaryDeviceAssignments}
         canManage={canManage}
         onAdd={() => setWizardOpen(true)}
+        microgridEdgesSetupHref={`/microgrids/${microgridId}/setup/edges`}
       />
     </div>
   );

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
@@ -95,6 +95,10 @@ export default async function SetupHouseholdsPage({
     (edgesForMg ?? []).map((e) => [e.id, e.name ?? ""])
   );
 
+  // The wizard call site still filters out devices that are already linked
+  // (StepMeter expects only assignable meters). DeviceSelect (used by the
+  // Household Edit dialog from #145) consumes the *un-filtered* list so it
+  // can grey already-assigned devices inline.
   const availableMeters: AvailableMeter[] = (devices ?? [])
     .filter(
       (d) =>
@@ -105,7 +109,11 @@ export default async function SetupHouseholdsPage({
       id: d.id,
       name: d.name,
       device_type: d.device_type,
+      edge_id: d.edge_id,
       edge_name: edgeNameById.get(d.edge_id) ?? "",
+      // Always null in the wizard path — the wizard pre-filters linked
+      // devices out so this field has no caller-visible effect here.
+      linked_household_name: null,
     }))
     // Sort by (edge_name, device name) as per the spec query.
     .sort((a, b) => {

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
@@ -82,11 +82,10 @@ export default async function SetupHouseholdsPage({
     primaryDeviceAssignments[row.household_id] = row.device_id;
   }
 
-  // Build the set of device_ids already assigned as primary_consumption_meter
-  // so we can exclude them from the wizard's available-meters list. The
-  // server-side RLS scope ensures we only see household_devices rows within
-  // this user's accessible orgs, but we additionally filter by this
-  // microgrid's edges below.
+  // The wizard's StepMeter still pre-filters out already-assigned devices
+  // (it asks "pick a meter for a NEW household"). The Household Edit dialog
+  // (#145) feeds DeviceSelect with the un-filtered list and greys assigned
+  // devices inline.
   const assignedPrimaryDeviceIds = new Set(
     (primaryAssignments ?? []).map((r) => r.device_id)
   );
@@ -134,18 +133,22 @@ export default async function SetupHouseholdsPage({
     ])
   );
 
-  // BillingDeviceOptions: ALL devices on this microgrid (not just unassigned),
-  // enriched with edge_name and (when assigned elsewhere) linkedToHouseholdName.
-  // HouseholdTable is responsible for suppressing the "linked" label on the
-  // device that is the CURRENT row's own assignment.
-  const billingDevices: BillingDeviceOption[] = (devices ?? []).map((d) => ({
-    id: d.id,
-    name: d.name,
-    device_type: d.device_type,
-    edge_id: d.edge_id,
-    edge_name: edgeNameById.get(d.edge_id) ?? "",
-    linkedToHouseholdName: deviceLinkedHouseholdName.get(d.id),
-  }));
+  // BillingDeviceOptions: ALL consumption meters on this microgrid (not just
+  // unassigned), enriched with edge_id + edge_name and (when assigned
+  // elsewhere) linkedToHouseholdName. The Edit dialog's DeviceSelect (#145)
+  // greys assigned-elsewhere devices inline; HouseholdTable additionally
+  // suppresses the "linked" label on the device that is the CURRENT row's
+  // own assignment.
+  const billingDevices: BillingDeviceOption[] = (devices ?? [])
+    .filter((d) => d.device_type === "consumption_meter")
+    .map((d) => ({
+      id: d.id,
+      name: d.name,
+      device_type: d.device_type,
+      edge_id: d.edge_id,
+      edge_name: edgeNameById.get(d.edge_id) ?? "",
+      linkedToHouseholdName: deviceLinkedHouseholdName.get(d.id) ?? null,
+    }));
 
   return (
     <>

--- a/src/app/api/households/[id]/__tests__/route.test.ts
+++ b/src/app/api/households/[id]/__tests__/route.test.ts
@@ -25,6 +25,8 @@ const mockHouseholdsUpdateSingle = vi.fn();
 const mockHouseholdsRefetchSingle = vi.fn();
 const mockHouseholdDevicesDeleteEq2 = vi.fn();
 const mockHouseholdDevicesInsert = vi.fn();
+// Steal-check: SELECT household_id FROM household_devices WHERE device_id=? AND role=? AND household_id != ?
+const mockHouseholdDevicesStealCheckMaybeSingle = vi.fn();
 
 // Track call counts to dispatch successive .from("households") calls.
 let householdsCalls = 0;
@@ -70,6 +72,16 @@ const mockFrom = vi.fn((table: string) => {
   }
   if (table === "household_devices") {
     return {
+      // Steal-check path: select().eq().eq().neq().maybeSingle()
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            neq: () => ({
+              maybeSingle: () => mockHouseholdDevicesStealCheckMaybeSingle(),
+            }),
+          }),
+        }),
+      }),
       delete: () => ({
         eq: () => ({
           eq: () => mockHouseholdDevicesDeleteEq2(),
@@ -97,6 +109,7 @@ vi.mock("@/lib/auth/access", () => ({
 }));
 
 const HH_UUID = "660e8400-e29b-41d4-a716-446655440001";
+const HH_UUID_B = "660e8400-e29b-41d4-a716-446655440002";
 const MG_UUID = "660e8400-e29b-41d4-a716-446655440099";
 const DEVICE_UUID = "660e8400-e29b-41d4-a716-44665544aaaa";
 const BAD_ID = "not-a-uuid";
@@ -149,6 +162,11 @@ describe("PATCH /api/households/[id]", () => {
       error: null,
     });
     mockHouseholdDevicesInsert.mockReset().mockResolvedValue({
+      error: null,
+    });
+    // Default: no existing cross-household link (steal check passes)
+    mockHouseholdDevicesStealCheckMaybeSingle.mockReset().mockResolvedValue({
+      data: null,
       error: null,
     });
   });
@@ -294,6 +312,33 @@ describe("PATCH /api/households/[id]", () => {
     expect(res.status).toBe(409);
     const json = await res.json();
     expect(json.reason).toBe("device_already_linked");
+  });
+
+  it("409: cross-household device steal blocked before any mutation", async () => {
+    // Pre-seed: DEVICE_UUID is already the primary_consumption_meter for HH_UUID_B.
+    // Household A (HH_UUID) attempts to claim it.
+    mockHouseholdDevicesStealCheckMaybeSingle.mockResolvedValueOnce({
+      data: { household_id: HH_UUID_B },
+      error: null,
+    });
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { device_id: DEVICE_UUID }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+
+    // Should be rejected with 409 device_already_linked
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("device_already_linked");
+    expect(json.error).toMatch(/already linked to another household/);
+
+    // Steal check fires BEFORE any mutation — no household-row update,
+    // no delete, no insert on household_devices.
+    expect(mockHouseholdsUpdateSingle).not.toHaveBeenCalled();
+    expect(mockHouseholdDevicesDeleteEq2).not.toHaveBeenCalled();
+    expect(mockHouseholdDevicesInsert).not.toHaveBeenCalled();
   });
 
   it("403: RLS denial (42501) on household update", async () => {

--- a/src/app/api/households/[id]/__tests__/route.test.ts
+++ b/src/app/api/households/[id]/__tests__/route.test.ts
@@ -1,0 +1,316 @@
+/**
+ * PATCH /api/households/[id] — route tests (#145).
+ *
+ * Covers:
+ *   - 400: bad UUID, invalid JSON, empty diff, unsupported field, invalid display_name
+ *   - 200: happy path (display_name only, no device touch)
+ *   - 200: happy path (device_id link via delete-then-insert)
+ *   - 200: happy path (device_id: null → unlink only, no field update)
+ *   - 403: forbidden via currentUserCanAccessMicrogrid
+ *   - 404: not found (household missing or RLS-hidden)
+ *   - 409: device_id partial-unique-index conflict (23505)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+let canAccessMicrogridReturn = true;
+
+// Per-test handlers for each Supabase chain entry-point. Chain-callability is
+// emulated via thenable chains that return a fresh stub per entry.
+const mockHouseholdsFetchSingle = vi.fn();
+const mockHouseholdsUpdateSingle = vi.fn();
+const mockHouseholdsRefetchSingle = vi.fn();
+const mockHouseholdDevicesDeleteEq2 = vi.fn();
+const mockHouseholdDevicesInsert = vi.fn();
+
+// Track call counts to dispatch successive .from("households") calls.
+let householdsCalls = 0;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "households") {
+    householdsCalls += 1;
+    if (householdsCalls === 1) {
+      // Initial fetch: select(...).eq(...).maybeSingle()
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => mockHouseholdsFetchSingle(),
+          }),
+        }),
+      };
+    }
+    if (householdsCalls === 2) {
+      // The update or refetch path. Detect by what's called first.
+      return {
+        update: () => ({
+          eq: () => ({
+            select: () => ({
+              single: () => mockHouseholdsUpdateSingle(),
+            }),
+          }),
+        }),
+        select: () => ({
+          eq: () => ({
+            single: () => mockHouseholdsRefetchSingle(),
+          }),
+        }),
+      };
+    }
+    // 3rd+ call → refetch after device-only update
+    return {
+      select: () => ({
+        eq: () => ({
+          single: () => mockHouseholdsRefetchSingle(),
+        }),
+      }),
+    };
+  }
+  if (table === "household_devices") {
+    return {
+      delete: () => ({
+        eq: () => ({
+          eq: () => mockHouseholdDevicesDeleteEq2(),
+        }),
+      }),
+      insert: (row: unknown) => mockHouseholdDevicesInsert(row),
+    };
+  }
+  throw new Error(`Unexpected table: ${table}`);
+});
+
+const mockGetUser = vi.fn(async () => ({
+  data: { user: { id: "user-1" } },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+}));
+
+const HH_UUID = "660e8400-e29b-41d4-a716-446655440001";
+const MG_UUID = "660e8400-e29b-41d4-a716-446655440099";
+const DEVICE_UUID = "660e8400-e29b-41d4-a716-44665544aaaa";
+const BAD_ID = "not-a-uuid";
+
+function makePatchRequest(id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/households/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/households/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessMicrogridReturn = true;
+    householdsCalls = 0;
+
+    mockHouseholdsFetchSingle.mockReset().mockResolvedValue({
+      data: { id: HH_UUID, microgrid_id: MG_UUID },
+      error: null,
+    });
+    mockHouseholdsUpdateSingle.mockReset().mockResolvedValue({
+      data: {
+        id: HH_UUID,
+        microgrid_id: MG_UUID,
+        display_name: "Updated",
+        primary_email: null,
+        primary_phone: null,
+        address_line1: null,
+        address_line2: null,
+        unit_label: null,
+      },
+      error: null,
+    });
+    mockHouseholdsRefetchSingle.mockReset().mockResolvedValue({
+      data: {
+        id: HH_UUID,
+        microgrid_id: MG_UUID,
+        display_name: "Existing",
+        primary_email: null,
+        primary_phone: null,
+        address_line1: null,
+        address_line2: null,
+        unit_label: null,
+      },
+      error: null,
+    });
+    mockHouseholdDevicesDeleteEq2.mockReset().mockResolvedValue({
+      error: null,
+    });
+    mockHouseholdDevicesInsert.mockReset().mockResolvedValue({
+      error: null,
+    });
+  });
+
+  it("400: bad UUID", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(BAD_ID, { display_name: "x" }), {
+      params: Promise.resolve({ id: BAD_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: invalid JSON", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(HH_UUID, "{not json"), {
+      params: Promise.resolve({ id: HH_UUID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: empty diff", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(HH_UUID, {}), {
+      params: Promise.resolve({ id: HH_UUID }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("empty_diff");
+  });
+
+  it("400: unsupported field rejected", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { microgrid_id: "x" }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Unsupported field: microgrid_id");
+    expect(json.reason).toBe("unsupported_field");
+  });
+
+  it("400: empty display_name rejected", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { display_name: "   " }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("invalid_display_name");
+  });
+
+  it("400: non-UUID device_id rejected", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { device_id: "not-a-uuid" }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("invalid_device_id");
+  });
+
+  it("200: happy path — display_name only", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { display_name: "New Name" }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.household).toBeDefined();
+    expect(mockHouseholdsUpdateSingle).toHaveBeenCalledTimes(1);
+    expect(mockHouseholdDevicesDeleteEq2).not.toHaveBeenCalled();
+    expect(mockHouseholdDevicesInsert).not.toHaveBeenCalled();
+  });
+
+  it("200: happy path — device link (delete-then-insert)", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { device_id: DEVICE_UUID }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    expect(mockHouseholdDevicesDeleteEq2).toHaveBeenCalledTimes(1);
+    expect(mockHouseholdDevicesInsert).toHaveBeenCalledTimes(1);
+    expect(mockHouseholdDevicesInsert).toHaveBeenCalledWith({
+      household_id: HH_UUID,
+      device_id: DEVICE_UUID,
+      role: "primary_consumption_meter",
+    });
+  });
+
+  it("200: happy path — device unlink (device_id: null) → delete only, no insert, no household update", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { device_id: null }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    expect(mockHouseholdDevicesDeleteEq2).toHaveBeenCalledTimes(1);
+    expect(mockHouseholdDevicesInsert).not.toHaveBeenCalled();
+    // No household-field update — refetch path
+    expect(mockHouseholdsUpdateSingle).not.toHaveBeenCalled();
+    expect(mockHouseholdsRefetchSingle).toHaveBeenCalledTimes(1);
+  });
+
+  it("403: currentUserCanAccessMicrogrid returns false", async () => {
+    canAccessMicrogridReturn = false;
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { display_name: "x" }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.reason).toBe("forbidden");
+  });
+
+  it("404: household not found", async () => {
+    mockHouseholdsFetchSingle.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { display_name: "x" }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("409: device link conflict (Postgres 23505)", async () => {
+    mockHouseholdDevicesInsert.mockResolvedValueOnce({
+      error: { code: "23505", message: "duplicate key value violates unique constraint" },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { device_id: DEVICE_UUID }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("device_already_linked");
+  });
+
+  it("403: RLS denial (42501) on household update", async () => {
+    mockHouseholdsUpdateSingle.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "42501",
+        message: "new row violates row-level security policy for table households",
+      },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(HH_UUID, { display_name: "x" }),
+      { params: Promise.resolve({ id: HH_UUID }) }
+    );
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.reason).toBe("rls_denied");
+  });
+});

--- a/src/app/api/households/[id]/route.ts
+++ b/src/app/api/households/[id]/route.ts
@@ -37,8 +37,10 @@ import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
  * the explicit check here produces actionable 403s before a Postgres 42501
  * surfaces.
  *
- * Errors: `{ error, reason? }`. Postgres 42501 → 403, 23505 (partial unique
- * index on `household_devices.role='primary_consumption_meter'`) → 409,
+ * Errors: `{ error, reason? }`. Postgres 42501 → 403, 23505 → 409 (the
+ * schema's partial unique index guards one household having two primaries;
+ * cross-household steal is blocked by an explicit server-side SELECT guard
+ * added in the #145 review — see "Cross-household steal protection" below),
  * default → 500.
  */
 
@@ -269,6 +271,32 @@ export async function PATCH(
   }
 
   const changedFieldNames = Object.keys(update);
+
+  // Cross-household steal protection.
+  // The schema's unique index prevents one household from having two primary
+  // meters, not one device being claimed by two households. Guard server-side.
+  // Checked BEFORE any mutation so a 409 short-circuits the whole request and
+  // leaves both households untouched.
+  if (deviceIdProvided && deviceIdValue) {
+    const { data: existingLink } = await supabase
+      .from("household_devices")
+      .select("household_id")
+      .eq("device_id", deviceIdValue)
+      .eq("role", "primary_consumption_meter")
+      .neq("household_id", id)
+      .maybeSingle();
+
+    if (existingLink) {
+      return NextResponse.json(
+        {
+          error:
+            "Device is already linked to another household. Unlink it from the source household first.",
+          reason: "device_already_linked",
+        },
+        { status: 409 },
+      );
+    }
+  }
 
   // STEP 1 — household-row update (when any field changed)
   let updatedHousehold: Record<string, unknown> | null = null;

--- a/src/app/api/households/[id]/route.ts
+++ b/src/app/api/households/[id]/route.ts
@@ -1,0 +1,410 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+
+/**
+ * PATCH /api/households/[id]
+ *
+ * Added in #145 as part of the Household Edit dialog flow. Pattern follows
+ * `src/app/api/edges/[id]/route.ts`. Body shape:
+ *
+ *   {
+ *     display_name?: string;
+ *     primary_email?: string | null;
+ *     primary_phone?: string | null;
+ *     address_line1?: string | null;
+ *     address_line2?: string | null;
+ *     unit_label?:    string | null;
+ *     device_id?:     string | null;
+ *   }
+ *
+ * `device_id === null` clears the household's primary_consumption_meter
+ * assignment; a UUID links it (delete-then-insert into `household_devices`,
+ * mirroring `HouseholdTable.handleDeviceChange` from before the refactor).
+ *
+ * The household UPDATE and device reassignment are NOT wrapped in a
+ * transaction — sequential Supabase ops. A future RPC enhancement may
+ * collapse them. The order is: UPDATE household first, then reconcile the
+ * device link. If the device step fails after the UPDATE succeeds we
+ * surface the error without rolling back the field updates (the operator
+ * can retry the device assignment from the same dialog).
+ *
+ * At-least-one-contact is a form-level rule today; the route does NOT
+ * reject when both contacts are blank — schema CHECK is a separate ticket.
+ *
+ * Permission: super_admin OR org_manager via `currentUserCanAccessMicrogrid`,
+ * resolved via the household's microgrid_id. RLS is the authoritative gate;
+ * the explicit check here produces actionable 403s before a Postgres 42501
+ * surfaces.
+ *
+ * Errors: `{ error, reason? }`. Postgres 42501 → 403, 23505 (partial unique
+ * index on `household_devices.role='primary_consumption_meter'`) → 409,
+ * default → 500.
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ALLOWED_FIELDS = new Set([
+  "display_name",
+  "primary_email",
+  "primary_phone",
+  "address_line1",
+  "address_line2",
+  "unit_label",
+  "device_id",
+]);
+
+type HouseholdUpdate = {
+  display_name?: string;
+  primary_email?: string | null;
+  primary_phone?: string | null;
+  address_line1?: string | null;
+  address_line2?: string | null;
+  unit_label?: string | null;
+};
+
+function nullableString(v: unknown): string | null | undefined {
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  if (typeof v !== "string") return undefined;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+function nullableUuid(v: unknown): string | null | undefined {
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  if (typeof v !== "string") return undefined;
+  const t = v.trim();
+  if (t.length === 0) return null;
+  if (!UUID_RE.test(t)) return undefined;
+  return t;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid household ID — expected UUID" },
+      { status: 400 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "Request body must be an object" },
+      { status: 400 }
+    );
+  }
+
+  // Reject any unsupported fields up front so callers get a clear pointer.
+  const bodyRec = body as Record<string, unknown>;
+  for (const key of Object.keys(bodyRec)) {
+    if (!ALLOWED_FIELDS.has(key)) {
+      return NextResponse.json(
+        { error: `Unsupported field: ${key}`, reason: "unsupported_field" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Validate display_name (when present must be a non-empty string)
+  let displayName: string | undefined;
+  if ("display_name" in bodyRec) {
+    const dn = bodyRec.display_name;
+    if (typeof dn !== "string" || dn.trim().length === 0) {
+      return NextResponse.json(
+        {
+          error: "display_name must be a non-empty string",
+          reason: "invalid_display_name",
+        },
+        { status: 400 }
+      );
+    }
+    displayName = dn.trim();
+  }
+
+  // Validate device_id (UUID or null)
+  let deviceIdProvided = false;
+  let deviceIdValue: string | null = null;
+  if ("device_id" in bodyRec) {
+    const did = nullableUuid(bodyRec.device_id);
+    if (did === undefined) {
+      return NextResponse.json(
+        {
+          error: "device_id must be a valid UUID or null",
+          reason: "invalid_device_id",
+        },
+        { status: 400 }
+      );
+    }
+    deviceIdProvided = true;
+    deviceIdValue = did;
+  }
+
+  // Build the household-fields update payload (excludes device_id).
+  const update: HouseholdUpdate = {};
+  if (displayName !== undefined) update.display_name = displayName;
+  if ("primary_email" in bodyRec) {
+    const v = nullableString(bodyRec.primary_email);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "primary_email must be a string or null",
+          reason: "invalid_primary_email",
+        },
+        { status: 400 }
+      );
+    }
+    update.primary_email = v;
+  }
+  if ("primary_phone" in bodyRec) {
+    const v = nullableString(bodyRec.primary_phone);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "primary_phone must be a string or null",
+          reason: "invalid_primary_phone",
+        },
+        { status: 400 }
+      );
+    }
+    update.primary_phone = v;
+  }
+  if ("address_line1" in bodyRec) {
+    const v = nullableString(bodyRec.address_line1);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "address_line1 must be a string or null",
+          reason: "invalid_address_line1",
+        },
+        { status: 400 }
+      );
+    }
+    update.address_line1 = v;
+  }
+  if ("address_line2" in bodyRec) {
+    const v = nullableString(bodyRec.address_line2);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "address_line2 must be a string or null",
+          reason: "invalid_address_line2",
+        },
+        { status: 400 }
+      );
+    }
+    update.address_line2 = v;
+  }
+  if ("unit_label" in bodyRec) {
+    const v = nullableString(bodyRec.unit_label);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "unit_label must be a string or null",
+          reason: "invalid_unit_label",
+        },
+        { status: 400 }
+      );
+    }
+    update.unit_label = v;
+  }
+
+  const hasFieldUpdate = Object.keys(update).length > 0;
+  if (!hasFieldUpdate && !deviceIdProvided) {
+    return NextResponse.json(
+      { error: "No fields provided to update", reason: "empty_diff" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Fetch the row (RLS-filtered) to resolve microgrid_id for the perm check
+  // and to produce a clean 404 when missing/hidden.
+  const { data: existing, error: fetchError } = await supabase
+    .from("households")
+    .select("id, microgrid_id")
+    .eq("id", id)
+    .maybeSingle<{ id: string; microgrid_id: string }>();
+
+  if (fetchError) {
+    if (fetchError.code === "PGRST116") {
+      return NextResponse.json({ error: "Household not found" }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: fetchError.message ?? "Household not found" },
+      { status: 404 }
+    );
+  }
+  if (!existing) {
+    return NextResponse.json({ error: "Household not found" }, { status: 404 });
+  }
+
+  const canAccess = await currentUserCanAccessMicrogrid(
+    supabase,
+    existing.microgrid_id
+  );
+  if (!canAccess) {
+    return NextResponse.json(
+      {
+        error: "You do not have permission to update this household.",
+        reason: "forbidden",
+      },
+      { status: 403 }
+    );
+  }
+
+  const changedFieldNames = Object.keys(update);
+
+  // STEP 1 — household-row update (when any field changed)
+  let updatedHousehold: Record<string, unknown> | null = null;
+  if (hasFieldUpdate) {
+    const { data, error } = await supabase
+      .from("households")
+      .update(update)
+      .eq("id", id)
+      .select("*")
+      .single();
+
+    if (error) {
+      if (error.code === "42501" || error.message.includes("row-level security")) {
+        return NextResponse.json(
+          {
+            error: "Not authorized to update this household.",
+            reason: "rls_denied",
+          },
+          { status: 403 }
+        );
+      }
+      return NextResponse.json(
+        { error: `Failed to update household: ${error.message}` },
+        { status: 500 }
+      );
+    }
+    updatedHousehold = data as Record<string, unknown>;
+  }
+
+  // STEP 2 — device-link reconciliation (when device_id was provided)
+  if (deviceIdProvided) {
+    const { error: deleteError } = await supabase
+      .from("household_devices")
+      .delete()
+      .eq("household_id", id)
+      .eq("role", "primary_consumption_meter");
+
+    if (deleteError) {
+      if (
+        deleteError.code === "42501" ||
+        deleteError.message.includes("row-level security")
+      ) {
+        return NextResponse.json(
+          {
+            error: "Not authorized to update the household device link.",
+            reason: "rls_denied",
+          },
+          { status: 403 }
+        );
+      }
+      return NextResponse.json(
+        {
+          error: `Failed to clear existing device link: ${deleteError.message}`,
+        },
+        { status: 500 }
+      );
+    }
+
+    if (deviceIdValue) {
+      const { error: insertError } = await supabase
+        .from("household_devices")
+        .insert({
+          household_id: id,
+          device_id: deviceIdValue,
+          role: "primary_consumption_meter",
+        });
+
+      if (insertError) {
+        if (
+          insertError.code === "42501" ||
+          insertError.message.includes("row-level security")
+        ) {
+          return NextResponse.json(
+            {
+              error: "Not authorized to assign this device.",
+              reason: "rls_denied",
+            },
+            { status: 403 }
+          );
+        }
+        if (insertError.code === "23505") {
+          return NextResponse.json(
+            {
+              error: "Meter is already assigned to another household.",
+              reason: "device_already_linked",
+            },
+            { status: 409 }
+          );
+        }
+        return NextResponse.json(
+          {
+            error: `Failed to link device to household: ${insertError.message}`,
+          },
+          { status: 500 }
+        );
+      }
+    }
+  }
+
+  // If only the device link changed (no household-field update), re-fetch the
+  // current row so the response payload is consistent.
+  if (!updatedHousehold) {
+    const { data, error } = await supabase
+      .from("households")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (error) {
+      return NextResponse.json(
+        { error: `Failed to read updated household: ${error.message}` },
+        { status: 500 }
+      );
+    }
+    updatedHousehold = data as Record<string, unknown>;
+  }
+
+  // Structured success log — counts only, no PII payload values.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  console.info(
+    JSON.stringify({
+      event: "household.update",
+      household_id: id,
+      microgrid_id: existing.microgrid_id,
+      changed_fields: changedFieldNames,
+      device_link_changed: deviceIdProvided,
+      device_link_action: deviceIdProvided
+        ? deviceIdValue
+          ? "link"
+          : "clear"
+        : "none",
+      actor_user_id: user?.id ?? null,
+      at: new Date().toISOString(),
+    })
+  );
+
+  return NextResponse.json({ household: updatedHousehold }, { status: 200 });
+}

--- a/src/components/HouseholdTable.tsx
+++ b/src/components/HouseholdTable.tsx
@@ -1,18 +1,63 @@
 "use client";
 
-import { useState } from "react";
+/**
+ * HouseholdTable — list of households on a microgrid (#145 refactor).
+ *
+ * What this file does NOT do anymore:
+ *   - No inline create form (HouseholdsSection wraps HouseholdWizard)
+ *   - No inline name/phone/email edit (HouseholdEditDialog covers it)
+ *   - No per-row inline billing-device <select> (HouseholdEditDialog covers
+ *     it via DeviceSelect; superseded the #144 <optgroup> work)
+ *
+ * What this file DOES:
+ *   - Renders one row per household with: stacked name + contact, address
+ *     summary, click-to-edit billing-device chip, kebab menu
+ *   - Kebab menu (Radix DropdownMenu, used directly per edge-row-actions
+ *     pattern; no ui/dropdown-menu wrapper exists):
+ *       Edit household           → opens HouseholdEditDialog
+ *       Change/Link billing dev. → opens HouseholdEditDialog
+ *       View detail →            → Link to detail page
+ *       — separator —
+ *       Delete household         → existing destructive flow
+ *   - Click-to-edit chip column:
+ *       Assigned   → <button> wrapping <Chip tone="success" dot>
+ *       Unassigned → <button> wrapping <Chip tone="warn" dot>
+ *     Real <button> + explicit aria-label so focus ring + keyboard
+ *     activation come for free.
+ *   - Address column: today's 3 fields joined; #146 widens.
+ *
+ * Permission: kebab + chip-button render only when canManage. For non-
+ * managers the chip is a non-interactive <span>.
+ *
+ * BillingDeviceOption was added in #144 for the now-superseded native
+ * <select>/<optgroup>. The shape carries the fields DeviceSelect needs
+ * (edge_id, edge_name, linkedToHouseholdName) so it is reused as the prop
+ * shape unchanged. Marking it deprecated would force callers to convert
+ * shapes for no reason — leave the type in place as the public surface.
+ */
+
+import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { createClient } from "@/lib/supabase/client";
 import type { Device, Household } from "@/lib/types/domain";
+import { Chip } from "@/components/ui/chip";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
+import { HouseholdEditDialog } from "@/components/forms/HouseholdEditDialog";
 
 /**
- * An enriched device option for the billing-device <select>.
- * Carries edge_name (for disambiguation) and, when the device is already
- * the primary_consumption_meter of another household, the linked household
- * name so the operator knows they can't select it here.
+ * An enriched device option for the billing-device picker. Carries
+ * edge_id + edge_name (DeviceSelect groups by edge_id, labels with
+ * edge_name) and an optional linkedToHouseholdName when the device is
+ * already the primary_consumption_meter of a different household on this
+ * microgrid.
+ *
+ * Originally introduced in #144 for the native <select>/<optgroup>. After
+ * the #145 refactor the same shape feeds DeviceSelect — kept as the
+ * canonical billing-device shape rather than renamed to avoid a churning
+ * caller diff.
  */
 export type BillingDeviceOption = {
   id: string;
@@ -21,42 +66,24 @@ export type BillingDeviceOption = {
   edge_id: string;
   edge_name: string;
   /** Set when this device is already assigned as primary_consumption_meter
-   *  on a DIFFERENT household. The option renders disabled with a suffix. */
-  linkedToHouseholdName?: string;
+   *  on a DIFFERENT household. DeviceSelect renders these greyed + disabled. */
+  linkedToHouseholdName?: string | null;
 };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/**
- * Group BillingDeviceOptions by edge_name, sorted alphabetically by edge name.
- * Within each group: available (unlocked) devices first (A-Z), then
- * linked-elsewhere devices (A-Z, disabled).
- */
-function groupByEdge(
-  options: BillingDeviceOption[]
-): Array<{ edgeName: string; items: BillingDeviceOption[] }> {
-  const map = new Map<string, BillingDeviceOption[]>();
-  for (const opt of options) {
-    const key = opt.edge_name || "(unknown edge)";
-    if (!map.has(key)) map.set(key, []);
-    map.get(key)!.push(opt);
-  }
-  const groups = Array.from(map.entries()).map(([edgeName, items]) => ({
-    edgeName,
-    items,
-  }));
-  // Sort groups A-Z by edge name
-  groups.sort((a, b) => a.edgeName.localeCompare(b.edgeName));
-  // Within each group: available first (A-Z), linked-elsewhere last (A-Z)
-  for (const g of groups) {
-    g.items.sort((a, b) => {
-      const aLinked = Boolean(a.linkedToHouseholdName);
-      const bLinked = Boolean(b.linkedToHouseholdName);
-      if (aLinked !== bLinked) return aLinked ? 1 : -1;
-      return a.name.localeCompare(b.name);
-    });
-  }
-  return groups;
+interface Props {
+  microgridId: string;
+  households: Household[];
+  /** Flat device list — used by the "current device" lookup in chip column. */
+  devices: Device[];
+  /** Enriched device list for the edit dialog's DeviceSelect. */
+  billingDevices?: BillingDeviceOption[];
+  /** household_id → device_id for primary_consumption_meter rows */
+  primaryDeviceAssignments: Record<string, string>;
+  canManage?: boolean;
+  /** Called when the user clicks the "Add household" CTA in the empty state. */
+  onAdd?: () => void;
+  /** Edges discovery page href — surfaced in DeviceSelect's empty state. */
+  microgridEdgesSetupHref?: string;
 }
 
 export function HouseholdTable({
@@ -67,133 +94,94 @@ export function HouseholdTable({
   primaryDeviceAssignments,
   canManage = false,
   onAdd,
-}: {
-  microgridId: string;
-  households: Household[];
-  devices: Device[];
-  /**
-   * Enriched device list for the billing-device <select>. Each entry carries
-   * edge_name (for <optgroup> grouping and label disambiguation) and an
-   * optional linkedToHouseholdName (to mark already-assigned devices as
-   * disabled). When omitted the select falls back to the flat `devices` prop
-   * with no grouping (backward-compatible).
-   */
-  billingDevices?: BillingDeviceOption[];
-  /** Map of household_id → device_id for primary_consumption_meter rows */
-  primaryDeviceAssignments: Record<string, string>;
-  /** Whether the current user can manage households. Defaults to false. */
-  canManage?: boolean;
-  /** Called when the user clicks the "Add household" CTA in the empty state. */
-  onAdd?: () => void;
-}) {
+  microgridEdgesSetupHref,
+}: Props) {
   const router = useRouter();
   const supabase = createClient();
 
-  const [showAddForm, setShowAddForm] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // Edit dialog
+  const [editing, setEditing] = React.useState<Household | null>(null);
 
-  // Add form state
-  const [newName, setNewName] = useState("");
-  const [newPhone, setNewPhone] = useState("");
-  const [newEmail, setNewEmail] = useState("");
-  const [addSaving, setAddSaving] = useState(false);
+  // Delete dialog
+  const [householdToDelete, setHouseholdToDelete] =
+    React.useState<Household | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
 
-  // Edit form state
-  const [editName, setEditName] = useState("");
-  const [editPhone, setEditPhone] = useState("");
-  const [editEmail, setEditEmail] = useState("");
-  const [editSaving, setEditSaving] = useState(false);
+  // Map of household_id → display_name (for DeviceSelect's "linked to"
+  // suffix). Use this to enrich billingDevices on the fly.
+  const householdNameById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const h of households) m.set(h.id, h.display_name);
+    return m;
+  }, [households]);
 
-  // Delete dialog state
-  const [householdToDelete, setHouseholdToDelete] = useState<Household | null>(null);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-
-  // Optimistic device assignment overlay (household_id → device_id)
-  const [localAssignments, setLocalAssignments] = useState<Record<string, string>>(
-    primaryDeviceAssignments
-  );
-
-  function getDeviceName(deviceId: string | undefined): string {
-    if (!deviceId) return "Unassigned";
-    // Prefer billingDevices (enriched) if available, fall back to devices
-    const device =
-      billingDevices?.find((d) => d.id === deviceId) ??
-      devices.find((d) => d.id === deviceId);
-    return device?.name ?? "Unknown device";
-  }
-
-  async function handleAdd(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-
-    if (!newName.trim()) {
-      setError("Name is required");
-      return;
+  // device_id → owning household name (only for assigned devices that
+  // belong to another household on this microgrid).
+  const deviceLinkedHouseholdName = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const [hhId, devId] of Object.entries(primaryDeviceAssignments)) {
+      const name = householdNameById.get(hhId);
+      if (name) m.set(devId, name);
     }
+    return m;
+  }, [primaryDeviceAssignments, householdNameById]);
 
-    setAddSaving(true);
+  /**
+   * Build the DeviceSelect prop list for THIS row. We rebuild rather than
+   * passing a global list because the linked-elsewhere set depends on the
+   * row's own currentDeviceId (the dialog component itself also strips
+   * linked-to on the matching id, but doing it here keeps the prop list
+   * small and deterministic per row).
+   */
+  function devicesForHousehold(householdId: string): BillingDeviceOption[] {
+    const ownDeviceId = primaryDeviceAssignments[householdId];
+    const source =
+      billingDevices ??
+      // Fallback: derive a thin list from the flat `devices` prop. Edge
+      // grouping degrades to a single "(unknown edge)" group when this
+      // path is used. Callers should always pass `billingDevices`.
+      devices.map<BillingDeviceOption>((d) => ({
+        id: d.id,
+        name: d.name,
+        device_type: d.device_type,
+        edge_id: d.edge_id,
+        edge_name: "",
+      }));
 
-    const { error: insertError } = await supabase.from("households").insert({
-      microgrid_id: microgridId,
-      display_name: newName.trim(),
-      primary_phone: newPhone.trim() || null,
-      primary_email: newEmail.trim() || null,
+    return source.map((d) => {
+      // The device that's CURRENTLY linked to this household must not
+      // appear with a "linked to …" suffix in this row's picker.
+      if (d.id === ownDeviceId) {
+        return { ...d, linkedToHouseholdName: null };
+      }
+      // Devices linked to OTHER households get the suffix.
+      const ownerName = deviceLinkedHouseholdName.get(d.id);
+      if (ownerName) {
+        return { ...d, linkedToHouseholdName: ownerName };
+      }
+      return { ...d, linkedToHouseholdName: null };
     });
-
-    if (insertError) {
-      setError(insertError.message);
-      setAddSaving(false);
-      return;
-    }
-
-    setNewName("");
-    setNewPhone("");
-    setNewEmail("");
-    setShowAddForm(false);
-    setAddSaving(false);
-    router.refresh();
   }
 
-  function startEdit(household: Household) {
-    setEditingId(household.id);
-    setEditName(household.display_name);
-    setEditPhone(household.primary_phone ?? "");
-    setEditEmail(household.primary_email ?? "");
+  function getDeviceForHousehold(
+    householdId: string
+  ): { name: string; edge_name: string } | null {
+    const deviceId = primaryDeviceAssignments[householdId];
+    if (!deviceId) return null;
+    const enriched = billingDevices?.find((d) => d.id === deviceId);
+    if (enriched) {
+      return { name: enriched.name, edge_name: enriched.edge_name };
+    }
+    const flat = devices.find((d) => d.id === deviceId);
+    if (flat) {
+      return { name: flat.name, edge_name: "" };
+    }
+    return null;
   }
 
-  function cancelEdit() {
-    setEditingId(null);
-  }
-
-  async function handleEditSave(householdId: string) {
-    setError(null);
-
-    if (!editName.trim()) {
-      setError("Name is required");
-      return;
-    }
-
-    setEditSaving(true);
-
-    const { error: updateError } = await supabase
-      .from("households")
-      .update({
-        display_name: editName.trim(),
-        primary_phone: editPhone.trim() || null,
-        primary_email: editEmail.trim() || null,
-      })
-      .eq("id", householdId);
-
-    if (updateError) {
-      setError(updateError.message);
-      setEditSaving(false);
-      return;
-    }
-
-    setEditingId(null);
-    setEditSaving(false);
-    router.refresh();
+  function addressSummary(h: Household): string {
+    const parts = [h.address_line1, h.unit_label].filter(Boolean) as string[];
+    return parts.length > 0 ? parts.join(" · ") : "—";
   }
 
   function openDeleteDialog(household: Household) {
@@ -215,62 +203,8 @@ export function HouseholdTable({
     router.refresh();
   }
 
-  /**
-   * Assign a primary-consumption-meter device to a household via the
-   * household_devices join table (delete + insert pattern).
-   *
-   * The partial unique index (household_one_primary_consumption_meter) ensures
-   * at most one primary_consumption_meter per household. We delete any existing
-   * row for this household+role pair, then insert the new assignment.
-   */
-  async function handleDeviceChange(householdId: string, deviceId: string) {
-    setError(null);
-
-    // Optimistic update
-    setLocalAssignments((prev) => {
-      const next = { ...prev };
-      if (deviceId) {
-        next[householdId] = deviceId;
-      } else {
-        delete next[householdId];
-      }
-      return next;
-    });
-
-    // Remove existing primary_consumption_meter row for this household
-    const { error: deleteError } = await supabase
-      .from("household_devices")
-      .delete()
-      .eq("household_id", householdId)
-      .eq("role", "primary_consumption_meter");
-
-    if (deleteError) {
-      setError(deleteError.message);
-      return;
-    }
-
-    if (deviceId) {
-      // Insert new assignment
-      const { error: insertError } = await supabase
-        .from("household_devices")
-        .insert({
-          household_id: householdId,
-          device_id: deviceId,
-          role: "primary_consumption_meter",
-        });
-
-      if (insertError) {
-        setError(insertError.message);
-        return;
-      }
-    }
-
-    router.refresh();
-  }
-
   return (
     <div className="rounded-lg border border-border bg-card p-6">
-      {/* Delete Household ConfirmDialog */}
       <ConfirmDialog
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
@@ -285,73 +219,25 @@ export function HouseholdTable({
         onConfirm={handleDelete}
       />
 
+      {editing && (
+        <HouseholdEditDialog
+          open={Boolean(editing)}
+          onOpenChange={(o) => {
+            if (!o) setEditing(null);
+          }}
+          household={editing}
+          availableDevices={devicesForHousehold(editing.id)}
+          currentDeviceId={primaryDeviceAssignments[editing.id] ?? null}
+          edgesSetupHref={
+            microgridEdgesSetupHref ??
+            `/microgrids/${microgridId}/setup/edges`
+          }
+        />
+      )}
+
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Households</h2>
-        <button
-          onClick={() => setShowAddForm(!showAddForm)}
-          className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
-        >
-          {showAddForm ? "Cancel" : "Add Household"}
-        </button>
       </div>
-
-      {error && (
-        <div className="mb-4 rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
-          {error}
-        </div>
-      )}
-
-      {showAddForm && (
-        <form
-          onSubmit={handleAdd}
-          className="mb-4 space-y-3 rounded-md border border-border bg-muted p-4"
-        >
-          <div>
-            <label className="block text-sm font-medium text-foreground">
-              Name
-            </label>
-            <input
-              type="text"
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              required
-              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
-              placeholder="Household name"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-foreground">
-              Phone
-            </label>
-            <input
-              type="text"
-              value={newPhone}
-              onChange={(e) => setNewPhone(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
-              placeholder="Optional"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-foreground">
-              Email
-            </label>
-            <input
-              type="email"
-              value={newEmail}
-              onChange={(e) => setNewEmail(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground shadow-sm focus:outline-none"
-              placeholder="Optional"
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={addSaving}
-            className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {addSaving ? "Adding..." : "Add Household"}
-          </button>
-        </form>
-      )}
 
       {households.length === 0 ? (
         <EmptyState
@@ -384,167 +270,218 @@ export function HouseholdTable({
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
+            <caption className="sr-only">
+              Households on this microgrid
+            </caption>
             <thead>
-              <tr className="border-b border-border">
-                <th className="pb-2 pr-4 font-medium text-muted-foreground">Name</th>
-                <th className="pb-2 pr-4 font-medium text-muted-foreground">Phone</th>
-                <th className="pb-2 pr-4 font-medium text-muted-foreground">Email</th>
-                <th className="pb-2 pr-4 font-medium text-muted-foreground">
-                  Billing Device
-                </th>
-                <th className="pb-2 font-medium text-muted-foreground">Actions</th>
+              <tr className="border-b border-border text-muted-foreground">
+                <th className="pb-2 pr-4 font-medium">Household</th>
+                <th className="pb-2 pr-4 font-medium">Address</th>
+                <th className="pb-2 pr-4 font-medium">Billing device</th>
+                <th className="pb-2 text-right font-medium">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {households.map((household) => (
-                <tr key={household.id} className="border-b border-border">
-                  {editingId === household.id ? (
-                    <>
-                      <td className="py-3 pr-4">
-                        <input
-                          type="text"
-                          value={editName}
-                          onChange={(e) => setEditName(e.target.value)}
-                          required
-                          className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
-                        />
-                      </td>
-                      <td className="py-3 pr-4">
-                        <input
-                          type="text"
-                          value={editPhone}
-                          onChange={(e) => setEditPhone(e.target.value)}
-                          className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
-                        />
-                      </td>
-                      <td className="py-3 pr-4">
-                        <input
-                          type="email"
-                          value={editEmail}
-                          onChange={(e) => setEditEmail(e.target.value)}
-                          className="w-full rounded-md border border-border px-2 py-1 text-foreground focus:outline-none"
-                        />
-                      </td>
-                      <td className="py-3 pr-4">
-                        <span className="text-muted-foreground">
-                          {getDeviceName(localAssignments[household.id])}
-                        </span>
-                      </td>
-                      <td className="py-3">
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => handleEditSave(household.id)}
-                            disabled={editSaving}
-                            className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent disabled:opacity-50"
-                          >
-                            {editSaving ? "Saving..." : "Save"}
-                          </button>
-                          <button
-                            onClick={cancelEdit}
-                            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted"
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      </td>
-                    </>
-                  ) : (
-                    <>
-                      <td className="py-3 pr-4 text-foreground">
+              {households.map((household) => {
+                const device = getDeviceForHousehold(household.id);
+                return (
+                  <tr
+                    key={household.id}
+                    className="border-b border-border align-top"
+                  >
+                    <td className="py-3 pr-4">
+                      <div className="font-medium text-foreground">
                         {household.display_name}
-                      </td>
-                      <td className="py-3 pr-4 text-muted-foreground">
-                        {household.primary_phone ?? "-"}
-                      </td>
-                      <td className="py-3 pr-4 text-muted-foreground">
-                        {household.primary_email ?? "-"}
-                      </td>
-                      <td className="py-3 pr-4">
-                        <div>
-                          <select
-                            value={localAssignments[household.id] ?? ""}
-                            onChange={(e) =>
-                              handleDeviceChange(household.id, e.target.value)
-                            }
-                            className="rounded-md border border-border px-2 py-1 text-sm text-foreground focus:outline-none"
-                          >
-                            <option value="">Unassigned</option>
-                            {billingDevices
-                              ? // Enriched path: group by edge with <optgroup>
-                                groupByEdge(billingDevices).map((group) => (
-                                  <optgroup
-                                    key={group.edgeName}
-                                    label={group.edgeName}
-                                  >
-                                    {group.items.map((device) => {
-                                      // A device is "linked elsewhere" only when
-                                      // it's assigned to a DIFFERENT household.
-                                      // When it's this row's own assignment it
-                                      // should appear selected and enabled.
-                                      const isOwnAssignment =
-                                        localAssignments[household.id] ===
-                                        device.id;
-                                      const linkedElsewhere =
-                                        !isOwnAssignment &&
-                                        Boolean(device.linkedToHouseholdName);
-                                      return (
-                                        <option
-                                          key={device.id}
-                                          value={device.id}
-                                          disabled={linkedElsewhere}
-                                        >
-                                          [{device.device_type}] {device.name} ·{" "}
-                                          {device.edge_name}
-                                          {linkedElsewhere
-                                            ? ` (linked: ${device.linkedToHouseholdName})`
-                                            : ""}
-                                        </option>
-                                      );
-                                    })}
-                                  </optgroup>
-                                ))
-                              : // Fallback: flat list (no edge context)
-                                devices.map((device) => (
-                                  <option key={device.id} value={device.id}>
-                                    [{device.device_type}] {device.name}
-                                  </option>
-                                ))}
-                          </select>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            Assign a consumption_meter device to bill this household.
-                          </p>
-                        </div>
-                      </td>
-                      <td className="py-3">
-                        <div className="flex gap-2">
-                          <Link
-                            href={`/microgrids/${microgridId}/setup/households/${household.id}`}
-                            className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"
-                          >
-                            View
-                          </Link>
-                          <button
-                            onClick={() => startEdit(household)}
-                            className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"
-                          >
-                            Edit
-                          </button>
-                          <button
-                            onClick={() => openDeleteDialog(household)}
-                            className="rounded-md px-2 py-1 text-sm text-destructive hover:bg-destructive-muted"
-                          >
-                            Delete
-                          </button>
-                        </div>
-                      </td>
-                    </>
-                  )}
-                </tr>
-              ))}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {[household.primary_email, household.primary_phone]
+                          .filter(Boolean)
+                          .join(" · ") || "—"}
+                      </div>
+                    </td>
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      <span className="block max-w-[260px] truncate">
+                        {addressSummary(household)}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-4">
+                      <BillingDeviceCell
+                        household={household}
+                        device={device}
+                        canManage={canManage}
+                        onEdit={() => setEditing(household)}
+                      />
+                    </td>
+                    <td className="py-3 text-right">
+                      {canManage ? (
+                        <HouseholdRowActions
+                          household={household}
+                          microgridId={microgridId}
+                          hasDevice={Boolean(device)}
+                          onEdit={() => setEditing(household)}
+                          onDelete={() => openDeleteDialog(household)}
+                        />
+                      ) : (
+                        <Link
+                          href={`/microgrids/${microgridId}/setup/households/${household.id}`}
+                          className="rounded-md px-2 py-1 text-sm text-primary hover:bg-accent"
+                        >
+                          View
+                        </Link>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
       )}
     </div>
+  );
+}
+
+// ── Cell + actions ───────────────────────────────────────────────────────
+
+function BillingDeviceCell({
+  household,
+  device,
+  canManage,
+  onEdit,
+}: {
+  household: Household;
+  device: { name: string; edge_name: string } | null;
+  canManage: boolean;
+  onEdit: () => void;
+}) {
+  if (!canManage) {
+    if (device) {
+      return (
+        <Chip tone="success" dot>
+          {device.name}
+          {device.edge_name ? (
+            <span className="ml-1 text-[11px] text-muted-foreground">
+              · {device.edge_name}
+            </span>
+          ) : null}
+        </Chip>
+      );
+    }
+    return (
+      <Chip tone="warn" dot>
+        Unassigned
+      </Chip>
+    );
+  }
+
+  if (device) {
+    return (
+      <button
+        type="button"
+        onClick={onEdit}
+        aria-label={`Change billing device for ${household.display_name}`}
+        className="inline-flex items-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Chip tone="success" dot>
+          {device.name}
+          {device.edge_name ? (
+            <span className="ml-1 text-[11px] text-muted-foreground">
+              · {device.edge_name}
+            </span>
+          ) : null}
+        </Chip>
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onEdit}
+      aria-label={`Link a billing device for ${household.display_name}`}
+      className="inline-flex items-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Chip tone="warn" dot>
+        Unassigned
+      </Chip>
+    </button>
+  );
+}
+
+function HouseholdRowActions({
+  household,
+  microgridId,
+  hasDevice,
+  onEdit,
+  onDelete,
+}: {
+  household: Household;
+  microgridId: string;
+  hasDevice: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`Actions for ${household.display_name}`}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <KebabIcon />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className="z-50 min-w-[180px] rounded-md border border-border bg-card p-1 shadow-elev-2"
+        >
+          <DropdownMenu.Item
+            onSelect={onEdit}
+            className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-foreground outline-none data-[highlighted]:bg-muted"
+          >
+            Edit household
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={onEdit}
+            className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-foreground outline-none data-[highlighted]:bg-muted"
+          >
+            {hasDevice ? "Change billing device" : "Link device"}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item asChild>
+            <Link
+              href={`/microgrids/${microgridId}/setup/households/${household.id}`}
+              className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-foreground outline-none data-[highlighted]:bg-muted"
+            >
+              View detail →
+            </Link>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className="my-1 h-px bg-border" />
+          <DropdownMenu.Item
+            onSelect={onDelete}
+            className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-destructive-fg outline-none data-[highlighted]:bg-destructive-muted"
+          >
+            Delete household
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+function KebabIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+    >
+      <circle cx="8" cy="3" r="1.25" />
+      <circle cx="8" cy="8" r="1.25" />
+      <circle cx="8" cy="13" r="1.25" />
+    </svg>
   );
 }

--- a/src/components/__tests__/household-table.test.tsx
+++ b/src/components/__tests__/household-table.test.tsx
@@ -1,60 +1,94 @@
 // @vitest-environment jsdom
 /**
- * HouseholdTable tests.
+ * HouseholdTable tests — post-#145 refactor.
  *
- * EmptyState (#139 P5):
- *   (a) EmptyState renders with correct eyebrow + title + body when households empty
- *   (b) CTA visible when canManage=true + onAdd provided; hidden when canManage=false
- *   (c) Footnote visible in role-locked state (canManage=false)
- *   (d) Non-empty rendering is unchanged (CSS regression check)
- *   (e) border-0 override classes present (no cards-in-cards nesting)
+ * Coverage:
+ *   EmptyState (#139 P5):
+ *     (a) renders with eyebrow + title + body when households empty
+ *     (b) CTA visible when canManage=true + onAdd provided; hidden otherwise
+ *     (c) footnote in role-locked state
+ *     (d) non-empty rendering still works
  *
- * Edge disambiguation (#144):
- *   (f) Multi-edge: <optgroup> per edge + edge name in every option label
- *   (g) Single-edge: edge name STILL shown in option label (Variant B always)
- *   (h) Already-linked option: disabled + "(linked: HouseholdName)" suffix
- *   (i) Own assignment not disabled, no "(linked:)" suffix
- *   (j) Sort order: alphabetical by edge → available before linked within group
- *   (k) "Unassigned" is first option, outside any optgroup
+ *   Refactor surfaces (#145):
+ *     (e) NO inline create form
+ *     (f) NO inline name/phone/email edit affordance
+ *     (g) NO native <select> in any row (DeviceSelect is in the dialog only)
+ *     (h) Click-to-edit chip: assigned → success tone, role=button, opens dialog
+ *     (i) Click-to-edit chip: unassigned → warn tone, opens dialog
+ *     (j) Kebab menu present per row when canManage
+ *     (k) Kebab hidden when canManage=false (View link instead)
+ *     (l) Address summary uses address_line1 · unit_label
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { Device, Household } from "@/lib/types/domain";
 import type { BillingDeviceOption } from "../HouseholdTable";
 
-// Mock next/navigation
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => "/",
 }));
 
-// Mock next/link
 vi.mock("next/link", () => ({
-  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
-    <a href={href} className={className}>{children}</a>
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
   ),
 }));
 
-// Mock Supabase client
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
     from: () => ({
       delete: () => ({
-        eq: () => ({ eq: () => Promise.resolve({ error: null }) }),
-      }),
-      update: () => ({
         eq: () => Promise.resolve({ error: null }),
       }),
-      insert: () => Promise.resolve({ error: null }),
     }),
   }),
 }));
 
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = function () {};
+  }
+  if (typeof Element.prototype.hasPointerCapture !== "function") {
+    Element.prototype.hasPointerCapture = (() => false) as Element["hasPointerCapture"];
+  }
+});
+
 import { HouseholdTable } from "../HouseholdTable";
 
-// ─── Fixtures ─────────────────────────────────────────────────────────────────
+/**
+ * Open a Radix DropdownMenu trigger in jsdom. Radix listens on
+ * pointerdown + mousedown + click, so a plain fireEvent.click is not enough.
+ * Pattern lifted from edge-row-actions.test.tsx.
+ */
+function openKebab(name: RegExp) {
+  const trigger = screen.getByRole("button", { name });
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+  fireEvent.mouseDown(trigger);
+  fireEvent.click(trigger);
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
 
 const MICROGRID_ID = "mg-test-1";
 
@@ -62,12 +96,24 @@ const HOUSEHOLD: Household = {
   id: "hh-1",
   microgrid_id: MICROGRID_ID,
   display_name: "Household Alpha",
-  primary_phone: null,
+  primary_phone: "+256700000001",
   primary_email: null,
+  address_line1: "Plot 14",
+  address_line2: null,
+  unit_label: "Unit 1",
+  created_at: "2026-01-01T00:00:00Z",
+} as Household;
+
+const HOUSEHOLD_BETA: Household = {
+  id: "hh-2",
+  microgrid_id: MICROGRID_ID,
+  display_name: "Household Beta",
+  primary_phone: null,
+  primary_email: "beta@example.com",
   address_line1: null,
   address_line2: null,
   unit_label: null,
-  created_at: "2026-01-01T00:00:00Z",
+  created_at: "2026-01-02T00:00:00Z",
 } as Household;
 
 const DEVICE: Device = {
@@ -80,14 +126,31 @@ const DEVICE: Device = {
   config: {},
 } as Device;
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
+const BILLING_DEVICES: BillingDeviceOption[] = [
+  {
+    id: "dev-1",
+    name: "Meter 1",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+  {
+    id: "dev-2",
+    name: "Meter 2",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+];
+
+// ─── EmptyState tests (#139 P5 — preserved) ──────────────────────────────
 
 describe("HouseholdTable — EmptyState (#139 P5)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("(a) renders EmptyState with correct title, body when households empty", () => {
+  it("(a) renders EmptyState with title and body when households empty", () => {
     render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
@@ -98,10 +161,10 @@ describe("HouseholdTable — EmptyState (#139 P5)", () => {
         onAdd={() => {}}
       />
     );
-    // title
     expect(screen.getByText("Add the first household")).toBeTruthy();
-    // body
-    expect(screen.getByText(/Households are the customers on this microgrid/)).toBeTruthy();
+    expect(
+      screen.getByText(/Households are the customers on this microgrid/)
+    ).toBeTruthy();
   });
 
   it("(b) CTA '+ Add household' visible when canManage=true (EmptyState CTA)", () => {
@@ -116,7 +179,6 @@ describe("HouseholdTable — EmptyState (#139 P5)", () => {
         onAdd={onAdd}
       />
     );
-    // The EmptyState CTA is inside role="region"; find it there
     const region = container.querySelector("[role='region']");
     const cta = region?.querySelector("button");
     expect(cta).not.toBeNull();
@@ -125,7 +187,7 @@ describe("HouseholdTable — EmptyState (#139 P5)", () => {
     expect(onAdd).toHaveBeenCalledTimes(1);
   });
 
-  it("(b) EmptyState has no button inside region when canManage=false", () => {
+  it("(b) EmptyState has no button when canManage=false", () => {
     const { container } = render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
@@ -169,301 +231,246 @@ describe("HouseholdTable — EmptyState (#139 P5)", () => {
     expect(screen.queryByText("Add the first household")).toBeNull();
     expect(screen.getByText("Household Alpha")).toBeTruthy();
   });
-
-  it("(e) EmptyState rendered with border-0 override (no cards-in-cards)", () => {
-    const { container } = render(
-      <HouseholdTable
-        microgridId={MICROGRID_ID}
-        households={[]}
-        devices={[]}
-        primaryDeviceAssignments={{}}
-        canManage={true}
-        onAdd={() => {}}
-      />
-    );
-    const region = container.querySelector("[role='region']");
-    expect(region?.className).toContain("border-0");
-    expect(region?.className).toContain("shadow-none");
-    expect(region?.className).toContain("p-0");
-  });
 });
 
-// ─── Edge disambiguation fixtures (#144) ─────────────────────────────────────
+// ─── Refactor surfaces (#145) ─────────────────────────────────────────────
 
-const HH_ALPHA: Household = {
-  id: "hh-a",
-  microgrid_id: MICROGRID_ID,
-  display_name: "Household Alpha",
-  primary_phone: null,
-  primary_email: null,
-  address_line1: null,
-  address_line2: null,
-  unit_label: null,
-  created_at: "2026-01-01T00:00:00Z",
-} as Household;
-
-const HH_BETA: Household = {
-  id: "hh-b",
-  microgrid_id: MICROGRID_ID,
-  display_name: "Household Beta",
-  primary_phone: null,
-  primary_email: null,
-  address_line1: null,
-  address_line2: null,
-  unit_label: null,
-  created_at: "2026-01-01T00:00:00Z",
-} as Household;
-
-/** Two edges, each with a "Consumption" device (same name, different edge). */
-const BILLING_DEVICES_MULTI_EDGE: BillingDeviceOption[] = [
-  {
-    id: "dev-e1-c",
-    name: "Consumption",
-    device_type: "other",
-    edge_id: "edge-1",
-    edge_name: "Alpha Edge",
-  },
-  {
-    id: "dev-e1-g",
-    name: "Grid",
-    device_type: "grid_meter",
-    edge_id: "edge-1",
-    edge_name: "Alpha Edge",
-  },
-  {
-    id: "dev-e2-c",
-    name: "Consumption",
-    device_type: "other",
-    edge_id: "edge-2",
-    edge_name: "Beta Edge",
-  },
-  {
-    id: "dev-e2-pv",
-    name: "PV East",
-    device_type: "pv_meter",
-    edge_id: "edge-2",
-    edge_name: "Beta Edge",
-  },
-];
-
-/** Single edge variant — same billing-device list but all on one edge. */
-const BILLING_DEVICES_SINGLE_EDGE: BillingDeviceOption[] = [
-  {
-    id: "dev-s1",
-    name: "Consumption",
-    device_type: "other",
-    edge_id: "edge-1",
-    edge_name: "Alpha Edge",
-  },
-  {
-    id: "dev-s2",
-    name: "Grid",
-    device_type: "grid_meter",
-    edge_id: "edge-1",
-    edge_name: "Alpha Edge",
-  },
-];
-
-/** Billing devices where dev-e1-c is already linked to Household Alpha. */
-const BILLING_DEVICES_WITH_LINKED: BillingDeviceOption[] = [
-  {
-    id: "dev-e1-c",
-    name: "Consumption",
-    device_type: "other",
-    edge_id: "edge-1",
-    edge_name: "Alpha Edge",
-    linkedToHouseholdName: "Household Alpha",
-  },
-  {
-    id: "dev-e2-c",
-    name: "Consumption",
-    device_type: "other",
-    edge_id: "edge-2",
-    edge_name: "Beta Edge",
-  },
-];
-
-/** Helpers: find the select inside a given household row. */
-function getSelectForHousehold(container: HTMLElement, householdName: string): HTMLSelectElement {
-  // Find the row cell with the household name, then walk up to the row
-  const allRows = container.querySelectorAll("tbody tr");
-  for (const row of Array.from(allRows)) {
-    if (row.textContent?.includes(householdName)) {
-      const sel = row.querySelector("select");
-      if (sel) return sel as HTMLSelectElement;
-    }
-  }
-  throw new Error(`No <select> found in row for "${householdName}"`);
-}
-
-// ─── Edge disambiguation tests (#144) ────────────────────────────────────────
-
-describe("HouseholdTable — edge disambiguation (#144)", () => {
+describe("HouseholdTable — refactor surfaces (#145)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("(f) multi-edge: renders one <optgroup> per edge, each option label includes edge name", () => {
-    const { container } = render(
+  it("(e) renders NO inline create form (no Add Household button at the table top)", () => {
+    render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
-        households={[HH_ALPHA]}
+        households={[HOUSEHOLD]}
         devices={[DEVICE]}
-        billingDevices={BILLING_DEVICES_MULTI_EDGE}
+        billingDevices={BILLING_DEVICES}
         primaryDeviceAssignments={{}}
         canManage={true}
       />
     );
-    const sel = getSelectForHousehold(container, "Household Alpha");
-    const optgroups = sel.querySelectorAll("optgroup");
-    // Two edges → two optgroups
-    expect(optgroups).toHaveLength(2);
-    expect(optgroups[0].label).toBe("Alpha Edge");
-    expect(optgroups[1].label).toBe("Beta Edge");
-
-    // Every option text includes the edge name
-    const allOptions = Array.from(sel.querySelectorAll("option")).filter(
-      (o) => o.value !== ""
-    );
-    for (const opt of allOptions) {
-      // Label format: "[type] name · edge_name"
-      expect(opt.textContent).toMatch(/·\s*(Alpha Edge|Beta Edge)/);
-    }
+    // The header "Households" is present, but there should NOT be a button
+    // titled "Add Household" rendered inside the table widget itself
+    // (HouseholdsSection wraps it).
+    expect(screen.queryByRole("button", { name: /Add Household/i })).toBeNull();
   });
 
-  it("(g) single-edge: edge name STILL shown in option label (Variant B always)", () => {
-    const { container } = render(
+  it("(f) renders NO inline edit affordance (no 'Save'/'Cancel' inline buttons)", () => {
+    render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
-        households={[HH_ALPHA]}
+        households={[HOUSEHOLD]}
         devices={[DEVICE]}
-        billingDevices={BILLING_DEVICES_SINGLE_EDGE}
+        billingDevices={BILLING_DEVICES}
         primaryDeviceAssignments={{}}
         canManage={true}
       />
     );
-    const sel = getSelectForHousehold(container, "Household Alpha");
-    const optgroups = sel.querySelectorAll("optgroup");
-    // One edge → one optgroup
-    expect(optgroups).toHaveLength(1);
-    expect(optgroups[0].label).toBe("Alpha Edge");
-
-    // Options still include edge name
-    const allOptions = Array.from(sel.querySelectorAll("option")).filter(
-      (o) => o.value !== ""
-    );
-    for (const opt of allOptions) {
-      expect(opt.textContent).toContain("Alpha Edge");
-    }
+    // The previous inline-edit had Save/Cancel buttons in the row.
+    expect(screen.queryByRole("button", { name: /^Save$/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Cancel$/ })).toBeNull();
   });
 
-  it("(h) already-linked option in another row is disabled with linked-household suffix", () => {
-    // HH_ALPHA has dev-e1-c; HH_BETA's dropdown should show it as disabled
+  it("(g) renders NO native <select> in any row", () => {
     const { container } = render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
-        households={[HH_ALPHA, HH_BETA]}
+        households={[HOUSEHOLD]}
         devices={[DEVICE]}
-        billingDevices={BILLING_DEVICES_WITH_LINKED}
-        // dev-e1-c is assigned to hh-a
-        primaryDeviceAssignments={{ "hh-a": "dev-e1-c" }}
-        canManage={true}
-      />
-    );
-    // In HH_BETA's select, dev-e1-c should be disabled with the linked suffix
-    const selBeta = getSelectForHousehold(container, "Household Beta");
-    const linkedOpt = selBeta.querySelector("option[value='dev-e1-c']") as HTMLOptionElement | null;
-    expect(linkedOpt).not.toBeNull();
-    expect(linkedOpt!.disabled).toBe(true);
-    expect(linkedOpt!.textContent).toContain("(linked: Household Alpha)");
-  });
-
-  it("(i) own-assignment option is NOT disabled and has no linked suffix", () => {
-    const { container } = render(
-      <HouseholdTable
-        microgridId={MICROGRID_ID}
-        households={[HH_ALPHA]}
-        devices={[DEVICE]}
-        billingDevices={BILLING_DEVICES_WITH_LINKED}
-        // dev-e1-c is assigned to hh-a (this row)
-        primaryDeviceAssignments={{ "hh-a": "dev-e1-c" }}
-        canManage={true}
-      />
-    );
-    const selAlpha = getSelectForHousehold(container, "Household Alpha");
-    const ownOpt = selAlpha.querySelector("option[value='dev-e1-c']") as HTMLOptionElement | null;
-    expect(ownOpt).not.toBeNull();
-    expect(ownOpt!.disabled).toBe(false);
-    expect(ownOpt!.textContent).not.toContain("linked:");
-  });
-
-  it("(j) sort order: alphabetical by edge group; available before linked within group", () => {
-    const billingDevicesForSort: BillingDeviceOption[] = [
-      // Zed Edge — linked device (should appear last within group)
-      {
-        id: "dev-z-linked",
-        name: "Alpha Device",
-        device_type: "other",
-        edge_id: "edge-z",
-        edge_name: "Zed Edge",
-        linkedToHouseholdName: "Someone",
-      },
-      // Zed Edge — available (should appear first within group)
-      {
-        id: "dev-z-free",
-        name: "Beta Device",
-        device_type: "other",
-        edge_id: "edge-z",
-        edge_name: "Zed Edge",
-      },
-      // Alpha Edge — should be the first optgroup
-      {
-        id: "dev-a-free",
-        name: "Meter",
-        device_type: "other",
-        edge_id: "edge-a",
-        edge_name: "Alpha Edge",
-      },
-    ];
-
-    const { container } = render(
-      <HouseholdTable
-        microgridId={MICROGRID_ID}
-        households={[HH_ALPHA]}
-        devices={[DEVICE]}
-        billingDevices={billingDevicesForSort}
+        billingDevices={BILLING_DEVICES}
         primaryDeviceAssignments={{}}
         canManage={true}
       />
     );
-    const sel = getSelectForHousehold(container, "Household Alpha");
-    const optgroups = Array.from(sel.querySelectorAll("optgroup"));
-    // Groups sorted alphabetically
-    expect(optgroups[0].label).toBe("Alpha Edge");
-    expect(optgroups[1].label).toBe("Zed Edge");
-
-    // Within Zed Edge: free device before linked device
-    const zedOptions = Array.from(optgroups[1].querySelectorAll("option"));
-    expect(zedOptions[0].value).toBe("dev-z-free"); // available first
-    expect(zedOptions[1].value).toBe("dev-z-linked"); // linked last
+    const selects = container.querySelectorAll("tbody select");
+    expect(selects.length).toBe(0);
   });
 
-  it("(k) Unassigned option is first and outside any optgroup", () => {
+  it("(h) chip — assigned: success tone + button + opens dialog on click", async () => {
     const { container } = render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
-        households={[HH_ALPHA]}
+        households={[HOUSEHOLD]}
         devices={[DEVICE]}
-        billingDevices={BILLING_DEVICES_MULTI_EDGE}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{ "hh-1": "dev-1" }}
+        canManage={true}
+      />
+    );
+    // Find the chip-button by its aria-label
+    const chipBtn = screen.getByRole("button", {
+      name: /Change billing device for Household Alpha/i,
+    });
+    expect(chipBtn).toBeTruthy();
+    // Inner Chip span carries success tokens
+    const chipSpan = chipBtn.querySelector("span");
+    expect(chipSpan?.className).toContain("bg-success-muted");
+    expect(chipSpan?.className).toContain("text-success-fg");
+
+    // Clicking opens the dialog
+    fireEvent.click(chipBtn);
+    await waitFor(() => {
+      expect(screen.getByText(/Edit household/i)).toBeTruthy();
+    });
+
+    // Suppress unused-var lint
+    void container;
+  });
+
+  it("(i) chip — unassigned: warn tone + button + opens dialog on click", async () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD_BETA]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
         primaryDeviceAssignments={{}}
         canManage={true}
       />
     );
-    const sel = getSelectForHousehold(container, "Household Alpha");
-    // First child of the select should be the "Unassigned" option (not optgroup)
-    const firstChild = sel.firstElementChild;
-    expect(firstChild?.tagName.toLowerCase()).toBe("option");
-    expect((firstChild as HTMLOptionElement).value).toBe("");
-    expect(firstChild?.textContent).toBe("Unassigned");
+    const chipBtn = screen.getByRole("button", {
+      name: /Link a billing device for Household Beta/i,
+    });
+    expect(chipBtn).toBeTruthy();
+    const chipSpan = chipBtn.querySelector("span");
+    expect(chipSpan?.className).toContain("bg-warning-muted");
+    expect(chipSpan?.className).toContain("text-warning-fg");
+    expect(chipSpan?.textContent).toContain("Unassigned");
+
+    fireEvent.click(chipBtn);
+    await waitFor(() => {
+      expect(screen.getByText(/Edit household/i)).toBeTruthy();
+    });
+  });
+
+  it("(j) kebab menu present per row when canManage", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD, HOUSEHOLD_BETA]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /Actions for Household Alpha/i })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Actions for Household Beta/i })
+    ).toBeTruthy();
+  });
+
+  it("(j) kebab menu items: Edit, Change/Link device, View detail, Delete", async () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{ "hh-1": "dev-1" }}
+        canManage={true}
+      />
+    );
+    openKebab(/Actions for Household Alpha/i);
+
+    await waitFor(() => {
+      const menu = screen.getByRole("menu");
+      expect(menu.textContent).toContain("Edit household");
+    });
+    const menu = screen.getByRole("menu");
+    expect(menu.textContent).toContain("Change billing device");
+    expect(menu.textContent).toContain("View detail");
+    expect(menu.textContent).toContain("Delete household");
+  });
+
+  it("(j) kebab 'Link device' label when no device assigned", async () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD_BETA]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+      />
+    );
+    openKebab(/Actions for Household Beta/i);
+
+    await waitFor(() => {
+      const menu = screen.getByRole("menu");
+      expect(menu.textContent).toContain("Link device");
+    });
+    const menu = screen.getByRole("menu");
+    expect(menu.textContent).not.toContain("Change billing device");
+  });
+
+  it("(k) kebab hidden when canManage=false; View link rendered instead", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{ "hh-1": "dev-1" }}
+        canManage={false}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /Actions for Household Alpha/i })
+    ).toBeNull();
+    // Plain "View" link is rendered
+    expect(screen.getByRole("link", { name: /^View$/i })).toBeTruthy();
+  });
+
+  it("(k) chip is non-interactive when canManage=false (no button)", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{ "hh-1": "dev-1" }}
+        canManage={false}
+      />
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: /Change billing device for Household Alpha/i,
+      })
+    ).toBeNull();
+  });
+
+  it("(l) address summary uses address_line1 · unit_label", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+      />
+    );
+    expect(screen.getByText(/Plot 14 · Unit 1/)).toBeTruthy();
+  });
+
+  it("(l) address summary renders '—' when blank", () => {
+    render(
+      <HouseholdTable
+        microgridId={MICROGRID_ID}
+        households={[HOUSEHOLD_BETA]}
+        devices={[DEVICE]}
+        billingDevices={BILLING_DEVICES}
+        primaryDeviceAssignments={{}}
+        canManage={true}
+      />
+    );
+    // HOUSEHOLD_BETA has no address — should show em-dash
+    const dashCells = screen.getAllByText(/—/);
+    expect(dashCells.length).toBeGreaterThan(0);
   });
 });

--- a/src/components/forms/HouseholdEditDialog.tsx
+++ b/src/components/forms/HouseholdEditDialog.tsx
@@ -1,0 +1,534 @@
+"use client";
+
+/**
+ * HouseholdEditDialog — combined Identity / Contact / Billing-device /
+ * Address edit modal (#145).
+ *
+ * Replaces the inline name/phone/email edit and the per-row billing-device
+ * <select> previously rendered in HouseholdTable. Create flow remains via
+ * <HouseholdWizard> (PM-pinned in #143); this dialog is edit-only.
+ *
+ * Surface contract:
+ *   - Width 640px, mirroring HouseholdWizard
+ *   - Save semantics: PATCH /api/households/[id] with the diff of changed
+ *     fields only. Includes device_id when the linked device changed.
+ *   - device_id semantics: the route reconciles the household_devices link
+ *     by deleting any existing primary_consumption_meter row and (when
+ *     non-null) inserting the new one. The dialog passes `null` to clear.
+ *   - At-least-one-contact: form-level validation only. When both
+ *     primary_email AND primary_phone are blank the contact section flags
+ *     red (border-destructive ring) and the helper-text reads "At least
+ *     one contact method is required (Pesapal needs to reach the
+ *     customer)". Save remains disabled until the rule passes.
+ *   - Cancel-when-dirty: opens neutral <ConfirmDialog tone="neutral">
+ *     with the discard prompt. Cancel-while-clean closes immediately.
+ *   - Initial focus: display_name (the keystone identity field).
+ *
+ * Forward-compatibility for #146 (address widening): the address subform is
+ * extracted into <AddressSubsection>. When #146 lands the new fields slot
+ * in there without disturbing the dialog skeleton or the diff machinery.
+ */
+
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { DeviceSelect, type DeviceOption } from "@/components/ui/device-select";
+import { cn } from "@/lib/utils";
+import type { Household } from "@/lib/types/domain";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface HouseholdEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  household: Household;
+  /**
+   * All consumption_meter devices on this microgrid, including ones already
+   * assigned to another household. The dialog filters the *current* device
+   * out of the linked-elsewhere set so it isn't disabled in its own picker.
+   */
+  availableDevices: DeviceOption[];
+  /** household_devices.role='primary_consumption_meter' device id, if any. */
+  currentDeviceId: string | null;
+  /** href to the microgrid's edges discovery page (empty-state CTA). */
+  edgesSetupHref: string;
+}
+
+type FormState = {
+  display_name: string;
+  primary_email: string;
+  primary_phone: string;
+  address_line1: string;
+  address_line2: string;
+  unit_label: string;
+  device_id: string | null;
+};
+
+function initialState(h: Household, deviceId: string | null): FormState {
+  return {
+    display_name: h.display_name ?? "",
+    primary_email: h.primary_email ?? "",
+    primary_phone: h.primary_phone ?? "",
+    address_line1: h.address_line1 ?? "",
+    address_line2: h.address_line2 ?? "",
+    unit_label: h.unit_label ?? "",
+    device_id: deviceId,
+  };
+}
+
+function isDirty(cur: FormState, init: FormState): boolean {
+  return (
+    cur.display_name !== init.display_name ||
+    cur.primary_email !== init.primary_email ||
+    cur.primary_phone !== init.primary_phone ||
+    cur.address_line1 !== init.address_line1 ||
+    cur.address_line2 !== init.address_line2 ||
+    cur.unit_label !== init.unit_label ||
+    cur.device_id !== init.device_id
+  );
+}
+
+/** Build the PATCH-diff: only changed fields, with empty strings → null. */
+function buildDiff(
+  cur: FormState,
+  init: FormState
+): Record<string, string | null> {
+  const out: Record<string, string | null> = {};
+  if (cur.display_name !== init.display_name) {
+    out.display_name = cur.display_name.trim();
+  }
+  if (cur.primary_email !== init.primary_email) {
+    const v = cur.primary_email.trim();
+    out.primary_email = v.length > 0 ? v : null;
+  }
+  if (cur.primary_phone !== init.primary_phone) {
+    const v = cur.primary_phone.trim();
+    out.primary_phone = v.length > 0 ? v : null;
+  }
+  if (cur.address_line1 !== init.address_line1) {
+    const v = cur.address_line1.trim();
+    out.address_line1 = v.length > 0 ? v : null;
+  }
+  if (cur.address_line2 !== init.address_line2) {
+    const v = cur.address_line2.trim();
+    out.address_line2 = v.length > 0 ? v : null;
+  }
+  if (cur.unit_label !== init.unit_label) {
+    const v = cur.unit_label.trim();
+    out.unit_label = v.length > 0 ? v : null;
+  }
+  if (cur.device_id !== init.device_id) {
+    out.device_id = cur.device_id;
+  }
+  return out;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+const CONTACT_HELPER_ID = "hh-edit-contact-helper";
+const DEVICE_HELPER_ID = "hh-edit-device-helper";
+
+export function HouseholdEditDialog({
+  open,
+  onOpenChange,
+  household,
+  availableDevices,
+  currentDeviceId,
+  edgesSetupHref,
+}: HouseholdEditDialogProps) {
+  const router = useRouter();
+
+  const init = React.useMemo(
+    () => initialState(household, currentDeviceId),
+    [household, currentDeviceId]
+  );
+
+  const [state, setState] = React.useState<FormState>(init);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [topError, setTopError] = React.useState<string | null>(null);
+  const [confirmCancelOpen, setConfirmCancelOpen] = React.useState(false);
+  const firstFieldRef = React.useRef<HTMLInputElement>(null);
+
+  // Reset form whenever the dialog opens (or the underlying household
+  // changes while open).
+  React.useEffect(() => {
+    if (open) {
+      setState(init);
+      setSubmitting(false);
+      setTopError(null);
+    }
+  }, [open, init]);
+
+  const dirty = isDirty(state, init);
+  const displayNameValid = state.display_name.trim().length > 0;
+  const hasContact =
+    state.primary_email.trim().length > 0 ||
+    state.primary_phone.trim().length > 0;
+  const canSave = dirty && displayNameValid && hasContact && !submitting;
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setState((prev) => ({ ...prev, [key]: value }));
+  }
+
+  // The DeviceSelect's "linked to" suffix should NOT appear on the device
+  // currently linked to THIS household — otherwise the picker would render
+  // its own current value as disabled. We strip linkedToHouseholdName on
+  // the matching id.
+  const devicesForPicker = React.useMemo<DeviceOption[]>(() => {
+    return availableDevices.map((d) =>
+      d.id === currentDeviceId ? { ...d, linkedToHouseholdName: null } : d
+    );
+  }, [availableDevices, currentDeviceId]);
+
+  async function handleSubmit(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (!canSave) return;
+    if (!dirty) {
+      onOpenChange(false);
+      return;
+    }
+    setSubmitting(true);
+    setTopError(null);
+    try {
+      const res = await fetch(`/api/households/${household.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildDiff(state, init)),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setTopError(body.error ?? `Could not save (HTTP ${res.status}).`);
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+      onOpenChange(false);
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : "Network error.");
+      setSubmitting(false);
+    }
+  }
+
+  function requestClose(next: boolean) {
+    if (!next && dirty) {
+      setConfirmCancelOpen(true);
+      return;
+    }
+    onOpenChange(next);
+  }
+
+  const contactInvalid = !hasContact;
+
+  return (
+    <>
+      <Dialog.Root open={open} onOpenChange={requestClose}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55" />
+          <Dialog.Content
+            aria-modal
+            aria-describedby="hh-edit-desc"
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+              firstFieldRef.current?.focus();
+            }}
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[640px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+              "max-h-[92vh] overflow-y-auto rounded-md border border-border bg-card shadow-elev-3 outline-none"
+            )}
+          >
+            {/* top rail */}
+            <div aria-hidden="true" className="h-[6px] bg-primary" />
+
+            <div className="px-6 pt-5">
+              <Dialog.Title className="text-xl font-semibold tracking-tight text-foreground">
+                Edit household
+              </Dialog.Title>
+              <Dialog.Description
+                id="hh-edit-desc"
+                className="mt-1 text-[13px] text-muted-foreground"
+              >
+                Only changed fields are saved. Switch the billing meter at any
+                time — historical bills retain their original device link.
+              </Dialog.Description>
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              className="space-y-5 px-6 pb-2 pt-4"
+              noValidate
+            >
+              {topError && (
+                <Banner tone="destructive" title="Could not save">
+                  {topError}
+                </Banner>
+              )}
+
+              {/* IDENTITY */}
+              <Section title="Identity">
+                <Field
+                  id="hh-edit-display-name"
+                  label="Display name"
+                  required
+                  value={state.display_name}
+                  onChange={(v) => update("display_name", v)}
+                  inputRef={firstFieldRef}
+                  ariaInvalid={!displayNameValid}
+                />
+              </Section>
+
+              {/* CONTACT */}
+              <Section
+                title="Contact"
+                helper="At least one contact method is required (Pesapal needs to reach the customer)."
+                helperId={CONTACT_HELPER_ID}
+                helperTone={contactInvalid ? "destructive" : "default"}
+              >
+                <Pair>
+                  <Field
+                    id="hh-edit-email"
+                    label="Primary email"
+                    type="email"
+                    value={state.primary_email}
+                    onChange={(v) => update("primary_email", v)}
+                    describedBy={CONTACT_HELPER_ID}
+                    ariaInvalid={contactInvalid}
+                  />
+                  <Field
+                    id="hh-edit-phone"
+                    label="Primary phone"
+                    type="tel"
+                    value={state.primary_phone}
+                    onChange={(v) => update("primary_phone", v)}
+                    describedBy={CONTACT_HELPER_ID}
+                    ariaInvalid={contactInvalid}
+                  />
+                </Pair>
+              </Section>
+
+              {/* BILLING DEVICE */}
+              <Section
+                title="Billing device"
+                helper="The consumption meter that produces this household's bill each period. Unassigned households are skipped at billing time."
+                helperId={DEVICE_HELPER_ID}
+              >
+                <DeviceSelect
+                  devices={devicesForPicker}
+                  value={state.device_id}
+                  onChange={(id) => update("device_id", id)}
+                  edgesSetupHref={edgesSetupHref}
+                  aria-describedby={DEVICE_HELPER_ID}
+                  aria-label="Billing device"
+                />
+              </Section>
+
+              {/* ADDRESS */}
+              <AddressSubsection
+                state={state}
+                update={update}
+                disabled={submitting}
+              />
+            </form>
+
+            <div className="mt-2 flex items-center justify-end gap-2 border-t border-border bg-muted px-6 pb-[18px] pt-[14px]">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  disabled={submitting}
+                  className="inline-flex h-8 items-center rounded-md px-3.5 text-[13px] font-medium text-foreground hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="button"
+                onClick={() => handleSubmit()}
+                disabled={!canSave}
+                className="inline-flex h-8 items-center rounded-md bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {submitting ? "Saving…" : "Save changes"}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <ConfirmDialog
+        open={confirmCancelOpen}
+        onOpenChange={setConfirmCancelOpen}
+        tone="neutral"
+        title="Discard unsaved changes?"
+        description="Your edits will be lost."
+        confirmLabel="Discard"
+        onConfirm={async () => {
+          setConfirmCancelOpen(false);
+          onOpenChange(false);
+        }}
+      />
+    </>
+  );
+}
+
+// ── Local primitives ─────────────────────────────────────────────────────
+
+function Section({
+  title,
+  helper,
+  helperId,
+  helperTone = "default",
+  children,
+}: {
+  title: string;
+  helper?: string;
+  helperId?: string;
+  helperTone?: "default" | "destructive";
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </p>
+      {children}
+      {helper && (
+        <p
+          id={helperId}
+          className={cn(
+            "text-xs",
+            helperTone === "destructive"
+              ? "text-destructive-fg"
+              : "text-muted-foreground"
+          )}
+        >
+          {helper}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function Pair({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">{children}</div>
+  );
+}
+
+function Field({
+  id,
+  label,
+  value,
+  onChange,
+  required,
+  type = "text",
+  placeholder,
+  describedBy,
+  inputRef,
+  ariaInvalid,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  required?: boolean;
+  type?: string;
+  placeholder?: string;
+  describedBy?: string;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  ariaInvalid?: boolean;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {label}
+        {required && (
+          <>
+            <span aria-hidden="true" className="ml-0.5 text-destructive-fg">
+              *
+            </span>
+            <span className="sr-only"> (required)</span>
+          </>
+        )}
+      </label>
+      <Input
+        id={id}
+        ref={inputRef}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        required={required}
+        aria-required={required ? "true" : undefined}
+        aria-describedby={describedBy}
+        aria-invalid={ariaInvalid ? "true" : undefined}
+        className={cn(
+          ariaInvalid && "border-destructive ring-1 ring-destructive"
+        )}
+      />
+    </div>
+  );
+}
+
+/**
+ * AddressSubsection — extracted so #146's address widening
+ * (address_city, address_region, address_country, address_postal_code,
+ * geography_notes) can be slotted in here without touching the parent
+ * form skeleton or the diff machinery.
+ */
+function AddressSubsection({
+  state,
+  update,
+  disabled,
+}: {
+  state: FormState;
+  update: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  disabled: boolean;
+}) {
+  return (
+    <details
+      className="group rounded-md border border-border bg-card"
+      open
+    >
+      <summary className="flex cursor-pointer items-center justify-between px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <span>Address</span>
+        <span
+          aria-hidden
+          className="text-muted-foreground transition group-open:rotate-180"
+        >
+          ▾
+        </span>
+      </summary>
+      <fieldset
+        disabled={disabled}
+        className="space-y-3 border-t border-border px-3 py-4"
+      >
+        <Field
+          id="hh-edit-line1"
+          label="Address line 1"
+          value={state.address_line1}
+          onChange={(v) => update("address_line1", v)}
+        />
+        <Pair>
+          <Field
+            id="hh-edit-line2"
+            label="Address line 2"
+            value={state.address_line2}
+            onChange={(v) => update("address_line2", v)}
+          />
+          <Field
+            id="hh-edit-unit-label"
+            label="Unit label"
+            value={state.unit_label}
+            onChange={(v) => update("unit_label", v)}
+          />
+        </Pair>
+      </fieldset>
+    </details>
+  );
+}

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -38,12 +38,24 @@ import type { DeviceType } from "@/lib/types/domain";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
-/** Shape of an available-meter row passed from the server component. */
+/**
+ * Shape of an available-meter row passed from the server component.
+ *
+ * Widened in #145 to include `edge_id` (required by `<DeviceSelect>` for
+ * grouping by edge) and `linked_household_name` (rendered as a
+ * "(linked: …)" suffix on already-assigned consumption meters when surfaced
+ * in `<DeviceSelect>`). The wizard's StepMeter still filters out linked
+ * meters at the call site, so AvailableMeter populates `linked_household_name`
+ * with `null` for the wizard's own usage but is shaped for cross-surface
+ * reuse in the Household Edit dialog.
+ */
 export type AvailableMeter = {
   id: string;
   name: string;
   device_type: DeviceType;
+  edge_id: string;
   edge_name: string;
+  linked_household_name: string | null;
 };
 
 export interface HouseholdWizardProps {

--- a/src/components/forms/__tests__/HouseholdEditDialog.test.tsx
+++ b/src/components/forms/__tests__/HouseholdEditDialog.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+/**
+ * HouseholdEditDialog tests (#145).
+ *
+ * Coverage:
+ *   (1) renders with current device assignment
+ *   (2) renders Unassigned state when currentDeviceId is null
+ *   (3) PATCH-diff sends only changed fields
+ *   (4) clean-form save closes without PATCH (no-op exit)
+ *   (5) cancel-when-dirty opens ConfirmDialog
+ *   (6) at-least-one-contact validation blocks save and surfaces helper
+ *   (7) display_name required (blank disables Save)
+ *   (8) device_id change is included in PATCH diff
+ */
+
+import * as React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Household } from "@/lib/types/domain";
+import type { DeviceOption } from "@/components/ui/device-select";
+import { HouseholdEditDialog } from "../HouseholdEditDialog";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = function () {};
+  }
+});
+
+const HOUSEHOLD: Household = {
+  id: "660e8400-e29b-41d4-a716-446655440111",
+  microgrid_id: "660e8400-e29b-41d4-a716-446655440000",
+  display_name: "Block A, Unit 1",
+  primary_phone: "+256700000000",
+  primary_email: null,
+  address_line1: "Plot 14",
+  address_line2: null,
+  unit_label: null,
+  created_at: "2026-01-01T00:00:00Z",
+} as Household;
+
+const DEVICES: DeviceOption[] = [
+  {
+    id: "dev-1",
+    name: "Meter A",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+  {
+    id: "dev-2",
+    name: "Meter B",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+];
+
+function renderDialog(
+  props: Partial<React.ComponentProps<typeof HouseholdEditDialog>> = {}
+) {
+  const onOpenChange = vi.fn();
+  const defaults: React.ComponentProps<typeof HouseholdEditDialog> = {
+    open: true,
+    onOpenChange,
+    household: HOUSEHOLD,
+    availableDevices: DEVICES,
+    currentDeviceId: null,
+    edgesSetupHref: "/microgrids/mg-1/setup/edges",
+  };
+  return {
+    onOpenChange,
+    ...render(<HouseholdEditDialog {...defaults} {...props} />),
+  };
+}
+
+describe("HouseholdEditDialog (#145)", () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("(1) renders with current device assignment", () => {
+    renderDialog({ currentDeviceId: "dev-1" });
+    // Trigger displays the current selection: chip + name + edge
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers[0].textContent).toContain("Meter A");
+    expect(triggers[0].textContent).toContain("Alpha Edge");
+  });
+
+  it("(2) renders Unassigned state when currentDeviceId is null", () => {
+    renderDialog({ currentDeviceId: null });
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers[0].textContent).toContain("Unassigned");
+  });
+
+  it("(3) PATCH-diff sends only changed fields", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ household: { id: HOUSEHOLD.id } }),
+    } as Response);
+
+    renderDialog({ currentDeviceId: "dev-1" });
+
+    // Change ONLY display_name
+    const dn = screen.getByLabelText(/Display name/i) as HTMLInputElement;
+    fireEvent.change(dn, { target: { value: "Updated Name" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`/api/households/${HOUSEHOLD.id}`);
+    expect(init?.method).toBe("PATCH");
+
+    const body = JSON.parse(init?.body as string);
+    // Only display_name changed → only display_name in diff
+    expect(body).toEqual({ display_name: "Updated Name" });
+  });
+
+  it("(4) save without changes is disabled (no PATCH)", () => {
+    renderDialog({ currentDeviceId: "dev-1" });
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("(5) cancel-when-dirty opens ConfirmDialog", async () => {
+    renderDialog({ currentDeviceId: "dev-1" });
+
+    const dn = screen.getByLabelText(/Display name/i) as HTMLInputElement;
+    fireEvent.change(dn, { target: { value: "Edited" } });
+
+    // Click the dialog's Cancel (footer)
+    const cancelBtns = screen.getAllByRole("button", { name: /^Cancel$/ });
+    fireEvent.click(cancelBtns[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Discard unsaved changes/i)).toBeTruthy();
+    });
+  });
+
+  it("(6) at-least-one-contact rule disables save AND surfaces helper", () => {
+    // Start with email=null (already), then clear phone
+    renderDialog({ currentDeviceId: "dev-1" });
+
+    const phone = screen.getByLabelText(/Primary phone/i) as HTMLInputElement;
+    fireEvent.change(phone, { target: { value: "" } });
+
+    // Helper text appears (color: destructive)
+    expect(
+      screen.getByText(/At least one contact method is required/i)
+    ).toBeTruthy();
+
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("(7) display_name required — blank disables save", () => {
+    renderDialog({ currentDeviceId: "dev-1" });
+    const dn = screen.getByLabelText(/Display name/i) as HTMLInputElement;
+    fireEvent.change(dn, { target: { value: "   " } });
+
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("(8) device_id change is included in PATCH diff", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ household: { id: HOUSEHOLD.id } }),
+    } as Response);
+
+    renderDialog({ currentDeviceId: "dev-1" });
+
+    // Open the device picker and select Meter B
+    const triggers = screen.getAllByRole("combobox");
+    fireEvent.click(triggers[0]);
+
+    const meterBOption = await waitFor(() =>
+      screen
+        .getAllByRole("option")
+        .find((o) => o.textContent?.includes("Meter B"))
+    );
+    expect(meterBOption).toBeDefined();
+    fireEvent.click(meterBOption!);
+
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({ device_id: "dev-2" });
+  });
+});

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -43,13 +43,17 @@ const METERS: AvailableMeter[] = [
     id: "dev-1",
     name: "Household A Meter",
     device_type: "consumption_meter",
+    edge_id: "edge-1",
     edge_name: "Metering Pi",
+    linked_household_name: null,
   },
   {
     id: "dev-2",
     name: "Household B Meter",
     device_type: "consumption_meter",
+    edge_id: "edge-1",
     edge_name: "Metering Pi",
+    linked_household_name: null,
   },
 ];
 

--- a/src/components/ui/__tests__/device-select.test.tsx
+++ b/src/components/ui/__tests__/device-select.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+/**
+ * DeviceSelect — unit tests (#145).
+ *
+ * Variant B always: edge label + group header are present even on
+ * single-edge microgrids. Already-linked devices are disabled. Empty state
+ * surfaces an in-dropdown empty card with a Discover link.
+ *
+ * Note: Radix Select renders its options into a portal that materialises
+ * only when the trigger is opened. We open the picker via a click on the
+ * trigger; jsdom + Radix don't replicate real focus, so we assert on the
+ * actual rendered DOM after open.
+ */
+
+import * as React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DeviceSelect, type DeviceOption } from "../device-select";
+
+// next/link mock
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// Polyfills for Radix Select
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  // Radix internally calls these in jsdom and they don't exist by default.
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = function () {};
+  }
+  if (typeof Element.prototype.hasPointerCapture !== "function") {
+    (Element.prototype as { hasPointerCapture?: () => boolean }).hasPointerCapture = () => false;
+  }
+  if (typeof Element.prototype.releasePointerCapture !== "function") {
+    (Element.prototype as { releasePointerCapture?: () => void }).releasePointerCapture = () => {};
+  }
+});
+
+const SINGLE_EDGE: DeviceOption[] = [
+  {
+    id: "dev-a",
+    name: "Meter A",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+  {
+    id: "dev-b",
+    name: "Meter B",
+    device_type: "grid_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+];
+
+const MULTI_EDGE: DeviceOption[] = [
+  {
+    id: "dev-z",
+    name: "Zed device",
+    device_type: "consumption_meter",
+    edge_id: "edge-z",
+    edge_name: "Zed Edge",
+  },
+  {
+    id: "dev-a",
+    name: "Apple device",
+    device_type: "consumption_meter",
+    edge_id: "edge-a",
+    edge_name: "Apple Edge",
+  },
+];
+
+const WITH_LINKED: DeviceOption[] = [
+  {
+    id: "dev-free",
+    name: "Free meter",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+  },
+  {
+    id: "dev-linked",
+    name: "Linked meter",
+    device_type: "consumption_meter",
+    edge_id: "edge-1",
+    edge_name: "Alpha Edge",
+    linkedToHouseholdName: "Household X",
+  },
+];
+
+function openTrigger() {
+  // The trigger renders as a <button> (Radix Select.Trigger). Multiple
+  // matches happen because Radix sometimes adds hidden input copies — we
+  // pick the first.
+  const triggers = screen.getAllByRole("combobox");
+  fireEvent.click(triggers[0]);
+}
+
+describe("DeviceSelect (#145)", () => {
+  it("(single-edge) shows edge label + group header even with one edge", () => {
+    render(
+      <DeviceSelect
+        devices={SINGLE_EDGE}
+        value={null}
+        onChange={() => {}}
+        edgesSetupHref="/microgrids/mg-1/setup/edges"
+      />
+    );
+    openTrigger();
+
+    // Group header present
+    expect(screen.getByText(/Edge · Alpha Edge/i)).toBeTruthy();
+
+    // Each device option shows the edge name as the second line
+    const edgeNameOccurrences = screen.getAllByText(/Alpha Edge/i);
+    // 1 for the group label + 1 per device = 3
+    expect(edgeNameOccurrences.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("(multi-edge) groups alphabetically by edge name", () => {
+    render(
+      <DeviceSelect
+        devices={MULTI_EDGE}
+        value={null}
+        onChange={() => {}}
+        edgesSetupHref="/microgrids/mg-1/setup/edges"
+      />
+    );
+    openTrigger();
+
+    const groupLabels = screen.getAllByText(/^Edge ·/);
+    expect(groupLabels).toHaveLength(2);
+    // Apple Edge sorts before Zed Edge
+    expect(groupLabels[0].textContent).toContain("Apple Edge");
+    expect(groupLabels[1].textContent).toContain("Zed Edge");
+  });
+
+  it("(linked-elsewhere) renders disabled item with 'linked to' suffix", () => {
+    render(
+      <DeviceSelect
+        devices={WITH_LINKED}
+        value={null}
+        onChange={() => {}}
+        edgesSetupHref="/microgrids/mg-1/setup/edges"
+      />
+    );
+    openTrigger();
+
+    // "linked to Household X" suffix is rendered for the linked device
+    expect(screen.getByText(/linked to Household X/i)).toBeTruthy();
+
+    // The linked option carries aria-disabled (Radix sets this from the
+    // `disabled` prop on Select.Item).
+    const options = screen.getAllByRole("option");
+    const linkedOpt = options.find((o) =>
+      o.textContent?.includes("Linked meter")
+    );
+    expect(linkedOpt).toBeDefined();
+    expect(linkedOpt?.getAttribute("data-disabled")).not.toBeNull();
+  });
+
+  it("(empty) renders in-dropdown empty state with Discover link", () => {
+    render(
+      <DeviceSelect
+        devices={[]}
+        value={null}
+        onChange={() => {}}
+        edgesSetupHref="/microgrids/mg-1/setup/edges"
+      />
+    );
+    // The trigger is disabled when no devices, so we can't click to open.
+    // The disabled trigger is wrapping the placeholder text.
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers[0].getAttribute("data-disabled")).not.toBeNull();
+    // Placeholder reflects the empty state
+    expect(triggers[0].textContent).toContain("No devices on this microgrid yet");
+  });
+
+  it("calls onChange(null) when sentinel 'Unassigned' option chosen", () => {
+    const onChange = vi.fn();
+    render(
+      <DeviceSelect
+        devices={SINGLE_EDGE}
+        value="dev-a"
+        onChange={onChange}
+        edgesSetupHref="/microgrids/mg-1/setup/edges"
+      />
+    );
+    openTrigger();
+
+    const unassignedOption = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.trim() === "Unassigned");
+    expect(unassignedOption).toBeDefined();
+    fireEvent.click(unassignedOption!);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/ui/__tests__/device-select.test.tsx
+++ b/src/components/ui/__tests__/device-select.test.tsx
@@ -48,10 +48,10 @@ beforeAll(() => {
     Element.prototype.scrollIntoView = function () {};
   }
   if (typeof Element.prototype.hasPointerCapture !== "function") {
-    (Element.prototype as { hasPointerCapture?: () => boolean }).hasPointerCapture = () => false;
+    Element.prototype.hasPointerCapture = (() => false) as Element["hasPointerCapture"];
   }
   if (typeof Element.prototype.releasePointerCapture !== "function") {
-    (Element.prototype as { releasePointerCapture?: () => void }).releasePointerCapture = () => {};
+    Element.prototype.releasePointerCapture = (() => {}) as Element["releasePointerCapture"];
   }
 });
 

--- a/src/components/ui/device-select.tsx
+++ b/src/components/ui/device-select.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+/**
+ * DeviceSelect — Radix-based picker for billing devices, replacing the bare
+ * native <select> + <optgroup> previously rendered inline in HouseholdTable.
+ *
+ * Variant B always: every option shows the edge label as a second line and
+ * groups are headed with `Edge · <edge_name>`, even on single-edge
+ * microgrids. The previous `showEdgeLabel` toggle is gone — operator
+ * decision on 2026-04-25 (#145 ticket): always disambiguate by edge so
+ * the rendering doesn't shift when an edge is added later.
+ *
+ * Already-linked devices: greyed (`opacity-60`) + Radix `disabled` + suffix
+ * "linked to <household>". They are NOT selectable from this surface; the
+ * source household's edit dialog is the only place to reassign.
+ *
+ * Empty state: when `devices.length === 0`, the dropdown collapses to an
+ * inline mini empty-state with a link to the microgrid's edges page.
+ *
+ * Sort order:
+ *   1. Groups: alphabetical by edge_name
+ *   2. Within a group: AVAILABLE devices first (alphabetical by name),
+ *      then LINKED-elsewhere devices (alphabetical, dimmed)
+ *
+ * A11y:
+ *   - Radix Select handles roving-tabindex, type-ahead, ESC dismiss
+ *   - Group headers are SelectLabel inside SelectGroup
+ *   - Disabled items get `aria-disabled` automatically via the Radix prop
+ *   - `aria-describedby` on the trigger is forwarded by the caller
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Chip } from "@/components/ui/chip";
+import { humanReadable } from "@/lib/openems/device-descriptions";
+import { cn } from "@/lib/utils";
+
+export type DeviceOption = {
+  id: string;
+  name: string;
+  device_type: string;
+  edge_id: string;
+  edge_name: string;
+  /**
+   * When set, this device is already the primary_consumption_meter of
+   * another household. The option renders disabled with a "linked" suffix.
+   * The CALLER is responsible for clearing this on the option that matches
+   * `value` when this household is the device's owner — otherwise the
+   * current selection would render disabled in its own picker.
+   */
+  linkedToHouseholdName?: string | null;
+};
+
+export interface DeviceSelectProps {
+  devices: DeviceOption[];
+  value: string | null;
+  onChange: (deviceId: string | null) => void;
+  /** Href to the microgrid's edges page — surfaced inside the empty-state. */
+  edgesSetupHref: string;
+  /** Forwarded to the SelectTrigger for screen-reader linkage to helper text. */
+  "aria-describedby"?: string;
+  disabled?: boolean;
+  /** Forwarded to the SelectTrigger for label association. */
+  "aria-label"?: string;
+}
+
+const UNASSIGNED_VALUE = "__unassigned__";
+
+export function DeviceSelect({
+  devices,
+  value,
+  onChange,
+  edgesSetupHref,
+  "aria-describedby": describedBy,
+  "aria-label": ariaLabel,
+  disabled,
+}: DeviceSelectProps) {
+  const grouped = React.useMemo(() => groupByEdge(devices), [devices]);
+  const isEmpty = devices.length === 0;
+  const selected = devices.find((d) => d.id === value) ?? null;
+
+  function handleValueChange(next: string) {
+    if (next === UNASSIGNED_VALUE) {
+      onChange(null);
+    } else {
+      onChange(next);
+    }
+  }
+
+  return (
+    <Select
+      value={value ?? UNASSIGNED_VALUE}
+      onValueChange={handleValueChange}
+      disabled={disabled || isEmpty}
+    >
+      <SelectTrigger
+        className="w-full"
+        aria-describedby={describedBy}
+        aria-label={ariaLabel}
+      >
+        <SelectValue
+          placeholder={
+            isEmpty ? "No devices on this microgrid yet" : "Unassigned"
+          }
+        >
+          {isEmpty ? (
+            <span className="text-muted-foreground">
+              No devices on this microgrid yet
+            </span>
+          ) : selected ? (
+            <span className="flex items-center gap-2">
+              <Chip tone="neutral" size="sm">
+                {humanReadable(selected.device_type)}
+              </Chip>
+              <span className="text-foreground">{selected.name}</span>
+              <span className="text-xs text-muted-foreground">
+                · {selected.edge_name}
+              </span>
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Unassigned</span>
+          )}
+        </SelectValue>
+      </SelectTrigger>
+
+      <SelectContent className="max-h-[360px]">
+        {isEmpty ? (
+          <DropdownEmptyState edgesSetupHref={edgesSetupHref} />
+        ) : (
+          <>
+            {/* Sentinel "Unassigned" option — always first, outside groups */}
+            <SelectItem value={UNASSIGNED_VALUE} className="py-1.5">
+              <span className="text-muted-foreground">Unassigned</span>
+            </SelectItem>
+
+            {grouped.map((group) => (
+              <SelectGroup key={group.edge_id}>
+                <SelectLabel className="bg-muted px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Edge · {group.edge_name}
+                </SelectLabel>
+                {group.items.map((d) => {
+                  const linked = Boolean(d.linkedToHouseholdName);
+                  return (
+                    <SelectItem
+                      key={d.id}
+                      value={d.id}
+                      disabled={linked}
+                      className={cn("py-1.5", linked && "opacity-60")}
+                    >
+                      <div className="flex flex-col">
+                        <span className="flex items-center gap-2">
+                          <Chip tone="neutral" size="sm">
+                            {humanReadable(d.device_type)}
+                          </Chip>
+                          <span className="text-foreground">{d.name}</span>
+                          {linked && (
+                            <span className="text-xs text-muted-foreground">
+                              · linked to {d.linkedToHouseholdName}
+                            </span>
+                          )}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {d.edge_name}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  );
+                })}
+              </SelectGroup>
+            ))}
+            <div className="border-t border-border bg-muted px-3 py-2 text-[11px] text-muted-foreground">
+              Linked devices are managed from the household they&apos;re assigned to.
+            </div>
+          </>
+        )}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ── In-dropdown empty-state ──────────────────────────────────────────────
+
+function DropdownEmptyState({ edgesSetupHref }: { edgesSetupHref: string }) {
+  return (
+    <div
+      role="region"
+      aria-label="No devices available"
+      className="px-4 py-5 text-center"
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        DEVICES
+      </p>
+      <h4 className="mt-1 text-sm font-semibold text-foreground">
+        No consumption meters yet
+      </h4>
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Run discovery on this microgrid&apos;s edges to make meters available
+        for household assignment.
+      </p>
+      <Link
+        href={edgesSetupHref}
+        className="mt-3 inline-flex items-center text-xs font-medium text-primary hover:underline"
+      >
+        Discover devices →
+      </Link>
+    </div>
+  );
+}
+
+// ── Sort + group helpers ─────────────────────────────────────────────────
+
+function groupByEdge(
+  devices: DeviceOption[]
+): Array<{ edge_id: string; edge_name: string; items: DeviceOption[] }> {
+  const map = new Map<
+    string,
+    { edge_id: string; edge_name: string; items: DeviceOption[] }
+  >();
+  for (const d of devices) {
+    if (!map.has(d.edge_id)) {
+      map.set(d.edge_id, {
+        edge_id: d.edge_id,
+        edge_name: d.edge_name,
+        items: [],
+      });
+    }
+    map.get(d.edge_id)!.items.push(d);
+  }
+  const groups = Array.from(map.values());
+  groups.sort((a, b) => a.edge_name.localeCompare(b.edge_name));
+  for (const g of groups) {
+    g.items.sort((a, b) => {
+      const aLinked = Boolean(a.linkedToHouseholdName);
+      const bLinked = Boolean(b.linkedToHouseholdName);
+      if (aLinked !== bLinked) return aLinked ? 1 : -1;
+      return a.name.localeCompare(b.name);
+    });
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary
- New `PATCH /api/households/[id]` route — allowlist body (display_name, primary_email, primary_phone, address_line1/2, unit_label, device_id) + `currentUserCanAccessMicrogrid` permission gate + delete-then-insert device-link reconciliation
- New `<DeviceSelect>` Radix primitive — Variant B always (edge label + group header for ALL microgrids, even single-edge); already-linked-elsewhere devices greyed + disabled with `(linked: HouseholdName)` suffix
- New `<HouseholdEditDialog>` — 640px modal, PATCH-diff submit, at-least-one-contact form rule, neutral cancel-when-dirty discard, address subsection extracted for #146 expansion
- `<HouseholdTable>` refactor: removes inline create form, inline name/phone/email edit, and #144's per-row `<select>`+`<optgroup>` (naturally superseded). Adds kebab menu (Radix DropdownMenu used directly) + click-to-edit chip (success when assigned, warn when unassigned)
- `AvailableMeter` widened with `edge_id` + `linked_household_name`; page data fetch stops pre-filtering linked devices for the dialog feed
- 43 new tests across 4 surfaces

## Review fixes included
- **B1 (security blocker)**: cross-household device-stealing now rejected server-side with 409 `device_already_linked`. Schema's existing unique index only protected one-household-two-primaries (NOT one-device-two-households); UI grey-out was UI sugar only. Added a guarded SELECT before any mutation; PATCH short-circuits before field updates if the steal would land. New test asserts both households remain untouched on rejection.

## Supersedes
PR #147 (#144) — the `<optgroup>` quick-fix is naturally retired by replacing the native `<select>` with `<DeviceSelect>`. The `BillingDeviceOption` type is reused as the public type.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `SKIP_RLS_TESTS=1 npm test` (908 pass)
- [x] `npm run build`
- [ ] Manual: kebab opens dialog; chip click opens dialog; PATCH-diff sends only changed fields; cancel-when-dirty shows discard prompt; assigned device cannot be stolen from another household via curl

Closes #145.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)