### PR TITLE
Device reclassify: PATCH route + edit dialog (#151)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/device-row-actions.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/device-row-actions.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * DeviceRowActions — client shell for the per-device kebab on the edge detail
+ * page (#151).
+ *
+ * Renders a kebab affordance ("⋮") that opens a dropdown with a single
+ * "Edit device" item. Selecting it opens <DeviceEditDialog>. Permission gate
+ * is already applied at the parent (the kebab is only rendered when
+ * canManage). Pattern mirrors HouseholdRowActions in HouseholdTable.tsx.
+ */
+
+import * as React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { DeviceEditDialog } from "@/components/forms/DeviceEditDialog";
+import type { DeviceEditDialogDevice } from "@/components/forms/DeviceEditDialog";
+
+export function DeviceRowActions({ device }: { device: DeviceEditDialogDevice }) {
+  const [editing, setEditing] = React.useState(false);
+
+  return (
+    <>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label={`Actions for ${device.name}`}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <KebabIcon />
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={4}
+            className="z-50 min-w-[160px] rounded-md border border-border bg-card p-1 shadow-elev-2"
+          >
+            <DropdownMenu.Item
+              onSelect={() => setEditing(true)}
+              className="flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-[13px] text-foreground outline-none data-[highlighted]:bg-muted"
+            >
+              Edit device
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+
+      {editing && (
+        <DeviceEditDialog
+          open={editing}
+          onOpenChange={setEditing}
+          device={device}
+        />
+      )}
+    </>
+  );
+}
+
+function KebabIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+    >
+      <circle cx="8" cy="3" r="1.25" />
+      <circle cx="8" cy="8" r="1.25" />
+      <circle cx="8" cy="13" r="1.25" />
+    </svg>
+  );
+}

--- a/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/edges/[edgeId]/page.tsx
@@ -7,6 +7,7 @@ import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { DiscoverDevices } from "@/components/DiscoverDevices";
 import { EdgeDetailConfigureButton } from "./edge-detail-configure-button";
+import { DeviceRowActions } from "./device-row-actions";
 import { DeleteEntityButton } from "@/components/forms/DeleteEntityButton";
 import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -209,6 +210,11 @@ export default async function EdgeDetailPage({
                 <th className="px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                   Linked household
                 </th>
+                {canManage && (
+                  <th className="px-4 py-2 text-right text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Actions
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -238,6 +244,19 @@ export default async function EdgeDetailPage({
                         </span>
                       )}
                     </td>
+                    {canManage && (
+                      <td className="px-4 py-3 text-right">
+                        <DeviceRowActions
+                          device={{
+                            id: device.id,
+                            name: device.name,
+                            device_type: device.device_type,
+                            openems_component_id:
+                              device.openems_component_id ?? null,
+                          }}
+                        />
+                      </td>
+                    )}
                   </tr>
                 );
               })}

--- a/src/app/api/devices/[id]/__tests__/route.test.ts
+++ b/src/app/api/devices/[id]/__tests__/route.test.ts
@@ -1,0 +1,489 @@
+/**
+ * PATCH /api/devices/[id] — route tests (#151).
+ *
+ * Covers AC-12 cases:
+ *   - Happy path: device_type only
+ *   - Happy path: name only
+ *   - Happy path: both
+ *   - Idempotent PATCH (supplied values equal current values) → 200
+ *   - Empty body → 400 no_changes
+ *   - Body with extra field (openems_component_id) → 400 unsupported_field
+ *   - Body with edge_id → 400 unsupported_field
+ *   - Invalid device_type → 400 invalid_device_type
+ *   - Empty/whitespace name → 400 name_required
+ *   - Invalid UUID in [id] → 400
+ *   - RLS-hidden device → 404
+ *   - Cross-org device for org_manager → 404 (RLS hides at SELECT)
+ *   - AC-CASCADE: reclassify a consumption_meter that has a primary
+ *     household link → 409 device_type_role_conflict
+ *   - Race protection: simulate concurrent change (UPDATE returns 0 rows) →
+ *     409 device_type_changed_concurrently
+ *   - Reclassify a non-consumption_meter device with no primary link → 200
+ *   - Reclassify consumption_meter → consumption_meter (no type change) does
+ *     NOT trigger AC-CASCADE
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Per-test mock state ─────────────────────────────────────────────────
+
+let canAccessMicrogridReturn = true;
+
+const mockDeviceFetchSingle = vi.fn();
+const mockEdgeFetchSingle = vi.fn();
+const mockHouseholdDevicesLinkSingle = vi.fn();
+const mockHouseholdsFetchSingle = vi.fn();
+const mockDevicesUpdateSingle = vi.fn();
+const mockHouseholdDevicesAllForDevice = vi.fn();
+
+let devicesFromCalls = 0;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "devices") {
+    devicesFromCalls += 1;
+    if (devicesFromCalls === 1) {
+      // First .from("devices") = the initial SELECT for fetch-by-id.
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => mockDeviceFetchSingle(),
+          }),
+        }),
+      };
+    }
+    // Second .from("devices") = the compare-and-set UPDATE.
+    return {
+      update: () => ({
+        eq: () => ({
+          eq: () => ({
+            select: () => ({
+              maybeSingle: () => mockDevicesUpdateSingle(),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === "edges") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => mockEdgeFetchSingle(),
+        }),
+      }),
+    };
+  }
+  if (table === "household_devices") {
+    return {
+      // Two distinct chains:
+      //   AC-CASCADE link check: select().eq().eq().maybeSingle()
+      //   Linked-households loop: select().eq().returns()  (returns array)
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: () => mockHouseholdDevicesLinkSingle(),
+          }),
+          // For the loop fetch: chain ends at .eq() with .returns()
+          returns: () => mockHouseholdDevicesAllForDevice(),
+        }),
+      }),
+    };
+  }
+  if (table === "households") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => mockHouseholdsFetchSingle(),
+        }),
+      }),
+    };
+  }
+  throw new Error(`Unexpected table: ${table}`);
+});
+
+const mockGetUser = vi.fn(async () => ({
+  data: { user: { id: "user-1" } },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const DEVICE_UUID = "660e8400-e29b-41d4-a716-446655440aaa";
+const EDGE_UUID = "660e8400-e29b-41d4-a716-446655440bbb";
+const MG_UUID = "660e8400-e29b-41d4-a716-446655440ccc";
+const HH_UUID = "660e8400-e29b-41d4-a716-446655440ddd";
+const BAD_ID = "not-a-uuid";
+
+function makeRequest(id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/devices/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("PATCH /api/devices/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessMicrogridReturn = true;
+    devicesFromCalls = 0;
+
+    mockDeviceFetchSingle.mockReset().mockResolvedValue({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "consumption_meter",
+        name: "meter3",
+      },
+      error: null,
+    });
+    mockEdgeFetchSingle.mockReset().mockResolvedValue({
+      data: { id: EDGE_UUID, microgrid_id: MG_UUID },
+      error: null,
+    });
+    // Default: no primary-meter link blocks reclassification.
+    mockHouseholdDevicesLinkSingle.mockReset().mockResolvedValue({
+      data: null,
+      error: null,
+    });
+    mockHouseholdsFetchSingle.mockReset().mockResolvedValue({
+      data: { id: HH_UUID, display_name: "Block A, Unit 1" },
+      error: null,
+    });
+    mockDevicesUpdateSingle.mockReset().mockResolvedValue({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "other",
+        name: "meter3",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    // Default: no extra households linked to this device (just the empty
+    // list — drives the revalidate loop).
+    mockHouseholdDevicesAllForDevice.mockReset().mockResolvedValue({
+      data: [],
+      error: null,
+    });
+  });
+
+  it("400: invalid UUID in [id]", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest(BAD_ID, { name: "x" }), {
+      params: Promise.resolve({ id: BAD_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: empty body → no_changes", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest(DEVICE_UUID, {}), {
+      params: Promise.resolve({ id: DEVICE_UUID }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("no_changes");
+  });
+
+  it("400: extra field (openems_component_id) → unsupported_field", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { openems_component_id: "meter9" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("unsupported_field");
+    expect(json.error).toContain("openems_component_id");
+  });
+
+  it("400: edge_id field → unsupported_field", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { edge_id: EDGE_UUID }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("unsupported_field");
+    expect(json.error).toContain("edge_id");
+  });
+
+  it("400: invalid device_type → invalid_device_type", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { device_type: "smart_fridge" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("invalid_device_type");
+  });
+
+  it("400: whitespace-only name → name_required", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest(DEVICE_UUID, { name: "   " }), {
+      params: Promise.resolve({ id: DEVICE_UUID }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("name_required");
+  });
+
+  it("404: device missing or RLS-hidden", async () => {
+    mockDeviceFetchSingle.mockResolvedValueOnce({ data: null, error: null });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest(DEVICE_UUID, { name: "x" }), {
+      params: Promise.resolve({ id: DEVICE_UUID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("404: cross-org device for org_manager (RLS hides at SELECT, .maybeSingle() returns null)", async () => {
+    // This is exactly the same shape as the missing-row case — RLS hides
+    // the row from the SELECT, and the route's null-check fires the 404
+    // path BEFORE the explicit currentUserCanAccessMicrogrid gate, so a
+    // 403 never surfaces for cross-org access.
+    mockDeviceFetchSingle.mockResolvedValueOnce({ data: null, error: null });
+    // Even if the gate WOULD have returned false, we never get there.
+    canAccessMicrogridReturn = false;
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { device_type: "pv_meter" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("200: happy path — device_type only", async () => {
+    mockDevicesUpdateSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "pv_meter",
+        name: "meter3",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    // Start state: device_type = pv_meter so reclassifying TO pv_meter
+    // requires we change the seed to something else first. Simplify by
+    // starting as "other" and reclassifying to "pv_meter" — neither
+    // direction triggers AC-CASCADE.
+    mockDeviceFetchSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "other",
+        name: "meter3",
+      },
+      error: null,
+    });
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { device_type: "pv_meter" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.device).toBeDefined();
+    expect(json.device.device_type).toBe("pv_meter");
+  });
+
+  it("200: happy path — name only", async () => {
+    mockDevicesUpdateSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "consumption_meter",
+        name: "Renamed Meter",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { name: "Renamed Meter" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.device.name).toBe("Renamed Meter");
+    // Name-only change does not flip type — AC-CASCADE must NOT trigger
+    // (so no link probe fires).
+    expect(mockHouseholdDevicesLinkSingle).not.toHaveBeenCalled();
+  });
+
+  it("200: happy path — both device_type and name", async () => {
+    mockDeviceFetchSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "other",
+        name: "meter3",
+      },
+      error: null,
+    });
+    mockDevicesUpdateSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "consumption_meter",
+        name: "Block A Meter",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, {
+        device_type: "consumption_meter",
+        name: "Block A Meter",
+      }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.device.device_type).toBe("consumption_meter");
+    expect(json.device.name).toBe("Block A Meter");
+  });
+
+  it("200: idempotent PATCH (supplied values equal current values)", async () => {
+    // Fetched + supplied values match. The route still issues the UPDATE
+    // (Supabase .update() is naturally idempotent). 200 with the row.
+    mockDevicesUpdateSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "consumption_meter",
+        name: "meter3",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, {
+        device_type: "consumption_meter",
+        name: "meter3",
+      }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    // No type change → no AC-CASCADE probe.
+    expect(mockHouseholdDevicesLinkSingle).not.toHaveBeenCalled();
+  });
+
+  it("409: AC-CASCADE — consumption_meter with primary link → device_type_role_conflict", async () => {
+    mockHouseholdDevicesLinkSingle.mockResolvedValueOnce({
+      data: { household_id: HH_UUID },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { device_type: "other" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("device_type_role_conflict");
+    expect(json.household).toBeDefined();
+    expect(json.household.id).toBe(HH_UUID);
+    expect(json.household.display_name).toBe("Block A, Unit 1");
+    // Conflict path short-circuits BEFORE the UPDATE.
+    expect(mockDevicesUpdateSingle).not.toHaveBeenCalled();
+  });
+
+  it("409: race protection — UPDATE returns 0 rows → device_type_changed_concurrently", async () => {
+    // No primary link blocks the change…
+    mockHouseholdDevicesLinkSingle.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    });
+    // …but a concurrent writer flipped device_type between SELECT and
+    // UPDATE — the compare-and-set guard returns no row.
+    mockDevicesUpdateSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { device_type: "other" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("device_type_changed_concurrently");
+  });
+
+  it("200: reclassify a non-consumption_meter device with no primary link", async () => {
+    mockDeviceFetchSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "other",
+        name: "meter3",
+      },
+      error: null,
+    });
+    mockDevicesUpdateSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "pv_meter",
+        name: "meter3",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, { device_type: "pv_meter" }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    // Going FROM "other" → not consumption_meter → AC-CASCADE doesn't
+    // probe (the guard only fires when going AWAY FROM consumption_meter).
+    expect(mockHouseholdDevicesLinkSingle).not.toHaveBeenCalled();
+  });
+
+  it("200: reclassify consumption_meter → consumption_meter (no type change) does NOT trigger AC-CASCADE", async () => {
+    mockDevicesUpdateSingle.mockResolvedValueOnce({
+      data: {
+        id: DEVICE_UUID,
+        edge_id: EDGE_UUID,
+        device_type: "consumption_meter",
+        name: "meter3-renamed",
+        openems_component_id: "meter3",
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest(DEVICE_UUID, {
+        device_type: "consumption_meter",
+        name: "meter3-renamed",
+      }),
+      { params: Promise.resolve({ id: DEVICE_UUID }) }
+    );
+    expect(res.status).toBe(200);
+    expect(mockHouseholdDevicesLinkSingle).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/devices/[id]/route.ts
+++ b/src/app/api/devices/[id]/route.ts
@@ -1,0 +1,342 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import type { DeviceType } from "@/lib/types/domain";
+
+/**
+ * PATCH /api/devices/[id] — reclassify a discovered device (#151).
+ *
+ * Reclassifies a previously-saved device's `device_type` and/or renames it.
+ * Targets the recovery path for misclassifications detected after the
+ * Discover-and-save flow finished — operators previously had to either re-run
+ * Discover (operationally awkward for an already-added device) or drop into
+ * SQL.
+ *
+ * Body shape (allow-list — anything else returns 400 `unsupported_field`):
+ *
+ *   {
+ *     device_type?: DeviceType;
+ *     name?:        string;   // trimmed; non-empty
+ *   }
+ *
+ * Identity fields (`openems_component_id`, `edge_id`) are NEVER editable here
+ * — changing identity is a delete + re-add. Reject loudly so callers get a
+ * clear pointer.
+ *
+ * Permission gate: super_admin OR org_manager via
+ * `currentUserCanAccessMicrogrid` (resolved through devices → edges →
+ * microgrid_id). Mirrors the closest sibling — `POST /api/devices` — which
+ * also has no super-admin-only gate. This is a data PATCH, not OpenEMS-config.
+ *
+ * AC-CASCADE — role/device_type conflict guard:
+ *   When changing `device_type` AWAY from `consumption_meter` and the device
+ *   is currently linked as a household's `primary_consumption_meter`, the
+ *   route returns 409 `device_type_role_conflict` (with the linked
+ *   household's id + display_name in the body). The UI surfaces this as a
+ *   destructive ConfirmDialog offering "Unlink household and reclassify",
+ *   which performs the unlink then re-issues the PATCH (two sequential
+ *   server calls — no transactional combiner).
+ *
+ * Race protection (compare-and-set):
+ *   After the conflict-check passes, the actual UPDATE includes
+ *   `.eq("device_type", observedDeviceType)` so a concurrent state change
+ *   between the SELECT and the UPDATE produces a zero-row result — the
+ *   route then returns 409 `device_type_changed_concurrently`. This closes
+ *   the unlink-then-relink race window where a parallel
+ *   PATCH /api/households/[id] could reclaim the just-unlinked device.
+ *
+ * Pattern mirrors `src/app/api/households/[id]/route.ts` for ALLOWED_FIELDS
+ * + UUID_RE + .maybeSingle() null-as-404, with the AC-6 compare-and-set
+ * UPDATE as the one place this route diverges (households doesn't need it
+ * because there's no equivalent role↔device_type cross-table invariant).
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ALLOWED_FIELDS = new Set(["device_type", "name"]);
+
+const VALID_DEVICE_TYPES: ReadonlySet<DeviceType> = new Set<DeviceType>([
+  "consumption_meter",
+  "grid_meter",
+  "pv_meter",
+  "battery",
+  "inverter",
+  "ev_charger",
+  "other",
+]);
+
+type DeviceUpdate = {
+  device_type?: DeviceType;
+  name?: string;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid device ID — expected UUID" },
+      { status: 400 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "Request body must be an object" },
+      { status: 400 }
+    );
+  }
+
+  // Reject any unsupported field up front so callers get a clear pointer.
+  const bodyRec = body as Record<string, unknown>;
+  for (const key of Object.keys(bodyRec)) {
+    if (!ALLOWED_FIELDS.has(key)) {
+      return NextResponse.json(
+        { error: `Unsupported field: ${key}`, reason: "unsupported_field" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Validate device_type when present.
+  const update: DeviceUpdate = {};
+  if ("device_type" in bodyRec) {
+    const dt = bodyRec.device_type;
+    if (typeof dt !== "string" || !VALID_DEVICE_TYPES.has(dt as DeviceType)) {
+      return NextResponse.json(
+        {
+          error:
+            "device_type must be one of consumption_meter, grid_meter, pv_meter, battery, inverter, ev_charger, other.",
+          reason: "invalid_device_type",
+        },
+        { status: 400 }
+      );
+    }
+    update.device_type = dt as DeviceType;
+  }
+
+  // Validate name when present (must be non-empty after trim).
+  if ("name" in bodyRec) {
+    const n = bodyRec.name;
+    if (typeof n !== "string" || n.trim().length === 0) {
+      return NextResponse.json(
+        {
+          error: "name must be a non-empty string",
+          reason: "name_required",
+        },
+        { status: 400 }
+      );
+    }
+    update.name = n.trim();
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json(
+      { error: "No fields provided to update", reason: "no_changes" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Fetch the device (RLS-filtered) — `.maybeSingle()` + null-check produces
+  // a clean 404 for missing OR RLS-hidden rows. We need the edge_id to
+  // resolve microgrid_id (perm check + revalidatePath) and the current
+  // device_type as the compare-and-set guard value.
+  const { data: existing, error: fetchError } = await supabase
+    .from("devices")
+    .select("id, edge_id, device_type, name")
+    .eq("id", id)
+    .maybeSingle<{
+      id: string;
+      edge_id: string;
+      device_type: DeviceType;
+      name: string;
+    }>();
+
+  if (fetchError) {
+    if (fetchError.code === "PGRST116") {
+      return NextResponse.json({ error: "Device not found" }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: fetchError.message ?? "Device not found" },
+      { status: 404 }
+    );
+  }
+  if (!existing) {
+    return NextResponse.json({ error: "Device not found" }, { status: 404 });
+  }
+
+  // Resolve microgrid_id via the edge.
+  const { data: edgeRow, error: edgeError } = await supabase
+    .from("edges")
+    .select("id, microgrid_id")
+    .eq("id", existing.edge_id)
+    .maybeSingle<{ id: string; microgrid_id: string }>();
+
+  if (edgeError || !edgeRow) {
+    // RLS-hidden edge — surface as 404 like the device case above.
+    return NextResponse.json({ error: "Device not found" }, { status: 404 });
+  }
+
+  const microgridId = edgeRow.microgrid_id;
+
+  const canAccess = await currentUserCanAccessMicrogrid(supabase, microgridId);
+  if (!canAccess) {
+    return NextResponse.json(
+      {
+        error: "You do not have permission to update this device.",
+        reason: "forbidden",
+      },
+      { status: 403 }
+    );
+  }
+
+  const observedDeviceType = existing.device_type;
+  const newDeviceType = update.device_type ?? observedDeviceType;
+  const typeIsChanging = newDeviceType !== observedDeviceType;
+
+  // AC-CASCADE — role/device_type conflict guard.
+  // When the type would change AWAY from consumption_meter and the device
+  // is currently linked as a household's primary_consumption_meter, abort
+  // with 409 (with the household details so the UI can offer the
+  // unlink-and-reclassify confirm flow).
+  if (
+    typeIsChanging &&
+    observedDeviceType === "consumption_meter" &&
+    newDeviceType !== "consumption_meter"
+  ) {
+    const { data: link } = await supabase
+      .from("household_devices")
+      .select("household_id")
+      .eq("device_id", id)
+      .eq("role", "primary_consumption_meter")
+      .maybeSingle<{ household_id: string }>();
+
+    if (link?.household_id) {
+      const { data: hh } = await supabase
+        .from("households")
+        .select("id, display_name")
+        .eq("id", link.household_id)
+        .maybeSingle<{ id: string; display_name: string }>();
+
+      return NextResponse.json(
+        {
+          error:
+            "This device is the primary consumption meter for a household. Unlink the household first, then reclassify.",
+          reason: "device_type_role_conflict",
+          household: {
+            id: hh?.id ?? link.household_id,
+            display_name: hh?.display_name ?? null,
+          },
+        },
+        { status: 409 }
+      );
+    }
+  }
+
+  // Compare-and-set UPDATE (AC-6 race protection). Including
+  // `.eq("device_type", observedDeviceType)` ensures a concurrent writer
+  // that mutated device_type between our SELECT and UPDATE produces a
+  // zero-row result — surfaced as 409 device_type_changed_concurrently.
+  const { data: updated, error: updateError } = await supabase
+    .from("devices")
+    .update(update)
+    .eq("id", id)
+    .eq("device_type", observedDeviceType)
+    .select("id, edge_id, device_type, name, openems_component_id")
+    .maybeSingle();
+
+  if (updateError) {
+    if (
+      updateError.code === "42501" ||
+      updateError.message.includes("row-level security")
+    ) {
+      return NextResponse.json(
+        {
+          error: "Not authorized to update this device.",
+          reason: "rls_denied",
+        },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to update device: ${updateError.message}` },
+      { status: 500 }
+    );
+  }
+
+  if (!updated) {
+    // CAS guard fired — device_type changed under us between SELECT and UPDATE.
+    return NextResponse.json(
+      {
+        error:
+          "Device state changed during update. Refresh and retry the reclassification.",
+        reason: "device_type_changed_concurrently",
+      },
+      { status: 409 }
+    );
+  }
+
+  // revalidatePath calls (AC-7) — refresh every server-rendered surface
+  // that reads device_type.
+  revalidatePath(
+    `/microgrids/${microgridId}/setup/edges/${existing.edge_id}`,
+    "page"
+  );
+  revalidatePath(`/microgrids/${microgridId}/setup/edges/shared`, "page");
+  revalidatePath(`/microgrids/${microgridId}/setup/households`, "page");
+
+  // Loop the household-detail revalidation across every household linked
+  // through household_devices — the household-detail page filters on
+  // device_type to surface the billing meter, so any linked household must
+  // be invalidated regardless of role.
+  const { data: linkedHouseholds } = await supabase
+    .from("household_devices")
+    .select("household_id")
+    .eq("device_id", id)
+    .returns<{ household_id: string }[]>();
+
+  const linkedIds = new Set<string>(
+    (linkedHouseholds ?? []).map((r) => r.household_id)
+  );
+  for (const householdId of linkedIds) {
+    revalidatePath(
+      `/microgrids/${microgridId}/setup/households/${householdId}`,
+      "page"
+    );
+  }
+
+  // Structured success log — counts only, no PII.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  console.info(
+    JSON.stringify({
+      event: "device.update",
+      device_id: id,
+      microgrid_id: microgridId,
+      edge_id: existing.edge_id,
+      changed_fields: Object.keys(update),
+      type_changed: typeIsChanging,
+      from_device_type: typeIsChanging ? observedDeviceType : null,
+      to_device_type: typeIsChanging ? newDeviceType : null,
+      actor_user_id: user?.id ?? null,
+      at: new Date().toISOString(),
+    })
+  );
+
+  return NextResponse.json({ device: updated }, { status: 200 });
+}

--- a/src/components/forms/DeviceEditDialog.tsx
+++ b/src/components/forms/DeviceEditDialog.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+/**
+ * DeviceEditDialog — reclassify a discovered device (#151).
+ *
+ * Surface contract:
+ *   - 640px width, mirroring HouseholdEditDialog (#145).
+ *   - Header shows the CURRENT device_type via <StatusChip
+ *     kind="deviceType">. Per CLAUDE.md Design System rule 1, never hand-roll
+ *     a status chip.
+ *   - Body has:
+ *       1. `name` text input
+ *       2. `device_type` Select (reusing the DEVICE_TYPE_HELP option list
+ *          from src/components/DiscoverDevices.tsx)
+ *       3. `openems_component_id` rendered read-only (Out of Scope per
+ *          AC-3 — identity fields are immutable).
+ *   - Save: PATCH /api/devices/[id] with the diff of changed fields only.
+ *     Disabled when (a) submitting, (b) name is empty after trim, (c) no
+ *     field is dirty vs initial state.
+ *   - 409 device_type_role_conflict — surface a destructive ConfirmDialog
+ *     ("Unlink household and reclassify") that, on confirm, runs:
+ *        1. PATCH /api/households/[id] { device_id: null }  — unlink
+ *        2. PATCH /api/devices/[id] { ...same diff }        — reclassify
+ *     Two sequential server calls (no transactional combiner) — matches
+ *     AC-CASCADE.
+ *   - 409 device_type_changed_concurrently — surface a "Device state
+ *     changed — refresh and retry" inline error (Banner). Operator hits
+ *     refresh.
+ */
+
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { StatusChip } from "@/components/ui/status-chip";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DEVICE_TYPE_HELP } from "@/lib/device-type-help";
+import { cn } from "@/lib/utils";
+import type { DeviceType } from "@/lib/types/domain";
+
+const DEVICE_TYPE_OPTIONS: DeviceType[] = [
+  "consumption_meter",
+  "grid_meter",
+  "pv_meter",
+  "battery",
+  "inverter",
+  "ev_charger",
+  "other",
+];
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type DeviceEditDialogDevice = {
+  id: string;
+  name: string;
+  device_type: DeviceType;
+  openems_component_id: string | null;
+};
+
+export interface DeviceEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  device: DeviceEditDialogDevice;
+}
+
+type FormState = {
+  name: string;
+  device_type: DeviceType;
+};
+
+function initialState(d: DeviceEditDialogDevice): FormState {
+  return { name: d.name ?? "", device_type: d.device_type };
+}
+
+function isDirty(cur: FormState, init: FormState): boolean {
+  return cur.name !== init.name || cur.device_type !== init.device_type;
+}
+
+function buildDiff(
+  cur: FormState,
+  init: FormState
+): Partial<{ name: string; device_type: DeviceType }> {
+  const out: Partial<{ name: string; device_type: DeviceType }> = {};
+  if (cur.name.trim() !== init.name) out.name = cur.name.trim();
+  if (cur.device_type !== init.device_type) out.device_type = cur.device_type;
+  return out;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function DeviceEditDialog({
+  open,
+  onOpenChange,
+  device,
+}: DeviceEditDialogProps) {
+  const router = useRouter();
+
+  const init = React.useMemo(() => initialState(device), [device]);
+
+  const [state, setState] = React.useState<FormState>(init);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [topError, setTopError] = React.useState<string | null>(null);
+  const [confirmCancelOpen, setConfirmCancelOpen] = React.useState(false);
+  const [conflictHousehold, setConflictHousehold] = React.useState<{
+    id: string;
+    display_name: string | null;
+  } | null>(null);
+  const firstFieldRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      setState(init);
+      setSubmitting(false);
+      setTopError(null);
+      setConflictHousehold(null);
+    }
+  }, [open, init]);
+
+  const dirty = isDirty(state, init);
+  const nameValid = state.name.trim().length > 0;
+  const canSave = dirty && nameValid && !submitting;
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setState((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function postPatch(
+    body: Partial<{ name: string; device_type: DeviceType }>
+  ): Promise<Response> {
+    return fetch(`/api/devices/${device.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function handleSubmit(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (!canSave) return;
+    setSubmitting(true);
+    setTopError(null);
+    setConflictHousehold(null);
+    try {
+      const res = await postPatch(buildDiff(state, init));
+      if (res.ok) {
+        router.refresh();
+        onOpenChange(false);
+        return;
+      }
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        reason?: string;
+        household?: { id: string; display_name: string | null };
+      };
+      if (res.status === 409 && body.reason === "device_type_role_conflict") {
+        setConflictHousehold(
+          body.household ?? { id: "", display_name: null }
+        );
+        setSubmitting(false);
+        return;
+      }
+      setTopError(body.error ?? `Could not save (HTTP ${res.status}).`);
+      setSubmitting(false);
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : "Network error.");
+      setSubmitting(false);
+    }
+  }
+
+  // Unlink-and-reclassify: two sequential server calls (no transactional
+  // combiner). On any failure, surface inline; the dialog stays open.
+  async function handleUnlinkAndReclassify(): Promise<void> {
+    if (!conflictHousehold) return;
+    // Step 1 — unlink
+    const unlinkRes = await fetch(
+      `/api/households/${conflictHousehold.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_id: null }),
+      }
+    );
+    if (!unlinkRes.ok) {
+      const body = (await unlinkRes.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      throw new Error(
+        body.error ?? `Unlink failed (HTTP ${unlinkRes.status}).`
+      );
+    }
+    // Step 2 — reclassify
+    const reclassifyRes = await postPatch(buildDiff(state, init));
+    if (!reclassifyRes.ok) {
+      const body = (await reclassifyRes.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      throw new Error(
+        body.error ?? `Reclassify failed (HTTP ${reclassifyRes.status}).`
+      );
+    }
+    router.refresh();
+    setConflictHousehold(null);
+    onOpenChange(false);
+  }
+
+  function requestClose(next: boolean) {
+    if (!next && dirty) {
+      setConfirmCancelOpen(true);
+      return;
+    }
+    onOpenChange(next);
+  }
+
+  return (
+    <>
+      <Dialog.Root open={open} onOpenChange={requestClose}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55" />
+          <Dialog.Content
+            aria-modal
+            aria-describedby="dev-edit-desc"
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+              firstFieldRef.current?.focus();
+            }}
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[640px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+              "max-h-[92vh] overflow-y-auto rounded-md border border-border bg-card shadow-elev-3 outline-none"
+            )}
+          >
+            {/* top rail */}
+            <div aria-hidden="true" className="h-[6px] bg-primary" />
+
+            <div className="px-6 pt-5">
+              <Dialog.Title className="text-xl font-semibold tracking-tight text-foreground">
+                Edit device
+              </Dialog.Title>
+              <Dialog.Description
+                id="dev-edit-desc"
+                className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground"
+              >
+                <span>Currently classified as</span>
+                <StatusChip kind="deviceType" status={device.device_type} />
+              </Dialog.Description>
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              className="space-y-5 px-6 pb-2 pt-4"
+              noValidate
+            >
+              {topError && (
+                <Banner tone="destructive" title="Could not save">
+                  {topError}
+                </Banner>
+              )}
+
+              {/* NAME */}
+              <div>
+                <label
+                  htmlFor="dev-edit-name"
+                  className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Device name
+                  <span aria-hidden="true" className="ml-0.5 text-destructive-fg">
+                    *
+                  </span>
+                  <span className="sr-only"> (required)</span>
+                </label>
+                <Input
+                  id="dev-edit-name"
+                  ref={firstFieldRef}
+                  value={state.name}
+                  onChange={(e) => update("name", e.target.value)}
+                  required
+                  aria-required="true"
+                  aria-invalid={nameValid ? undefined : "true"}
+                  className={cn(
+                    !nameValid && "border-destructive ring-1 ring-destructive"
+                  )}
+                />
+              </div>
+
+              {/* DEVICE TYPE */}
+              <div>
+                <label
+                  htmlFor="dev-edit-type"
+                  className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Device type
+                </label>
+                <Select
+                  value={state.device_type}
+                  onValueChange={(val) => update("device_type", val as DeviceType)}
+                >
+                  <SelectTrigger id="dev-edit-type" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DEVICE_TYPE_OPTIONS.map((dt) => (
+                      <SelectItem key={dt} value={dt}>
+                        {DEVICE_TYPE_HELP[dt].label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {DEVICE_TYPE_HELP[state.device_type].description}
+                </p>
+              </div>
+
+              {/* OPENEMS COMPONENT ID — read-only */}
+              <div>
+                <label
+                  htmlFor="dev-edit-component-id"
+                  className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  OpenEMS component ID
+                </label>
+                <Input
+                  id="dev-edit-component-id"
+                  value={device.openems_component_id ?? "—"}
+                  readOnly
+                  disabled
+                  className="font-mono"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Identity field — to change, remove the device and re-run Discover.
+                </p>
+              </div>
+            </form>
+
+            <div className="mt-2 flex items-center justify-end gap-2 border-t border-border bg-muted px-6 pb-[18px] pt-[14px]">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  disabled={submitting}
+                  className="inline-flex h-8 items-center rounded-md px-3.5 text-[13px] font-medium text-foreground hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="button"
+                onClick={() => handleSubmit()}
+                disabled={!canSave}
+                className="inline-flex h-8 items-center rounded-md bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {submitting ? "Saving…" : "Save changes"}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      {/* Cancel-when-dirty confirm — neutral. */}
+      <ConfirmDialog
+        open={confirmCancelOpen}
+        onOpenChange={setConfirmCancelOpen}
+        tone="neutral"
+        title="Discard unsaved changes?"
+        description="Your edits will be lost."
+        confirmLabel="Discard"
+        onConfirm={async () => {
+          setConfirmCancelOpen(false);
+          onOpenChange(false);
+        }}
+      />
+
+      {/* AC-CASCADE confirm — destructive. Two sequential server calls
+          (unlink, then reclassify). */}
+      <ConfirmDialog
+        open={Boolean(conflictHousehold)}
+        onOpenChange={(o) => {
+          if (!o) setConflictHousehold(null);
+        }}
+        tone="destructive"
+        title="Unlink household and reclassify?"
+        description={
+          conflictHousehold
+            ? `This device is currently the primary consumption meter for "${
+                conflictHousehold.display_name ?? "a household"
+              }". Reclassifying will unlink the household — you'll need to assign a new meter before billing the next period.`
+            : undefined
+        }
+        confirmLabel="Unlink and reclassify"
+        onConfirm={handleUnlinkAndReclassify}
+      />
+    </>
+  );
+}

--- a/src/components/forms/__tests__/DeviceEditDialog.test.tsx
+++ b/src/components/forms/__tests__/DeviceEditDialog.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+/**
+ * DeviceEditDialog smoke test (#151).
+ *
+ * Coverage: open dialog → change device_type → save → PATCH fired → dialog closes.
+ */
+
+import * as React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DeviceEditDialog } from "../DeviceEditDialog";
+import type { DeviceEditDialogDevice } from "../DeviceEditDialog";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = function () {};
+  }
+  if (typeof Element.prototype.hasPointerCapture !== "function") {
+    Element.prototype.hasPointerCapture = function () {
+      return false;
+    };
+  }
+  if (typeof Element.prototype.releasePointerCapture !== "function") {
+    Element.prototype.releasePointerCapture = function () {};
+  }
+});
+
+const DEVICE: DeviceEditDialogDevice = {
+  id: "660e8400-e29b-41d4-a716-446655440aaa",
+  name: "meter3",
+  device_type: "other",
+  openems_component_id: "meter3",
+};
+
+describe("DeviceEditDialog (#151)", () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens, changes type via Select, saves, PATCHes the diff, closes", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ device: { id: DEVICE.id } }),
+    } as Response);
+
+    const onOpenChange = vi.fn();
+    render(
+      <DeviceEditDialog open={true} onOpenChange={onOpenChange} device={DEVICE} />
+    );
+
+    // Save is initially disabled (clean form).
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+
+    // Change name to dirty the form (Select keyboard-nav under jsdom is
+    // brittle; the diff-builder cares about field equality, not which
+    // input drives the change).
+    const nameInput = screen.getByLabelText(/Device name/i) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Block A meter" } });
+
+    // Save is now enabled.
+    const saveBtnAfter = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtnAfter).toHaveProperty("disabled", false);
+
+    fireEvent.click(saveBtnAfter);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`/api/devices/${DEVICE.id}`);
+    expect(init?.method).toBe("PATCH");
+
+    const body = JSON.parse(init?.body as string);
+    // Only the name changed → diff has only `name`.
+    expect(body).toEqual({ name: "Block A meter" });
+
+    // Dialog closes (onOpenChange(false) called).
+    await waitFor(() =>
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    );
+  });
+
+  it("renders the current device_type as a StatusChip in the header", () => {
+    render(
+      <DeviceEditDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        device={{ ...DEVICE, device_type: "consumption_meter" }}
+      />
+    );
+    // StatusChip kind="deviceType" status="consumption_meter" → "Consumption meter"
+    expect(screen.getAllByText(/Consumption meter/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders openems_component_id as a read-only input", () => {
+    render(
+      <DeviceEditDialog open={true} onOpenChange={vi.fn()} device={DEVICE} />
+    );
+    const componentIdInput = screen.getByLabelText(
+      /OpenEMS component ID/i
+    ) as HTMLInputElement;
+    expect(componentIdInput.value).toBe("meter3");
+    expect(componentIdInput.readOnly || componentIdInput.disabled).toBe(true);
+  });
+
+  it("disables Save when name is whitespace-only", () => {
+    render(
+      <DeviceEditDialog open={true} onOpenChange={vi.fn()} device={DEVICE} />
+    );
+    const nameInput = screen.getByLabelText(/Device name/i) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "   " } });
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+});


### PR DESCRIPTION
## Summary

- New `PATCH /api/devices/[id]` route: allow-listed `device_type` and `name` only; `.maybeSingle()` 404 on RLS-hidden rows; `currentUserCanAccessMicrogrid` permission gate (super_admin + org_manager).
- AC-CASCADE conflict guard: when `device_type` changes away from `consumption_meter`, returns 409 `device_type_role_conflict` with linked household details. UI surfaces a destructive ConfirmDialog offering "Unlink household and reclassify".
- Compare-and-set race guard on UPDATE (`.eq("device_type", observedDeviceType)`) → 409 `device_type_changed_concurrently` if state changed between SELECT and write. Closes the unlink-then-relink window.
- `revalidatePath` fans out to all four affected surfaces (edge detail, shared edges, household-create, each linked household).
- New `DeviceEditDialog` (640px, mirrors HouseholdEditDialog) wired into the edge detail page via a kebab/dropdown affordance per device row.
- 20 new tests (16 route + 4 dialog smoke).

Closes #151.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `SKIP_RLS_TESTS=1 npm test` — 934/934 pass
- [x] `npm run build`
- [x] Reviewer agent walked all 13 ACs — VERDICT: APPROVE, zero blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)