### PR TITLE
Pesapal: shrink order id with crockford-base32 (#156)

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
@@ -179,7 +179,8 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
 
     // Pesapal rejects reused ids — every call must generate a fresh orderId.
     const call = generatePaymentLinkMock.mock.calls[0][0];
-    expect(call.orderId).toMatch(new RegExp(`^INV-${LINE_ITEM_ID}-\\d+$`));
+    expect(call.orderId).toMatch(/^INV-[0-9A-HJKMNPQ-TV-Z]{26}-\d+$/);
+    expect(call.orderId.length).toBeLessThanOrEqual(50);
     expect(call.currency).toBe("UGX");
 
     infoSpy.mockRestore();

--- a/src/app/api/billing-line-items/[lineItemId]/url/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/route.ts
@@ -34,6 +34,7 @@ import {
 } from "@/lib/payments";
 import { getCommunityPaymentConfig } from "@/lib/payments/config";
 import { buildOrderParamsFromLineItem } from "@/lib/payments/pesapal/build-params";
+import { buildOrderId } from "@/lib/payments/pesapal/order-id";
 import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
 
 const UUID_RE =
@@ -231,8 +232,10 @@ export async function POST(
     currency = "UGX";
   }
 
-  // 6. Pesapal rejects reused `id` — fresh per click.
-  const orderId = `INV-${lineItemId}-${Date.now()}`;
+  // 6. Pesapal rejects reused `id` — fresh per click. Pesapal caps `id` at
+  //    50 chars; `buildOrderId` encodes the UUID as crockford-base32 so the
+  //    composed id stays at 44 chars. See src/lib/payments/pesapal/order-id.ts.
+  const orderId = buildOrderId(lineItemId);
 
   // 7. Dispatch through the factory. The PesapalProvider constructor itself
   //    throws PESAPAL_NO_IPN when the persisted config lacks ipn_id (a

--- a/src/lib/payments/pesapal/__tests__/order-id.test.ts
+++ b/src/lib/payments/pesapal/__tests__/order-id.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildOrderId, uuidToCrockfordBase32 } from "../order-id";
+
+const CROCKFORD_REGEX = /^[0-9A-HJKMNPQ-TV-Z]{26}$/;
+const ORDER_ID_REGEX = /^INV-[0-9A-HJKMNPQ-TV-Z]{26}-\d+$/;
+
+describe("uuidToCrockfordBase32", () => {
+  it("encodes a UUID to exactly 26 crockford-base32 chars", () => {
+    const out = uuidToCrockfordBase32("00000000-0000-0000-0000-000000000000");
+    expect(out).toHaveLength(26);
+    expect(out).toMatch(CROCKFORD_REGEX);
+  });
+
+  it("is deterministic — same UUID input produces same output", () => {
+    const uuid = "5b1d9e2a-7c4f-4d5b-8e6f-1a2b3c4d5e6f";
+    expect(uuidToCrockfordBase32(uuid)).toBe(uuidToCrockfordBase32(uuid));
+  });
+
+  it("uses only crockford alphabet chars (no I/L/O/U) for 10 random UUIDs", () => {
+    for (let i = 0; i < 10; i++) {
+      const uuid = crypto.randomUUID();
+      const out = uuidToCrockfordBase32(uuid);
+      expect(out).toHaveLength(26);
+      expect(out).toMatch(CROCKFORD_REGEX);
+    }
+  });
+
+  it("produces distinct outputs for distinct UUIDs (no-collision sanity)", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      seen.add(uuidToCrockfordBase32(crypto.randomUUID()));
+    }
+    expect(seen.size).toBe(50);
+  });
+
+  it("accepts UUIDs without dashes", () => {
+    const dashed = "5b1d9e2a-7c4f-4d5b-8e6f-1a2b3c4d5e6f";
+    const undashed = dashed.replace(/-/g, "");
+    expect(uuidToCrockfordBase32(undashed)).toBe(uuidToCrockfordBase32(dashed));
+  });
+
+  it("throws on invalid UUID input", () => {
+    expect(() => uuidToCrockfordBase32("not-a-uuid")).toThrow();
+    expect(() => uuidToCrockfordBase32("")).toThrow();
+  });
+
+  it("encodes the all-ones UUID to the expected high-bit value", () => {
+    // 16 bytes of 0xFF = 128 bits set. Crockford encoding of all-ones bits
+    // ends with the alphabet's last char in the high-bit nibble; the final
+    // char is the 3-bit-payload + 2-bit-zero-pad, so it should be 'W'
+    // (binary 11100, decimal 28 — index of 'W' in
+    // 0123456789ABCDEFGHJKMNPQRSTVWXYZ).
+    const out = uuidToCrockfordBase32("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    expect(out).toHaveLength(26);
+    expect(out.slice(0, 25)).toBe("Z".repeat(25));
+    expect(out[25]).toBe("W");
+  });
+});
+
+describe("buildOrderId", () => {
+  it("matches the INV-{26}-{ms} pattern", () => {
+    const id = buildOrderId(crypto.randomUUID());
+    expect(id).toMatch(ORDER_ID_REGEX);
+  });
+
+  it("stays at or below Pesapal's 50-char limit for 10 random UUIDs", () => {
+    for (let i = 0; i < 10; i++) {
+      const id = buildOrderId(crypto.randomUUID());
+      expect(id.length).toBeLessThanOrEqual(50);
+      // Sanity: 4 ('INV-') + 26 (base32) + 1 ('-') + ≥13 (ms) = ≥44.
+      expect(id.length).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  it("uses the encoded base32 form, not the raw UUID", () => {
+    const uuid = "5b1d9e2a-7c4f-4d5b-8e6f-1a2b3c4d5e6f";
+    const id = buildOrderId(uuid);
+    expect(id).not.toContain(uuid);
+    expect(id).toContain(uuidToCrockfordBase32(uuid));
+  });
+});

--- a/src/lib/payments/pesapal/order-id.ts
+++ b/src/lib/payments/pesapal/order-id.ts
@@ -1,0 +1,63 @@
+/**
+ * Pesapal order-id construction.
+ *
+ * ID layout: `INV-{26}-{13}` = 44 chars
+ *   - `INV-`            (4 chars)  fixed prefix
+ *   - 26 base32 chars   (26 chars) crockford-base32 of the 16-byte UUID
+ *   - `-`               (1 char)
+ *   - `Date.now()`      (13 chars) millisecond timestamp; Pesapal rejects
+ *                                  duplicate ids, so re-clicks on the same
+ *                                  line item must produce a fresh suffix
+ *
+ * Pesapal caps `id` at 50 chars (see
+ * https://developer.pesapal.com/how-to-integrate/e-commerce/api-30-json/submitorderrequest).
+ * The previous `INV-{uuid}-{ms}` format was 54 chars and would have failed
+ * Pesapal-side validation; this encoding leaves a 6-char safety margin.
+ *
+ * Why crockford-base32: alphabet `0123456789ABCDEFGHJKMNPQRSTVWXYZ` omits
+ * `I`, `L`, `O`, `U` so the id remains unambiguous if it is ever read aloud
+ * or transcribed by hand. The encoding is bijective on the 128-bit UUID
+ * input, so collisions on the base32 piece occur iff the source UUIDs
+ * collide (i.e. it inherits v4-UUID's 122 bits of entropy).
+ */
+
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/**
+ * Encode a UUID string (with or without dashes) as 26 chars of
+ * crockford-base32. The 128-bit input → 26 × 5-bit chars (the final char
+ * carries 3 valid bits + 2 zero pad bits — no `=` padding emitted).
+ */
+export function uuidToCrockfordBase32(uuid: string): string {
+  const hex = uuid.replace(/-/g, "");
+  if (!/^[0-9a-fA-F]{32}$/.test(hex)) {
+    throw new Error(`Invalid UUID: ${uuid}`);
+  }
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    value = (value << 8) | bytes[i];
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += CROCKFORD_ALPHABET[(value >>> bits) & 0x1f];
+    }
+  }
+  if (bits > 0) {
+    out += CROCKFORD_ALPHABET[(value << (5 - bits)) & 0x1f];
+  }
+  return out;
+}
+
+/**
+ * Build a Pesapal-safe order id from a `billing_line_items.id` UUID.
+ * Returns `INV-{26 base32 chars}-{ms}` (44 chars total, ≤50 char limit).
+ */
+export function buildOrderId(lineItemId: string): string {
+  return `INV-${uuidToCrockfordBase32(lineItemId)}-${Date.now()}`;
+}


### PR DESCRIPTION
## Summary

- New `order-id.ts` helper with crockford-base32 UUID encoding (`0123456789ABCDEFGHJKMNPQRSTVWXYZ`, no I/L/O/U).
- Replaces `INV-{uuid}-{ms}` (54 chars) with `INV-{base32(uuid)}-{ms}` (44 chars) — under Pesapal's 50-char `id` cap.
- 10 unit tests in `order-id.test.ts` cover length, determinism, alphabet, edge cases, no-collision.

Closes #156.

## Test plan

- [x] lint, tsc, test (964 pass), build all green
- [x] Reviewer agent walked all ACs — VERDICT: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)