### PR TITLE
Close period dialog: collapse phases, neutral tone (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Five rules every contributor must follow:
 
 4. **Copy table:** Use `<CopyTable>` for billing data tables (built-in per-cell copy + keyboard nav). Grand-total footer rows go BELOW the CopyTable as a `<div>` — CopyTable doesn't support footer rows. Retain `<CopyButton>` only for footer cells.
 
-5. **Destructive actions:** Use `<ConfirmDialog tone="destructive">` for delete flows (Delete Period, Delete Meter, Delete Tenant). Use `<ClosePeriodDialog>` for billing-period close (irreversible, needs multi-channel confirm). Use `<ConfirmDialog tone="neutral">` for non-destructive warnings (e.g. remove-last-tier). Never use `confirm()` — it blocks the main thread and can't be tested.
+5. **Destructive actions:** Use `<ConfirmDialog tone="destructive">` for delete flows (Delete Period, Delete Meter, Delete Tenant). Use `<ClosePeriodDialog>` for billing-period close (irreversible, needs multi-channel confirm via totals review + checkbox). Styled in neutral/primary tone — closing is a final commit, not a destruction. Reserve destructive tone for delete-entity flows (`<ConfirmDialog tone="destructive">`). Use `<ConfirmDialog tone="neutral">` for non-destructive warnings (e.g. remove-last-tier). Never use `confirm()` — it blocks the main thread and can't be tested.
 
 ## Local Dev Setup
 

--- a/src/app/_dev/components/page.tsx
+++ b/src/app/_dev/components/page.tsx
@@ -159,7 +159,7 @@ export default function ComponentsDevPage() {
         <Section title="ClosePeriodDialog">
           <button
             onClick={() => setClosePeriodOpen(true)}
-            className="inline-flex h-8 items-center rounded-md border border-destructive bg-card px-3.5 text-[13px] font-medium text-destructive hover:bg-destructive-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex h-8 items-center rounded-md border border-primary bg-card px-3.5 text-[13px] font-medium text-primary hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Open Close Period Dialog
           </button>

--- a/src/components/__tests__/close-period-dialog.test.tsx
+++ b/src/components/__tests__/close-period-dialog.test.tsx
@@ -1,0 +1,291 @@
+// ClosePeriodDialog unit tests
+//
+// Pin the post-collapse contract:
+//   - Single open surface: totals + checkbox + "Close period" button visible
+//     immediately on open. Button starts disabled.
+//   - Checkbox tick toggles button enable.
+//   - Click confirm dispatches onConfirm exactly once with no preceding screen.
+//   - Pending state shows "Closing…" footer + disabled button.
+//   - Success state renders green "Closed: <periodLabel>" header + CSV CTA.
+//   - Error state renders destructive banner + "Retry close" that re-invokes.
+//   - Re-open after error resets state (checkbox unchecked, banner gone, button
+//     back to disabled "Close period").
+//   - Cancel-first focus order on open.
+
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { LocaleProvider } from "../format/locale-context";
+import { ClosePeriodDialog, type ClosePeriodSummaryRow } from "../ui/close-period-dialog";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SUMMARY_ROWS: ClosePeriodSummaryRow[] = [
+  { label: "Households", value: "12" },
+  { label: "Total kWh", value: "487.3" },
+  { label: "Tier 1 kWh", value: "392.1" },
+  { label: "Tier 2 kWh", value: "95.2" },
+];
+const GRAND_TOTAL = 4_216_800;
+const PERIOD_LABEL = "April 2026";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <LocaleProvider locale="en-UG" currency="UGX">
+      {children}
+    </LocaleProvider>
+  );
+}
+
+/**
+ * A controlled wrapper around ClosePeriodDialog so tests can flip `open`
+ * (closed → open) to exercise the reset-on-open useEffect, and so they can
+ * provide an `onConfirm` whose resolution timing is controlled per-test.
+ */
+function ControlledHarness(props: {
+  initialOpen?: boolean;
+  onConfirm: () => Promise<void>;
+  onExportCsv?: () => void;
+}) {
+  const [open, setOpen] = React.useState(props.initialOpen ?? true);
+  return (
+    <Wrapper>
+      <button onClick={() => setOpen(true)} data-testid="harness-reopen">
+        reopen
+      </button>
+      <button onClick={() => setOpen(false)} data-testid="harness-close">
+        close
+      </button>
+      <ClosePeriodDialog
+        open={open}
+        onOpenChange={setOpen}
+        periodLabel={PERIOD_LABEL}
+        summaryRows={SUMMARY_ROWS}
+        grandTotal={GRAND_TOTAL}
+        onConfirm={props.onConfirm}
+        onExportCsv={props.onExportCsv}
+      />
+    </Wrapper>
+  );
+}
+
+// Helper: a deferred promise — caller controls when it resolves/rejects.
+function defer<T = void>() {
+  let resolve!: (v: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ClosePeriodDialog — collapsed surface", () => {
+  it("on open, totals + grand total + checkbox + disabled 'Close period' are all visible", () => {
+    render(<ControlledHarness onConfirm={() => Promise.resolve()} />);
+
+    // Totals grid: every label and value renders.
+    for (const row of SUMMARY_ROWS) {
+      expect(screen.getByText(row.label)).toBeTruthy();
+      expect(screen.getByText(String(row.value))).toBeTruthy();
+    }
+    // Grand total label.
+    expect(screen.getByText("Grand total")).toBeTruthy();
+
+    // Checkbox visible.
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeTruthy();
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+
+    // The confirm CTA renders as "Close period" (no ellipsis, no "Review &").
+    const closeBtn = screen.getByRole("button", { name: /^Close period$/ });
+    expect(closeBtn).toBeTruthy();
+    expect((closeBtn as HTMLButtonElement).disabled).toBe(true);
+
+    // No phase-1 ceremony: there is NO "Review & close…" trigger.
+    expect(screen.queryByRole("button", { name: /Review/i })).toBeNull();
+
+    // Eyebrow shows the new "Final review" copy in primary tone.
+    const eyebrow = screen.getByText("Final review");
+    expect(eyebrow).toBeTruthy();
+    expect(eyebrow.className).toContain("text-primary");
+  });
+
+  it("ticking the checkbox enables the button; unticking re-disables", () => {
+    render(<ControlledHarness onConfirm={() => Promise.resolve()} />);
+    const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+    const closeBtn = screen.getByRole("button", { name: /^Close period$/ }) as HTMLButtonElement;
+
+    expect(closeBtn.disabled).toBe(true);
+
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    expect(closeBtn.disabled).toBe(false);
+
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+    expect(closeBtn.disabled).toBe(true);
+  });
+
+  it("clicking 'Close period' invokes onConfirm exactly once with no arguments", async () => {
+    const onConfirm = vi.fn(() => Promise.resolve());
+    render(<ControlledHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^Close period$/ }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(onConfirm.mock.calls[0]).toEqual([]);
+  });
+
+  it("rail and confirm button render in primary tone (token-class drift sanity)", () => {
+    const { container } = render(<ControlledHarness onConfirm={() => Promise.resolve()} />);
+
+    // Rail: aria-hidden div with bg-primary; not bg-destructive.
+    const rail = container.ownerDocument.querySelector('[aria-hidden="true"].bg-primary');
+    expect(rail).not.toBeNull();
+    expect(container.ownerDocument.querySelector('[aria-hidden="true"].bg-destructive')).toBeNull();
+
+    // Confirm button: bg-primary tokens (pre-click; not destructive).
+    const closeBtn = screen.getByRole("button", { name: /^Close period$/ });
+    expect(closeBtn.className).toContain("bg-primary");
+    expect(closeBtn.className).toContain("text-primary-foreground");
+    expect(closeBtn.className).not.toContain("bg-destructive");
+
+    // Checkbox accent uses --primary, not --destructive.
+    const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(checkbox.className).toContain("accent-[color:var(--primary)]");
+    expect(checkbox.className).not.toContain("accent-[color:var(--destructive)]");
+  });
+});
+
+describe("ClosePeriodDialog — pending / success / error states", () => {
+  it("pending: while onConfirm is in-flight, shows 'Closing…' and disables the button", async () => {
+    const d = defer<void>();
+    const onConfirm = vi.fn(() => d.promise);
+    render(<ControlledHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^Close period$/ }));
+
+    // Pending state: footer copy + button label "Closing…"
+    await waitFor(() => {
+      // Multiple "Closing…" matches possible (footer + button) — both indicate pending.
+      expect(screen.getAllByText(/Closing…/).length).toBeGreaterThanOrEqual(1);
+    });
+    const closingBtn = screen.getByRole("button", { name: /^Closing…$/ }) as HTMLButtonElement;
+    expect(closingBtn.disabled).toBe(true);
+
+    // Resolve to clean up.
+    d.resolve();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /^Closing…$/ })).toBeNull();
+    });
+  });
+
+  it("success: after onConfirm resolves, green 'Closed:' header + 'Export CSV for URA' CTA render and dispatch onExportCsv", async () => {
+    const onConfirm = vi.fn(() => Promise.resolve());
+    const onExportCsv = vi.fn();
+    render(<ControlledHarness onConfirm={onConfirm} onExportCsv={onExportCsv} />);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^Close period$/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(`Closed: ${PERIOD_LABEL}`)).toBeTruthy();
+    });
+    // Eyebrow flips to success tone.
+    const eyebrow = screen.getByText("Closed");
+    expect(eyebrow.className).toContain("text-success-fg");
+
+    const csvBtn = screen.getByRole("button", { name: /Export CSV for URA/i });
+    fireEvent.click(csvBtn);
+    expect(onExportCsv).toHaveBeenCalledTimes(1);
+  });
+
+  it("error: when onConfirm rejects, destructive banner + 'Retry close' render; retry re-invokes onConfirm", async () => {
+    let attempt = 0;
+    const onConfirm = vi.fn(() => {
+      attempt += 1;
+      return attempt === 1
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve();
+    });
+    render(<ControlledHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^Close period$/ }));
+
+    // Banner shows the rejection message in destructive tone.
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't close period\./)).toBeTruthy();
+    });
+    expect(screen.getByText(/boom/)).toBeTruthy();
+
+    const retryBtn = screen.getByRole("button", { name: /Retry close/i });
+    // Retry button keeps destructive tone (genuine failure state).
+    expect(retryBtn.className).toContain("bg-destructive");
+
+    fireEvent.click(retryBtn);
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(2);
+    });
+    // Second attempt resolves → success surface.
+    await waitFor(() => {
+      expect(screen.getByText(`Closed: ${PERIOD_LABEL}`)).toBeTruthy();
+    });
+  });
+
+  it("re-open after error resets state (checkbox unchecked, banner gone, button back to disabled 'Close period')", async () => {
+    const onConfirm = vi.fn(() => Promise.reject(new Error("boom")));
+    render(<ControlledHarness onConfirm={onConfirm} />);
+
+    // Tick + click → error surface.
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^Close period$/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't close period\./)).toBeTruthy();
+    });
+
+    // Close, then reopen via the harness controls.
+    fireEvent.click(screen.getByTestId("harness-close"));
+    await waitFor(() => {
+      expect(screen.queryByText(/Couldn't close period\./)).toBeNull();
+    });
+    fireEvent.click(screen.getByTestId("harness-reopen"));
+
+    // After reopen: error banner gone, checkbox unchecked, confirm button disabled
+    // and labelled "Close period" again.
+    await waitFor(() => {
+      const reopenedBtn = screen.queryByRole("button", { name: /^Close period$/ });
+      expect(reopenedBtn).not.toBeNull();
+    });
+    expect(screen.queryByText(/Couldn't close period\./)).toBeNull();
+    const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    const closeBtn = screen.getByRole("button", { name: /^Close period$/ }) as HTMLButtonElement;
+    expect(closeBtn.disabled).toBe(true);
+    // No "Retry close" button — error state cleared.
+    expect(screen.queryByRole("button", { name: /Retry close/i })).toBeNull();
+  });
+});
+
+describe("ClosePeriodDialog — a11y", () => {
+  it("on open, focus lands on the Cancel button (cancel-first), not the checkbox", async () => {
+    render(<ControlledHarness onConfirm={() => Promise.resolve()} />);
+
+    // Radix runs onOpenAutoFocus async-microtask-ish; wait until cancel is focused.
+    await waitFor(() => {
+      const cancelBtn = screen.getByRole("button", { name: /^Cancel$/ });
+      expect(document.activeElement).toBe(cancelBtn);
+    });
+
+    // And NOT the checkbox.
+    const checkbox = screen.getByRole("checkbox");
+    expect(document.activeElement).not.toBe(checkbox);
+  });
+});

--- a/src/components/ui/close-period-dialog.tsx
+++ b/src/components/ui/close-period-dialog.tsx
@@ -1,30 +1,41 @@
 "use client";
 
-// ClosePeriodDialog — Radix Dialog wrapping the two-phase close flow.
+// ClosePeriodDialog — Radix Dialog wrapping the close-period flow.
 //
 // Phases (internal state):
-//   1 = summary       — grid of totals + "Review & close…" button
-//   2 = confirm        — checkbox "I have copied the values for URA"
-//                        + primary destructive "Close period" button
-//   2.5 = pending      — disabled "Closing…" button while mutation runs
-//   3 = closed         — green header, "Export CSV for URA" primary CTA
-//   E = error          — destructive inline error with Retry
+//   2   = confirm   — totals grid + grand total + checkbox
+//                     ("I have copied the values for URA") + filled-primary
+//                     "Close period" button (disabled until checkbox ticked).
+//                     This is the open surface — no preceding "Review & close…"
+//                     ceremony; the totals are visible immediately so the
+//                     user can review and commit in a single gesture.
+//   2.5 = pending   — disabled "Closing…" button while the mutation runs.
+//   3   = closed    — green header + "Export CSV for URA" primary CTA.
+//   E   = error     — destructive inline banner with "Retry close".
 //
 // A11y commitments (handled via Radix Dialog primitives):
 //   • role="dialog" + aria-modal on the content panel.
 //   • Focus trap while open; Esc to close; focus returns to trigger on close.
-//   • Cancel renders BEFORE the destructive trigger in DOM order so screen-
-//     reader users reach the safe option first.
+//   • Cancel renders BEFORE the confirm trigger in DOM order so screen-
+//     reader users reach the safe option first. Radix's default would land
+//     focus on the first focusable in DOM (the checkbox); we override that
+//     via onOpenAutoFocus + cancelRef to keep cancel-first focus order.
 //   • `aria-labelledby` references the dialog title; `aria-describedby`
 //     references the warning copy.
 //
 // Why multi-channel confirm over typed-phrase:
 //   The original typed "CLOSE 2026-03" phrase was shown on-screen, so the
 //   user just typed (or pasted) what they saw — friction illusory. A
-//   checkbox "I have copied the values for URA" + final "I confirm" button
-//   is a deliberate two-gesture commit AND names the real-world precondition
-//   (the transcription must be done). Forks that want typed-phrase ceremony
-//   can swap the confirm row; match case-insensitively.
+//   checkbox "I have copied the values for URA" + final "Close period"
+//   button is a deliberate two-gesture commit AND names the real-world
+//   precondition (the transcription must be done). Forks that want
+//   typed-phrase ceremony can swap the confirm row.
+//
+// Tone calibration:
+//   Closing a period is a final commit, not a destruction — destructive
+//   tone is reserved for delete flows. The rail and eyebrow render in
+//   primary tone; only the error-state banner and Retry button keep the
+//   destructive tokens (genuine failure state).
 
 import * as React from "react";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -51,7 +62,7 @@ export interface ClosePeriodDialogProps {
   onExportCsv?: () => void;
 }
 
-type Phase = 1 | 2 | 2.5 | 3 | "E";
+type Phase = 2 | 2.5 | 3 | "E";
 
 export function ClosePeriodDialog({
   open,
@@ -62,7 +73,7 @@ export function ClosePeriodDialog({
   onConfirm,
   onExportCsv,
 }: ClosePeriodDialogProps) {
-  const [phase, setPhase] = React.useState<Phase>(1);
+  const [phase, setPhase] = React.useState<Phase>(2);
   const [confirmed, setConfirmed] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const cancelRef = React.useRef<HTMLButtonElement>(null);
@@ -70,7 +81,7 @@ export function ClosePeriodDialog({
   // Reset phase whenever the dialog is opened (don't carry state between openings).
   React.useEffect(() => {
     if (open) {
-      setPhase(1);
+      setPhase(2);
       setConfirmed(false);
       setError(null);
     }
@@ -104,8 +115,9 @@ export function ClosePeriodDialog({
         <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55 data-[state=open]:animate-in data-[state=closed]:animate-out" />
         <Dialog.Content
           // Cancel-first focus order: when the dialog opens, Radix tries to
-          // focus the first focusable element inside. We explicitly forward
-          // initial focus to the Cancel button below via onOpenAutoFocus.
+          // focus the first focusable element inside (the checkbox in the
+          // collapsed surface). We explicitly forward initial focus to the
+          // Cancel button below via onOpenAutoFocus.
           onOpenAutoFocus={(e) => {
             e.preventDefault();
             cancelRef.current?.focus();
@@ -117,8 +129,8 @@ export function ClosePeriodDialog({
             "outline-none",
           )}
         >
-          {/* destructive top-rail — 6px, token color */}
-          <div aria-hidden="true" className="h-[6px] bg-destructive" />
+          {/* primary top-rail — 6px, token color (commit moment, not destruction) */}
+          <div aria-hidden="true" className="h-[6px] bg-primary" />
 
           <div
             className={cn(
@@ -129,10 +141,10 @@ export function ClosePeriodDialog({
             <span
               className={cn(
                 "text-[11px] font-semibold uppercase tracking-wide",
-                phase === 3 ? "text-success-fg" : "text-destructive",
+                phase === 3 ? "text-success-fg" : "text-primary",
               )}
             >
-              {phase === 3 ? "Closed" : "Irreversible action"}
+              {phase === 3 ? "Closed" : "Final review"}
             </span>
             <Dialog.Title className="mt-1.5 text-xl font-semibold tracking-tight">
               {title}
@@ -170,7 +182,7 @@ export function ClosePeriodDialog({
                   type="checkbox"
                   checked={confirmed}
                   onChange={(e) => setConfirmed(e.target.checked)}
-                  className="mt-0.5 accent-[color:var(--destructive)]"
+                  className="mt-0.5 accent-[color:var(--primary)]"
                 />
                 <span>
                   I have copied the tier values into URA&apos;s portal and confirm these
@@ -210,19 +222,11 @@ export function ClosePeriodDialog({
                 Cancel
               </button>
             </Dialog.Close>
-            {phase === 1 && (
-              <button
-                onClick={() => setPhase(2)}
-                className="inline-flex h-8 items-center rounded-md border border-destructive bg-card px-3.5 text-[13px] font-medium text-destructive hover:bg-destructive-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                Review &amp; close…
-              </button>
-            )}
             {phase === 2 && (
               <button
                 onClick={handleClose}
                 disabled={!confirmed}
-                className="inline-flex h-8 items-center rounded-md border border-destructive bg-destructive px-3.5 text-[13px] font-medium text-destructive-foreground disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex h-8 items-center rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 Close period
               </button>
@@ -230,7 +234,7 @@ export function ClosePeriodDialog({
             {phase === 2.5 && (
               <button
                 disabled
-                className="inline-flex h-8 items-center rounded-md border border-destructive bg-destructive px-3.5 text-[13px] font-medium text-destructive-foreground opacity-60 cursor-not-allowed"
+                className="inline-flex h-8 items-center rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground opacity-60 cursor-not-allowed"
               >
                 Closing…
               </button>


### PR DESCRIPTION
## Summary

- Collapse phase 1 + phase 2 into single open surface (totals + checkbox + button visible immediately).
- Tone calibration: destructive rail/eyebrow → primary; \`IRREVERSIBLE ACTION\` → \`FINAL REVIEW\`; \`Close period\` button (filled-primary, disabled until checkbox).
- Cancel-first focus preserved; error banner stays destructive (real failure state); success state stays green.
- CLAUDE.md rule 5 amended (one-sentence replacement).
- 9 new test cases.

Closes #131.

## Test plan

- [x] lint, tsc, test (963 pass), build all green
- [x] Reviewer agent walked all ACs — VERDICT: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)