### PR TITLE
Tighten microgrid SELECT lists to exclude encrypted secret (#106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ src/
 - **Adapter pattern** — MBE doesn't import OpenEMS-specific types in billing logic. `DeviceDataAdapter` interface in `src/lib/adapters/types.ts` (renamed from `MeterDataAdapter` in C #51)
 - **Codegen types** — import entity types from `@/lib/types/domain`, never from `database.gen.ts` directly. Run `npm run db:types` after schema changes.
 - **Role constants** — import `SUPER_ADMIN`, `ORG_MANAGER`, `SCOPE_ORG` from `@/lib/roles` instead of spelling out string literals. Two MVP roles ship: `super_admin` and `org_manager`.
+- **Microgrid SELECT lists** — avoid `.select('*')` on `microgrids`; enumerate columns via `MICROGRID_PUBLIC_COLUMNS` (`src/lib/types/microgrid-columns.ts`) so new sensitive additions don't silently leak. Enforced by `src/lib/__tests__/no-microgrid-star-select.test.ts`.
 - **DCO sign-off** on docker-openems commits (`git commit -s`)
 
 ### Entity model (post-AB #50)

--- a/src/app/(dashboard)/microgrids/[id]/layout.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
+import { MICROGRID_PUBLIC_COLUMNS } from "@/lib/types/microgrid-columns";
 import { TabNav } from "./tab-nav";
 import { LocaleProvider } from "@/components/format/locale-context";
 import { EditEntityButton } from "@/components/forms/EditEntityButton";
@@ -21,7 +22,7 @@ export default async function MicrogridLayout({
 
   const { data, error } = await supabase
     .from("microgrids")
-    .select("*")
+    .select(MICROGRID_PUBLIC_COLUMNS)
     .eq("id", id)
     .single();
 
@@ -29,7 +30,7 @@ export default async function MicrogridLayout({
     notFound();
   }
 
-  const microgrid = data as Microgrid;
+  const microgrid = data as Omit<Microgrid, "ems_aws_secret_access_key_encrypted">;
 
   // Build location label from structured columns (location TEXT was dropped in AB)
   const locationParts = [microgrid.address_city, microgrid.address_country].filter(Boolean);

--- a/src/app/(dashboard)/microgrids/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/page.test.tsx
@@ -89,8 +89,22 @@ function makeBuilder(tableName: string) {
       if (_head) {
         return Promise.resolve({ count: 0 }).then(resolve);
       }
-      // Should not normally be reached.
-      return Promise.resolve({ data: null, error: null }).then(resolve);
+      // Bare-builder await (no terminal .single()/.maybeSingle()/.returns()):
+      // resolve to filtered rows. The page no longer calls .returns<…>() after
+      // issue #106 (column list narrows the type at the source).
+      let rows = (tables[tableName] ?? []) as Record<string, unknown>[];
+      for (const [col, val] of _eqs) {
+        if (col.includes(".")) {
+          const [joinTable, joinCol] = col.split(".");
+          rows = rows.filter((r) => {
+            const joined = r[joinTable] as Record<string, unknown> | undefined;
+            return joined?.[joinCol] === val;
+          });
+        } else {
+          rows = rows.filter((r) => r[col] === val);
+        }
+      }
+      return Promise.resolve({ data: rows, error: null }).then(resolve);
     },
   };
   return proxy;

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -1,11 +1,15 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Microgrid } from "@/lib/types/domain";
+import { MICROGRID_PUBLIC_COLUMNS } from "@/lib/types/microgrid-columns";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
 import { AddEntityButton } from "@/components/forms/AddEntityButton";
 import type { CommunityOption } from "@/components/forms/AddEntityButton";
 
-type MicrogridWithHouseholdCount = Microgrid & {
+type MicrogridWithHouseholdCount = Omit<
+  Microgrid,
+  "ems_aws_secret_access_key_encrypted"
+> & {
   household_count: number;
 };
 
@@ -70,19 +74,26 @@ export default async function MicrogridsPage({
           .maybeSingle()
       : Promise.resolve({ data: null, error: null }),
     (() => {
-      let query = supabase.from("microgrids").select("*");
+      // Three branches. The org-filtered branch uses an embed (`communities!inner`)
+      // so its row shape differs from the other two branches; rather than fight
+      // the union type, we narrow `data` to the public columns at the
+      // destructure site below.
       if (communityId) {
         // Community filter is narrower — it wins.
-        query = query.eq("community_id", communityId);
-      } else if (orgValid) {
+        return supabase
+          .from("microgrids")
+          .select(MICROGRID_PUBLIC_COLUMNS)
+          .eq("community_id", communityId);
+      }
+      if (orgValid) {
         // Org filter: join via communities to filter by org_id.
         // PostgREST syntax: select from the embedded communities resource.
-        query = supabase
+        return supabase
           .from("microgrids")
-          .select("*, communities!inner(org_id)")
+          .select(`${MICROGRID_PUBLIC_COLUMNS}, communities!inner(org_id)`)
           .eq("communities.org_id", orgId!);
       }
-      return query.returns<Microgrid[]>();
+      return supabase.from("microgrids").select(MICROGRID_PUBLIC_COLUMNS);
     })(),
   ]);
 

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -153,6 +153,7 @@ export async function PUT(
   // Permission check — 404 on hidden/missing (don't leak existence).
   // Also read the existing encrypted secret so we can support the
   // "leave blank to keep the current secret" flow (#102 AC-SECRET-PRESERVE).
+  // SECURITY: ciphertext read server-side only — never returned to client (issue #106).
   const { data: mgRow, error: mgErr } = await supabase
     .from("microgrids")
     .select(

--- a/src/app/api/microgrids/[id]/route.ts
+++ b/src/app/api/microgrids/[id]/route.ts
@@ -11,6 +11,7 @@ import {
   UUID_RE,
   type EntityDeleteLogPayload,
 } from "@/lib/entity-deletion/shared";
+import { MICROGRID_PUBLIC_COLUMNS } from "@/lib/types/microgrid-columns";
 
 /**
  * PATCH /api/microgrids/[id] — update a microgrid (#76).
@@ -127,7 +128,7 @@ export async function PATCH(
     .from("microgrids")
     .update(updates)
     .eq("id", id)
-    .select("*")
+    .select(MICROGRID_PUBLIC_COLUMNS)
     .maybeSingle();
 
   if (error) {

--- a/src/app/api/microgrids/route.ts
+++ b/src/app/api/microgrids/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { currentUserCanAccessCommunity } from "@/lib/auth/access";
 import { validateCurrency } from "@/lib/validation/currency";
+import { MICROGRID_PUBLIC_COLUMNS } from "@/lib/types/microgrid-columns";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -88,7 +89,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { data, error } = await supabase
     .from("microgrids")
     .insert(row)
-    .select("*")
+    .select(MICROGRID_PUBLIC_COLUMNS)
     .single();
 
   if (error) {

--- a/src/components/forms/EditEntityButton.tsx
+++ b/src/components/forms/EditEntityButton.tsx
@@ -27,7 +27,9 @@ type Props =
     }
   | {
       entity: "microgrid";
-      initialValues: Microgrid;
+      // Omit the encrypted ciphertext column so SSR-rendered HTML / client
+      // components never receive it (defense-in-depth, see issue #106).
+      initialValues: Omit<Microgrid, "ems_aws_secret_access_key_encrypted">;
       label?: string;
       className?: string;
     };

--- a/src/lib/__tests__/no-microgrid-star-select.test.ts
+++ b/src/lib/__tests__/no-microgrid-star-select.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression guard for issue #106 — defense-in-depth against `.select('*')` on
+ * the `microgrids` table.
+ *
+ * Migration 00018 added `microgrids.ems_aws_secret_access_key_encrypted`
+ * (bytea ciphertext, envelope-encrypted via Vault). Any `.select("*")` on
+ * `microgrids` lands that ciphertext in JSON API responses and (for SSR pages)
+ * the `__NEXT_DATA__` payload sent to every browser. Use the shared
+ * `MICROGRID_PUBLIC_COLUMNS` constant instead — see
+ * `src/lib/types/microgrid-columns.ts`.
+ *
+ * This test scans every `.ts`/`.tsx` file under `src/app/`, `src/components/`,
+ * and `src/lib/` (excluding `__tests__/` directories AND co-located
+ * `*.test.{ts,tsx}` files) and fails if any file matches the pattern
+ * `.from("microgrids").select("*` (covers double, single, AND backtick
+ * quotes; matches both `select("*")` and the embed form
+ * `select("*, communities!inner(...)")`).
+ *
+ * Cheaper than a custom eslint rule; integrates with the existing Vitest setup.
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const ROOTS = ["src/app", "src/components", "src/lib"].map((p) =>
+  path.join(REPO_ROOT, p),
+);
+
+// Character class on both sides covers single, double, AND backtick quotes.
+// Trailing `\*` (without a closing quote) catches both `select("*")` and the
+// embed form `select("*, communities!inner(...)")`.
+const FORBIDDEN = /\.from\(["'`]microgrids["'`]\)[\s\S]{0,200}?\.select\(["'`]\*/;
+
+const ALLOWED_FILES = new Set<string>(); // empty allowlist by design
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "__tests__" || entry === "node_modules") continue;
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walk(full, out);
+    } else if (
+      stat.isFile() &&
+      (full.endsWith(".ts") || full.endsWith(".tsx")) &&
+      // Skip co-located test files — they may reference the forbidden pattern
+      // in mocks, comments, or fixtures.
+      !full.endsWith(".test.ts") &&
+      !full.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("no .select('*') on microgrids (issue #106)", () => {
+  it("source files do not call .from('microgrids').select('*')", () => {
+    const offenders: string[] = [];
+    for (const root of ROOTS) {
+      for (const file of walk(root)) {
+        const rel = path.relative(REPO_ROOT, file);
+        if (ALLOWED_FILES.has(rel)) continue;
+        const text = readFileSync(file, "utf8");
+        if (FORBIDDEN.test(text)) {
+          offenders.push(rel);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `\nFound .from("microgrids").select("*") in:\n  ${offenders.join("\n  ")}\n` +
+        `Use MICROGRID_PUBLIC_COLUMNS from src/lib/types/microgrid-columns.ts instead.\n` +
+        `See issue #106.`,
+    ).toEqual([]);
+  });
+});

--- a/src/lib/types/microgrid-columns.ts
+++ b/src/lib/types/microgrid-columns.ts
@@ -1,0 +1,18 @@
+// Defense-in-depth: keep ems_aws_secret_access_key_encrypted (bytea ciphertext)
+// out of any client-bound JSON or SSR HTML. See issue #106.
+//
+// This is the canonical `Microgrid` Row column list MINUS the one encrypted
+// column. Use this constant in `.select(...)` calls on the `microgrids` table
+// instead of `.select("*")`. For PostgREST embed queries, interpolate via
+// template literal:
+//
+//   .select(`${MICROGRID_PUBLIC_COLUMNS}, communities!inner(org_id)`)
+//
+// Declared `as const` (single literal, no concatenation) so that Supabase's
+// PostgREST type machinery can narrow `.select(MICROGRID_PUBLIC_COLUMNS)` to
+// a `Pick<Microgrid, …>` row type — generic `string` would fall through to
+// the error-shape fallback.
+//
+// Enforced by `src/lib/__tests__/no-microgrid-star-select.test.ts`.
+export const MICROGRID_PUBLIC_COLUMNS =
+  "id, community_id, name, currency, address_line1, address_line2, address_city, address_region, address_country, address_postal_code, lat, lng, created_at, ems_type, ems_backend_url, ems_aws_region, ems_aws_access_key_id, ems_known_edge_ids, ems_last_discover_at, ems_last_discover_count, ems_last_discover_error, ems_last_discover_status" as const;


### PR DESCRIPTION
## Summary

- New \`MICROGRID_PUBLIC_COLUMNS\` shared constant in \`src/lib/types/microgrid-columns.ts\`.
- 4 sites tightened: \`/api/microgrids/route.ts\`, \`/api/microgrids/[id]/route.ts\`, \`/microgrids/page.tsx\` (incl. embed form), \`/microgrids/[id]/layout.tsx\` (was leaking ciphertext into SSR HTML).
- \`EditEntityButton\` widened to \`Omit<Microgrid, \"ems_aws_secret_access_key_encrypted\">\`.
- Automated grep-guard test prevents regressions.
- CLAUDE.md note added.

Closes #106.

## Test plan

- [x] lint, tsc, test (955 pass), build all green
- [x] Reviewer agent walked all ACs — VERDICT: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)