### PR TITLE
Pesapal IPN Phase A: register IPN at Save & test (#121)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/payment/__tests__/payment-shell.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/__tests__/payment-shell.test.tsx
@@ -50,7 +50,8 @@ const BASE_COMMUNITY = {
   name: "Kisakye",
   payment_provider: null,
   payment_last_configured_at: null,
-  config: { consumer_key: "", base_url: "", sandbox: false },
+  config: { consumer_key: "", base_url: "", sandbox: false, ipn_id: "" },
+  callback_url: "",
 } as const;
 
 const CONFIGURED_COMMUNITY = {
@@ -62,7 +63,9 @@ const CONFIGURED_COMMUNITY = {
     consumer_key: "ck_live_example",
     base_url: "https://pay.pesapal.com/v3",
     sandbox: false,
+    ipn_id: "f3a2b1c0-9d8e-7f6a-5b4c-3d2e1f0a9b8c",
   },
+  callback_url: "https://app.example.com/api/payments/ipn",
 };
 
 beforeEach(() => {
@@ -140,6 +143,55 @@ describe("PaymentShell — configured state", () => {
       screen.getByText(/only super admins can update payment credentials/i),
     ).toBeDefined();
     expect(container.textContent).toContain("—");
+  });
+
+  it("(4b) super_admin: callback URL + truncated ipn_id rendered (#121)", () => {
+    const { container } = render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    expect(container.textContent).toContain("IPN callback URL");
+    expect(container.textContent).toContain(
+      "https://app.example.com/api/payments/ipn",
+    );
+    // Truncated middle: 4 leading + ellipsis + 4 trailing chars.
+    expect(container.textContent).toContain("f3a2…9b8c");
+    // Full GUID never rendered as inline text — it's only on a `title` attr.
+    expect(container.textContent).not.toContain(
+      "f3a2b1c0-9d8e-7f6a-5b4c-3d2e1f0a9b8c",
+    );
+  });
+
+  it("(4c) org_manager does not see callback URL / ipn_id (super_admin gated)", () => {
+    const { container } = render(
+      <PaymentShell
+        community={CONFIGURED_COMMUNITY}
+        health="healthy"
+        secretLast4={null}
+        isSuperAdmin={false}
+      />,
+    );
+    expect(container.textContent).not.toContain("IPN callback URL");
+    expect(container.textContent).not.toContain("Registered IPN id");
+  });
+
+  it("(4d) super_admin sees 'Not registered yet' hint when ipn_id is missing", () => {
+    const { container } = render(
+      <PaymentShell
+        community={{
+          ...CONFIGURED_COMMUNITY,
+          config: { ...CONFIGURED_COMMUNITY.config, ipn_id: "" },
+        }}
+        health="healthy"
+        secretLast4="9xYZ"
+        isSuperAdmin={true}
+      />,
+    );
+    expect(container.textContent).toContain("Not registered yet");
   });
 });
 

--- a/src/app/(dashboard)/communities/[id]/payment/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/page.tsx
@@ -77,12 +77,23 @@ export default async function PaymentPage({
       typeof cfgObj.consumer_key === "string" ? cfgObj.consumer_key : "",
     base_url: typeof cfgObj.base_url === "string" ? cfgObj.base_url : "",
     sandbox: typeof cfgObj.sandbox === "boolean" ? cfgObj.sandbox : false,
+    ipn_id: typeof cfgObj.ipn_id === "string" ? cfgObj.ipn_id : "",
   };
 
   const health = derivePaymentHealth({
     payment_provider: community.payment_provider,
     payment_last_configured_at: community.payment_last_configured_at,
   });
+
+  // Server-derived public callback URL surfaced in the configured-mode panel
+  // (super_admin only) for operator visibility — matches the URL Save & test
+  // registers with Pesapal. Always recomputed; never persisted client-side.
+  const callbackBase = (
+    process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL ?? ""
+  )
+    .trim()
+    .replace(/\/+$/, "");
+  const callbackUrl = callbackBase ? `${callbackBase}/api/payments/ipn` : "";
 
   return (
     <div className="space-y-4">
@@ -93,6 +104,7 @@ export default async function PaymentPage({
           payment_provider: community.payment_provider,
           payment_last_configured_at: community.payment_last_configured_at,
           config: normalizedConfig,
+          callback_url: callbackUrl,
         }}
         health={health}
         secretLast4={secretLast4}

--- a/src/app/(dashboard)/communities/[id]/payment/payment-shell.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/payment-shell.tsx
@@ -37,7 +37,20 @@ type CommunityProps = {
     consumer_key: string;
     base_url: string;
     sandbox: boolean;
+    /**
+     * GUID Pesapal returned from RegisterIPN when Save & test last ran (#121).
+     * Empty string when the row pre-dates #121 — the configured panel surfaces
+     * a "Not registered yet" hint and Save & test will fix it on next click.
+     */
+    ipn_id: string;
   };
+  /**
+   * Server-derived public IPN callback URL — always
+   * `${NEXT_PUBLIC_PAYMENT_CALLBACK_URL}/api/payments/ipn`. Empty string when
+   * the env var is unset (e.g. in some test setups). Read-only display field;
+   * never round-tripped through the form.
+   */
+  callback_url: string;
 };
 
 export type PaymentShellProps = {
@@ -52,6 +65,8 @@ type SaveOutcome =
   | { kind: "auth_failed"; message: string }
   | { kind: "unreachable"; message: string }
   | { kind: "invalid_config"; message: string }
+  | { kind: "register_ipn_failed"; message: string }
+  | { kind: "callback_url_unknown"; message: string }
   | { kind: "permission_denied"; message: string }
   | { kind: "generic_error"; message: string };
 
@@ -164,6 +179,20 @@ export function PaymentShell(props: PaymentShellProps) {
             message:
               (typeof json.error === "string" && json.error) ||
               "Could not reach Pesapal. Check your network and try again.",
+          });
+        } else if (reason === "register_ipn_failed") {
+          setOutcome({
+            kind: "register_ipn_failed",
+            message:
+              (typeof json.error === "string" && json.error) ||
+              "Pesapal accepted the credentials but rejected the IPN registration.",
+          });
+        } else if (reason === "callback_url_unknown") {
+          setOutcome({
+            kind: "callback_url_unknown",
+            message:
+              (typeof json.error === "string" && json.error) ||
+              "Server configuration error: the IPN callback URL is not set.",
           });
         } else {
           setOutcome({
@@ -332,6 +361,36 @@ export function PaymentShell(props: PaymentShellProps) {
                 {community.config.base_url || "—"}
               </p>
             </div>
+            {isSuperAdmin && (
+              <>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    IPN callback URL
+                  </p>
+                  <p className="mt-1 break-all font-mono text-xs text-foreground">
+                    {community.callback_url || "—"}
+                  </p>
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    Pesapal calls this URL after a checkout completes.
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Registered IPN id
+                  </p>
+                  <p
+                    className="mt-1 break-all font-mono text-xs text-foreground"
+                    title={community.config.ipn_id || ""}
+                  >
+                    {formatIpnId(community.config.ipn_id) || (
+                      <span className="text-muted-foreground">
+                        Not registered yet — run Save & test connection.
+                      </span>
+                    )}
+                  </p>
+                </div>
+              </>
+            )}
           </div>
 
           {/* Right column */}
@@ -514,6 +573,17 @@ export function PaymentShell(props: PaymentShellProps) {
   );
 }
 
+/**
+ * Truncate the Pesapal IPN GUID for display. Full value remains accessible
+ * via the surrounding `<p title="…">`. Returns empty string when no value
+ * is registered so the caller can render a placeholder.
+ */
+function formatIpnId(ipnId: string): string {
+  if (!ipnId) return "";
+  if (ipnId.length <= 12) return ipnId;
+  return `${ipnId.slice(0, 4)}…${ipnId.slice(-4)}`;
+}
+
 function OutcomeBanner({ outcome }: { outcome: SaveOutcome }) {
   if (outcome.kind === "success") {
     return (
@@ -539,6 +609,20 @@ function OutcomeBanner({ outcome }: { outcome: SaveOutcome }) {
   if (outcome.kind === "invalid_config") {
     return (
       <Banner tone="warn" title="Invalid configuration">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "register_ipn_failed") {
+    return (
+      <Banner tone="destructive" title="IPN registration failed">
+        {outcome.message}
+      </Banner>
+    );
+  }
+  if (outcome.kind === "callback_url_unknown") {
+    return (
+      <Banner tone="destructive" title="Callback URL not configured">
         {outcome.message}
       </Banner>
     );

--- a/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
@@ -276,36 +276,28 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
     expect(body.reason).toBe("not_found");
   });
 
-  // ─── (9) IPN not registered (post-#119 deferred-IPN state) ───────────────
+  // ─── (9) IPN not registered → 409 ipn_not_registered (post-#121) ─────────
   //
-  // A community configured with empty ipn_id is "configured for auth" but
-  // not yet "ready for link generation". The PesapalProvider constructor
-  // throws PESAPAL_NO_IPN; the route maps it to 409 reason: "invalid_config"
-  // with a distinct message so the UI can render the Designer §8 gate copy.
+  // Post-#121, parsePesapalConfig REQUIRES `ipn_id`. A community whose
+  // payment_provider_config is missing `ipn_id` causes parsePesapalConfig to
+  // throw `PAYMENT_IPN_NOT_REGISTERED` (a distinct PaymentError code
+  // surfaced by the config loader). The route maps it to 409 with reason
+  // `ipn_not_registered` and an actionable hint pointing the user to
+  // Save & test connection.
   //
-  // Since this test mocks `getPaymentProviderClient`, we simulate the
-  // constructor-time throw by having the factory's generatePaymentLink mock
-  // raise PESAPAL_NO_IPN. End-to-end coverage (real factory + real provider
-  // constructor) is out of scope for this route test — the library-side
-  // validation is covered by parsePesapalConfig + PesapalProvider unit tests.
-  it("(9) returns 409 invalid_config when config has empty ipn_id (deferred-IPN state)", async () => {
-    const { PesapalError } = await import("@/lib/payments/pesapal/errors");
-    generatePaymentLinkMock.mockRejectedValueOnce(
-      new PesapalError(
-        "Pesapal config missing ipn_id — register an IPN via Pesapal first",
-        "PESAPAL_NO_IPN",
-        400,
+  // We simulate the parse-time rejection by having the (mocked)
+  // `getCommunityPaymentConfig` reject with that error — which is what the
+  // real loader does when parsePesapalConfig throws. End-to-end coverage of
+  // parsePesapalConfig itself lives in a dedicated unit test.
+  it("(9) returns 409 ipn_not_registered when config has no ipn_id (post-#121)", async () => {
+    const { PaymentError } = await import("@/lib/payments/errors");
+    getCommunityPaymentConfigMock.mockRejectedValueOnce(
+      new PaymentError(
+        "Pesapal config is missing ipn_id — open Community Payment settings and run Save & test connection to register the IPN URL with Pesapal.",
+        "PAYMENT_IPN_NOT_REGISTERED",
+        409,
       ),
     );
-    getCommunityPaymentConfigMock.mockResolvedValueOnce({
-      ...GOOD_CONFIG,
-      config: {
-        consumer_key: GOOD_CONFIG.config.consumer_key,
-        base_url: GOOD_CONFIG.config.base_url,
-        // ipn_id intentionally omitted — parsePesapalConfig now accepts this
-        // shape and returns a PesapalConfig without ipn_id.
-      },
-    });
 
     const { POST } = await import("../route");
     const res = await POST(makeReq(), {
@@ -313,8 +305,11 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
     });
     expect(res.status).toBe(409);
     const body = await res.json();
-    expect(body.reason).toBe("invalid_config");
+    expect(body.reason).toBe("ipn_not_registered");
     expect(String(body.error)).toMatch(/IPN/i);
+    expect(String(body.error)).toMatch(/Save & test/i);
+    // generatePaymentLink must NOT be reached — config-parse rejected first.
+    expect(generatePaymentLinkMock).not.toHaveBeenCalled();
   });
 
   // ─── (8) Log scrubber strips secret + token + URL ─────────────────────────

--- a/src/app/api/billing-line-items/[lineItemId]/url/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/route.ts
@@ -234,11 +234,12 @@ export async function POST(
   // 6. Pesapal rejects reused `id` — fresh per click.
   const orderId = `INV-${lineItemId}-${Date.now()}`;
 
-  // 7. Dispatch through the factory. The PesapalProvider constructor itself
-  //    throws PESAPAL_NO_IPN when the persisted config lacks ipn_id (a
-  //    per-#119 deferred-IPN state). Wrap both the constructor and the
-  //    generatePaymentLink call under a single try so every Pesapal-layer
-  //    error lands in the same mapPaymentError branch.
+  // 7. Dispatch through the factory. Post-#121, parsePesapalConfig rejects
+  //    upstream when the persisted config is missing `ipn_id` (throws
+  //    PAYMENT_IPN_NOT_REGISTERED — 409), so the legacy
+  //    PesapalProvider-constructor PESAPAL_NO_IPN branch is unreachable here.
+  //    Wrap both the constructor and the generatePaymentLink call under a
+  //    single try so every Pesapal-layer error lands in mapPaymentError.
   let result: GeneratePaymentLinkResult;
   try {
     const client = getPaymentProviderClient(paymentConfig);
@@ -315,6 +316,16 @@ function mapPaymentError(err: unknown): MappedError {
       return { message: err.message, reason: "forbidden", httpStatus: 403 };
     case "PAYMENT_INVALID_CONFIG":
       return { message: err.message, reason: "invalid_config", httpStatus: 503 };
+    case "PAYMENT_IPN_NOT_REGISTERED":
+      // Post-#121: parsePesapalConfig throws this when the saved Pesapal
+      // config has no `ipn_id`. Distinct from generic invalid_config so the
+      // UI can render an actionable hint ("re-run Save & test connection").
+      return {
+        message:
+          "Payment provider is configured but no IPN has been registered yet. A super admin must run Save & test connection on the Community Payment tab to register the IPN URL.",
+        reason: "ipn_not_registered",
+        httpStatus: 409,
+      };
     case "PAYMENT_UNKNOWN_PROVIDER":
       return { message: err.message, reason: "invalid_config", httpStatus: 500 };
 
@@ -324,16 +335,18 @@ function mapPaymentError(err: unknown): MappedError {
     case "PESAPAL_UNREACHABLE":
       return { message: err.message, reason: "unreachable", httpStatus: 503 };
     case "PESAPAL_NO_IPN":
-      // Per #119 AC-LIB-2: community has a provider configured but no IPN
-      // registered yet — a user-caused not-ready state distinct from the
-      // malformed/invalid (503) case. 409 signals "config exists but link
-      // generation is gated on IPN registration (ships with #121)".
+      // Legacy code retained for defense-in-depth: post-#121 parsePesapalConfig
+      // rejects missing ipn_id upstream as PAYMENT_IPN_NOT_REGISTERED, so this
+      // branch is unreachable in practice. Mapped to the same 409 reason for
+      // consistency if it ever fires.
       return {
         message:
-          "Payment provider is configured but no IPN has been registered yet. A super admin must complete IPN registration before links can be generated.",
-        reason: "invalid_config",
+          "Payment provider is configured but no IPN has been registered yet. A super admin must run Save & test connection on the Community Payment tab to register the IPN URL.",
+        reason: "ipn_not_registered",
         httpStatus: 409,
       };
+    case "PESAPAL_REGISTER_IPN_FAILED":
+      return { message: err.message, reason: "register_ipn_failed", httpStatus: 503 };
     case "PESAPAL_INVALID_CONFIG":
       return { message: err.message, reason: "invalid_config", httpStatus: 503 };
     case "PESAPAL_MISSING_CONTACT":

--- a/src/app/api/communities/[id]/payment/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/payment/__tests__/route.test.ts
@@ -14,15 +14,28 @@
  *  (10) base_url is server-derived from sandbox (NOT taken from body)
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { NextRequest } from "next/server";
 
 const COMMUNITY_ID = "550e8400-e29b-41d4-a716-446655440010";
 const ORG_ID = "550e8400-e29b-41d4-a716-446655440020";
 
+// Vercel env var used by the route to derive the IPN callback URL.
+const PRIOR_CALLBACK_URL = process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL;
+process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL = "https://app.example.com";
+
+afterAll(() => {
+  if (PRIOR_CALLBACK_URL === undefined) {
+    delete process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL;
+  } else {
+    process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL = PRIOR_CALLBACK_URL;
+  }
+});
+
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
 const getAccessTokenMock = vi.fn();
+const registerIpnMock = vi.fn();
 
 vi.mock("@/lib/payments/pesapal/client", async () => {
   const actual = await vi.importActual<
@@ -31,6 +44,7 @@ vi.mock("@/lib/payments/pesapal/client", async () => {
   class PesapalClientMock {
     constructor(public cfg: unknown) {}
     getAccessToken = getAccessTokenMock;
+    registerIpn = registerIpnMock;
   }
   return {
     ...actual,
@@ -48,10 +62,9 @@ vi.mock("@/lib/auth/access", () => ({
 
 // ─── Supabase mock — sequenced from() handlers, shared mockRpc ─────────────
 //
-// Route's from() sequence (success path):
+// Route's from() sequence (success path, post-#121):
 //   1. communities.select(... payment_provider_secret_encrypted).eq(id).maybeSingle()
-//   2. communities.select(payment_provider_config).eq(id).maybeSingle()     ← pre-update read
-//   3. communities.update(payload).eq(id)
+//   2. communities.update(payload).eq(id)
 //
 // Plus: mockRpc is used for fn_get_community_payment_secret (preserve path)
 // and fn_ems_encrypt_secret.
@@ -64,13 +77,8 @@ let communitySelectResp: { data: unknown; error: unknown } = {
   },
   error: null,
 };
-let existingCfgSelectResp: { data: unknown; error: unknown } = {
-  data: { payment_provider_config: null },
-  error: null,
-};
 let updateError: unknown = null;
 let updatePayloadCapture: Record<string, unknown> | null = null;
-let fromCallIndex = 0;
 
 const mockFrom = vi.fn();
 const mockRpc = vi.fn();
@@ -100,7 +108,6 @@ function makePutRequest(body: unknown): NextRequest {
 describe("PUT /api/communities/[id]/payment", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fromCallIndex = 0;
     canAccessOrgReturn = true;
     isSuperAdminReturn = true;
     communitySelectResp = {
@@ -111,22 +118,15 @@ describe("PUT /api/communities/[id]/payment", () => {
       },
       error: null,
     };
-    existingCfgSelectResp = {
-      data: { payment_provider_config: null },
-      error: null,
-    };
     updateError = null;
     updatePayloadCapture = null;
+    process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL = "https://app.example.com";
 
     mockFrom.mockImplementation(() => {
-      const idx = fromCallIndex++;
       return {
         select: () => ({
           eq: () => ({
-            maybeSingle: () => {
-              if (idx === 0) return Promise.resolve(communitySelectResp);
-              return Promise.resolve(existingCfgSelectResp);
-            },
+            maybeSingle: () => Promise.resolve(communitySelectResp),
           }),
         }),
         update: (payload: Record<string, unknown>) => {
@@ -149,6 +149,11 @@ describe("PUT /api/communities/[id]/payment", () => {
     });
 
     getAccessTokenMock.mockResolvedValue("fake-token");
+    registerIpnMock.mockResolvedValue({
+      url: "https://app.example.com/api/payments/ipn",
+      created_date: "2026-04-25T00:00:00Z",
+      ipn_id: "ipn-fresh-guid",
+    });
   });
 
   // ─── (1) Happy path ────────────────────────────────────────────────────
@@ -166,6 +171,13 @@ describe("PUT /api/communities/[id]/payment", () => {
     const body = await res.json();
     expect(body.status).toBe("success");
     expect(getAccessTokenMock).toHaveBeenCalledTimes(1);
+    // #121: registerIpn called once, with the canonical callback URL.
+    expect(registerIpnMock).toHaveBeenCalledTimes(1);
+    expect(registerIpnMock).toHaveBeenCalledWith(
+      "fake-token",
+      "https://app.example.com/api/payments/ipn",
+      "POST",
+    );
     expect(updatePayloadCapture).toBeTruthy();
     const payload = updatePayloadCapture!;
     expect(payload.payment_provider).toBe("pesapal");
@@ -173,6 +185,8 @@ describe("PUT /api/communities/[id]/payment", () => {
       consumer_key: "ck_live_abc",
       base_url: "https://pay.pesapal.com/v3",
       sandbox: false,
+      // #121: freshly-registered ipn_id persisted as a flat key.
+      ipn_id: "ipn-fresh-guid",
     });
     expect(payload.payment_provider_secret_encrypted).toBe("\\x0a0b0c0d");
     expect(payload.payment_last_configured_at).toEqual(expect.any(String));
@@ -216,6 +230,16 @@ describe("PUT /api/communities/[id]/payment", () => {
         >
       ).base_url,
     ).toBe("https://cybqa.pesapal.com/pesapalv3");
+    // #121: ipn_id is still re-registered + persisted on a secret-preserve.
+    expect(registerIpnMock).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        updatePayloadCapture!.payment_provider_config as Record<
+          string,
+          unknown
+        >
+      ).ipn_id,
+    ).toBe("ipn-fresh-guid");
   });
 
   // ─── (3) org_manager → 403 ─────────────────────────────────────────────
@@ -361,5 +385,100 @@ describe("PUT /api/communities/[id]/payment", () => {
       unknown
     >).base_url;
     expect(stored).toBe("https://cybqa.pesapal.com/pesapalv3");
+  });
+
+  // ─── (11) #121 IPN registration failure → 503 register_ipn_failed ──────
+  it("(11) IPN registration failure → 503 register_ipn_failed, no DB write", async () => {
+    const { PesapalError } = await import("@/lib/payments/pesapal/errors");
+    registerIpnMock.mockRejectedValueOnce(
+      new PesapalError(
+        "RegisterIPN returned 401",
+        "PESAPAL_REGISTER_IPN_FAILED",
+        502,
+      ),
+    );
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        config: { consumer_key: "ck_live_abc", sandbox: false },
+        secret_access_key: "cs_live_verylongsecret",
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.reason).toBe("register_ipn_failed");
+    expect(updatePayloadCapture).toBeNull();
+    // Encrypt is gated on the success path — never called when IPN fails.
+    const rpcNames = mockRpc.mock.calls.map((c) => c[0]);
+    expect(rpcNames).not.toContain("fn_ems_encrypt_secret");
+  });
+
+  // ─── (12) #121 callback URL env var unset → 503 callback_url_unknown ───
+  it("(12) NEXT_PUBLIC_PAYMENT_CALLBACK_URL unset → 503 callback_url_unknown", async () => {
+    const prior = process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL;
+    delete process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL;
+    try {
+      const { PUT } = await import("../route");
+      const res = await PUT(
+        makePutRequest({
+          provider: "pesapal",
+          config: { consumer_key: "ck_live_abc", sandbox: false },
+          secret_access_key: "cs_live_verylongsecret",
+        }),
+        { params: Promise.resolve({ id: COMMUNITY_ID }) },
+      );
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.reason).toBe("callback_url_unknown");
+      expect(updatePayloadCapture).toBeNull();
+      // registerIpn never called because the URL is unknown.
+      expect(registerIpnMock).not.toHaveBeenCalled();
+    } finally {
+      process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL = prior;
+    }
+  });
+
+  // ─── (13) #121 sandbox toggle replaces ipn_id ──────────────────────────
+  //
+  // Save & test always re-registers, so toggling sandbox produces a NEW GUID
+  // and the PRIOR ipn_id (which belonged to the other Pesapal environment)
+  // is overwritten — never preserved.
+  it("(13) sandbox toggle: ipn_id is replaced with the freshly-registered GUID", async () => {
+    // Existing config used to be sandbox=false with an old prod ipn_id.
+    communitySelectResp = {
+      data: {
+        id: COMMUNITY_ID,
+        org_id: ORG_ID,
+        payment_provider_secret_encrypted: "\\xdeadbeef",
+      },
+      error: null,
+    };
+    registerIpnMock.mockResolvedValueOnce({
+      url: "https://app.example.com/api/payments/ipn",
+      created_date: "2026-04-25T00:00:00Z",
+      ipn_id: "ipn-sandbox-new-guid",
+    });
+
+    const { PUT } = await import("../route");
+    const res = await PUT(
+      makePutRequest({
+        provider: "pesapal",
+        // Toggle sandbox=true → new IPN must be registered with the
+        // sandbox account; the old prod GUID would be invalid.
+        config: { consumer_key: "ck_live_abc", sandbox: true },
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(200);
+    const cfg = updatePayloadCapture!.payment_provider_config as Record<
+      string,
+      unknown
+    >;
+    expect(cfg.ipn_id).toBe("ipn-sandbox-new-guid");
+    expect(cfg.sandbox).toBe(true);
+    expect(cfg.base_url).toBe("https://cybqa.pesapal.com/pesapalv3");
   });
 });

--- a/src/app/api/communities/[id]/payment/route.ts
+++ b/src/app/api/communities/[id]/payment/route.ts
@@ -9,7 +9,7 @@ import { PesapalError } from "@/lib/payments/pesapal/errors";
 import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
 
 /**
- * PUT /api/communities/[id]/payment — Save & test payment-provider config (#119).
+ * PUT /api/communities/[id]/payment — Save & test payment-provider config (#119, #121).
  *
  * Body shape (super_admin only):
  *   {
@@ -22,7 +22,7 @@ import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
  * from the `sandbox` boolean so the JSONB stays canonical and typo'd URLs
  * can never reach the DB.
  *
- * Execution order (AC-ROUTE-1..6 in #119):
+ * Execution order (post-#121):
  *
  *   1. UUID check on [id] → 400 on malformed.
  *   2. JSON parse + manual shape validation → 400 on malformed body.
@@ -36,13 +36,20 @@ import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
  *      preserve it. Otherwise require a non-empty secret → 400.
  *   6. Decrypt the preserved secret via fn_get_community_payment_secret so we
  *      can run a live auth test against Pesapal with it.
- *   7. Save & test: call PesapalClient.getAccessToken() with the effective
- *      credentials. On failure → 503 { reason } with no DB write.
- *   8. On success: atomic UPDATE of all 4 columns
- *      (payment_provider, payment_provider_config JSONB,
- *      payment_provider_secret_encrypted BYTEA via fn_ems_encrypt_secret,
- *      payment_last_configured_at = now()).
- *   9. Log payment.save_test with scrubbed secret + token.
+ *   7. Save & test (auth): call PesapalClient.getAccessToken() with the
+ *      effective credentials. On failure → 503 { reason: 'auth_failed' }
+ *      with no DB write.
+ *   8. Save & test (IPN registration, #121): derive the public callback URL
+ *      from `NEXT_PUBLIC_PAYMENT_CALLBACK_URL` (required), append
+ *      `/api/payments/ipn`, and call `PesapalClient.registerIpn`. Always
+ *      re-register so a sandbox/prod toggle replaces the stale GUID
+ *      automatically. On failure → 503 { reason: 'register_ipn_failed' or
+ *      'callback_url_unknown' } with no DB write.
+ *   9. On success: atomic UPDATE of all 4 columns
+ *      (payment_provider, payment_provider_config JSONB with the freshly
+ *      registered ipn_id, payment_provider_secret_encrypted BYTEA via
+ *      fn_ems_encrypt_secret, payment_last_configured_at = now()).
+ *  10. Log payment.save_test with scrubbed secret + token.
  *
  * Response:
  *   200 → { status: 'success', message: string }
@@ -208,13 +215,14 @@ export async function PUT(
     : PESAPAL_BASE_URL_PROD;
 
   // Save & test — call Pesapal auth BEFORE any persist.
+  const client = new PesapalClient({
+    consumerKey: parsed.consumer_key,
+    consumerSecret: effectiveSecret,
+    baseUrl: base_url,
+  });
+  let token: string;
   try {
-    const client = new PesapalClient({
-      consumerKey: parsed.consumer_key,
-      consumerSecret: effectiveSecret,
-      baseUrl: base_url,
-    });
-    await client.getAccessToken();
+    token = await client.getAccessToken();
   } catch (err) {
     let reason: "auth_failed" | "unreachable" | "unknown_error" =
       "unknown_error";
@@ -246,7 +254,67 @@ export async function PUT(
     return NextResponse.json({ error: message, reason }, { status: 503 });
   }
 
-  // Pesapal validated the creds → persist.
+  // #121 — Register the IPN URL with Pesapal so subsequent submitOrder calls
+  // can pass `notification_id`. We always re-register: this handles the
+  // sandbox/prod toggle automatically (the previous GUID belongs to the
+  // OTHER environment's Pesapal account and is invalid).
+  const callbackBase = (process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL ?? "").trim();
+  if (!callbackBase) {
+    logSaveTest({
+      communityId,
+      provider: parsed.provider,
+      status: "callback_url_unknown",
+      durationMs: Date.now() - startedAt,
+      sensitive: [effectiveSecret],
+      supabase,
+    });
+    return NextResponse.json(
+      {
+        error:
+          "Server configuration error: NEXT_PUBLIC_PAYMENT_CALLBACK_URL is not set, so the IPN URL cannot be registered with Pesapal. Ask an administrator to set this environment variable in all Vercel scopes (Production, Preview, Development).",
+        reason: "callback_url_unknown",
+      },
+      { status: 503 },
+    );
+  }
+  const ipnUrl = `${callbackBase.replace(/\/+$/, "")}/api/payments/ipn`;
+
+  let registeredIpnId: string;
+  try {
+    const registered = await client.registerIpn(token, ipnUrl, "POST");
+    registeredIpnId = registered.ipn_id;
+  } catch (err) {
+    let reason:
+      | "register_ipn_failed"
+      | "unreachable"
+      | "unknown_error" = "unknown_error";
+    let message =
+      "Could not register the IPN URL with Pesapal. Check server logs and try again.";
+    if (err instanceof PesapalError) {
+      if (err.code === "PESAPAL_REGISTER_IPN_FAILED") {
+        reason = "register_ipn_failed";
+        message =
+          "Pesapal accepted the credentials but rejected the IPN registration. Verify the callback URL is publicly reachable and try again.";
+      } else if (err.code === "PESAPAL_UNREACHABLE") {
+        reason = "unreachable";
+        message =
+          "Could not reach Pesapal while registering the IPN URL. Check your network and try again.";
+      }
+    }
+
+    logSaveTest({
+      communityId,
+      provider: parsed.provider,
+      status: reason,
+      durationMs: Date.now() - startedAt,
+      sensitive: [effectiveSecret],
+      supabase,
+    });
+
+    return NextResponse.json({ error: message, reason }, { status: 503 });
+  }
+
+  // Pesapal validated the creds AND registered the IPN → persist.
   // 1. Encrypt the (possibly reused) plaintext secret.
   let encryptedSecret: string | null = null;
   if (!preserveExistingSecret) {
@@ -265,33 +333,17 @@ export async function PUT(
     encryptedSecret = enc as string;
   }
 
-  // 2. Build the atomic UPDATE payload. Preserve existing ipn_id if present
-  //    on the current row (IPN registration UX ships with #121; until then
-  //    the column may carry a stale ipn_id from pre-#119 configs). Read the
-  //    existing config first to avoid dropping the field.
-  const { data: existingCfg } = await supabase
-    .from("communities")
-    .select("payment_provider_config")
-    .eq("id", communityId)
-    .maybeSingle<{ payment_provider_config: unknown }>();
-
-  const existingIpnId =
-    existingCfg &&
-    existingCfg.payment_provider_config &&
-    typeof existingCfg.payment_provider_config === "object" &&
-    typeof (
-      existingCfg.payment_provider_config as Record<string, unknown>
-    ).ipn_id === "string"
-      ? ((existingCfg.payment_provider_config as Record<string, unknown>)
-          .ipn_id as string)
-      : undefined;
-
+  // 2. Build the atomic UPDATE payload. Save & test ALWAYS overwrites
+  //    `ipn_id` with the freshly registered GUID — no preservation of the
+  //    prior value. This makes the sandbox↔prod toggle correct by
+  //    construction (the new GUID belongs to the now-effective Pesapal
+  //    environment).
   const newConfig: Record<string, unknown> = {
     consumer_key: parsed.consumer_key,
     base_url,
     sandbox: parsed.sandbox,
+    ipn_id: registeredIpnId,
   };
-  if (existingIpnId) newConfig.ipn_id = existingIpnId;
 
   const updatePayload: Record<string, unknown> = {
     payment_provider: parsed.provider,

--- a/src/app/api/payments/ipn/__tests__/route.test.ts
+++ b/src/app/api/payments/ipn/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * /api/payments/ipn — Pesapal IPN webhook receiver tests (#121, Phase A).
+ *
+ * Phase A acks 200 with no state work. Tests pin:
+ *   - POST returns 200 { received: true }
+ *   - GET (legacy Pesapal) returns 200 { received: true }
+ *   - JSON body is parsed and surfaces in the structured log line
+ *   - Query params surface in the structured log line
+ *   - The receiver never throws / mutates state (no Supabase client used)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/payments/ipn (Phase A)", () => {
+  it("acks 200 { received: true } and logs the parsed JSON body", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { POST } = await import("../route");
+    const req = new NextRequest("http://localhost/api/payments/ipn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        OrderTrackingId: "OT-123",
+        OrderMerchantReference: "INV-abc",
+        OrderNotificationType: "IPNCHANGE",
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ received: true });
+
+    const logged = infoSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('"payment.ipn.received"'));
+    expect(logged).toBeTruthy();
+    expect(logged!).toContain('"phase":"A"');
+    expect(logged!).toContain('"method":"POST"');
+    expect(logged!).toContain("OT-123");
+    expect(logged!).toContain("INV-abc");
+
+    infoSpy.mockRestore();
+  });
+
+  it("returns 200 even when the body is malformed JSON", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { POST } = await import("../route");
+    const req = new NextRequest("http://localhost/api/payments/ipn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json-at-all",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ received: true });
+
+    infoSpy.mockRestore();
+  });
+});
+
+describe("GET /api/payments/ipn (legacy Pesapal flow)", () => {
+  it("acks 200 { received: true } and logs the query parameters", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const { GET } = await import("../route");
+    const req = new NextRequest(
+      "http://localhost/api/payments/ipn?OrderTrackingId=OT-456&OrderMerchantReference=INV-xyz&OrderNotificationType=IPNCHANGE",
+      { method: "GET" },
+    );
+
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ received: true });
+
+    const logged = infoSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('"payment.ipn.received"'));
+    expect(logged).toBeTruthy();
+    expect(logged!).toContain('"method":"GET"');
+    expect(logged!).toContain("OT-456");
+    expect(logged!).toContain("INV-xyz");
+
+    infoSpy.mockRestore();
+  });
+});

--- a/src/app/api/payments/ipn/route.ts
+++ b/src/app/api/payments/ipn/route.ts
@@ -1,0 +1,109 @@
+/**
+ * PHASE A behavior — REPLACED in Phase B (#157).
+ * Phase A: ack 200 with no state work so Pesapal stops retrying.
+ * Phase B (#157) will replace the body with: server-to-server
+ * getTransactionStatus verify → idempotent state transition → payment_events
+ * audit row. Do NOT add state logic here — file it on #157 instead.
+ *
+ * Body must be replaced by the state machine when #157 lands; the file path
+ * stays.
+ *
+ * --------------------------------------------------------------------------
+ *
+ * /api/payments/ipn — Pesapal IPN webhook receiver (public).
+ *
+ * Pesapal calls this URL after a checkout completes. The newer JSON 3.0 flow
+ * uses POST with a JSON body; older integrations use GET with query params
+ * (`OrderTrackingId`, `OrderMerchantReference`, `OrderNotificationType`).
+ * Both verbs MUST 200 in Phase A so Pesapal does not retry — Phase B will
+ * verify and act on the payload.
+ *
+ * Security: Pesapal does not sign IPN posts. Signature verification belongs
+ * to Phase B's threat-model task. Phase A relies on Vercel's default
+ * rate-limiting (sufficient for the pilot) and never trusts the body — it
+ * only logs it.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+// Public route — no auth, no Supabase client. Phase B will introduce a
+// service-role client to look up the order and update state idempotently.
+const PHASE_A_RESPONSE = { received: true } as const;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  await logIpnEvent(request, "POST");
+  return NextResponse.json(PHASE_A_RESPONSE, { status: 200 });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  await logIpnEvent(request, "GET");
+  return NextResponse.json(PHASE_A_RESPONSE, { status: 200 });
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort structured log: method, parsed query params, parsed body
+ * (when JSON), redacted headers. We never throw from the logger — the route
+ * MUST 200 even if logging fails. No PII / secrets are expected on Pesapal's
+ * payload (just opaque tracking ids), but we still go through `safeStringify`
+ * with a length cap to keep log lines bounded.
+ */
+async function logIpnEvent(
+  request: NextRequest,
+  method: "POST" | "GET",
+): Promise<void> {
+  let body: unknown = null;
+  if (method === "POST") {
+    try {
+      const text = await request.text();
+      if (text.length > 0) {
+        try {
+          body = JSON.parse(text);
+        } catch {
+          // Pesapal may post form-urlencoded in some configurations; fall back
+          // to the raw text (length-capped).
+          body = text.slice(0, 1000);
+        }
+      }
+    } catch {
+      body = null;
+    }
+  }
+
+  const queryParams: Record<string, string> = {};
+  try {
+    request.nextUrl.searchParams.forEach((value, key) => {
+      queryParams[key] = value;
+    });
+  } catch {
+    // ignore
+  }
+
+  const safeHeaders: Record<string, string> = {};
+  for (const headerName of [
+    "user-agent",
+    "content-type",
+    "x-forwarded-for",
+    "x-vercel-ip-country",
+  ]) {
+    const value = request.headers.get(headerName);
+    if (value) safeHeaders[headerName] = value;
+  }
+
+  try {
+    console.info(
+      JSON.stringify({
+        event: "payment.ipn.received",
+        phase: "A",
+        method,
+        query: queryParams,
+        body,
+        headers: safeHeaders,
+        at: new Date().toISOString(),
+      }),
+    );
+  } catch {
+    // Never let logging fail the 200 ack.
+  }
+}

--- a/src/lib/payments/__tests__/config.test.ts
+++ b/src/lib/payments/__tests__/config.test.ts
@@ -1,0 +1,80 @@
+/**
+ * parsePesapalConfig unit tests (#121).
+ *
+ * Pins the post-#121 contract:
+ *   - `consumer_key`, `base_url`, `ipn_id` are all REQUIRED.
+ *   - Missing `ipn_id` throws `PAYMENT_IPN_NOT_REGISTERED` (distinct from
+ *     generic `PAYMENT_INVALID_CONFIG`) so route handlers can map it to a
+ *     409 `ipn_not_registered` with an actionable hint.
+ *   - `sandbox` round-trips through unchanged when supplied.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parsePesapalConfig } from "../config";
+import { PaymentError } from "../errors";
+
+describe("parsePesapalConfig", () => {
+  it("accepts a fully-populated config and round-trips fields", () => {
+    const cfg = parsePesapalConfig({
+      consumer_key: "ck_live",
+      base_url: "https://pay.pesapal.com/v3",
+      ipn_id: "ipn-abc",
+      sandbox: false,
+    });
+    expect(cfg).toEqual({
+      consumer_key: "ck_live",
+      base_url: "https://pay.pesapal.com/v3",
+      ipn_id: "ipn-abc",
+      sandbox: false,
+    });
+  });
+
+  it("rejects null/undefined / non-object input", () => {
+    expect(() => parsePesapalConfig(null)).toThrow(PaymentError);
+    expect(() => parsePesapalConfig(undefined)).toThrow(PaymentError);
+    expect(() => parsePesapalConfig("string")).toThrow(PaymentError);
+  });
+
+  it("rejects config missing consumer_key with PAYMENT_INVALID_CONFIG", () => {
+    try {
+      parsePesapalConfig({
+        base_url: "https://pay.pesapal.com/v3",
+        ipn_id: "ipn-abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaymentError);
+      expect((err as PaymentError).code).toBe("PAYMENT_INVALID_CONFIG");
+    }
+  });
+
+  it("rejects config missing ipn_id with PAYMENT_IPN_NOT_REGISTERED (409)", () => {
+    try {
+      parsePesapalConfig({
+        consumer_key: "ck_live",
+        base_url: "https://pay.pesapal.com/v3",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaymentError);
+      const pe = err as PaymentError;
+      expect(pe.code).toBe("PAYMENT_IPN_NOT_REGISTERED");
+      expect(pe.statusCode).toBe(409);
+      expect(pe.message).toMatch(/Save & test/i);
+    }
+  });
+
+  it("rejects config with empty-string ipn_id (after trim)", () => {
+    try {
+      parsePesapalConfig({
+        consumer_key: "ck_live",
+        base_url: "https://pay.pesapal.com/v3",
+        ipn_id: "   ",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaymentError);
+      expect((err as PaymentError).code).toBe("PAYMENT_IPN_NOT_REGISTERED");
+    }
+  });
+});

--- a/src/lib/payments/config.ts
+++ b/src/lib/payments/config.ts
@@ -98,16 +98,16 @@ export async function getCommunityPaymentConfig(
 /**
  * Validate the JSONB shape for Pesapal.
  *
- * Required fields: `consumer_key`, `base_url`.
+ * Required fields (post-#121): `consumer_key`, `base_url`, `ipn_id`.
  *
- * `ipn_id` is **optional** (#119 contract amendment — IPN registration UX
- * ships with #121). A configured community without ipn_id is "ready for auth
- * validation" but not yet "ready to generate links" — the strict check lives
- * further downstream in `PesapalProvider` / `submitOrder`, which throws
- * `PESAPAL_NO_IPN` when a link is actually requested.
+ * `ipn_id` is now **required**. The Save & test flow registers an IPN with
+ * Pesapal and persists the returned GUID; a saved Pesapal config without an
+ * `ipn_id` is malformed and rejected here. Route handlers translate the
+ * resulting `PAYMENT_INVALID_CONFIG` into a 409 `ipn_not_registered` reason
+ * with an actionable hint to re-run Save & test.
  *
- * Throws `PAYMENT_INVALID_CONFIG` only when the shape itself is wrong or the
- * truly-required fields are missing.
+ * Throws `PAYMENT_INVALID_CONFIG` when the shape itself is wrong or any
+ * required field is missing.
  */
 export function parsePesapalConfig(raw: unknown): PesapalConfig {
   if (!raw || typeof raw !== "object") {
@@ -120,6 +120,8 @@ export function parsePesapalConfig(raw: unknown): PesapalConfig {
   const obj = raw as Record<string, unknown>;
   const consumer_key = typeof obj.consumer_key === "string" ? obj.consumer_key : "";
   const base_url = typeof obj.base_url === "string" ? obj.base_url : "";
+  const ipn_id =
+    typeof obj.ipn_id === "string" ? obj.ipn_id.trim() : "";
   if (!consumer_key || !base_url) {
     throw new PaymentError(
       "payment_provider_config is missing required fields (consumer_key, base_url)",
@@ -127,10 +129,18 @@ export function parsePesapalConfig(raw: unknown): PesapalConfig {
       500,
     );
   }
-  const ipn_id_raw = typeof obj.ipn_id === "string" ? obj.ipn_id : "";
+  if (!ipn_id) {
+    // Distinct code so route handlers can map this to a 409
+    // `ipn_not_registered` (actionable: "re-run Save & test") rather than the
+    // generic 503 `invalid_config`. Required since #121.
+    throw new PaymentError(
+      "Pesapal config is missing ipn_id — open Community Payment settings and run Save & test connection to register the IPN URL with Pesapal.",
+      "PAYMENT_IPN_NOT_REGISTERED",
+      409,
+    );
+  }
   const sandbox = typeof obj.sandbox === "boolean" ? obj.sandbox : undefined;
-  const parsed: PesapalConfig = { consumer_key, base_url };
-  if (ipn_id_raw) parsed.ipn_id = ipn_id_raw;
+  const parsed: PesapalConfig = { consumer_key, base_url, ipn_id };
   if (sandbox !== undefined) parsed.sandbox = sandbox;
   return parsed;
 }

--- a/src/lib/payments/errors.ts
+++ b/src/lib/payments/errors.ts
@@ -24,11 +24,12 @@ export class PaymentError extends Error {
 }
 
 // Generic codes (provider-agnostic):
-//   "PAYMENT_NOT_CONFIGURED"    (409) — community has no provider set
-//   "PAYMENT_FORBIDDEN"         (403) — caller may not decrypt the secret
-//   "PAYMENT_INVALID_CONFIG"    (500) — stored config is malformed / partial
-//   "PAYMENT_UNKNOWN_PROVIDER"  (500) — factory received an unknown provider
-//                                        discriminator (exhaustiveness guard)
+//   "PAYMENT_NOT_CONFIGURED"      (409) — community has no provider set
+//   "PAYMENT_FORBIDDEN"           (403) — caller may not decrypt the secret
+//   "PAYMENT_INVALID_CONFIG"      (500) — stored config is malformed / partial
+//   "PAYMENT_IPN_NOT_REGISTERED"  (409) — Pesapal config has no ipn_id (post-#121)
+//   "PAYMENT_UNKNOWN_PROVIDER"    (500) — factory received an unknown provider
+//                                          discriminator (exhaustiveness guard)
 //
 // Provider-specific codes live on the subclass and are mapped to a short
 // `reason` string by the route handler.

--- a/src/lib/payments/pesapal/__tests__/client.test.ts
+++ b/src/lib/payments/pesapal/__tests__/client.test.ts
@@ -1,0 +1,136 @@
+/**
+ * PesapalClient.registerIpn unit tests (#121).
+ *
+ * Pins behavior:
+ *   - POSTs to /api/URLSetup/RegisterIPN with the URL + notification type.
+ *   - Returns the parsed `{ ipn_id, ... }` shape.
+ *   - Throws `PESAPAL_REGISTER_IPN_FAILED` on non-2xx.
+ *   - Throws `PESAPAL_REGISTER_IPN_FAILED` if the 200 response lacks `ipn_id`.
+ *   - Throws `PESAPAL_UNREACHABLE` on network failure.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PesapalClient } from "../client";
+import { PesapalError } from "../errors";
+
+const BASE_URL = "https://pay.pesapal.com/v3";
+
+function makeClient(): PesapalClient {
+  return new PesapalClient({
+    consumerKey: "ck",
+    consumerSecret: "cs_long_enough",
+    baseUrl: BASE_URL,
+  });
+}
+
+describe("PesapalClient.registerIpn", () => {
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  it("POSTs to /api/URLSetup/RegisterIPN with url + ipn_notification_type", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          url: "https://app/api/payments/ipn",
+          created_date: "2026-04-25",
+          ipn_id: "ipn-xyz",
+          notification_type: 1,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const client = makeClient();
+    const out = await client.registerIpn(
+      "fake-token",
+      "https://app/api/payments/ipn",
+      "POST",
+    );
+    expect(out.ipn_id).toBe("ipn-xyz");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchSpy.mock.calls[0];
+    expect(String(calledUrl)).toBe(`${BASE_URL}/api/URLSetup/RegisterIPN`);
+    expect((init as RequestInit).method).toBe("POST");
+    const sentBody = JSON.parse(String((init as RequestInit).body));
+    expect(sentBody).toEqual({
+      url: "https://app/api/payments/ipn",
+      ipn_notification_type: "POST",
+    });
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer fake-token");
+  });
+
+  it("defaults to POST notification type when omitted", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          url: "https://app/api/payments/ipn",
+          created_date: "2026-04-25",
+          ipn_id: "ipn-default",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const client = makeClient();
+    await client.registerIpn("tok", "https://app/api/payments/ipn");
+    const [, init] = fetchSpy.mock.calls[0];
+    const sentBody = JSON.parse(String((init as RequestInit).body));
+    expect(sentBody.ipn_notification_type).toBe("POST");
+  });
+
+  it("throws PESAPAL_REGISTER_IPN_FAILED on non-2xx", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response("denied", {
+        status: 401,
+      }),
+    );
+
+    const client = makeClient();
+    await expect(
+      client.registerIpn("tok", "https://app/api/payments/ipn"),
+    ).rejects.toMatchObject({
+      code: "PESAPAL_REGISTER_IPN_FAILED",
+    });
+  });
+
+  it("throws PESAPAL_REGISTER_IPN_FAILED when 200 but ipn_id is missing", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const client = makeClient();
+    await expect(
+      client.registerIpn("tok", "https://app/api/payments/ipn"),
+    ).rejects.toBeInstanceOf(PesapalError);
+    fetchSpy.mockReset();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ipn_id: "" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(
+      client.registerIpn("tok", "https://app/api/payments/ipn"),
+    ).rejects.toMatchObject({ code: "PESAPAL_REGISTER_IPN_FAILED" });
+  });
+
+  it("throws PESAPAL_UNREACHABLE on network failure", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("connect ECONNREFUSED"));
+
+    const client = makeClient();
+    await expect(
+      client.registerIpn("tok", "https://app/api/payments/ipn"),
+    ).rejects.toMatchObject({ code: "PESAPAL_UNREACHABLE" });
+  });
+});

--- a/src/lib/payments/pesapal/client.ts
+++ b/src/lib/payments/pesapal/client.ts
@@ -2,9 +2,13 @@ import { PesapalError } from "./errors";
 import type {
   AuthTokenResponse,
   IpnEntry,
+  RegisterIpnResponse,
   SubmitOrderParams,
   SubmitOrderResponse,
 } from "./types";
+
+/** Pesapal supports POST or GET for IPN delivery. We default to POST. */
+export type IpnNotificationType = "POST" | "GET";
 
 /**
  * Pesapal client (stateless).
@@ -115,6 +119,49 @@ export class PesapalClient {
       },
       "PESAPAL_HTTP_ERROR",
     );
+  }
+
+  /**
+   * Register an IPN URL with Pesapal and return the canonical record (incl.
+   * `ipn_id`). Called by the Save & test flow (#121) so subsequent
+   * `submitOrder` calls can pass `notification_id`.
+   *
+   * Pesapal returns 200 with `{ ipn_id: "<GUID>", ... }` on success. Any 2xx
+   * payload missing `ipn_id` surfaces as `PESAPAL_REGISTER_IPN_FAILED`.
+   * Non-2xx and network failures surface via `pesapalFetch` as
+   * `PESAPAL_REGISTER_IPN_FAILED` and `PESAPAL_UNREACHABLE` respectively.
+   */
+  async registerIpn(
+    token: string,
+    url: string,
+    type: IpnNotificationType = "POST",
+  ): Promise<RegisterIpnResponse> {
+    const data = await this.pesapalFetch<RegisterIpnResponse>(
+      "/api/URLSetup/RegisterIPN",
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          url,
+          ipn_notification_type: type,
+        }),
+      },
+      "PESAPAL_REGISTER_IPN_FAILED",
+    );
+
+    if (!data.ipn_id || !String(data.ipn_id).trim()) {
+      throw new PesapalError(
+        `Pesapal RegisterIPN returned no ipn_id: ${JSON.stringify(data).slice(0, 500)}`,
+        "PESAPAL_REGISTER_IPN_FAILED",
+        502,
+        data,
+      );
+    }
+    return data;
   }
 
   /** Step 3: Submit order request. */

--- a/src/lib/payments/pesapal/errors.ts
+++ b/src/lib/payments/pesapal/errors.ts
@@ -22,14 +22,17 @@ export class PesapalError extends PaymentError {
 }
 
 // Error codes:
-// "PESAPAL_INVALID_CONFIG"      (503) — config missing consumer_key / secret / base_url
-// "PESAPAL_AUTH_FAILED"         (401) — auth token request failed
-// "PESAPAL_HTTP_ERROR"          (502) — non-2xx from Pesapal
-// "PESAPAL_NO_IPN"              (400) — no IPN registrations on the account
-// "PESAPAL_UNREACHABLE"         (503) — network/fetch failure
-// "PESAPAL_MISSING_CONTACT"     (400) — household has neither email nor phone
-// "PESAPAL_ZERO_AMOUNT"         (400) — line item total is <= 0
-// "PESAPAL_LINE_ITEM_NOT_FOUND" (404) — line item lookup returned no row
-// "PESAPAL_PERIOD_NOT_FOUND"    (404) — billing_periods join returned no row
-// "PESAPAL_HOUSEHOLD_NOT_FOUND" (404) — household lookup returned no row
-// "PESAPAL_NO_REDIRECT"         (502) — submit order succeeded but redirect_url missing
+// "PESAPAL_INVALID_CONFIG"        (503) — config missing consumer_key / secret / base_url
+// "PESAPAL_AUTH_FAILED"           (401) — auth token request failed
+// "PESAPAL_HTTP_ERROR"            (502) — non-2xx from Pesapal
+// "PESAPAL_NO_IPN"                (400) — no IPN registrations on the account
+//                                          (legacy; post-#121 parsePesapalConfig
+//                                          rejects upstream with PAYMENT_INVALID_CONFIG)
+// "PESAPAL_REGISTER_IPN_FAILED"   (502) — RegisterIPN endpoint failed or returned no ipn_id
+// "PESAPAL_UNREACHABLE"           (503) — network/fetch failure
+// "PESAPAL_MISSING_CONTACT"       (400) — household has neither email nor phone
+// "PESAPAL_ZERO_AMOUNT"           (400) — line item total is <= 0
+// "PESAPAL_LINE_ITEM_NOT_FOUND"   (404) — line item lookup returned no row
+// "PESAPAL_PERIOD_NOT_FOUND"      (404) — billing_periods join returned no row
+// "PESAPAL_HOUSEHOLD_NOT_FOUND"   (404) — household lookup returned no row
+// "PESAPAL_NO_REDIRECT"           (502) — submit order succeeded but redirect_url missing

--- a/src/lib/payments/pesapal/types.ts
+++ b/src/lib/payments/pesapal/types.ts
@@ -69,21 +69,39 @@ export interface SubmitOrderResponse {
 }
 
 /**
+ * Response from /api/URLSetup/RegisterIPN.
+ *
+ * Pesapal returns the canonical record for the registered IPN, including the
+ * `ipn_id` GUID which we persist on `communities.payment_provider_config` and
+ * pass back into `submitOrder` as `notification_id`.
+ */
+export interface RegisterIpnResponse {
+  url: string;
+  created_date: string;
+  ipn_id: string;
+  notification_type?: number | string;
+  ipn_notification_type_description?: string;
+  ipn_status?: number;
+  ipn_status_description?: string;
+  status?: string;
+  error?: unknown;
+}
+
+/**
  * Non-secret Pesapal config stored as JSONB in
  * `communities.payment_provider_config`. `consumer_secret` is stored separately
  * in `payment_provider_secret_encrypted` (envelope-encrypted BYTEA) and
  * surfaced via `fn_get_community_payment_secret`.
  *
- * `ipn_id` is **optional** today (#119 contract amendment): Save & test
- * persists a config with no IPN registered yet — IPN registration UX lands
- * with #121. `submitOrder` remains strict; the PesapalProvider constructor
- * throws PESAPAL_NO_IPN at link-generation time when ipn_id is missing,
- * which surfaces as a clean 409/503 to the user rather than a silent crash.
+ * `ipn_id` is **required** post-#121: Save & test now registers an IPN with
+ * Pesapal as part of the success path and writes the returned GUID here. A
+ * persisted Pesapal config without `ipn_id` is treated as malformed by
+ * `parsePesapalConfig` (throws `PAYMENT_INVALID_CONFIG`).
  */
 export interface PesapalConfig {
   consumer_key: string;
   base_url: string;
-  ipn_id?: string;
+  ipn_id: string;
   /**
    * Persisted reflection of the Sandbox toggle in the config UI. Server
    * derives `base_url` from this boolean on write, but we also persist the


### PR DESCRIPTION
## Summary

- \`registerIpn\` method on \`PesapalClient\`. \`parsePesapalConfig\` re-tightened to require non-empty \`ipn_id\`.
- Save & test route always re-registers IPN (sandbox/prod toggle correct by construction).
- Link-generator passes \`ipn_id\` as \`notification_id\`; missing → 409 \`ipn_not_registered\`.
- New \`/api/payments/ipn\` webhook receiver — Phase A only: 200-only ack, no state work. Header comment marks the file as the integration point for Phase B (#157).
- Read-only callback URL + ipn_id display in Community Payment tab (super_admin gated).
- No migration (JSONB shape unchanged).

⚠ **Deployment**: \`NEXT_PUBLIC_PAYMENT_CALLBACK_URL\` MUST be set in Vercel **Production + Preview + Development** scopes before merge — Save & test 503s without it.

Closes #121.

## Test plan

- [x] lint, tsc, test (973 pass), build all green
- [x] Reviewer agent walked all ACs — VERDICT: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)