### PR TITLE
Households: support manual-billing without OpenEMS meter (#158)

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/usage/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/usage/__tests__/route.test.ts
@@ -1,0 +1,369 @@
+/**
+ * PATCH /api/billing-line-items/[lineItemId]/usage — route tests (#158).
+ *
+ * Coverage:
+ *   - 400: invalid UUID, invalid JSON, missing body keys, negative number,
+ *          non-numeric value, end_kwh < start_kwh derivation underflow
+ *   - 403: caller cannot access microgrid
+ *   - 404: line item not found / RLS-hidden
+ *   - 409: device_linked — line item still has a device_id (metered)
+ *   - 409: device_linked — household has a primary_consumption_meter link
+ *   - 409: period_closed — billing period is closed
+ *   - 200: happy path with usage_kwh only — server recomputes tier_breakdown
+ *   - 200: happy path with end_kwh only — server derives usage_kwh
+ *   - 200: tier_breakdown + total_amount math is correct against a fixture
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+let canAccessMicrogridReturn = true;
+
+const mockLineItemMaybeSingle = vi.fn();
+const mockMeterLinkMaybeSingle = vi.fn();
+const mockRateScheduleMaybeSingle = vi.fn();
+let capturedUpdatePayload: Record<string, unknown> | null = null;
+const mockUpdateResult = vi.fn();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeFromImpl(): any {
+  return (table: string) => {
+    if (table === "billing_line_items") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => mockLineItemMaybeSingle(),
+          }),
+        }),
+        update: (payload: Record<string, unknown>) => {
+          capturedUpdatePayload = payload;
+          return {
+            eq: () => ({
+              select: () => ({
+                single: () => mockUpdateResult(),
+              }),
+            }),
+          };
+        },
+      };
+    }
+    if (table === "household_devices") {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () => mockMeterLinkMaybeSingle(),
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "rate_schedules") {
+      return {
+        select: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: () => ({
+                maybeSingle: () => mockRateScheduleMaybeSingle(),
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  };
+}
+
+const mockFrom = vi.fn(makeFromImpl());
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+}));
+
+const LI_UUID = "660e8400-e29b-41d4-a716-446655440111";
+const HH_UUID = "660e8400-e29b-41d4-a716-446655440222";
+const PERIOD_UUID = "660e8400-e29b-41d4-a716-446655440333";
+const MG_UUID = "660e8400-e29b-41d4-a716-446655440444";
+const DEVICE_UUID = "660e8400-e29b-41d4-a716-44665544aaaa";
+const BAD_ID = "not-a-uuid";
+
+function makePatchRequest(id: string, body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/billing-line-items/${id}/usage`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }
+  );
+}
+
+const FIXTURE_RATE_SCHEDULE = {
+  id: "rs-1",
+  microgrid_id: MG_UUID,
+  // Two-tier schedule: 0–50 kWh at 500/kWh, 51+ at 800/kWh.
+  tiers: [
+    { label: "Tier 1", min_kwh: 1, max_kwh: 50, rate_per_kwh: 500 },
+    { label: "Tier 2", min_kwh: 51, max_kwh: null, rate_per_kwh: 800 },
+  ],
+  service_charge: 0,
+  tax_rate: 0,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+describe("PATCH /api/billing-line-items/[lineItemId]/usage (#158)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessMicrogridReturn = true;
+    capturedUpdatePayload = null;
+    mockFrom.mockImplementation(makeFromImpl());
+
+    // Default un-metered line item (device_id null), draft period, no
+    // household meter link, fresh rate schedule.
+    mockLineItemMaybeSingle.mockResolvedValue({
+      data: {
+        id: LI_UUID,
+        device_id: null,
+        start_kwh: 0,
+        end_kwh: null,
+        usage_kwh: null,
+        household_id: HH_UUID,
+        billing_period_id: PERIOD_UUID,
+        billing_periods: {
+          id: PERIOD_UUID,
+          microgrid_id: MG_UUID,
+          status: "draft",
+        },
+      },
+      error: null,
+    });
+    mockMeterLinkMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockRateScheduleMaybeSingle.mockResolvedValue({
+      data: FIXTURE_RATE_SCHEDULE,
+      error: null,
+    });
+    mockUpdateResult.mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          id: LI_UUID,
+          device_id: null,
+          ...(capturedUpdatePayload ?? {}),
+        },
+        error: null,
+      })
+    );
+  });
+
+  it("400: invalid UUID", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(BAD_ID, { usage_kwh: 10 }), {
+      params: Promise.resolve({ lineItemId: BAD_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: invalid JSON", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(LI_UUID, "{not json"), {
+      params: Promise.resolve({ lineItemId: LI_UUID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: missing both keys", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(LI_UUID, {}), {
+      params: Promise.resolve({ lineItemId: LI_UUID }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("invalid_body");
+  });
+
+  it("400: negative number rejected", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: -5 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("400: non-numeric usage_kwh rejected", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: "lots" as unknown as number }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("403: caller cannot access microgrid", async () => {
+    canAccessMicrogridReturn = false;
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: 10 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("404: line item not found", async () => {
+    mockLineItemMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: 10 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("409: device_linked — line item already has a device_id", async () => {
+    mockLineItemMaybeSingle.mockResolvedValueOnce({
+      data: {
+        id: LI_UUID,
+        device_id: DEVICE_UUID, // metered row — must reject manual edit
+        start_kwh: 0,
+        end_kwh: 100,
+        usage_kwh: 100,
+        household_id: HH_UUID,
+        billing_period_id: PERIOD_UUID,
+        billing_periods: {
+          id: PERIOD_UUID,
+          microgrid_id: MG_UUID,
+          status: "draft",
+        },
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: 10 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("device_linked");
+  });
+
+  it("409: device_linked — household has primary_consumption_meter link (line item device_id null)", async () => {
+    // Belt-and-braces: even when the line item itself has no device_id,
+    // a household-level meter link blocks manual edit. The meter link
+    // would be filled in on the next Refresh Readings.
+    mockMeterLinkMaybeSingle.mockResolvedValueOnce({
+      data: { device_id: DEVICE_UUID },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: 10 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("device_linked");
+  });
+
+  it("409: period_closed — closed period rejects", async () => {
+    mockLineItemMaybeSingle.mockResolvedValueOnce({
+      data: {
+        id: LI_UUID,
+        device_id: null,
+        start_kwh: 0,
+        end_kwh: null,
+        usage_kwh: null,
+        household_id: HH_UUID,
+        billing_period_id: PERIOD_UUID,
+        billing_periods: {
+          id: PERIOD_UUID,
+          microgrid_id: MG_UUID,
+          status: "closed",
+        },
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: 10 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.reason).toBe("period_closed");
+  });
+
+  it("200: happy path with usage_kwh only — recomputes tier_breakdown via calculateTieredCost", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { usage_kwh: 80 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(200);
+
+    // 80 kWh on the fixture schedule:
+    //   tier 1: 50 kWh × 500 = 25000
+    //   tier 2: 30 kWh × 800 = 24000
+    //   total: 49000
+    expect(capturedUpdatePayload).not.toBeNull();
+    const payload = capturedUpdatePayload as Record<string, unknown>;
+    expect(payload.usage_kwh).toBe(80);
+    expect(payload.total_amount).toBe(49000);
+    const breakdown = payload.tier_breakdown as {
+      label: string;
+      kwh: number;
+      amount: number;
+    }[];
+    expect(breakdown.length).toBe(2);
+    expect(breakdown[0]).toEqual({ label: "Tier 1", kwh: 50, amount: 25000 });
+    expect(breakdown[1]).toEqual({ label: "Tier 2", kwh: 30, amount: 24000 });
+  });
+
+  it("200: happy path with end_kwh only — derives usage_kwh = end_kwh - start_kwh", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { end_kwh: 80 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(200);
+
+    expect(capturedUpdatePayload).not.toBeNull();
+    const payload = capturedUpdatePayload as Record<string, unknown>;
+    expect(payload.usage_kwh).toBe(80);
+    expect(payload.end_kwh).toBe(80);
+    expect(payload.total_amount).toBe(49000);
+  });
+
+  it("400: end_kwh < start_kwh derivation underflow rejected", async () => {
+    // Override start_kwh = 100, send end_kwh = 50 → derived usage = -50 → 400.
+    mockLineItemMaybeSingle.mockResolvedValueOnce({
+      data: {
+        id: LI_UUID,
+        device_id: null,
+        start_kwh: 100,
+        end_kwh: null,
+        usage_kwh: null,
+        household_id: HH_UUID,
+        billing_period_id: PERIOD_UUID,
+        billing_periods: {
+          id: PERIOD_UUID,
+          microgrid_id: MG_UUID,
+          status: "draft",
+        },
+      },
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest(LI_UUID, { end_kwh: 50 }),
+      { params: Promise.resolve({ lineItemId: LI_UUID }) }
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/billing-line-items/[lineItemId]/usage/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/usage/route.ts
@@ -1,0 +1,313 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { calculateTieredCost } from "@/lib/billing/calculations";
+import type { TierConfig } from "@/lib/types/domain";
+
+/**
+ * PATCH /api/billing-line-items/[lineItemId]/usage
+ *
+ * Manual usage entry for un-metered (manual-billing) households. Added in
+ * #158 alongside the no-meter household-creation path. The route is the
+ * single write surface for the BillingTable's inline-edit cells (END kWh,
+ * USAGE kWh) on rows where `device_id IS NULL`.
+ *
+ * Body:
+ *   { usage_kwh?: number; end_kwh?: number }
+ *   At least one of the two must be present (else 400).
+ *
+ * Server-side semantics:
+ *   - When both `usage_kwh` and `end_kwh` are provided, prefer the explicit
+ *     values (no derivation override).
+ *   - When only `end_kwh` is provided, derive `usage_kwh = end_kwh -
+ *     start_kwh` (where start_kwh is read from the row).
+ *   - When only `usage_kwh` is provided, leave `end_kwh` untouched.
+ *
+ * Recomputes `tier_breakdown` and `total_amount` via `calculateTieredCost`
+ * using the microgrid's most recent rate_schedule (mirrors the Refresh
+ * Readings code path in src/app/api/billing/generate/route.ts).
+ *
+ * Authorization:
+ *   - currentUserCanAccessMicrogrid via the line-item → period → microgrid
+ *     chain (mirrors households/[id]/route.ts pattern).
+ *
+ * Rejects:
+ *   - 400 invalid JSON / missing both keys / negative or non-numeric values
+ *   - 403 caller cannot access this microgrid
+ *   - 404 line item not found / RLS-hidden
+ *   - 409 device_linked — household has a primary_consumption_meter
+ *     (Refresh Readings is the only valid update path for metered rows)
+ *   - 409 period_closed — billing period status is 'closed'
+ *
+ * Response:
+ *   200 { lineItem: <updated row> }
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type ParsedBody = {
+  usage_kwh: number | undefined;
+  end_kwh: number | undefined;
+};
+
+function parseBody(raw: unknown): ParsedBody | { error: string } {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { error: "Request body must be an object" };
+  }
+  const rec = raw as Record<string, unknown>;
+
+  let usage_kwh: number | undefined;
+  let end_kwh: number | undefined;
+
+  if ("usage_kwh" in rec && rec.usage_kwh !== undefined) {
+    if (typeof rec.usage_kwh !== "number" || !Number.isFinite(rec.usage_kwh)) {
+      return { error: "usage_kwh must be a finite number" };
+    }
+    if (rec.usage_kwh < 0) {
+      return { error: "usage_kwh must be a non-negative number" };
+    }
+    usage_kwh = rec.usage_kwh;
+  }
+
+  if ("end_kwh" in rec && rec.end_kwh !== undefined) {
+    if (typeof rec.end_kwh !== "number" || !Number.isFinite(rec.end_kwh)) {
+      return { error: "end_kwh must be a finite number" };
+    }
+    if (rec.end_kwh < 0) {
+      return { error: "end_kwh must be a non-negative number" };
+    }
+    end_kwh = rec.end_kwh;
+  }
+
+  if (usage_kwh === undefined && end_kwh === undefined) {
+    return { error: "At least one of usage_kwh or end_kwh is required" };
+  }
+
+  return { usage_kwh, end_kwh };
+}
+
+type LineItemScope = {
+  id: string;
+  device_id: string | null;
+  start_kwh: number | null;
+  end_kwh: number | null;
+  usage_kwh: number | null;
+  household_id: string;
+  billing_period_id: string;
+  billing_periods: {
+    id: string;
+    microgrid_id: string;
+    status: string;
+  } | null;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ lineItemId: string }> }
+): Promise<NextResponse> {
+  const { lineItemId } = await params;
+
+  if (!UUID_RE.test(lineItemId)) {
+    return NextResponse.json(
+      { error: "Invalid line item id — expected UUID.", reason: "bad_request" },
+      { status: 400 }
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body", reason: "bad_request" },
+      { status: 400 }
+    );
+  }
+
+  const parsed = parseBody(raw);
+  if ("error" in parsed) {
+    return NextResponse.json(
+      { error: parsed.error, reason: "invalid_body" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  // 1. Resolve line item → period → microgrid in one shot. RLS-hidden rows
+  //    surface as null → 404.
+  const { data: scopedRaw, error: scopeErr } = await supabase
+    .from("billing_line_items")
+    .select(
+      `
+      id,
+      device_id,
+      start_kwh,
+      end_kwh,
+      usage_kwh,
+      household_id,
+      billing_period_id,
+      billing_periods!inner (
+        id,
+        microgrid_id,
+        status
+      )
+    `
+    )
+    .eq("id", lineItemId)
+    .maybeSingle();
+
+  if (scopeErr) {
+    return NextResponse.json(
+      { error: `Failed to look up line item: ${scopeErr.message}`, reason: "unknown_error" },
+      { status: 500 }
+    );
+  }
+  if (!scopedRaw) {
+    return NextResponse.json(
+      { error: "Line item not found.", reason: "not_found" },
+      { status: 404 }
+    );
+  }
+
+  // PostgREST sometimes returns single relations as single-element arrays;
+  // normalize that just like the payment-status route does.
+  const scoped = scopedRaw as unknown as LineItemScope;
+  const period = Array.isArray(scoped.billing_periods)
+    ? scoped.billing_periods[0]
+    : scoped.billing_periods;
+  if (!period) {
+    return NextResponse.json(
+      { error: "Line item not found.", reason: "not_found" },
+      { status: 404 }
+    );
+  }
+
+  // 2. Permission gate.
+  if (!(await currentUserCanAccessMicrogrid(supabase, period.microgrid_id))) {
+    return NextResponse.json(
+      { error: "You do not have permission to update this line item.", reason: "forbidden" },
+      { status: 403 }
+    );
+  }
+
+  // 3. Reject manual-edit on closed periods.
+  if (period.status === "closed") {
+    return NextResponse.json(
+      { error: "Cannot edit a closed period", reason: "period_closed" },
+      { status: 409 }
+    );
+  }
+
+  // 4. Reject manual-edit on rows whose household has a primary_consumption_meter
+  //    link. The presence of a non-null device_id on the line item is a
+  //    fast first signal, but a household may have a meter linked WITHOUT
+  //    the line item having captured a device_id yet (e.g. between create
+  //    and first Refresh). The authoritative check is on household_devices.
+  if (scoped.device_id !== null) {
+    return NextResponse.json(
+      { error: "Use Refresh Readings for metered households", reason: "device_linked" },
+      { status: 409 }
+    );
+  }
+
+  const { data: meterLink, error: linkErr } = await supabase
+    .from("household_devices")
+    .select("device_id")
+    .eq("household_id", scoped.household_id)
+    .eq("role", "primary_consumption_meter")
+    .maybeSingle();
+
+  if (linkErr) {
+    return NextResponse.json(
+      { error: `Failed to verify household meter link: ${linkErr.message}`, reason: "unknown_error" },
+      { status: 500 }
+    );
+  }
+  if (meterLink) {
+    return NextResponse.json(
+      { error: "Use Refresh Readings for metered households", reason: "device_linked" },
+      { status: 409 }
+    );
+  }
+
+  // 5. Resolve final usage/end values.
+  //    - both provided → use both verbatim
+  //    - only end_kwh   → derive usage_kwh = end_kwh - start_kwh
+  //    - only usage_kwh → leave end_kwh as-is on the row
+  const startKwh = scoped.start_kwh ?? 0;
+  let nextUsage: number;
+  let nextEnd: number | null;
+
+  if (parsed.usage_kwh !== undefined && parsed.end_kwh !== undefined) {
+    nextUsage = parsed.usage_kwh;
+    nextEnd = parsed.end_kwh;
+  } else if (parsed.end_kwh !== undefined) {
+    nextEnd = parsed.end_kwh;
+    const derived = parsed.end_kwh - startKwh;
+    if (derived < 0) {
+      return NextResponse.json(
+        { error: "end_kwh must be greater than or equal to start_kwh", reason: "invalid_body" },
+        { status: 400 }
+      );
+    }
+    nextUsage = derived;
+  } else {
+    nextUsage = parsed.usage_kwh as number;
+    nextEnd = scoped.end_kwh;
+  }
+
+  // 6. Re-fetch the microgrid's latest rate_schedule + recompute the bill.
+  const { data: schedule, error: scheduleError } = await supabase
+    .from("rate_schedules")
+    .select("*")
+    .eq("microgrid_id", period.microgrid_id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (scheduleError || !schedule) {
+    return NextResponse.json(
+      { error: "No rate schedule found for this microgrid", reason: "missing_rate_schedule" },
+      { status: 400 }
+    );
+  }
+
+  const calc = calculateTieredCost(
+    nextUsage,
+    schedule.tiers as TierConfig[],
+    schedule.service_charge,
+    schedule.tax_rate
+  );
+
+  // 7. Update the row + return the fresh payload.
+  const updatePayload = {
+    usage_kwh: nextUsage,
+    end_kwh: nextEnd,
+    tier_breakdown: calc.tierBreakdown,
+    total_amount: calc.totalAmount,
+  };
+
+  const { data: updated, error: updateError } = await supabase
+    .from("billing_line_items")
+    .update(updatePayload)
+    .eq("id", lineItemId)
+    .select()
+    .single();
+
+  if (updateError) {
+    if (updateError.code === "42501" || updateError.message.includes("row-level security")) {
+      return NextResponse.json(
+        { error: "Not authorized to update this line item.", reason: "rls_denied" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to update line item: ${updateError.message}`, reason: "unknown_error" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ lineItem: updated }, { status: 200 });
+}

--- a/src/app/api/billing/generate/__tests__/route.test.ts
+++ b/src/app/api/billing/generate/__tests__/route.test.ts
@@ -1,0 +1,313 @@
+/**
+ * POST /api/billing/generate — Refresh Readings tests (#158).
+ *
+ * Coverage focus: the LEFT-join shape change introduced for un-metered
+ * (manual-billing) households. Specifically:
+ *   - Un-metered households now appear in the result set with an empty
+ *     `household_devices` array. The route must skip the OpenEMS query for
+ *     them but STILL insert a `billing_line_items` row with null device_id,
+ *     null end_kwh, null usage_kwh, [] tier_breakdown, total_amount=0.
+ *   - Metered households produce identical line items to pre-#158
+ *     (regression: same start_kwh, end_kwh, usage_kwh, tier_breakdown,
+ *     total_amount given the same OpenEMS reading).
+ *
+ * Note on mocking strategy: the route is heavily Supabase-chained. We
+ * stub each from(table) entry-point and capture the row payload passed
+ * to insert(). That gives us a per-row assertion surface against the spec.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockPeriodSingle = vi.fn();
+const mockRateScheduleMaybeSingle = vi.fn();
+const mockHouseholdsResult = vi.fn();
+const mockPriorPeriods = vi.fn();
+const mockPriorItems = vi.fn();
+let capturedDeleteFilter: { period_id?: string } = {};
+let capturedInsertRows: Record<string, unknown>[] | null = null;
+const mockGetReadings = vi.fn();
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "billing_periods") {
+    return {
+      select: (cols: string) => ({
+        eq: (col: string, val: string) => ({
+          single: () => mockPeriodSingle(),
+          // The "list prior periods" path:
+          lte: () => ({
+            neq: () => ({
+              order: () => mockPriorPeriods(),
+            }),
+          }),
+          // Caught by the closer:
+          _meta: { table, cols, col, val },
+        }),
+      }),
+    };
+  }
+  if (table === "rate_schedules") {
+    return {
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            limit: () => ({
+              maybeSingle: () => mockRateScheduleMaybeSingle(),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === "households") {
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => mockHouseholdsResult(),
+        }),
+      }),
+    };
+  }
+  if (table === "billing_line_items") {
+    return {
+      select: () => ({
+        in: () => ({
+          in: () => ({
+            not: () => mockPriorItems(),
+          }),
+        }),
+      }),
+      delete: () => ({
+        eq: (_col: string, val: string) => {
+          capturedDeleteFilter = { period_id: val };
+          return Promise.resolve({ error: null });
+        },
+      }),
+      insert: (rows: Record<string, unknown> | Record<string, unknown>[]) => {
+        capturedInsertRows = Array.isArray(rows) ? rows : [rows];
+        return Promise.resolve({ error: null });
+      },
+    };
+  }
+  throw new Error(`Unexpected table: ${table}`);
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/openems/config", () => ({
+  getMicrogridEmsConfig: async () => ({
+    backendUrl: "https://example.test",
+    authStrategy: "basic",
+    auth: { username: "u", password: "p" },
+  }),
+}));
+
+vi.mock("@/lib/openems", () => ({
+  createOpenEmsClient: () => ({ getReadings: mockGetReadings }),
+  OpenEmsError: class OpenEmsError extends Error {
+    code = "test_error";
+    statusCode = 500;
+  },
+}));
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const PERIOD_ID = "660e8400-e29b-41d4-a716-446655441000";
+const MG_ID = "660e8400-e29b-41d4-a716-446655442000";
+const RATE_SCHEDULE = {
+  id: "rs-1",
+  microgrid_id: MG_ID,
+  tiers: [
+    { label: "Tier 1", min_kwh: 1, max_kwh: 50, rate_per_kwh: 500 },
+    { label: "Tier 2", min_kwh: 51, max_kwh: null, rate_per_kwh: 800 },
+  ],
+  service_charge: 0,
+  tax_rate: 0,
+};
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/billing/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/billing/generate (#158 LEFT join + manual-billing rows)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedInsertRows = null;
+    capturedDeleteFilter = {};
+
+    mockPeriodSingle.mockResolvedValue({
+      data: {
+        id: PERIOD_ID,
+        microgrid_id: MG_ID,
+        start_date: "2026-04-01",
+        end_date: "2026-04-30",
+        status: "draft",
+      },
+      error: null,
+    });
+    mockRateScheduleMaybeSingle.mockResolvedValue({
+      data: RATE_SCHEDULE,
+      error: null,
+    });
+    mockPriorPeriods.mockResolvedValue({ data: [], error: null });
+    mockPriorItems.mockResolvedValue({ data: [], error: null });
+    mockGetReadings.mockResolvedValue([]);
+  });
+
+  it("inserts an un-metered placeholder row when a household has no primary_consumption_meter (#158)", async () => {
+    // LEFT-join shape: household_devices array is empty for un-metered.
+    mockHouseholdsResult.mockResolvedValue({
+      data: [
+        {
+          id: "hh-unmetered",
+          display_name: "Manual Family",
+          household_devices: [],
+        },
+      ],
+      error: null,
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest({ billingPeriodId: PERIOD_ID }));
+    expect(res.status).toBe(200);
+
+    expect(capturedDeleteFilter.period_id).toBe(PERIOD_ID);
+    expect(capturedInsertRows).not.toBeNull();
+    expect(capturedInsertRows).toHaveLength(1);
+    const row = (capturedInsertRows as Record<string, unknown>[])[0];
+    // Manual-billing placeholder shape from AC-5:
+    //   device_id null, start_kwh 0, end_kwh null, usage_kwh null,
+    //   tier_breakdown [], total_amount 0.
+    expect(row).toMatchObject({
+      billing_period_id: PERIOD_ID,
+      household_id: "hh-unmetered",
+      device_id: null,
+      start_kwh: 0,
+      end_kwh: null,
+      usage_kwh: null,
+      total_amount: 0,
+    });
+    expect((row as Record<string, unknown>).tier_breakdown).toEqual([]);
+  });
+
+  it("regression: metered household produces identical line item shape to pre-#158", async () => {
+    // The metered fixture mirrors the production-pinned period
+    // (912c684e-7db1-4543-b02e-cd6d35cad46c) shape: one household with a
+    // valid primary_consumption_meter device + edge.
+    mockHouseholdsResult.mockResolvedValue({
+      data: [
+        {
+          id: "hh-metered",
+          display_name: "Metered Family",
+          household_devices: [
+            {
+              role: "primary_consumption_meter",
+              devices: {
+                id: "dev-1",
+                openems_component_id: "meter1",
+                edges: { openems_edge_id: "edge0" },
+              },
+            },
+          ],
+        },
+      ],
+      error: null,
+    });
+    mockGetReadings.mockResolvedValue([
+      { deviceId: "dev-1", usageKwh: 80 },
+    ]);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest({ billingPeriodId: PERIOD_ID }));
+    expect(res.status).toBe(200);
+
+    expect(capturedInsertRows).toHaveLength(1);
+    const row = (capturedInsertRows as Record<string, unknown>[])[0];
+    expect(row).toMatchObject({
+      billing_period_id: PERIOD_ID,
+      household_id: "hh-metered",
+      device_id: "dev-1",
+      usage_kwh: 80,
+      start_kwh: 0,
+      end_kwh: 80, // start_kwh + usage_kwh
+      total_amount: 49000, // 50 × 500 + 30 × 800
+    });
+    const breakdown = (row as Record<string, unknown>).tier_breakdown as {
+      label: string;
+      kwh: number;
+      amount: number;
+    }[];
+    expect(breakdown).toEqual([
+      { label: "Tier 1", kwh: 50, amount: 25000 },
+      { label: "Tier 2", kwh: 30, amount: 24000 },
+    ]);
+  });
+
+  it("inserts BOTH metered + un-metered rows in the same Refresh run (#158)", async () => {
+    mockHouseholdsResult.mockResolvedValue({
+      data: [
+        {
+          id: "hh-metered",
+          display_name: "Metered Family",
+          household_devices: [
+            {
+              role: "primary_consumption_meter",
+              devices: {
+                id: "dev-1",
+                openems_component_id: "meter1",
+                edges: { openems_edge_id: "edge0" },
+              },
+            },
+          ],
+        },
+        {
+          id: "hh-unmetered",
+          display_name: "Manual Family",
+          household_devices: [],
+        },
+      ],
+      error: null,
+    });
+    mockGetReadings.mockResolvedValue([
+      { deviceId: "dev-1", usageKwh: 80 },
+    ]);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest({ billingPeriodId: PERIOD_ID }));
+    expect(res.status).toBe(200);
+
+    expect(capturedInsertRows).toHaveLength(2);
+    const byHousehold = new Map(
+      (capturedInsertRows as Record<string, unknown>[]).map((r) => [
+        r.household_id,
+        r,
+      ])
+    );
+    // Metered row preserved exactly.
+    const metered = byHousehold.get("hh-metered");
+    expect(metered).toBeDefined();
+    expect(metered).toMatchObject({
+      device_id: "dev-1",
+      usage_kwh: 80,
+      end_kwh: 80,
+      total_amount: 49000,
+    });
+    // Un-metered placeholder.
+    const unmetered = byHousehold.get("hh-unmetered");
+    expect(unmetered).toBeDefined();
+    expect(unmetered).toMatchObject({
+      device_id: null,
+      usage_kwh: null,
+      end_kwh: null,
+      total_amount: 0,
+    });
+  });
+});

--- a/src/app/api/billing/generate/route.ts
+++ b/src/app/api/billing/generate/route.ts
@@ -77,20 +77,26 @@ export async function POST(request: NextRequest) {
 
   const rateSchedule = schedule as RateSchedule;
 
-  // 3. Fetch households with their primary-consumption-meter device + parent edge
-  //    in a single relational query. Post-#101: openems_backend_url lives on the
-  //    microgrid, not the edge — so we don't select it per-device here.
+  // 3. Fetch households + their primary-consumption-meter device + parent
+  //    edge. #158 widens this from an INNER join to a LEFT join so un-metered
+  //    households are returned alongside metered ones — they just arrive with
+  //    an empty `household_devices` array. Concrete change: drop `!inner` on
+  //    both `household_devices` and `devices` and add a filter on the join
+  //    predicate so the include set is unchanged for metered households.
+  //
+  //    Post-#101: openems_backend_url lives on the microgrid, not the edge —
+  //    so we don't select it per-device here.
   const { data: householdsRaw, error: householdsError } = await supabase
     .from("households")
     .select(`
       id,
       display_name,
-      household_devices!inner(
+      household_devices(
         role,
-        devices!inner(
+        devices(
           id,
           openems_component_id,
-          edges!inner(
+          edges(
             openems_edge_id
           )
         )
@@ -112,6 +118,11 @@ export async function POST(request: NextRequest) {
   // Map: deviceId → householdId (for line item assembly)
   const deviceToHouseholdMap = new Map<string, string>();
 
+  // #158: track households that have NO primary_consumption_meter link.
+  // These get null-device "manual entry pending" line items inserted alongside
+  // the metered rows so Aaron can fill them in from the BillingTable.
+  const unmeteredHouseholdIds: string[] = [];
+
   type HouseholdRow = {
     id: string;
     display_name: string;
@@ -122,31 +133,38 @@ export async function POST(request: NextRequest) {
         openems_component_id: string | null;
         edges: {
           openems_edge_id: string | null;
-        };
-      };
+        } | null;
+      } | null;
     }[];
   };
 
   for (const h of (householdsRaw ?? []) as unknown as HouseholdRow[]) {
-    // Should have exactly one primary_consumption_meter due to partial unique index,
-    // but iterate defensively.
+    // Should have at most one primary_consumption_meter due to the partial
+    // unique index. The LEFT join may surface zero rows for un-metered
+    // households — those go to the manual-billing path.
     const primaryHD = h.household_devices.find(
       (hd) => hd.role === "primary_consumption_meter"
     );
 
     if (!primaryHD) {
-      errors.push({
-        householdId: h.id,
-        householdName: h.display_name,
-        error: "No primary_consumption_meter device assigned",
-      });
+      // #158: no meter linked — manual-billing path. We still emit a
+      // line-item row with null device + null usage so the BillingTable
+      // surfaces the household and the operator can enter usage by hand.
+      unmeteredHouseholdIds.push(h.id);
       continue;
     }
 
     const device = primaryHD.devices;
+    if (!device) {
+      // Defensive: a household_devices row with role=primary_consumption_meter
+      // but a nullable joined `devices` payload means the device row was
+      // dropped underneath us. Treat as un-metered for this run.
+      unmeteredHouseholdIds.push(h.id);
+      continue;
+    }
     const edge = device.edges;
 
-    if (!edge.openems_edge_id || !device.openems_component_id) {
+    if (!edge || !edge.openems_edge_id || !device.openems_component_id) {
       errors.push({
         householdId: h.id,
         householdName: h.display_name,
@@ -211,14 +229,62 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // #158: shape an "unmetered placeholder" row per un-metered household.
+  // These rows have null device_id, null end_kwh, null usage_kwh,
+  // empty tier_breakdown, and total_amount=0. Aaron fills end/usage in
+  // manually from the BillingTable; the PATCH /usage route then recomputes
+  // tier_breakdown + total_amount via calculateTieredCost.
+  type UnmeteredLineItem = {
+    billing_period_id: string;
+    household_id: string;
+    device_id: null;
+    usage_kwh: null;
+    start_kwh: number;
+    end_kwh: null;
+    tier_breakdown: { label: string; kwh: number; amount: number }[];
+    total_amount: number;
+  };
+  const unmeteredLineItems: UnmeteredLineItem[] = unmeteredHouseholdIds.map(
+    (householdId) => ({
+      billing_period_id: body.billingPeriodId,
+      household_id: householdId,
+      device_id: null,
+      usage_kwh: null,
+      // start_kwh stays 0 for un-metered rows: the manual entry IS the
+      // usage_kwh, and end_kwh - start_kwh = usage_kwh holds when
+      // start_kwh=0 + end_kwh=usage_kwh. Aaron can edit either field.
+      start_kwh: 0,
+      end_kwh: null,
+      tier_breakdown: [],
+      total_amount: 0,
+    })
+  );
+
   if (deviceConfigs.length === 0) {
-    // No devices to query — delete old line items and return
+    // No metered devices to query. Still delete-then-insert the unmetered
+    // placeholders so re-runs don't accumulate stale rows.
     await supabase
       .from("billing_line_items")
       .delete()
       .eq("billing_period_id", body.billingPeriodId);
 
-    return NextResponse.json({ lineItems: 0, errors });
+    if (unmeteredLineItems.length > 0) {
+      const { error: insertError } = await supabase
+        .from("billing_line_items")
+        .insert(unmeteredLineItems);
+
+      if (insertError) {
+        return NextResponse.json(
+          { error: `Failed to insert manual-billing line items: ${insertError.message}` },
+          { status: 500 }
+        );
+      }
+    }
+
+    return NextResponse.json({
+      lineItems: unmeteredLineItems.length,
+      errors,
+    });
   }
 
   // 5. Call OpenEMS for readings. Resolve the microgrid-level config first
@@ -314,11 +380,15 @@ export async function POST(request: NextRequest) {
       .delete()
       .eq("billing_period_id", body.billingPeriodId);
 
-    // 9. Insert new line items
-    if (lineItemRows.length > 0) {
+    // 9. Insert new line items — metered rows (from OpenEMS) + un-metered
+    //    placeholder rows (for households with no primary meter linked).
+    //    The two are inserted together so the delete-then-insert pattern
+    //    stays atomic from the operator's POV.
+    const allRows = [...lineItemRows, ...unmeteredLineItems];
+    if (allRows.length > 0) {
       const { error: insertError } = await supabase
         .from("billing_line_items")
-        .insert(lineItemRows);
+        .insert(allRows);
 
       if (insertError) {
         return NextResponse.json(
@@ -329,7 +399,7 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({
-      lineItems: lineItemRows.length,
+      lineItems: allRows.length,
       errors,
     });
   } catch (err) {

--- a/src/app/api/households/with-meter/__tests__/route.test.ts
+++ b/src/app/api/households/with-meter/__tests__/route.test.ts
@@ -80,14 +80,19 @@ describe("POST /api/households/with-meter", () => {
     expect(json.field).toBe("display_name");
   });
 
-  it("422: missing device_id", async () => {
+  it("201: empty device_id routes to fn_create_household (manual billing) (#158)", async () => {
+    // #158: device_id is now optional. Empty/missing/null device_id routes
+    // to fn_create_household (no meter wiring); a non-empty UUID still
+    // routes to fn_create_household_with_meter.
     const { POST } = await import("../route");
     const res = await POST(
       makePostRequest({ ...VALID_BODY, device_id: "" })
     );
-    expect(res.status).toBe(422);
-    const json = await res.json();
-    expect(json.field).toBe("device_id");
+    expect(res.status).toBe(201);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    const [fnName, args] = mockRpc.mock.calls[0];
+    expect(fnName).toBe("fn_create_household");
+    expect((args as Record<string, unknown>).p_device_id).toBeNull();
   });
 
   it("400: #155 — primary_phone key missing returns household_phone_required", async () => {
@@ -162,5 +167,55 @@ describe("POST /api/households/with-meter", () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe("household_phone_required");
+  });
+
+  it("201: #158 — null device_id calls fn_create_household with p_device_id=null", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({ ...VALID_BODY, device_id: null })
+    );
+    expect(res.status).toBe(201);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    const [fnName, args] = mockRpc.mock.calls[0];
+    expect(fnName).toBe("fn_create_household");
+    expect((args as Record<string, unknown>).p_device_id).toBeNull();
+    expect((args as Record<string, unknown>).p_primary_phone).toBe(
+      "+256700000000"
+    );
+  });
+
+  it("201: #158 — missing device_id key calls fn_create_household", async () => {
+    const { POST } = await import("../route");
+    const { device_id: _drop, ...withoutDeviceId } = VALID_BODY;
+    void _drop;
+    const res = await POST(makePostRequest(withoutDeviceId));
+    expect(res.status).toBe(201);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    const [fnName, args] = mockRpc.mock.calls[0];
+    expect(fnName).toBe("fn_create_household");
+    expect((args as Record<string, unknown>).p_device_id).toBeNull();
+  });
+
+  it("201: #158 — non-empty device_id calls fn_create_household_with_meter", async () => {
+    // Backwards compatibility: existing metered path is preserved.
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    const [fnName, args] = mockRpc.mock.calls[0];
+    expect(fnName).toBe("fn_create_household_with_meter");
+    expect((args as Record<string, unknown>).p_device_id).toBe(DEVICE_UUID);
+  });
+
+  it("400: #158 — null phone with null device_id still rejects (phone-required preserved)", async () => {
+    // Coordinated #155 + #158: even on the no-meter path, phone is required.
+    const { POST } = await import("../route");
+    const res = await POST(
+      makePostRequest({ ...VALID_BODY, device_id: null, primary_phone: null })
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("household_phone_required");
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/households/with-meter/route.ts
+++ b/src/app/api/households/with-meter/route.ts
@@ -4,21 +4,28 @@ import { createClient } from "@/lib/supabase/server";
 /**
  * POST /api/households/with-meter
  *
- * Creates a household AND links its primary_consumption_meter in one atomic
- * RPC (`fn_create_household_with_meter`). Used by the Add-Household wizard
- * (UX2 / #74). The RPC is SECURITY INVOKER — RLS on households and
- * household_devices decides whether the caller may write.
+ * Creates a household. Originally written for the Add-Household wizard
+ * (UX2 / #74) when meter assignment was mandatory; route name is preserved
+ * for back-compat. Two paths post-#158:
+ *
+ *   - `device_id` present and non-empty → calls `fn_create_household_with_meter`
+ *     (which now wraps `fn_create_household` with a non-null device id).
+ *   - `device_id` null/missing/empty → calls `fn_create_household` directly
+ *     with `p_device_id => null` (manual-billing household, no meter wiring).
+ *
+ * The RPC is SECURITY INVOKER — RLS on households and household_devices
+ * decides whether the caller may write.
  *
  * Authorization:
  *   - RLS via user_can_access_microgrid(microgrid_id) on households INSERT
- *   - The RPC's own safety guards reject cross-microgrid device_ids and
+ *   - The RPC's safety guards reject cross-microgrid device_ids and
  *     non-consumption-meter device types BEFORE any write happens.
  *
  * Request body:
  * {
  *   microgrid_id:         string;
  *   display_name:         string;
- *   device_id:            string;
+ *   device_id?:           string | null;     // optional — manual billing if null
  *   primary_phone:        string;            // required (#155)
  *   primary_email?:       string | null;
  *   address_line1?:       string | null;
@@ -65,13 +72,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const device_id =
-    typeof body.device_id === "string" ? body.device_id.trim() : "";
-  if (!device_id) {
-    return NextResponse.json(
-      { error: "device_id is required.", field: "device_id" },
-      { status: 422 }
-    );
+  // #158: device_id is optional. `null`, missing, or empty string → manual
+  // billing path (call fn_create_household with p_device_id => null). A
+  // non-empty string → metered path (call fn_create_household_with_meter
+  // wrapper). Anything that's not a string is rejected by the trim/optional
+  // helpers below.
+  let device_id: string | null = null;
+  if (body.device_id !== undefined && body.device_id !== null) {
+    if (typeof body.device_id !== "string") {
+      return NextResponse.json(
+        { error: "device_id must be a string, null, or omitted.", field: "device_id" },
+        { status: 422 }
+      );
+    }
+    const trimmed = body.device_id.trim();
+    device_id = trimmed.length > 0 ? trimmed : null;
   }
 
   // #155: primary_phone is required. Defense-in-depth — the RPC also raises
@@ -95,10 +110,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const supabase = await createClient();
 
-  const { data, error } = await supabase.rpc("fn_create_household_with_meter", {
+  // #158: dispatch to the meter-required wrapper (back-compat) or the
+  // no-meter path on fn_create_household. The wrapper itself just delegates
+  // to fn_create_household; the split is preserved at the route level so
+  // existing observability/logs keep their function-name signal.
+  const rpcArgs = {
     p_microgrid_id: microgrid_id,
     p_display_name: display_name,
-    p_device_id: device_id,
     p_primary_phone: primary_phone,
     p_primary_email: optional(body.primary_email) ?? undefined,
     p_address_line1: optional(body.address_line1) ?? undefined,
@@ -109,7 +127,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     p_address_country: optional(body.address_country) ?? undefined,
     p_address_postal_code: optional(body.address_postal_code) ?? undefined,
     p_geography_notes: optional(body.geography_notes) ?? undefined,
-  });
+  };
+
+  const { data, error } = device_id
+    ? await supabase.rpc("fn_create_household_with_meter", {
+        ...rpcArgs,
+        p_device_id: device_id,
+      })
+    : await supabase.rpc("fn_create_household", {
+        ...rpcArgs,
+        p_device_id: null,
+      });
 
   if (error) {
     // Row-level security denial → 403.

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -17,6 +17,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { ClosePeriodDialog, type ClosePeriodSummaryRow } from "@/components/ui/close-period-dialog";
 import { Banner } from "@/components/ui/banner";
 import { PaymentRowActions } from "@/components/billing/payment-row-actions";
+import { ManualUsageCell } from "@/components/billing/manual-usage-cell";
 import type {
   BillingLineItem,
   BillingPeriod,
@@ -74,6 +75,25 @@ export function BillingTable({
     lineItemMap.set(item.household_id, item);
   }
 
+  // #158: per-row error message surfaced from the inline-edit cells. Keyed
+  // by line item id so a failure on one un-metered row doesn't clobber the
+  // others. Cleared on next successful save or Esc-revert.
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+  const recordRowError = React.useCallback(
+    (lineItemId: string, message: string | null) => {
+      setRowErrors((prev) => {
+        if (message === null) {
+          if (!(lineItemId in prev)) return prev;
+          const next = { ...prev };
+          delete next[lineItemId];
+          return next;
+        }
+        return { ...prev, [lineItemId]: message };
+      });
+    },
+    []
+  );
+
   // Grand totals
   let grandTotalKwh = 0;
   let grandTotal = 0;
@@ -81,7 +101,10 @@ export function BillingTable({
   const grandTierAmount: number[] = tiers.map(() => 0);
 
   for (const item of lineItems) {
-    grandTotalKwh += item.usage_kwh;
+    // #158: usage_kwh may be NULL on un-metered rows that haven't been
+    // filled in yet. Treat NULL as 0 in the grand total — the row reads as
+    // an em-dash in the per-cell display, but it shouldn't poison the sum.
+    grandTotalKwh += item.usage_kwh ?? 0;
     grandTotal += item.total_amount;
 
     const breakdown = item.tier_breakdown as { label: string; kwh: number; amount: number }[];
@@ -204,17 +227,51 @@ export function BillingTable({
       accessor: (h) => lineItemMap.get(h.id)?.start_kwh ?? null,
       format: (v) => (v == null ? "—" : kwhFormat(v)),
     },
+    // #158: END (kWh) and USAGE (kWh) are inline-editable for un-metered
+    // rows (lineItem.device_id == null). Metered rows render the same
+    // visual as before via ManualUsageCell's read-only path. We render
+    // these as `action` columns so the inline <input> doesn't fight the
+    // CopyTable's keyboard nav grid; un-metered rows are operator-entry
+    // surfaces, not URA-paste targets.
     {
-      kind: "value",
+      kind: "action",
       header: "End (kWh)",
-      accessor: (h) => lineItemMap.get(h.id)?.end_kwh ?? null,
-      format: (v) => (v == null ? "—" : kwhFormat(v)),
+      className: "text-right",
+      render: (h) => {
+        const item = lineItemMap.get(h.id);
+        if (!item) return <span className="text-muted-foreground">—</span>;
+        const isUnmetered = item.device_id == null;
+        return (
+          <ManualUsageCell
+            lineItemId={item.id}
+            field="end_kwh"
+            value={item.end_kwh}
+            format={(v) => (v == null ? "—" : kwhFormat(v))}
+            editable={isUnmetered && isDraft}
+            onError={recordRowError}
+          />
+        );
+      },
     },
     {
-      kind: "value",
+      kind: "action",
       header: "Usage (kWh)",
-      accessor: (h) => lineItemMap.get(h.id)?.usage_kwh ?? null,
-      format: (v) => (v == null ? "—" : kwhFormat(v)),
+      className: "text-right",
+      render: (h) => {
+        const item = lineItemMap.get(h.id);
+        if (!item) return <span className="text-muted-foreground">—</span>;
+        const isUnmetered = item.device_id == null;
+        return (
+          <ManualUsageCell
+            lineItemId={item.id}
+            field="usage_kwh"
+            value={item.usage_kwh}
+            format={(v) => (v == null ? "—" : kwhFormat(v))}
+            editable={isUnmetered && isDraft}
+            onError={recordRowError}
+          />
+        );
+      },
     },
     ...tiers.flatMap((tier, i): ColumnDef<Household>[] => [
       {
@@ -429,6 +486,36 @@ export function BillingTable({
               caption={`Billing table for period ${periodLabel} — ${householdsWithItems.length} household${householdsWithItems.length !== 1 ? "s" : ""}`}
               ariaLabel={`Billing data for ${periodLabel}`}
             />
+
+            {/* #158: surface per-row inline-edit errors below the grid so
+                they aren't trapped inside the CopyTable's static markup.
+                Cleared automatically when the user successfully retries or
+                presses Esc on the cell. */}
+            {Object.keys(rowErrors).length > 0 && (
+              <ul className="space-y-1 rounded-md border border-destructive bg-destructive-muted p-3 text-xs text-destructive-fg">
+                {Object.entries(rowErrors).map(([lineItemId, message]) => {
+                  const item = lineItems.find((li) => li.id === lineItemId);
+                  const householdName = households.find(
+                    (h) => h.id === item?.household_id
+                  )?.display_name;
+                  return (
+                    <li key={lineItemId} className="flex items-center justify-between gap-2">
+                      <span>
+                        {householdName ? `${householdName}: ` : ""}
+                        Could not save: {message}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => recordRowError(lineItemId, null)}
+                        className="rounded-sm border border-destructive bg-card px-2 py-0.5 text-[11px] font-medium text-destructive-fg hover:bg-muted"
+                      >
+                        Dismiss
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
 
             {/* Grand-total footer — rendered BELOW the CopyTable */}
             {lineItems.length > 0 && (

--- a/src/components/HouseholdTable.tsx
+++ b/src/components/HouseholdTable.tsx
@@ -43,6 +43,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { createClient } from "@/lib/supabase/client";
 import type { Device, Household } from "@/lib/types/domain";
 import { Chip } from "@/components/ui/chip";
+import { StatusChip } from "@/components/ui/status-chip";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
 import { HouseholdEditDialog } from "@/components/forms/HouseholdEditDialog";
@@ -369,11 +370,10 @@ function BillingDeviceCell({
         </Chip>
       );
     }
-    return (
-      <Chip tone="warn" dot>
-        Unassigned
-      </Chip>
-    );
+    // #158: an un-metered household is an intentional manual-billing state,
+    // not a missing assignment. Render the canonical "No meter" status chip
+    // so it reads as a configured (if non-automated) lifecycle state.
+    return <StatusChip kind="meter" status="not_configured" />;
   }
 
   if (device) {
@@ -395,6 +395,8 @@ function BillingDeviceCell({
       </button>
     );
   }
+  // #158: clickable "No meter" chip — opens the edit dialog so the operator
+  // can link a meter retroactively if a physical install lands later.
   return (
     <button
       type="button"
@@ -402,9 +404,7 @@ function BillingDeviceCell({
       aria-label={`Link a billing device for ${household.display_name}`}
       className="inline-flex items-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
-      <Chip tone="warn" dot>
-        Unassigned
-      </Chip>
+      <StatusChip kind="meter" status="not_configured" />
     </button>
   );
 }

--- a/src/components/__tests__/billing-table.test.tsx
+++ b/src/components/__tests__/billing-table.test.tsx
@@ -319,6 +319,60 @@ describe("BillingTable", () => {
     expect(banner).toBeNull();
   });
 
+  it("(#158) un-metered row renders editable END/USAGE inputs; metered rows do not", () => {
+    // Mix of metered (h-1, h-2) + un-metered (h-3) to exercise both paths
+    // in the same render pass.
+    const mixedLineItems: BillingLineItem[] = [
+      {
+        ...lineItems[0],
+      },
+      {
+        ...lineItems[1],
+      },
+      {
+        ...lineItems[2],
+        // un-metered: device_id null, usage_kwh null, end_kwh null
+        device_id: null,
+        usage_kwh: null,
+        end_kwh: null,
+        tier_breakdown: [],
+        total_amount: 0,
+      } as BillingLineItem,
+    ];
+
+    const { container } = render(
+      <Wrapper>
+        <BillingTable {...baseProps} lineItems={mixedLineItems} />
+      </Wrapper>
+    );
+
+    // Inline-edit inputs render only for the un-metered row → 2 inputs
+    // (end_kwh + usage_kwh). Metered rows render read-only spans.
+    const numberInputs = Array.from(
+      container.querySelectorAll("input[type='number']")
+    );
+    expect(numberInputs.length).toBe(2);
+
+    // Each input is associated with the un-metered line item id (li-3).
+    const labels = numberInputs.map((i) => i.getAttribute("aria-label"));
+    expect(labels.every((l) => l?.includes("li-3"))).toBe(true);
+    // One end_kwh + one usage_kwh
+    expect(labels.some((l) => l?.startsWith("End kWh"))).toBe(true);
+    expect(labels.some((l) => l?.startsWith("Usage kWh"))).toBe(true);
+  });
+
+  it("(#158) metered row's END/USAGE cells stay read-only when ALL rows are metered", () => {
+    const { container } = render(
+      <Wrapper>
+        <BillingTable {...baseProps} />
+      </Wrapper>
+    );
+    const numberInputs = Array.from(
+      container.querySelectorAll("input[type='number']")
+    );
+    expect(numberInputs.length).toBe(0);
+  });
+
   it("(f) payment buttons disabled when !isPaymentConfigured", () => {
     const { container } = render(
       <Wrapper>

--- a/src/components/__tests__/household-table.test.tsx
+++ b/src/components/__tests__/household-table.test.tsx
@@ -329,7 +329,7 @@ describe("HouseholdTable — refactor surfaces (#145)", () => {
     void container;
   });
 
-  it("(i) chip — unassigned: warn tone + button + opens dialog on click", async () => {
+  it("(i) chip — unassigned: warn tone + button + 'No meter' copy + opens dialog on click (#158)", async () => {
     render(
       <HouseholdTable
         microgridId={MICROGRID_ID}
@@ -344,10 +344,13 @@ describe("HouseholdTable — refactor surfaces (#145)", () => {
       name: /Link a billing device for Household Beta/i,
     });
     expect(chipBtn).toBeTruthy();
+    // #158: chip copy changed from 'Unassigned' to 'No meter' (rendered via
+    // <StatusChip kind="meter" status="not_configured">). Tone (warn) and
+    // dot stay the same so the visual signal Aaron recognises is preserved.
     const chipSpan = chipBtn.querySelector("span");
     expect(chipSpan?.className).toContain("bg-warning-muted");
     expect(chipSpan?.className).toContain("text-warning-fg");
-    expect(chipSpan?.textContent).toContain("Unassigned");
+    expect(chipSpan?.textContent).toContain("No meter");
 
     fireEvent.click(chipBtn);
     await waitFor(() => {

--- a/src/components/billing/manual-usage-cell.tsx
+++ b/src/components/billing/manual-usage-cell.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+/**
+ * ManualUsageCell — inline-editable kWh cell for un-metered (manual-billing)
+ * billing line items. Used in BillingTable for the END (kWh) and USAGE (kWh)
+ * columns when `lineItem.device_id == null`.
+ *
+ * Spec (#158 AC-6 + AC-7):
+ *   - Renders as a `<input type="number" step="0.001" min="0">` styled to
+ *     look like a copy-cell when not focused (right-aligned monospace,
+ *     subtle hover outline).
+ *   - Save semantics: blur OR Enter fires PATCH /api/billing-line-items/
+ *     [lineItemId]/usage. Esc reverts and unfocuses.
+ *   - Optimistic UI: the local value updates on blur/Enter; spinner shows
+ *     in-flight. On 200, router.refresh() reconciles. On error, the cell
+ *     reverts AND a row-level error message renders below the row (caller's
+ *     responsibility — this component surfaces the error via `onError`).
+ *   - Validation: empty input reverts without saving. Negative or
+ *     non-numeric → don't fire PATCH; instead surface "Must be a non-
+ *     negative number" via `onError`.
+ *   - The route recomputes tier_breakdown + total_amount server-side via
+ *     calculateTieredCost; this component just hands off the new value.
+ *
+ * Read-only fallback: when `editable={false}`, renders a plain right-
+ * aligned span matching the copy-cell visual style. This keeps metered-row
+ * cells visually identical to the rest of the BillingTable.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+export type ManualUsageField = "end_kwh" | "usage_kwh";
+
+export interface ManualUsageCellProps {
+  /** The billing_line_items.id to patch. */
+  lineItemId: string;
+  /** Which numeric field this cell represents — sent in the PATCH body. */
+  field: ManualUsageField;
+  /** Current persisted value (null when un-entered). */
+  value: number | null;
+  /** Format function used for the display state (matches BillingTable). */
+  format: (v: number | null) => string;
+  /** When false, cell renders as read-only (used for metered rows). */
+  editable: boolean;
+  /** Caller fires `router.refresh()` already on success; this lets the parent
+   *  surface row-level errors below the table row. */
+  onError?: (lineItemId: string, message: string | null) => void;
+  /** Tailwind classes appended to the rendered element. */
+  className?: string;
+}
+
+/**
+ * Parse a number input string. Returns:
+ *   - { ok: true, value: number } on success
+ *   - { ok: false, reason: 'empty' | 'invalid' | 'negative' } on rejection
+ */
+function parseInput(raw: string):
+  | { ok: true; value: number }
+  | { ok: false; reason: "empty" | "invalid" | "negative" } {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { ok: false, reason: "empty" };
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return { ok: false, reason: "invalid" };
+  if (n < 0) return { ok: false, reason: "negative" };
+  return { ok: true, value: n };
+}
+
+export function ManualUsageCell({
+  lineItemId,
+  field,
+  value,
+  format,
+  editable,
+  onError,
+  className,
+}: ManualUsageCellProps) {
+  const router = useRouter();
+  const [draft, setDraft] = React.useState<string>(
+    value == null ? "" : String(value)
+  );
+  const [saving, setSaving] = React.useState(false);
+
+  // Re-sync the draft whenever the persisted value changes (e.g. after
+  // router.refresh() pulls a new server-confirmed number).
+  React.useEffect(() => {
+    setDraft(value == null ? "" : String(value));
+  }, [value]);
+
+  // Read-only path — match the surrounding CopyTable visual (right-aligned
+  // monospace) so metered rows render identically to before.
+  if (!editable) {
+    return (
+      <span
+        className={cn(
+          "inline-block w-full text-right font-mono text-[12px] tabular-nums",
+          className
+        )}
+      >
+        {format(value)}
+      </span>
+    );
+  }
+
+  async function commit(rawCandidate: string): Promise<void> {
+    const parsed = parseInput(rawCandidate);
+    if (!parsed.ok) {
+      if (parsed.reason === "empty") {
+        // Empty input: revert silently to the persisted value, no save fire.
+        setDraft(value == null ? "" : String(value));
+        onError?.(lineItemId, null);
+        return;
+      }
+      if (parsed.reason === "negative" || parsed.reason === "invalid") {
+        onError?.(lineItemId, "Must be a non-negative number");
+        return;
+      }
+    }
+    if (!parsed.ok) return;
+
+    // Only PATCH when the value actually changed.
+    if (parsed.value === value) {
+      onError?.(lineItemId, null);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch(
+        `/api/billing-line-items/${lineItemId}/usage`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ [field]: parsed.value }),
+        }
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          reason?: string;
+        };
+        // Revert local draft to the persisted value.
+        setDraft(value == null ? "" : String(value));
+        onError?.(
+          lineItemId,
+          body.error ?? `Could not save (HTTP ${res.status}).`
+        );
+        setSaving(false);
+        return;
+      }
+      onError?.(lineItemId, null);
+      setSaving(false);
+      router.refresh();
+    } catch (err) {
+      setDraft(value == null ? "" : String(value));
+      onError?.(
+        lineItemId,
+        err instanceof Error ? err.message : "Network error. Please retry."
+      );
+      setSaving(false);
+    }
+  }
+
+  return (
+    <span className={cn("relative inline-flex w-full items-center justify-end", className)}>
+      <input
+        type="number"
+        step="0.001"
+        min="0"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          // Blur-to-save. If the value didn't change, commit() will short-
+          // circuit before firing the PATCH.
+          void commit(draft);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            (e.currentTarget as HTMLInputElement).blur();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            // Revert to the persisted value and unfocus.
+            setDraft(value == null ? "" : String(value));
+            onError?.(lineItemId, null);
+            (e.currentTarget as HTMLInputElement).blur();
+          }
+        }}
+        disabled={saving}
+        aria-label={`${field === "end_kwh" ? "End kWh" : "Usage kWh"} for line item ${lineItemId}`}
+        className={cn(
+          "w-full bg-transparent text-right font-mono text-[12px] tabular-nums",
+          "rounded-sm px-1 py-0.5 outline-none",
+          "hover:ring-1 hover:ring-border focus:ring-2 focus:ring-ring",
+          "disabled:opacity-60",
+        )}
+      />
+      {saving && (
+        <span
+          aria-hidden="true"
+          className="ml-1 inline-block h-3 w-3 animate-spin rounded-full border border-border border-t-transparent"
+        />
+      )}
+    </span>
+  );
+}

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -82,6 +82,13 @@ type FormState = {
   address_postal_code: string;
   geography_notes: string;
   device_id: string;
+  /**
+   * #158: when true, Step 3 surfaces no meter picker — the household will
+   * be created without a primary_consumption_meter link and Aaron enters
+   * usage manually each period from the BillingTable. Step 3 is treated as
+   * valid regardless of meter count when this is set.
+   */
+  no_meter: boolean;
 };
 
 const EMPTY_STATE: FormState = {
@@ -97,6 +104,7 @@ const EMPTY_STATE: FormState = {
   address_postal_code: "",
   geography_notes: "",
   device_id: "",
+  no_meter: false,
 };
 
 const STEP_LABELS: Record<Step, string> = {
@@ -121,16 +129,21 @@ function isStepValid(step: Step, state: FormState, meterCount: number): boolean 
       // All fields optional.
       return true;
     case 3:
-      // Must pick one of the available meters. Empty-state (zero meters) can
-      // never satisfy this — Save is disabled at the caller.
+      // #158: when no_meter is checked, Step 3 is valid regardless of
+      // meter count or device_id (the household will bill manually).
+      if (state.no_meter) return true;
+      // Otherwise: must pick one of the available meters. Empty-state (zero
+      // meters) can never satisfy this — Save is disabled at the caller.
       return meterCount > 0 && state.device_id.length > 0;
     case 4:
-      // Review is valid iff 1 + 3 are (address is always optional).
+      // Review folds rules from #155 (phone-required) and #158 (no-meter
+      // alternative path): step1 must pass AND step2 trivially passes AND
+      // either no_meter is set OR a valid meter is picked.
       return (
         state.display_name.trim().length > 0 &&
         state.primary_phone.trim().length > 0 &&
-        meterCount > 0 &&
-        state.device_id.length > 0
+        (state.no_meter ||
+          (meterCount > 0 && state.device_id.length > 0))
       );
   }
 }
@@ -148,7 +161,8 @@ function hasAnyData(state: FormState): boolean {
     state.address_country.trim().length > 0 ||
     state.address_postal_code.trim().length > 0 ||
     state.geography_notes.trim().length > 0 ||
-    state.device_id.length > 0
+    state.device_id.length > 0 ||
+    state.no_meter
   );
 }
 
@@ -173,7 +187,9 @@ export function HouseholdWizard({
   // Refs for focus management — each step's first required/focusable field.
   const step1FirstFieldRef = React.useRef<HTMLInputElement>(null);
   const step2FirstFieldRef = React.useRef<HTMLInputElement>(null);
-  const step3FirstFieldRef = React.useRef<HTMLButtonElement>(null);
+  // #158: step3FirstFieldRef may resolve to a checkbox (no-meter info path)
+  // or a radio (meter-pick path). Type it as the union accordingly.
+  const step3FirstFieldRef = React.useRef<HTMLButtonElement | HTMLInputElement | null>(null);
   const step4FirstElementRef = React.useRef<HTMLButtonElement>(null);
 
   // Reset wizard state when opened.
@@ -270,7 +286,10 @@ export function HouseholdWizard({
           address_country: state.address_country.trim() || null,
           address_postal_code: state.address_postal_code.trim() || null,
           geography_notes: state.geography_notes.trim() || null,
-          device_id: state.device_id,
+          // #158: send null when the user opted out of meter assignment.
+          // The route distinguishes the two paths and dispatches to
+          // fn_create_household vs fn_create_household_with_meter.
+          device_id: state.no_meter ? null : state.device_id,
         }),
       });
       if (!res.ok) {
@@ -291,6 +310,9 @@ export function HouseholdWizard({
 
   const canProceed = isStepValid(step, state, availableMeters.length);
   const noMeters = availableMeters.length === 0;
+  // #158: when no_meter is checked, the empty-meters condition no longer
+  // blocks Next/Save — the household path doesn't need a device.
+  const blockedByNoMeters = noMeters && !state.no_meter;
   const canSave = isStepValid(4, state, availableMeters.length);
 
   // Pre-computed completed-set for the progress indicator. A step is
@@ -389,6 +411,13 @@ export function HouseholdWizard({
                   onFirstRadio={(el) => {
                     step3FirstFieldRef.current = el;
                   }}
+                  onCheckboxRef={(el) => {
+                    // #158: when no_meter is the active path, the first
+                    // focusable element is the checkbox itself.
+                    if (state.no_meter || availableMeters.length === 0) {
+                      step3FirstFieldRef.current = el;
+                    }
+                  }}
                   meters={availableMeters}
                   edgesSetupHref={edgesSetupHref}
                   disabled={submitting}
@@ -434,7 +463,11 @@ export function HouseholdWizard({
                   <button
                     type="button"
                     onClick={handleNext}
-                    disabled={!canProceed || submitting || (step === 3 && noMeters)}
+                    disabled={
+                      !canProceed ||
+                      submitting ||
+                      (step === 3 && blockedByNoMeters)
+                    }
                     className={cn(
                       "inline-flex h-8 items-center rounded-md bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       "disabled:cursor-not-allowed disabled:opacity-50"
@@ -446,7 +479,7 @@ export function HouseholdWizard({
                   <button
                     type="button"
                     onClick={handleSubmit}
-                    disabled={!canSave || submitting || noMeters}
+                    disabled={!canSave || submitting || blockedByNoMeters}
                     className={cn(
                       "inline-flex h-8 items-center rounded-md bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       "disabled:cursor-not-allowed disabled:opacity-50"
@@ -790,6 +823,7 @@ function StepMeter({
   state,
   update,
   onFirstRadio,
+  onCheckboxRef,
   meters,
   edgesSetupHref,
   disabled,
@@ -797,75 +831,111 @@ function StepMeter({
   state: FormState;
   update: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
   onFirstRadio: (el: HTMLButtonElement) => void;
+  onCheckboxRef: (el: HTMLInputElement | null) => void;
   meters: AvailableMeter[];
   edgesSetupHref: string;
   disabled: boolean;
 }) {
-  if (meters.length === 0) {
-    return (
-      <div className="space-y-3">
-        <Banner
-          tone="warn"
-          title="No available meters"
-          action={
-            <Link
-              href={edgesSetupHref}
-              className="inline-flex items-center rounded-md border border-warning bg-card px-3 py-1 text-xs font-medium text-warning-fg hover:bg-muted"
-            >
-              Go to Setup &gt; Edges
-            </Link>
-          }
-        >
-          All consumption meters on this microgrid are already assigned to a
-          household. Discover more devices on the edges setup page before
-          adding another household here.
-        </Banner>
-      </div>
-    );
-  }
+  // #158: top-of-step "no meter" checkbox. When checked we clear device_id
+  // defensively so an accidental prior pick doesn't leak into the submit
+  // body, then collapse the meter picker into an info panel.
+  const handleNoMeterToggle = (checked: boolean) => {
+    update("no_meter", checked);
+    if (checked) {
+      update("device_id", "");
+    }
+  };
 
   return (
-    <fieldset className="space-y-3" disabled={disabled}>
+    <fieldset className="space-y-4" disabled={disabled}>
       <legend className="sr-only">Step 3 of 4: Meter assignment</legend>
-      <p className="text-xs text-muted-foreground">
-        Pick the consumption meter that will produce this household&apos;s bill
-        each period.
-      </p>
-      <RadioGroup
-        value={state.device_id}
-        onValueChange={(v) => update("device_id", v)}
-        aria-label="Available consumption meters"
-        className="gap-2"
-      >
-        {meters.map((meter, idx) => {
-          // The first radio input needs to be a focus target when entering
-          // this step. We attach the ref to the first card only by wrapping
-          // the RadioCard's inner item via a side-effect — but RadioCard
-          // doesn't forward the inner radio ref. Instead we use a targetted
-          // DOM query after mount: we focus the first `role=radio` element
-          // in the list if this is the first card.
-          return (
-            <RadioCard
-              key={meter.id}
-              value={meter.id}
-              title={
-                <span className="flex items-center gap-2">
-                  <span>{meter.name}</span>
-                  <StatusChip
-                    kind="deviceType"
-                    status={meter.device_type}
-                  />
-                </span>
-              }
-              description={meter.edge_name}
-              meta={humanReadable(meter.device_type)}
-              // Mark the first card so we can locate it for focus.
-              id={idx === 0 ? "hh-meter-first" : undefined}
-            />
-          );
-        })}
-      </RadioGroup>
-      <FirstMeterFocuser onFound={onFirstRadio} meters={meters} />
+
+      {/* #158: no-meter (manual billing) checkbox. */}
+      <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border bg-card p-3 hover:bg-muted">
+        <input
+          id="hh-no-meter-checkbox"
+          ref={onCheckboxRef}
+          type="checkbox"
+          checked={state.no_meter}
+          onChange={(e) => handleNoMeterToggle(e.target.checked)}
+          className="mt-0.5"
+        />
+        <span className="text-sm text-foreground">
+          <span className="font-medium">
+            This household does not have a meter
+          </span>{" "}
+          <span className="text-muted-foreground">(manual billing).</span>
+        </span>
+      </label>
+
+      {state.no_meter ? (
+        <div className="rounded-md border border-border bg-muted p-3 text-sm text-muted-foreground">
+          Without a meter, you&apos;ll enter usage manually each period. You
+          can link a meter later from the household&apos;s edit dialog.
+        </div>
+      ) : meters.length === 0 ? (
+        <div className="space-y-3">
+          <Banner
+            tone="warn"
+            title="No available meters"
+            action={
+              <Link
+                href={edgesSetupHref}
+                className="inline-flex items-center rounded-md border border-warning bg-card px-3 py-1 text-xs font-medium text-warning-fg hover:bg-muted"
+              >
+                Go to Setup &gt; Edges
+              </Link>
+            }
+          >
+            All consumption meters on this microgrid are already assigned to a
+            household. Discover more devices on the edges setup page before
+            adding another household here, or check &ldquo;manual
+            billing&rdquo; above to skip the meter assignment.
+          </Banner>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Pick the consumption meter that will produce this household&apos;s
+            bill each period.
+          </p>
+          <RadioGroup
+            value={state.device_id}
+            onValueChange={(v) => update("device_id", v)}
+            aria-label="Available consumption meters"
+            className="gap-2"
+          >
+            {meters.map((meter, idx) => {
+              // The first radio input needs to be a focus target when
+              // entering this step. We attach the ref to the first card only
+              // by wrapping the RadioCard's inner item via a side-effect —
+              // but RadioCard doesn't forward the inner radio ref. Instead
+              // we use a targetted DOM query after mount: we focus the first
+              // `role=radio` element in the list if this is the first card.
+              return (
+                <RadioCard
+                  key={meter.id}
+                  value={meter.id}
+                  title={
+                    <span className="flex items-center gap-2">
+                      <span>{meter.name}</span>
+                      <StatusChip
+                        kind="deviceType"
+                        status={meter.device_type}
+                      />
+                    </span>
+                  }
+                  description={meter.edge_name}
+                  meta={humanReadable(meter.device_type)}
+                  // Mark the first card so we can locate it for focus.
+                  id={idx === 0 ? "hh-meter-first" : undefined}
+                />
+              );
+            })}
+          </RadioGroup>
+          <FirstMeterFocuser onFound={onFirstRadio} meters={meters} />
+        </div>
+      )}
     </fieldset>
   );
 }
@@ -951,7 +1021,13 @@ function StepReview({
       </ReviewSection>
 
       <ReviewSection title="Primary meter" onEdit={() => onJumpTo(3)}>
-        {selectedMeter ? (
+        {state.no_meter ? (
+          // #158: explicit no-meter review row (manual billing path).
+          <ReviewRow
+            label="Primary meter"
+            value="— (manual billing)"
+          />
+        ) : selectedMeter ? (
           <>
             <ReviewRow label="Device" value={selectedMeter.name} />
             <ReviewRow label="Edge" value={selectedMeter.edge_name} />

--- a/src/components/forms/__tests__/HouseholdEditDialog.test.tsx
+++ b/src/components/forms/__tests__/HouseholdEditDialog.test.tsx
@@ -135,10 +135,12 @@ describe("HouseholdEditDialog (#145)", () => {
     expect(triggers[0].textContent).toContain("Alpha Edge");
   });
 
-  it("(2) renders Unassigned state when currentDeviceId is null", () => {
+  it("(2) renders 'No meter (manual billing)' state when currentDeviceId is null (#158)", () => {
     renderDialog({ currentDeviceId: null });
     const triggers = screen.getAllByRole("combobox");
-    expect(triggers[0].textContent).toContain("Unassigned");
+    // #158 replaced the bare 'Unassigned' copy with explicit manual-billing
+    // language so an un-metered household reads as an intentional state.
+    expect(triggers[0].textContent).toContain("No meter (manual billing)");
   });
 
   it("(3) PATCH-diff sends only changed fields", async () => {
@@ -278,5 +280,79 @@ describe("HouseholdEditDialog (#145)", () => {
     renderDialog();
     const textarea = screen.getByLabelText(/Geography notes/i);
     expect(textarea.tagName.toLowerCase()).toBe("textarea");
+  });
+
+  // ── #158 — manual-billing cascade transitions ────────────────────────
+
+  it("(12) #158 — same-null device_id keeps Save disabled (dirty=false)", () => {
+    renderDialog({ currentDeviceId: null });
+    // No edits, currentDeviceId stays null → dirty must remain false.
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("(12) #158 — same-device device_id keeps Save disabled (dirty=false)", () => {
+    renderDialog({ currentDeviceId: "dev-1" });
+    // No edits, currentDeviceId stays dev-1 → dirty must remain false.
+    const saveBtn = screen.getByRole("button", { name: /Save changes/i });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("(13) #158 — metered → no-meter sends device_id: null in PATCH diff (cascade unlink)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ household: { id: HOUSEHOLD.id } }),
+    } as Response);
+
+    renderDialog({ currentDeviceId: "dev-1" });
+
+    // Open dropdown and click the explicit "No meter (manual billing)" option.
+    const triggers = screen.getAllByRole("combobox");
+    fireEvent.click(triggers[0]);
+
+    const noMeterOption = await waitFor(() =>
+      screen
+        .getAllByRole("option")
+        .find((o) => o.textContent?.includes("No meter (manual billing)"))
+    );
+    expect(noMeterOption).toBeDefined();
+    fireEvent.click(noMeterOption!);
+
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init?.body as string);
+    // Cascade unlink — the route deletes the existing household_devices row.
+    expect(body).toEqual({ device_id: null });
+  });
+
+  it("(14) #158 — no-meter → metered sends device_id: <uuid> in PATCH diff (cascade insert)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ household: { id: HOUSEHOLD.id } }),
+    } as Response);
+
+    renderDialog({ currentDeviceId: null });
+
+    // Open dropdown, pick Meter A.
+    const triggers = screen.getAllByRole("combobox");
+    fireEvent.click(triggers[0]);
+
+    const meterAOption = await waitFor(() =>
+      screen.getAllByRole("option").find((o) => o.textContent?.includes("Meter A"))
+    );
+    fireEvent.click(meterAOption!);
+
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init?.body as string);
+    // Cascade insert — the route inserts a new household_devices row for
+    // the chosen device_id.
+    expect(body).toEqual({ device_id: "dev-1" });
   });
 });

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -510,6 +510,132 @@ describe("HouseholdWizard", () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────
+  // #158 — no-meter (manual billing) checkbox path
+  // ──────────────────────────────────────────────────────────────────────
+  describe("#158 no_meter checkbox", () => {
+    it("checkbox checked → submit body sends device_id: null", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ household_id: "manual-hh" }),
+      } as Response);
+
+      renderWizard();
+
+      // Step 1
+      fillDisplayName("Manual-Bill HH");
+      fillPhone("+256700000001");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Step 2 → Next
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Step 3 → tick "no meter" checkbox; Next must enable
+      await waitFor(() => {
+        expect(
+          screen.getByText(/This household does not have a meter/i)
+        ).toBeTruthy();
+      });
+      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+      fireEvent.click(checkbox);
+      expect(checkbox.checked).toBe(true);
+      const next = screen.getByRole("button", { name: /^Next$/ });
+      expect(next).toHaveProperty("disabled", false);
+      fireEvent.click(next);
+
+      // Step 4 → review shows manual-billing string
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /Create household/i })
+        ).toBeDefined()
+      );
+      expect(screen.getByText(/manual billing/i)).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: /Create household/i }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init?.body as string);
+      // The submit body sends null (not "") for device_id when no_meter is on.
+      expect(body.device_id).toBeNull();
+    });
+
+    it("checkbox unchecked → existing meter-required path preserved", async () => {
+      // Step 3 with no checkbox toggle → must pick a meter to advance.
+      renderWizard();
+      fillDisplayName("Metered HH");
+      fillPhone("+256700000002");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Step 3 — Next is disabled until a radio is picked
+      await waitFor(() =>
+        expect(screen.getAllByRole("radio").length).toBe(METERS.length)
+      );
+      const next = screen.getByRole("button", { name: /^Next$/ });
+      expect(next).toHaveProperty("disabled", true);
+      // Picking a meter enables Next
+      fireEvent.click(screen.getByRole("radio", { name: /Household A Meter/i }));
+      expect(next).toHaveProperty("disabled", false);
+    });
+
+    it("checkbox checked + zero available meters → Save (Create) is enabled (manual-billing path)", async () => {
+      renderWizard({ availableMeters: [] });
+      fillDisplayName("Manual-only");
+      fillPhone("+256700000003");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Step 3 — empty-state banner shows by default; tick the no-meter
+      // checkbox to fall into the manual-billing branch.
+      await waitFor(() =>
+        expect(
+          screen.getByText(/This household does not have a meter/i)
+        ).toBeTruthy()
+      );
+      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+      fireEvent.click(checkbox);
+
+      // Banner is replaced by the manual-billing info panel
+      expect(screen.queryByText(/No available meters/i)).toBeNull();
+
+      // Next is enabled
+      const next = screen.getByRole("button", { name: /^Next$/ });
+      expect(next).toHaveProperty("disabled", false);
+      fireEvent.click(next);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /Create household/i })
+        ).toBeDefined()
+      );
+      const submit = screen.getByRole("button", { name: /Create household/i });
+      expect(submit).toHaveProperty("disabled", false);
+    });
+
+    it("blank phone STILL blocks Submit when no_meter is checked (#155 preserved)", async () => {
+      // Coordinated #155 + #158: phone-required gates step 1 regardless of
+      // step-3 path. Verify by setting display_name and going manual-billing
+      // — without phone, Next stays disabled in step 1 and the user never
+      // reaches step 3.
+      renderWizard();
+      fillDisplayName("No-phone HH");
+      // Leave phone blank
+      const next = screen.getByRole("button", { name: /^Next$/ });
+      expect(next).toHaveProperty("disabled", true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
   // (g) Cancel with all-empty fields closes immediately
   // ──────────────────────────────────────────────────────────────────────
   describe("(g) cancel with all-empty fields", () => {

--- a/src/components/ui/__tests__/device-select.test.tsx
+++ b/src/components/ui/__tests__/device-select.test.tsx
@@ -195,7 +195,7 @@ describe("DeviceSelect (#145)", () => {
     expect(triggers[0].textContent).toContain("No devices on this microgrid yet");
   });
 
-  it("calls onChange(null) when sentinel 'Unassigned' option chosen", () => {
+  it("calls onChange(null) when sentinel 'No meter (manual billing)' option chosen (#158)", () => {
     const onChange = vi.fn();
     render(
       <DeviceSelect
@@ -207,9 +207,13 @@ describe("DeviceSelect (#145)", () => {
     );
     openTrigger();
 
+    // #158 renamed the sentinel option copy from 'Unassigned' to
+    // '— No meter (manual billing) —' so it reads as an intentional state.
+    // The underlying value (UNASSIGNED_VALUE) and onChange semantics
+    // (null) are preserved.
     const unassignedOption = screen
       .getAllByRole("option")
-      .find((o) => o.textContent?.trim() === "Unassigned");
+      .find((o) => o.textContent?.includes("No meter (manual billing)"));
     expect(unassignedOption).toBeDefined();
     fireEvent.click(unassignedOption!);
     expect(onChange).toHaveBeenCalledWith(null);

--- a/src/components/ui/device-select.tsx
+++ b/src/components/ui/device-select.tsx
@@ -109,7 +109,7 @@ export function DeviceSelect({
       >
         <SelectValue
           placeholder={
-            isEmpty ? "No devices on this microgrid yet" : "Unassigned"
+            isEmpty ? "No devices on this microgrid yet" : "— No meter (manual billing) —"
           }
         >
           {isEmpty ? (
@@ -127,7 +127,12 @@ export function DeviceSelect({
               </span>
             </span>
           ) : (
-            <span className="text-muted-foreground">Unassigned</span>
+            // #158: when value is null we render the explicit "no meter
+            // (manual billing)" copy so it reads as an intentional state,
+            // not a missing assignment.
+            <span className="text-muted-foreground">
+              — No meter (manual billing) —
+            </span>
           )}
         </SelectValue>
       </SelectTrigger>
@@ -137,9 +142,16 @@ export function DeviceSelect({
           <DropdownEmptyState edgesSetupHref={edgesSetupHref} />
         ) : (
           <>
-            {/* Sentinel "Unassigned" option — always first, outside groups */}
+            {/*
+              #158: explicit "No meter (manual billing)" option at the top of
+              the list. Maps to the existing UNASSIGNED_VALUE sentinel which
+              the onValueChange handler converts to `null`. Replaces the
+              previous bare "Unassigned" sentinel — same value, clearer intent.
+            */}
             <SelectItem value={UNASSIGNED_VALUE} className="py-1.5">
-              <span className="text-muted-foreground">Unassigned</span>
+              <span className="text-muted-foreground">
+                — No meter (manual billing) —
+              </span>
             </SelectItem>
 
             {grouped.map((group) => (

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -21,6 +21,7 @@ type Kind =
   | "deviceType"
   | "household"
   | "householdDeviceRole"
+  | "meter"
   | "meterType"
   | "openemsBackendHealth"
   | "paymentHealth";
@@ -101,6 +102,18 @@ const MAPS: Record<Kind, StatusMap> = {
     solar:                     { label: "Solar",           tone: "success" },
     ev_charger:                { label: "EV charger",      tone: "brand" },
     other:                     { label: "Other",           tone: "neutral" },
+  },
+  // #158: per-household meter assignment status. The HouseholdTable cell
+  // surfaces this so an entrepreneur can tell at a glance which households
+  // require a manual usage entry each period vs. the metered/automated flow.
+  //
+  // Tone rationale:
+  //   linked          → success (the OpenEMS reading flow is wired)
+  //   not_configured  → warn (manual billing is an active state, not an
+  //                     error — but it does need attention each period)
+  meter: {
+    linked:         { label: "Meter linked",   tone: "success", dot: true },
+    not_configured: { label: "No meter",       tone: "warn",    dot: true },
   },
   meterType: {
     // Lowercase keys (original)

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -49,7 +49,7 @@ export type Database = {
           start_kwh: number | null
           tier_breakdown: Json
           total_amount: number
-          usage_kwh: number
+          usage_kwh: number | null
         }
         Insert: {
           billing_period_id: string
@@ -65,7 +65,7 @@ export type Database = {
           start_kwh?: number | null
           tier_breakdown?: Json
           total_amount?: number
-          usage_kwh?: number
+          usage_kwh?: number | null
         }
         Update: {
           billing_period_id?: string
@@ -81,7 +81,7 @@ export type Database = {
           start_kwh?: number | null
           tier_breakdown?: Json
           total_amount?: number
-          usage_kwh?: number
+          usage_kwh?: number | null
         }
         Relationships: [
           {
@@ -785,6 +785,24 @@ export type Database = {
           p_user_id: string
         }
         Returns: undefined
+      }
+      fn_create_household: {
+        Args: {
+          p_address_city?: string
+          p_address_country?: string
+          p_address_line1?: string
+          p_address_line2?: string
+          p_address_postal_code?: string
+          p_address_region?: string
+          p_device_id?: string | null
+          p_display_name: string
+          p_geography_notes?: string
+          p_microgrid_id: string
+          p_primary_email?: string
+          p_primary_phone?: string
+          p_unit_label?: string
+        }
+        Returns: string
       }
       fn_create_household_with_meter: {
         Args: {

--- a/supabase/migrations/00026_household_optional_meter.sql
+++ b/supabase/migrations/00026_household_optional_meter.sql
@@ -1,0 +1,238 @@
+-- 00026_household_optional_meter.sql
+-- Households: support manual-billing without an OpenEMS meter (#158).
+--
+-- ── Why ──────────────────────────────────────────────────────────────────
+--
+-- Aaron's reality on the ground (Kisakye, 2026-04-25): not every tenant has
+-- a metered connection. Some communities run a mix of metered + un-metered
+-- tenants for years before full meter rollout. Today MBE forces him to lie
+-- about un-metered tenants (link to a fake "shared" meter) or omit them
+-- entirely — both are wrong.
+--
+-- User direction: "For now, just make it optional to integrate to a meter
+-- from openEMS." Minimum viable: meter at create time is optional; manual
+-- usage entry on the billing line item makes the household billable.
+--
+-- ── Behavior changes ─────────────────────────────────────────────────────
+--
+-- 1. NEW RPC `fn_create_household` accepts `p_device_id UUID DEFAULT NULL`
+--    plus the same 12 other args as `fn_create_household_with_meter`.
+--    When p_device_id is non-null it performs the existing meter-belongs-
+--    to-microgrid + consumption_meter validation and inserts a
+--    household_devices(role='primary_consumption_meter') row. When NULL
+--    the device wiring is skipped entirely.
+--    Inherits the #155 `household_phone_required` rule unchanged — the
+--    same EXCEPTION name; routes upstream already handle it.
+--
+-- 2. `fn_create_household_with_meter` is rewritten as a thin wrapper that
+--    delegates to fn_create_household with a non-null _device_id. The
+--    13-arg signature is preserved so existing callers (the API route)
+--    continue to work. The phone-check moves into the wrapped function;
+--    it remains effectively guarded because the wrapper passes phone
+--    through unchanged.
+--
+-- 3. `billing_line_items.usage_kwh` is altered from NOT NULL DEFAULT 0 to
+--    NULLable. Reason: un-metered households need to differentiate "not
+--    yet entered manually" (NULL) from "entered as 0" (legitimate zero
+--    usage). Existing rows have non-null values so the ALTER is safe; the
+--    DEFAULT 0 stays in place so metered Refresh-Readings inserts that
+--    omit the column still write 0 implicitly. (`device_id`, `start_kwh`,
+--    `end_kwh` are already nullable per 00001.)
+--
+-- ── #155 dependency ──────────────────────────────────────────────────────
+--
+-- This migration assumes 00024 (phone-required) is applied. The new
+-- fn_create_household raises the same `household_phone_required` exception
+-- name introduced there. The wrapper preserves the rule transitively.
+--
+-- ── Cross-ticket coordination ────────────────────────────────────────────
+--
+-- 00024 added the phone-required guard to fn_create_household_with_meter
+-- inline. This migration MOVES the guard into fn_create_household and the
+-- wrapper delegates — net behavior unchanged; do not double-raise.
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 1. Make billing_line_items.usage_kwh NULLable.
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- DEFAULT 0 stays in place: `INSERT INTO billing_line_items (...)` calls
+-- that omit usage_kwh continue to write 0 (matches legacy Refresh Readings
+-- behavior). NULL is now permitted for un-metered "awaiting manual entry"
+-- rows.
+
+ALTER TABLE billing_line_items
+  ALTER COLUMN usage_kwh DROP NOT NULL;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 2. Create fn_create_household (no-meter capable, p_device_id DEFAULT NULL).
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Same 13-arg shape as fn_create_household_with_meter, but p_device_id is
+-- NULLable with a DEFAULT NULL. When non-null, performs the meter-belongs-
+-- to-microgrid + consumption_meter checks and inserts the household_devices
+-- row. When NULL, skips the device wiring entirely.
+
+CREATE OR REPLACE FUNCTION fn_create_household(
+  p_microgrid_id        UUID,
+  p_display_name        TEXT,
+  p_device_id           UUID    DEFAULT NULL,
+  p_primary_phone       TEXT    DEFAULT NULL,
+  p_primary_email       TEXT    DEFAULT NULL,
+  p_address_line1       TEXT    DEFAULT NULL,
+  p_address_line2       TEXT    DEFAULT NULL,
+  p_unit_label          TEXT    DEFAULT NULL,
+  p_address_city        TEXT    DEFAULT NULL,
+  p_address_region      TEXT    DEFAULT NULL,
+  p_address_country     TEXT    DEFAULT NULL,
+  p_address_postal_code TEXT    DEFAULT NULL,
+  p_geography_notes     TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  _household_id UUID;
+BEGIN
+  -- Guard 0 (#155): phone is required for Pesapal billing-address contact.
+  -- Same exception name as 00024 — do not invent a new code.
+  IF p_primary_phone IS NULL OR trim(p_primary_phone) = '' THEN
+    RAISE EXCEPTION 'household_phone_required';
+  END IF;
+
+  -- Guards 1 + 2 only apply when a device is being linked.
+  IF p_device_id IS NOT NULL THEN
+    -- Guard 1: device's edge must belong to the target microgrid.
+    IF NOT EXISTS (
+      SELECT 1
+      FROM devices d
+      JOIN edges e ON e.id = d.edge_id
+      WHERE d.id = p_device_id
+        AND e.microgrid_id = p_microgrid_id
+    ) THEN
+      RAISE EXCEPTION
+        'device % does not belong to microgrid %',
+        p_device_id, p_microgrid_id;
+    END IF;
+
+    -- Guard 2: device must be of type consumption_meter.
+    IF (SELECT device_type FROM devices WHERE id = p_device_id) <> 'consumption_meter' THEN
+      RAISE EXCEPTION
+        'device % is not a consumption_meter',
+        p_device_id;
+    END IF;
+  END IF;
+
+  -- Atomic insert (+ optional device link). RLS on households /
+  -- household_devices applies via SECURITY INVOKER. A denial raises 42501
+  -- which propagates up to the caller.
+  INSERT INTO households (
+    microgrid_id,
+    display_name,
+    primary_phone,
+    primary_email,
+    address_line1,
+    address_line2,
+    unit_label,
+    address_city,
+    address_region,
+    address_country,
+    address_postal_code,
+    geography_notes
+  ) VALUES (
+    p_microgrid_id,
+    p_display_name,
+    p_primary_phone,
+    p_primary_email,
+    p_address_line1,
+    p_address_line2,
+    p_unit_label,
+    p_address_city,
+    p_address_region,
+    p_address_country,
+    p_address_postal_code,
+    p_geography_notes
+  )
+  RETURNING id INTO _household_id;
+
+  IF p_device_id IS NOT NULL THEN
+    INSERT INTO household_devices (household_id, device_id, role)
+    VALUES (_household_id, p_device_id, 'primary_consumption_meter');
+  END IF;
+
+  RETURN _household_id;
+END;
+$$;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 3. Rewrite fn_create_household_with_meter as a thin wrapper.
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Signature unchanged from 00022/00024 (13 args). Body now delegates to
+-- fn_create_household with the same args + non-null _device_id. The
+-- phone-required guard lives in fn_create_household — the wrapper passes
+-- p_primary_phone through unchanged so the rule remains in effect.
+
+CREATE OR REPLACE FUNCTION fn_create_household_with_meter(
+  p_microgrid_id        UUID,
+  p_display_name        TEXT,
+  p_device_id           UUID,
+  p_primary_phone       TEXT    DEFAULT NULL,
+  p_primary_email       TEXT    DEFAULT NULL,
+  p_address_line1       TEXT    DEFAULT NULL,
+  p_address_line2       TEXT    DEFAULT NULL,
+  p_unit_label          TEXT    DEFAULT NULL,
+  p_address_city        TEXT    DEFAULT NULL,
+  p_address_region      TEXT    DEFAULT NULL,
+  p_address_country     TEXT    DEFAULT NULL,
+  p_address_postal_code TEXT    DEFAULT NULL,
+  p_geography_notes     TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN fn_create_household(
+    p_microgrid_id        => p_microgrid_id,
+    p_display_name        => p_display_name,
+    p_device_id           => p_device_id,
+    p_primary_phone       => p_primary_phone,
+    p_primary_email       => p_primary_email,
+    p_address_line1       => p_address_line1,
+    p_address_line2       => p_address_line2,
+    p_unit_label          => p_unit_label,
+    p_address_city        => p_address_city,
+    p_address_region      => p_address_region,
+    p_address_country     => p_address_country,
+    p_address_postal_code => p_address_postal_code,
+    p_geography_notes     => p_geography_notes
+  );
+END;
+$$;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 4. Re-grant EXECUTE on both signatures (idempotent).
+-- ═════════════════════════════════════════════════════════════════════════
+
+GRANT EXECUTE ON FUNCTION fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO service_role;
+
+GRANT EXECUTE ON FUNCTION fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO service_role;


### PR DESCRIPTION
## Summary

- New migration 00026: \`fn_create_household\` (NULL-able \`_device_id\`); \`fn_create_household_with_meter\` becomes a wrapper. \`billing_line_items.usage_kwh\` made nullable. EXECUTE granted on both signatures.
- HouseholdWizard Step 3: "no meter" checkbox; Step 4 review reflects no-meter state. \`isStepValid(4)\` composes phone-required (#155) with optional meter.
- HouseholdEditDialog (via DeviceSelect): "— No meter (manual billing) —" option; cascade for unlink/insert/atomic swap; dirty-check tested for null===null and same-device equality.
- New PATCH \`/api/billing-line-items/[lineItemId]/usage\` (409 device_linked, 409 period_closed; recomputes tier_breakdown + total_amount).
- Refresh Readings: LEFT-join (drop \`!inner\`); un-metered households still get billing_line_items rows with device_id=null + usage_kwh=NULL. Regression test on the open Apr 20–25 period — metered output identical.
- BillingTable inline-edit on END/USAGE for unmetered rows (gated on \`device_id == null && isDraft\`); rendered as action columns to preserve URA-paste keyboard nav on metered rows.
- HouseholdTable: "No meter" + StatusChip kind="meter" status="not_configured".

Closes #158.

## Test plan

- [x] lint, tsc, test (1042 pass + 3 skipped), build all green
- [x] Reviewer agent → VERDICT: APPROVE (no blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)