### PR TITLE
Close-period dialog: warn-but-allow on un-filled rows (#167)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Five rules every contributor must follow:
 
 4. **Copy table:** Use `<CopyTable>` for billing data tables (built-in per-cell copy + keyboard nav). Grand-total footer rows go BELOW the CopyTable as a `<div>` — CopyTable doesn't support footer rows. Retain `<CopyButton>` only for footer cells.
 
-5. **Destructive actions:** Use `<ConfirmDialog tone="destructive">` for delete flows (Delete Period, Delete Meter, Delete Tenant). Use `<ClosePeriodDialog>` for billing-period close (irreversible, needs multi-channel confirm via totals review + checkbox). Styled in neutral/primary tone — closing is a final commit, not a destruction. Reserve destructive tone for delete-entity flows (`<ConfirmDialog tone="destructive">`). Use `<ConfirmDialog tone="neutral">` for non-destructive warnings (e.g. remove-last-tier). Never use `confirm()` — it blocks the main thread and can't be tested.
+5. **Destructive actions:** Use `<ConfirmDialog tone="destructive">` for delete flows (Delete Period, Delete Meter, Delete Tenant). Use `<ClosePeriodDialog>` for billing-period close (irreversible, needs multi-channel confirm via totals review + checkbox); when the caller passes `unfilledHouseholdNames`, the dialog renders a warning-toned banner above the totals, flips the confirm button to "Close anyway", and appends an explicit acknowledgement to the checkbox copy (warn-but-allow per #167). Styled in neutral/primary tone — closing is a final commit, not a destruction. Reserve destructive tone for delete-entity flows (`<ConfirmDialog tone="destructive">`). Use `<ConfirmDialog tone="neutral">` for non-destructive warnings (e.g. remove-last-tier). Never use `confirm()` — it blocks the main thread and can't be tested.
 
 ## Local Dev Setup
 

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -283,6 +283,23 @@ export function BillingTable({
       ? period.start_date
       : `${period.start_date} – ${period.end_date}`;
 
+  // #167 — derive the list of un-metered households whose `usage_kwh` is
+  // still NULL. These are the rows that would silently lock in zero kWh /
+  // zero amount on close. Surfaced to <ClosePeriodDialog> as a warning
+  // banner; closing is still permitted (operator may genuinely intend to
+  // bill nothing) but the gesture becomes more deliberate.
+  const unfilledHouseholdNames = lineItems
+    .filter(
+      (item) =>
+        item.device_id === null &&
+        (item.usage_kwh === null || item.usage_kwh === undefined)
+    )
+    .map(
+      (item) =>
+        households.find((h) => h.id === item.household_id)?.display_name ??
+        "Unknown household"
+    );
+
   // Build summary rows for ClosePeriodDialog
   const closePeriodSummaryRows: ClosePeriodSummaryRow[] = [
     {
@@ -445,6 +462,7 @@ export function BillingTable({
         summaryRows={closePeriodSummaryRows}
         grandTotal={grandTotal}
         onConfirm={handleClose}
+        unfilledHouseholdNames={unfilledHouseholdNames}
       />
 
       {/* Header */}

--- a/src/components/__tests__/close-period-dialog.test.tsx
+++ b/src/components/__tests__/close-period-dialog.test.tsx
@@ -46,6 +46,7 @@ function ControlledHarness(props: {
   initialOpen?: boolean;
   onConfirm: () => Promise<void>;
   onExportCsv?: () => void;
+  unfilledHouseholdNames?: string[];
 }) {
   const [open, setOpen] = React.useState(props.initialOpen ?? true);
   return (
@@ -64,6 +65,7 @@ function ControlledHarness(props: {
         grandTotal={GRAND_TOTAL}
         onConfirm={props.onConfirm}
         onExportCsv={props.onExportCsv}
+        unfilledHouseholdNames={props.unfilledHouseholdNames}
       />
     </Wrapper>
   );
@@ -287,5 +289,146 @@ describe("ClosePeriodDialog — a11y", () => {
     // And NOT the checkbox.
     const checkbox = screen.getByRole("checkbox");
     expect(document.activeElement).not.toBe(checkbox);
+  });
+});
+
+// ─── #167 — un-billed warning banner ──────────────────────────────────────────
+//
+// Pin the warn-but-allow contract:
+//   - With zero unfilled, no banner; button label is still "Close period";
+//     checkbox copy is unchanged.
+//   - With one unfilled, the banner appears with singular copy, lists the name,
+//     button label flips to "Close anyway", checkbox copy gets the
+//     " (including 1 un-billed household)" addendum.
+//   - With six unfilled, the banner shows plural copy and truncates the
+//     name list to the first five followed by "+ 1 more".
+//   - The banner uses warning tokens (bg-warning-muted + text-warning-fg),
+//     NOT destructive tokens.
+//   - The confirm flow still works end-to-end with the banner present:
+//     tick checkbox → button enables → click → onConfirm fires.
+
+describe("ClosePeriodDialog — un-billed warning banner (#167)", () => {
+  it("with zero unfilled: no banner, button reads 'Close period', checkbox copy has no addendum", () => {
+    render(
+      <ControlledHarness
+        onConfirm={() => Promise.resolve()}
+        unfilledHouseholdNames={[]}
+      />
+    );
+
+    // No banner rendered.
+    expect(screen.queryByTestId("close-period-unfilled-banner")).toBeNull();
+    expect(screen.queryByText(/un-billed/i)).toBeNull();
+
+    // Confirm button label unchanged.
+    const closeBtn = screen.getByRole("button", { name: /^Close period$/ });
+    expect(closeBtn).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Close anyway$/ })).toBeNull();
+
+    // Checkbox copy unchanged — no "(including ..." addendum.
+    expect(screen.queryByText(/including .* un-billed/i)).toBeNull();
+  });
+
+  it("with one unfilled: singular banner copy, lists the name, button reads 'Close anyway', checkbox addendum is singular", () => {
+    render(
+      <ControlledHarness
+        onConfirm={() => Promise.resolve()}
+        unfilledHouseholdNames={["House A"]}
+      />
+    );
+
+    // Banner present with singular heading.
+    const banner = screen.getByTestId("close-period-unfilled-banner");
+    expect(banner).toBeTruthy();
+    expect(screen.getByText("1 household still un-billed")).toBeTruthy();
+    // Plural form must NOT render in the singular case.
+    expect(screen.queryByText(/^1 households still un-billed$/)).toBeNull();
+
+    // Name listed in the body.
+    expect(screen.getByText("House A")).toBeTruthy();
+
+    // Confirm button label flips to "Close anyway".
+    expect(
+      screen.getByRole("button", { name: /^Close anyway$/ })
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Close period$/ })).toBeNull();
+
+    // Checkbox copy has the singular addendum.
+    expect(
+      screen.getByText(/including 1 un-billed household\)/)
+    ).toBeTruthy();
+  });
+
+  it("with six unfilled: plural banner copy, lists first 5 + '+ 1 more'", () => {
+    const names = [
+      "House A",
+      "House B",
+      "House C",
+      "House D",
+      "House E",
+      "House F",
+    ];
+    render(
+      <ControlledHarness
+        onConfirm={() => Promise.resolve()}
+        unfilledHouseholdNames={names}
+      />
+    );
+
+    // Plural heading.
+    expect(screen.getByText("6 households still un-billed")).toBeTruthy();
+
+    // First five listed in a comma-separated preview, followed by "+ 1 more".
+    const banner = screen.getByTestId("close-period-unfilled-banner");
+    expect(banner.textContent).toContain(
+      "House A, House B, House C, House D, House E + 1 more"
+    );
+    // The 6th name must NOT appear in the truncated preview.
+    expect(banner.textContent).not.toContain("House F");
+
+    // Plural addendum in checkbox copy.
+    expect(
+      screen.getByText(/including 6 un-billed households\)/)
+    ).toBeTruthy();
+  });
+
+  it("banner uses warning tokens, not destructive tokens (token-class drift sanity)", () => {
+    render(
+      <ControlledHarness
+        onConfirm={() => Promise.resolve()}
+        unfilledHouseholdNames={["House A", "House B"]}
+      />
+    );
+
+    const banner = screen.getByTestId("close-period-unfilled-banner");
+    expect(banner.className).toContain("bg-warning-muted");
+    expect(banner.className).toContain("text-warning-fg");
+    expect(banner.className).not.toContain("bg-destructive");
+    expect(banner.className).not.toContain("bg-destructive-muted");
+    expect(banner.className).not.toContain("text-destructive-fg");
+  });
+
+  it("confirm flow still works with the banner present: tick → enable → click → onConfirm", async () => {
+    const onConfirm = vi.fn(() => Promise.resolve());
+    render(
+      <ControlledHarness
+        onConfirm={onConfirm}
+        unfilledHouseholdNames={["House A"]}
+      />
+    );
+
+    const closeBtn = screen.getByRole("button", {
+      name: /^Close anyway$/,
+    }) as HTMLButtonElement;
+    expect(closeBtn.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(closeBtn.disabled).toBe(false);
+
+    fireEvent.click(closeBtn);
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(onConfirm.mock.calls[0]).toEqual([]);
   });
 });

--- a/src/components/ui/close-period-dialog.tsx
+++ b/src/components/ui/close-period-dialog.tsx
@@ -36,6 +36,16 @@
 //   tone is reserved for delete flows. The rail and eyebrow render in
 //   primary tone; only the error-state banner and Retry button keep the
 //   destructive tokens (genuine failure state).
+//
+// Un-billed warning (#167):
+//   When `unfilledHouseholdNames` is non-empty, the dialog renders a
+//   warning-toned banner above the totals grid listing the un-metered
+//   households whose `usage_kwh` is still NULL. Closing is permitted —
+//   Aaron may genuinely want to bill nothing for a tenant — but the
+//   gesture becomes more deliberate: the confirm button label flips to
+//   "Close anyway" and the checkbox copy gains an explicit acknowledgement
+//   of the un-billed count. Tone uses warning tokens, not destructive,
+//   per Design System rule 3 (this is a soft block, not a failure state).
 
 import * as React from "react";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -60,6 +70,12 @@ export interface ClosePeriodDialogProps {
   onConfirm: () => Promise<void>;
   /** Called when the user clicks "Export CSV for URA" in the closed state. */
   onExportCsv?: () => void;
+  /** Display names of un-metered households whose `usage_kwh` is still NULL.
+   *  When non-empty, the dialog renders a warning banner above the totals
+   *  grid, flips the confirm button label to "Close anyway", and appends
+   *  an acknowledgement of the un-billed count to the checkbox copy.
+   *  Default: `[]` (no banner, original "Close period" behavior). */
+  unfilledHouseholdNames?: string[];
 }
 
 type Phase = 2 | 2.5 | 3 | "E";
@@ -72,6 +88,7 @@ export function ClosePeriodDialog({
   grandTotal,
   onConfirm,
   onExportCsv,
+  unfilledHouseholdNames = [],
 }: ClosePeriodDialogProps) {
   const [phase, setPhase] = React.useState<Phase>(2);
   const [confirmed, setConfirmed] = React.useState(false);
@@ -108,6 +125,17 @@ export function ClosePeriodDialog({
     phase === 3
       ? "This period is now read-only. Export the CSV for your URA filing."
       : "Bills become final. This period will be filed with URA — values copied after this are the values you report.";
+
+  // #167 — un-billed warning derivations. Only relevant in the pre-close
+  // phases (2 / 2.5 / E); the closed surface intentionally drops the
+  // banner since the period is now committed and listing the un-billed
+  // households after-the-fact would be misleading.
+  const unfilledCount = unfilledHouseholdNames.length;
+  const hasUnfilled = unfilledCount > 0 && phase !== 3;
+  const unfilledHouseholdsWord = unfilledCount === 1 ? "household" : "households";
+  const unfilledNamesPreview = unfilledHouseholdNames.slice(0, 5).join(", ");
+  const unfilledNamesOverflow = unfilledCount > 5 ? unfilledCount - 5 : 0;
+  const confirmButtonLabel = hasUnfilled ? "Close anyway" : "Close period";
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -157,6 +185,24 @@ export function ClosePeriodDialog({
             </Dialog.Description>
           </div>
 
+          {hasUnfilled && (
+            <div className="px-6 pt-3">
+              <div
+                data-testid="close-period-unfilled-banner"
+                role="alert"
+                className="rounded-md bg-warning-muted px-3 py-2.5 text-[13px] text-warning-fg"
+              >
+                <div className="font-semibold">
+                  {unfilledCount} {unfilledHouseholdsWord} still un-billed
+                </div>
+                <div className="mt-0.5">
+                  {unfilledNamesPreview}
+                  {unfilledNamesOverflow > 0 ? ` + ${unfilledNamesOverflow} more` : ""}
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="grid grid-cols-2 gap-3 px-6 pt-3">
             {summaryRows.map((r, i) => (
               <div key={i} className="rounded-md bg-muted px-2.5 py-2">
@@ -187,6 +233,9 @@ export function ClosePeriodDialog({
                 <span>
                   I have copied the tier values into URA&apos;s portal and confirm these
                   totals are what I will file.
+                  {hasUnfilled
+                    ? ` (including ${unfilledCount} un-billed ${unfilledHouseholdsWord})`
+                    : ""}
                 </span>
               </label>
             </div>
@@ -228,7 +277,7 @@ export function ClosePeriodDialog({
                 disabled={!confirmed}
                 className="inline-flex h-8 items-center rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                Close period
+                {confirmButtonLabel}
               </button>
             )}
             {phase === 2.5 && (


### PR DESCRIPTION
## Summary

- New \`unfilledHouseholdNames\` prop on \`<ClosePeriodDialog>\`: when present, renders a \`bg-warning-muted\` banner above the totals grid listing the un-billed households (truncates after 5 with "+ N more").
- Button label flips "Close period" → "Close anyway" when banner is visible.
- Checkbox copy gets " (including N un-billed household[s])" addendum so the multi-channel confirm explicitly acknowledges the unfilled state.
- BillingTable derives the list from \`lineItems\` (\`device_id === null && usage_kwh == null\`) joined to households, passes to dialog.
- 5 new test cases (zero unfilled, 1 unfilled, 6 unfilled with truncation, warning-token sanity, confirm flow with banner).
- CLAUDE.md rule 5 single-sentence amendment.

Surfaces from the holistic post-merge review (warn-but-allow on the un-billed-row close path that #158 introduced).

Closes #167.

## Test plan

- [x] \`npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1107 pass) && npm run build\` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)