### PR TITLE
Wizard polish: drop "X / 4" + gate phone error on touch

### DIFF
--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -393,7 +393,6 @@ export function HouseholdWizard({
                   update={update}
                   firstFieldRef={step1FirstFieldRef}
                   disabled={submitting}
-                  visited={visited.has(1)}
                 />
               )}
               {step === 2 && (
@@ -560,9 +559,7 @@ function StepIndicator({
               >
                 {isCompleted && !isActive ? "✓" : s}
               </span>
-              <span>
-                {s} / 4 {STEP_LABELS[s]}
-              </span>
+              <span>{STEP_LABELS[s]}</span>
             </button>
             {idx < steps.length - 1 && (
               <span aria-hidden="true" className="h-px flex-1 bg-border" />
@@ -581,17 +578,20 @@ function StepBasics({
   update,
   firstFieldRef,
   disabled,
-  visited,
 }: {
   state: FormState;
   update: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
   firstFieldRef: React.RefObject<HTMLInputElement | null>;
   disabled: boolean;
-  visited: boolean;
 }) {
-  // #155: phone is required for Pesapal payment-link delivery.
+  // #155: phone is required for Pesapal payment-link delivery. The inline
+  // error fires only after the user has interacted with the phone field
+  // (focused-then-left), so the dialog doesn't yell on first render. The
+  // Next button stays disabled until phone is non-empty either way, so the
+  // user can't bypass the rule.
+  const [phoneTouched, setPhoneTouched] = React.useState(false);
   const phoneBlank = state.primary_phone.trim().length === 0;
-  const phoneInvalid = visited && phoneBlank;
+  const phoneInvalid = phoneTouched && phoneBlank;
   return (
     <fieldset className="space-y-4" disabled={disabled}>
       <legend className="sr-only">Step 1 of 4: Basics</legend>
@@ -628,6 +628,7 @@ function StepBasics({
             type="text"
             value={state.primary_phone}
             onChange={(e) => update("primary_phone", e.target.value)}
+            onBlur={() => setPhoneTouched(true)}
             placeholder="+256 …"
             required
             aria-required="true"

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -151,22 +151,30 @@ describe("HouseholdWizard", () => {
       expect(next).toHaveProperty("disabled", false);
     });
 
-    it("(#155) blank phone shows inline error AND blocks Next", () => {
+    it("(#155) inline error stays hidden until phone is touched, then blocks Next", () => {
       renderWizard();
-      // Step 1 is visited from open → inline error visible immediately.
+      // On first render the dialog must NOT yell — error appears only after
+      // the user has interacted with the phone field.
+      expect(
+        screen.queryByText(/Phone is required for payment links/i)
+      ).toBeNull();
+
+      fillDisplayName("Block A, Unit 1");
+      const next = screen.getByRole("button", { name: /^Next$/ });
+      // display_name set, phone still blank → Next disabled regardless of
+      // whether the error message is rendered.
+      expect(next).toHaveProperty("disabled", true);
+
+      // Touch the phone field (focus + blur) without typing → error appears.
+      const phone = screen.getByLabelText(
+        /Primary phone/i
+      ) as HTMLInputElement;
+      fireEvent.blur(phone);
       expect(
         screen.getByText(/Phone is required for payment links/i)
       ).toBeTruthy();
 
-      fillDisplayName("Block A, Unit 1");
-      // display_name set, phone still blank → Next disabled
-      const next = screen.getByRole("button", { name: /^Next$/ });
-      expect(next).toHaveProperty("disabled", true);
-
       // Fill phone → error clears and Next enables
-      const phone = screen.getByLabelText(
-        /Primary phone/i
-      ) as HTMLInputElement;
       fireEvent.change(phone, { target: { value: "+256 700 000 000" } });
       expect(
         screen.queryByText(/Phone is required for payment links/i)


### PR DESCRIPTION
## Summary

Two small UX bugs surfaced when re-opening the household wizard after #155 + #158 shipped:

1. **Step labels duplicate the bubble number** — \`1 / 4 Basics\` reads alongside the numbered ⓵ bubble. Drop the prefix; keep just the title.
2. **Phone "required" error fires on first render** — `phoneInvalid` was keyed on the parent's `visited` flag, which is `true` from open since step 1 is in the initial visited set. Switch to a local `phoneTouched` state set on \`onBlur\` so the error only appears after the user has actually engaged the field. The Next button stays disabled while phone is blank, so the rule is still enforced.

Test updated to assert the new touched-then-error flow.

## Test plan

- [x] \`npm run lint && tsc && SKIP_RLS_TESTS=1 npm test (HouseholdWizard suite — 19 pass) && build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)