### PR TITLE
BillingPeriodList: collapse three CTAs to one (#171)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,8 @@ Five rules every contributor must follow:
 
 5. **Destructive actions:** Use `<ConfirmDialog tone="destructive">` for delete flows (Delete Period, Delete Meter, Delete Tenant). Use `<ClosePeriodDialog>` for billing-period close (irreversible, needs multi-channel confirm via totals review + checkbox); when the caller passes `unfilledHouseholdNames`, the dialog renders a warning-toned banner above the totals, flips the confirm button to "Close anyway", and appends an explicit acknowledgement to the checkbox copy (warn-but-allow per #167). Styled in neutral/primary tone — closing is a final commit, not a destruction. Reserve destructive tone for delete-entity flows (`<ConfirmDialog tone="destructive">`). Use `<ConfirmDialog tone="neutral">` for non-destructive warnings (e.g. remove-last-tier). Never use `confirm()` — it blocks the main thread and can't be tested.
 
+6. **Picker / empty-state mutual exclusion:** When a list surface has both a switcher control (e.g. `<PeriodPicker>`) and an `<EmptyState>`, the switcher MUST NOT render when its underlying collection is empty. The empty-state owns the create CTA at zero; the switcher owns the create CTA at ≥1. Switchers must not include their own internal "no items" empty-state branch — that responsibility belongs to the parent surface, where the canonical first-run pedagogy copy lives. Additionally, when an inline create form is open, the parent's `<EmptyState>` must hide so the form is the sole CTA on screen; the form itself must include a `Cancel` action so the user has an escape hatch back to the empty-state.
+
 ## Local Dev Setup
 
 See `docs/setup.md` for three modes:

--- a/src/components/BillingPeriodList.tsx
+++ b/src/components/BillingPeriodList.tsx
@@ -142,14 +142,17 @@ export function BillingPeriodList({
 
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Billing Periods</h2>
-        {/* PeriodPicker replaces the standalone "New Period" button.
-            currentId is undefined — the index page has no "current" period to highlight. */}
-        <PeriodPicker
-          periods={periods.map((p) => toPeriodOption(p, summaries))}
-          currentId={undefined}
-          onSelect={(option) => router.push(`/microgrids/${microgridId}/billing/${option.id}`)}
-          onNewPeriod={() => setShowCreateForm(true)}
-        />
+        {/* PeriodPicker is a switcher — it has nothing to switch between when
+            periods.length === 0. The <EmptyState> below owns the create CTA at
+            zero. See CLAUDE.md Design System rule #6. */}
+        {periods.length > 0 && (
+          <PeriodPicker
+            periods={periods.map((p) => toPeriodOption(p, summaries))}
+            currentId={undefined}
+            onSelect={(option) => router.push(`/microgrids/${microgridId}/billing/${option.id}`)}
+            onNewPeriod={() => setShowCreateForm(true)}
+          />
+        )}
       </div>
 
       {error && (
@@ -189,17 +192,27 @@ export function BillingPeriodList({
               />
             </div>
           </div>
-          <button
-            type="submit"
-            disabled={creating}
-            className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {creating ? "Creating..." : "Create Period"}
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowCreateForm(false)}
+              disabled={creating}
+              className="rounded-md bg-muted px-4 py-2 text-sm text-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={creating}
+              className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {creating ? "Creating..." : "Create Period"}
+            </button>
+          </div>
         </form>
       )}
 
-      {periods.length === 0 ? (
+      {periods.length === 0 && !showCreateForm && (
         <EmptyState
           eyebrow="Billing periods"
           title="Create the first billing period"
@@ -229,7 +242,9 @@ export function BillingPeriodList({
           }
           className="border-0 shadow-none bg-transparent p-0"
         />
-      ) : (
+      )}
+
+      {periods.length > 0 && (
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead>

--- a/src/components/__tests__/billing-period-list.test.tsx
+++ b/src/components/__tests__/billing-period-list.test.tsx
@@ -211,3 +211,151 @@ describe("BillingPeriodList — EmptyState (#139)", () => {
     expect(screen.queryByText("Create the first billing period")).toBeNull();
   });
 });
+
+// ─── CTA collapse / picker invariant (#171) ──────────────────────────────────
+//
+// One CTA at zero, one CTA at >=1, no overlap. Mirrors AC-7 of the ticket.
+
+describe("BillingPeriodList — CTA collapse (#171)", () => {
+  beforeEach(() => {
+    pushSpy.mockClear();
+  });
+
+  it("at zero periods + form closed: PeriodPicker NOT rendered, EmptyState rendered with one CTA, form NOT rendered", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+
+    // Picker hidden — its trigger has aria-haspopup="listbox"
+    expect(document.querySelector("button[aria-haspopup='listbox']")).toBeNull();
+
+    // EmptyState rendered with the canonical first-run title
+    expect(screen.getByText("Create the first billing period")).toBeTruthy();
+
+    // Exactly one CTA: the EmptyState's "+ Create period" button
+    const createButtons = screen.getAllByRole("button", { name: /Create period/i });
+    expect(createButtons).toHaveLength(1);
+
+    // Form not rendered — there's no Cancel button visible
+    expect(screen.queryByRole("button", { name: /^Cancel$/i })).toBeNull();
+  });
+
+  it("at zero periods + clicking EmptyState CTA: form rendered, EmptyState NOT rendered, PeriodPicker still NOT rendered", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+
+    // Click the EmptyState CTA to open the form
+    fireEvent.click(screen.getByRole("button", { name: /\+ Create period/i }));
+
+    // Form is rendered — Cancel + Create Period buttons visible
+    expect(screen.getByRole("button", { name: /^Cancel$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Create Period/i })).toBeTruthy();
+
+    // EmptyState gone — its title no longer in the document
+    expect(screen.queryByText("Create the first billing period")).toBeNull();
+
+    // Picker still hidden — periods.length is still 0
+    expect(document.querySelector("button[aria-haspopup='listbox']")).toBeNull();
+  });
+
+  it("at zero periods + form open + clicking Cancel: form NOT rendered, EmptyState rendered with CTA", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[]}
+          summaries={{}}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+
+    // Open the form
+    fireEvent.click(screen.getByRole("button", { name: /\+ Create period/i }));
+    expect(screen.getByRole("button", { name: /^Cancel$/i })).toBeTruthy();
+
+    // Click Cancel
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
+
+    // Form gone — Cancel button no longer visible
+    expect(screen.queryByRole("button", { name: /^Cancel$/i })).toBeNull();
+
+    // EmptyState back with its "+ Create period" CTA
+    expect(screen.getByText("Create the first billing period")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /\+ Create period/i })).toBeTruthy();
+  });
+
+  it("at >=1 period + form closed: PeriodPicker rendered, EmptyState NOT rendered, list rendered", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[PERIOD_1, PERIOD_2]}
+          summaries={SUMMARIES}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+
+    // Picker rendered
+    expect(document.querySelector("button[aria-haspopup='listbox']")).not.toBeNull();
+
+    // EmptyState absent
+    expect(screen.queryByText("Create the first billing period")).toBeNull();
+
+    // List rendered — column headers present
+    expect(screen.getByText(/Date Range/i)).toBeTruthy();
+  });
+
+  it("at >=1 period + clicking picker '+ New period': form rendered, picker still rendered, list still rendered", () => {
+    render(
+      <Wrapper>
+        <BillingPeriodList
+          microgridId={MICROGRID_ID}
+          periods={[PERIOD_1, PERIOD_2]}
+          summaries={SUMMARIES}
+          currency="UGX"
+          canManage={true}
+        />
+      </Wrapper>
+    );
+
+    // Open the picker
+    const trigger = document.querySelector(
+      "button[aria-haspopup='listbox']",
+    ) as HTMLButtonElement;
+    fireEvent.click(trigger);
+
+    // Click the picker's "+ New period" header CTA
+    fireEvent.click(screen.getByRole("button", { name: /\+ New period/i }));
+
+    // Form is rendered — Cancel + Create Period buttons visible
+    expect(screen.getByRole("button", { name: /^Cancel$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Create Period/i })).toBeTruthy();
+
+    // Picker still rendered
+    expect(document.querySelector("button[aria-haspopup='listbox']")).not.toBeNull();
+
+    // List still rendered — column header still in DOM
+    expect(screen.getByText(/Date Range/i)).toBeTruthy();
+  });
+});

--- a/src/components/ui/period-picker.tsx
+++ b/src/components/ui/period-picker.tsx
@@ -13,8 +13,15 @@
 //     is one of three core admin actions, not a ghost.
 //   • Same-day periods render as a single date (e.g. "2026-02-15") not
 //     "Feb 15 → Feb 15".
-//   • States: empty (no periods) / loading (skeleton rows) / error
-//     (retry inline). Disabled trigger when the user can't select.
+//   • States: loading (skeleton rows) / error (retry inline). Disabled
+//     trigger when the user can't select.
+//
+// INVARIANT: PeriodPicker MUST NOT be rendered when periods.length === 0.
+// The picker is a switcher; with zero entries there is nothing to switch
+// between. The parent surface's <EmptyState> owns the create CTA at zero;
+// the picker owns the create CTA at >= 1. See CLAUDE.md Design System
+// rule #6. If a caller violates the invariant, this component renders
+// nothing (defensive null) rather than a misleading empty branch.
 
 import * as React from "react";
 import * as Popover from "@radix-ui/react-popover";
@@ -53,11 +60,18 @@ export function PeriodPicker({
   disabled,
   className,
 }: PeriodPickerProps) {
+  // PeriodPicker MUST NOT be rendered when periods.length === 0 — see
+  // CLAUDE.md rule 6. Caller is responsible for hiding the picker at zero.
+  // Defensive null render to enforce the invariant if a caller violates it.
   const current = periods.find((p) => p.id === currentId) ?? periods[0];
   const [open, setOpen] = React.useState(false);
   const [activeIdx, setActiveIdx] = React.useState(() =>
     Math.max(0, periods.findIndex((p) => p.id === currentId)),
   );
+
+  if (periods.length === 0 && !loading && !error) {
+    return null;
+  }
 
   const onPanelKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Escape") {
@@ -140,19 +154,11 @@ export function PeriodPicker({
               <div className="m-3 rounded-md bg-destructive-muted px-3 py-2.5 text-[13px] text-destructive-fg">
                 Couldn&apos;t load periods. <button className="underline">Retry</button>
               </div>
-            ) : periods.length === 0 ? (
-              <div className="m-3 rounded-md border border-dashed border-border bg-muted px-3 py-4 text-center text-[12px] text-muted-foreground">
-                <div className="mb-1.5 font-semibold text-foreground">No periods yet</div>
-                {onNewPeriod && (
-                  <button
-                    onClick={onNewPeriod}
-                    className="inline-flex h-6 items-center rounded-md bg-primary px-2.5 text-[12px] font-medium text-primary-foreground"
-                  >
-                    + Create the first
-                  </button>
-                )}
-              </div>
             ) : (
+              // INVARIANT: periods.length >= 1 here — the parent surface MUST
+              // hide PeriodPicker when periods.length === 0 (CLAUDE.md rule
+              // #6). The "No periods yet" empty branch was deleted because
+              // it is unreachable under the current contract.
               periods.map((p, i) => (
                 <button
                   key={p.id}


### PR DESCRIPTION
## Summary

Two related billing-period UX issues, fixed together per the [designer brief](https://github.com/energy-iot/mbe-docs/blob/main/design/mocks/billing-period-empty-state-2026-04-25/DESIGN-BRIEF.md):

- **Picker hides at zero**: \`<PeriodPicker>\` only renders when \`periods.length > 0\`. The picker is a switcher; with nothing to switch between it has no job.
- **Picker's internal empty branch deleted**: \`period-picker.tsx\` no longer ships the dead "No periods yet · + Create the first" body. Defensive null render + invariant comment if anyone passes \`length === 0\` in the future.
- **EmptyState hides while form is open**: gates on \`periods.length === 0 && !showCreateForm\`. No more stale "Create the first" empty-state lurking under the inline date-range form.
- **Cancel button on inline form**: gives the operator an escape hatch now that the EmptyState (which previously offered an implicit cancel via "click somewhere else") is hidden when the form is open.
- **CLAUDE.md rule #6** added: switcher controls MUST NOT render when their underlying collection is empty; switchers MUST NOT include their own internal empty-state branch.

5 new test cases cover the new behavior at zero / opened-form / cancel / ≥1 / picker-CTA states.

Closes #171.

## Test plan

- [x] lint, tsc, test (1112 pass + 11 skipped), build all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)