### PR TITLE
BC4 — Per-period audit history page (#176)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/history/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/history/__tests__/page.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * history/page.test.tsx — BC4 #176 server-component integration test.
+ *
+ * Mocks @/lib/supabase/server and @/lib/billing/audit-log-fetch so we
+ * can exercise the page's render branches without a live DB:
+ *
+ *   - Happy path: the page returns markup containing the audit list.
+ *   - With searchParams.household_id set: filter narrows the visible
+ *     entries; the "Show all" link clears the param.
+ *   - Empty period (zero entries) → "No changes recorded yet"; <ol>
+ *     is NOT rendered.
+ *
+ * Strategy: import the page module then call the default export directly
+ * (it's an async server component). Render the returned JSX with
+ * react-dom/server's renderToStaticMarkup. This mirrors the pattern in
+ * src/app/(dashboard)/microgrids/[id]/__tests__/page.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+
+const PERIOD_ID = "660e8400-e29b-41d4-a716-446655441000";
+const MICROGRID_ID = "770e8400-e29b-41d4-a716-446655442000";
+const HH_A = "880e8400-e29b-41d4-a716-446655443001";
+const HH_B = "880e8400-e29b-41d4-a716-446655443002";
+const LI_A = "990e8400-e29b-41d4-a716-446655444001";
+const LI_B = "990e8400-e29b-41d4-a716-446655444002";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Holders we mutate per-test.
+let MOCK_PERIOD: { id: string; microgrid_id: string } | null = {
+  id: PERIOD_ID,
+  microgrid_id: MICROGRID_ID,
+};
+let MOCK_HOUSEHOLDS: { id: string; display_name: string }[] = [
+  { id: HH_A, display_name: "HH-A" },
+  { id: HH_B, display_name: "HH-B" },
+];
+let MOCK_LINE_ITEMS: { id: string; household_id: string }[] = [
+  { id: LI_A, household_id: HH_A },
+  { id: LI_B, household_id: HH_B },
+];
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: (table: string) => {
+      if (table === "billing_periods") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: MOCK_PERIOD,
+                    error: MOCK_PERIOD ? null : { message: "not found" },
+                  }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "households") {
+        return {
+          select: () => ({
+            eq: () => ({
+              returns: () =>
+                Promise.resolve({ data: MOCK_HOUSEHOLDS, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "billing_line_items") {
+        return {
+          select: () => ({
+            in: () =>
+              Promise.resolve({ data: MOCK_LINE_ITEMS, error: null }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table in history page test: ${table}`);
+    },
+  }),
+}));
+
+vi.mock("@/lib/hierarchy", () => ({
+  getHierarchyLevels: vi.fn().mockResolvedValue([]),
+}));
+
+let MOCK_AUDIT_RESULT: {
+  kind: "ok" | "unauthorized" | "not_found" | "error";
+  entries?: BillingAuditLogEntry[];
+  message?: string;
+} = { kind: "ok", entries: [] };
+
+vi.mock("@/lib/billing/audit-log-fetch", () => ({
+  fetchAuditLogEntries: vi.fn(async () => MOCK_AUDIT_RESULT),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => React.createElement("a", { href, className }, children),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+import HistoryPage from "../page";
+
+const FIVE_ENTRIES: BillingAuditLogEntry[] = [
+  {
+    id: "audit:1",
+    eventType: "period_created",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorDisplayName: "Alice Doe",
+    createdAt: "2026-04-25T10:00:00Z",
+    billingLineItemId: null,
+    householdName: null,
+    details: {},
+  },
+  {
+    id: "audit:2",
+    eventType: "line_item_generated",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorDisplayName: "Alice Doe",
+    createdAt: "2026-04-25T11:00:00Z",
+    billingLineItemId: LI_A,
+    householdName: "HH-A",
+    details: { household_name: "HH-A", new_total_amount: 5000 },
+  },
+  {
+    id: "audit:3",
+    eventType: "line_item_regenerated",
+    actorUserId: null,
+    actorDisplayName: null,
+    createdAt: "2026-04-25T12:00:00Z",
+    billingLineItemId: LI_B,
+    householdName: "HH-B",
+    details: {
+      household_name: "HH-B",
+      previous_total_amount: 3000,
+      new_total_amount: 4000,
+      previous_reading_source: "edge",
+      new_reading_source: "manual",
+    },
+  },
+  {
+    id: "payment_event:4",
+    eventType: "payment_status_changed",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorDisplayName: "Alice Doe",
+    createdAt: "2026-04-25T13:00:00Z",
+    billingLineItemId: LI_A,
+    householdName: "HH-A",
+    details: { from: "unpaid", to: "paid", source: "manual" },
+  },
+  {
+    id: "payment_event:5",
+    eventType: "payment_link_generated",
+    actorUserId: null,
+    actorDisplayName: null,
+    createdAt: "2026-04-25T14:00:00Z",
+    billingLineItemId: LI_B,
+    householdName: "HH-B",
+    details: { from: "unpaid", to: "link_generated", source: "generate_link" },
+  },
+];
+
+beforeEach(() => {
+  MOCK_PERIOD = { id: PERIOD_ID, microgrid_id: MICROGRID_ID };
+  MOCK_HOUSEHOLDS = [
+    { id: HH_A, display_name: "HH-A" },
+    { id: HH_B, display_name: "HH-B" },
+  ];
+  MOCK_LINE_ITEMS = [
+    { id: LI_A, household_id: HH_A },
+    { id: LI_B, household_id: HH_B },
+  ];
+  MOCK_AUDIT_RESULT = { kind: "ok", entries: [] };
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("HistoryPage — happy path", () => {
+  it("renders one <li> per entry under <ol aria-label='Audit history'>", async () => {
+    MOCK_AUDIT_RESULT = { kind: "ok", entries: FIVE_ENTRIES };
+    const node = await HistoryPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+      searchParams: Promise.resolve({}),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    expect(html).toContain('aria-label="Audit history"');
+    // 5 entries → 5 li's. Use a regex that counts opening li tags.
+    const liCount = (html.match(/<li\b/g) ?? []).length;
+    expect(liCount).toBe(5);
+    expect(html).toContain("Bill generated for HH-A");
+    expect(html).toContain("Bill regenerated for HH-B");
+    expect(html).toContain("Payment status for HH-A");
+    expect(html).toContain("Payment link generated for HH-B");
+    expect(html).toContain("Period created");
+  });
+});
+
+describe("HistoryPage — household_id filter", () => {
+  it("only renders entries belonging to the filtered household + Show all link clears the param", async () => {
+    MOCK_AUDIT_RESULT = { kind: "ok", entries: FIVE_ENTRIES };
+    const node = await HistoryPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+      searchParams: Promise.resolve({ household_id: HH_A }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    // 2 entries belong to LI_A → HH_A.
+    const liCount = (html.match(/<li\b/g) ?? []).length;
+    expect(liCount).toBe(2);
+    expect(html).toContain("Bill generated for HH-A");
+    expect(html).toContain("Payment status for HH-A");
+    expect(html).not.toContain("Bill regenerated for HH-B");
+    expect(html).not.toContain("Payment link generated for HH-B");
+    // Show all link clears the param.
+    expect(html).toContain(
+      `href="/microgrids/${MICROGRID_ID}/billing/${PERIOD_ID}/history"`
+    );
+  });
+});
+
+describe("HistoryPage — empty states", () => {
+  it("renders 'No changes recorded yet' when zero entries (no filter), and omits the <ol>", async () => {
+    MOCK_AUDIT_RESULT = { kind: "ok", entries: [] };
+    const node = await HistoryPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+      searchParams: Promise.resolve({}),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    expect(html).toContain("No changes recorded yet");
+    expect(html).not.toContain('aria-label="Audit history"');
+  });
+
+  it("renders 'No changes recorded for HH-A' when filter narrows to zero, and omits the <ol>", async () => {
+    // entries exist but none for HH_A (LI_A absent from line-items map).
+    MOCK_AUDIT_RESULT = {
+      kind: "ok",
+      entries: [
+        {
+          id: "audit:other",
+          eventType: "line_item_generated",
+          actorUserId: null,
+          actorDisplayName: null,
+          createdAt: "2026-04-25T10:00:00Z",
+          billingLineItemId: LI_B,
+          householdName: "HH-B",
+          details: { household_name: "HH-B", new_total_amount: 100 },
+        },
+      ],
+    };
+    const node = await HistoryPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+      searchParams: Promise.resolve({ household_id: HH_A }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    expect(html).toContain("No changes recorded for HH-A");
+    expect(html).not.toContain('aria-label="Audit history"');
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/history/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/history/page.tsx
@@ -1,0 +1,151 @@
+// Per-period audit history page (BC4, #176).
+//
+// Server component. Reads the merged audit log via the shared
+// `fetchAuditLogEntries` helper (extracted from the BC1 route handler so
+// both surfaces share one implementation). Resolves household lookups
+// once on the server and hands precomputed maps to <AuditLogList>, which
+// owns the (client-side) filter pass + render.
+//
+// Route shape:
+//   /microgrids/[id]/billing/[periodId]/history
+//   /microgrids/[id]/billing/[periodId]/history?household_id=<uuid>
+//
+// The `household_id` query param is passed through from the BC2
+// `<RowActionsMenu>` deep link. Filter is applied client-side because
+// per-period data is already bounded at ~1000 rows by BC1's per-side
+// LIMIT 500.
+//
+// `searchParams` and `params` are both Promises in Next.js 15 server
+// components — `await` before reading.
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { fetchAuditLogEntries } from "@/lib/billing/audit-log-fetch";
+import { AuditLogList } from "@/components/billing/audit-log-list";
+import { HierarchyNav } from "@/components/ui/hierarchy-nav";
+import { getHierarchyLevels } from "@/lib/hierarchy";
+import type { BillingPeriod, Household } from "@/lib/types/domain";
+
+export default async function BillingPeriodHistoryPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string; periodId: string }>;
+  searchParams: Promise<{ household_id?: string }>;
+}) {
+  const { id, periodId } = await params;
+  const { household_id } = await searchParams;
+  const supabase = await createClient();
+
+  // Run independent queries in parallel.
+  const [
+    { data: period, error: periodError },
+    { data: households },
+    levels,
+    auditResult,
+  ] = await Promise.all([
+    supabase
+      .from("billing_periods")
+      .select("id, microgrid_id, start_date, end_date, status, created_at, closed_at")
+      .eq("id", periodId)
+      .eq("microgrid_id", id)
+      .single()
+      .then((res) => ({ ...res, data: res.data as BillingPeriod | null })),
+    supabase
+      .from("households")
+      .select("id, display_name")
+      .eq("microgrid_id", id)
+      .returns<Pick<Household, "id" | "display_name">[]>(),
+    getHierarchyLevels(supabase, { kind: "microgrid", microgridId: id }),
+    fetchAuditLogEntries(supabase, periodId),
+  ]);
+
+  if (periodError || !period) {
+    notFound();
+  }
+
+  // We don't fail the page on a household-list error — the filter banner
+  // just falls back to "unknown household". Surface it as a soft warning
+  // via dev console only.
+  const householdsList = households ?? [];
+
+  // Resolve the audit-log result discriminator. Anything but `ok` becomes
+  // either a notFound() or an inline error banner — never a hard throw.
+  if (auditResult.kind === "unauthorized") {
+    // Layout middleware should already have redirected, but guard just in
+    // case (matches the route handler's contract).
+    notFound();
+  }
+  if (auditResult.kind === "not_found") {
+    notFound();
+  }
+  if (auditResult.kind === "error") {
+    return (
+      <>
+        <HierarchyNav levels={levels} className="mb-4" />
+        <div className="rounded-md bg-destructive-muted p-4 text-sm text-destructive-fg">
+          Error loading audit history: {auditResult.message}
+        </div>
+      </>
+    );
+  }
+
+  const entries = auditResult.entries;
+
+  // ── Build lineItemId → householdId map ─────────────────────────────────
+  // The map only needs to cover the line items referenced by entries —
+  // we query `billing_line_items` once with an `in` filter scoped to the
+  // entry set. This is RLS-scoped (caller only sees line items in
+  // microgrids they can access).
+  const lineItemIds = Array.from(
+    new Set(
+      entries
+        .map((e) => e.billingLineItemId)
+        .filter((v): v is string => Boolean(v))
+    )
+  );
+
+  const lineItemIdToHouseholdId: Record<string, string> = {};
+  if (lineItemIds.length > 0) {
+    const { data: lis } = await supabase
+      .from("billing_line_items")
+      .select("id, household_id")
+      .in("id", lineItemIds);
+    for (const r of (lis ?? []) as { id: string; household_id: string }[]) {
+      lineItemIdToHouseholdId[r.id] = r.household_id;
+    }
+  }
+
+  const householdNamesById: Record<string, string> = {};
+  for (const h of householdsList) {
+    householdNamesById[h.id] = h.display_name;
+  }
+
+  return (
+    <>
+      <HierarchyNav levels={levels} className="mb-4" />
+
+      <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+        <h1 className="text-xl font-semibold text-foreground">
+          Audit history
+        </h1>
+        <Link
+          href={`/microgrids/${id}/billing/${periodId}`}
+          className="text-sm text-muted-foreground underline underline-offset-2 hover:opacity-80"
+        >
+          Back to period
+        </Link>
+      </div>
+
+      <AuditLogList
+        entries={entries}
+        lineItemIdToHouseholdId={lineItemIdToHouseholdId}
+        householdNamesById={householdNamesById}
+        filterHouseholdId={household_id}
+        microgridId={id}
+        periodId={periodId}
+      />
+    </>
+  );
+}

--- a/src/app/api/billing-periods/[periodId]/audit-log/route.ts
+++ b/src/app/api/billing-periods/[periodId]/audit-log/route.ts
@@ -1,99 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+import { fetchAuditLogEntries } from "@/lib/billing/audit-log-fetch";
 
 /**
  * GET /api/billing-periods/[periodId]/audit-log (#173, BC1)
  *
  * Returns the chronological audit history for a billing period — UNION of:
- *   - billing_audit_log (this ticket's append-only table; column `created_at`)
+ *   - billing_audit_log (BC1's append-only table; column `created_at`)
  *   - payment_events    (00028; column is `at`, NOT `created_at`)
  *
  * Both tables are queried under the user-bound supabase client so RLS
  * applies on each. We then merge in memory by createdAt DESC.
  *
- * ── Implementer pin: payment_events column is `at` ──────────────────────────
- *
- * `SELECT created_at FROM payment_events` will fail with "column does not
- * exist". The schema is `at TIMESTAMPTZ NOT NULL DEFAULT NOW()` (00028:156).
- * Always alias `at AS created_at` (or read `at` and map to `createdAt` in TS,
- * which is what we do here).
- *
- * ── LIMIT 500 per side ──────────────────────────────────────────────────────
- *
- * Memory-safety guard, NOT pagination. Worst case the response is ~1000
- * rows. If a period legitimately exceeds 500 events on either side, BC4
- * surfaces a "may be truncated" warning banner. Paginate when periods
- * routinely exceed 500 events on either side.
- *
- * ── user_directory RLS implication ──────────────────────────────────────────
- *
- * The `user_directory` view (00014) filters via
- * `user_can_see_user_profile(auth.uid())`. An org_manager looking at an
- * audit entry whose actor is a super_admin (e.g. a cross-org operator) sees
- * `actorDisplayName: null` — the helper hides super_admins from
- * org_managers (00012:71-76). This is intentional: org_managers know
- * "someone with elevated access touched this row" without learning the
- * super_admin's identity.
- *
- * ── Prefixed IDs ────────────────────────────────────────────────────────────
- *
- * `audit:<uuid>` and `payment_event:<uuid>` keep React keys stable across
- * the union (vanishingly unlikely UUID collision but free safety) and leave
- * room for a future "group by source" UX without a schema change.
+ * BC4 (#176) lifted the fetch + normalize logic into
+ * `src/lib/billing/audit-log-fetch.ts` so the server-rendered history
+ * page can share one implementation. This handler is now a thin wrapper
+ * — UUID validation, then `fetchAuditLogEntries`, then map the
+ * discriminated result to HTTP. The behavior contract pinned by
+ * `__tests__/route.test.ts` is unchanged.
  */
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-const PER_SIDE_LIMIT = 500;
-
-type AuditRow = {
-  id: string;
-  billing_period_id: string;
-  billing_line_item_id: string | null;
-  event_type:
-    | "period_created"
-    | "period_closed"
-    | "line_item_generated"
-    | "line_item_regenerated";
-  actor_user_id: string | null;
-  created_at: string;
-  details: Record<string, unknown> | null;
-};
-
-type PaymentEventRow = {
-  id: string;
-  line_item_id: string;
-  from_status: string | null;
-  to_status: string;
-  source: "ipn" | "manual" | "generate_link";
-  actor_user_id: string | null;
-  raw_payload: Record<string, unknown> | null;
-  at: string;
-  // Joined billing_line_items for line_item → period scoping + payment_notes.
-  billing_line_items: {
-    billing_period_id: string;
-    payment_notes: string | null;
-    households: { display_name: string } | null;
-  } | null;
-};
-
-type DirectoryRow = {
-  user_id: string;
-  email: string | null;
-  first_name: string | null;
-  last_name: string | null;
-};
-
-function pickDisplayName(row: DirectoryRow | undefined): string | null {
-  if (!row) return null;
-  const parts = [row.first_name, row.last_name].filter(
-    (s): s is string => typeof s === "string" && s.length > 0
-  );
-  if (parts.length > 0) return parts.join(" ");
-  return row.email ?? null;
-}
 
 export async function GET(
   _request: NextRequest,
@@ -109,205 +37,19 @@ export async function GET(
   }
 
   const supabase = await createClient();
+  const result = await fetchAuditLogEntries(supabase, periodId);
 
-  // Explicit auth gate — every other route in this ticket also has it.
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  switch (result.kind) {
+    case "unauthorized":
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    case "not_found":
+      return NextResponse.json(
+        { error: "Billing period not found" },
+        { status: 404 }
+      );
+    case "error":
+      return NextResponse.json({ error: result.message }, { status: 500 });
+    case "ok":
+      return NextResponse.json({ entries: result.entries });
   }
-
-  // Verify the period exists + caller can see it (RLS gates the query).
-  const { data: period, error: periodErr } = await supabase
-    .from("billing_periods")
-    .select("id")
-    .eq("id", periodId)
-    .maybeSingle<{ id: string }>();
-
-  if (periodErr) {
-    return NextResponse.json(
-      { error: `Failed to look up billing period: ${periodErr.message}` },
-      { status: 500 }
-    );
-  }
-  if (!period) {
-    return NextResponse.json(
-      { error: "Billing period not found" },
-      { status: 404 }
-    );
-  }
-
-  // ── 1. Read billing_audit_log (this ticket's table) ───────────────────────
-  const { data: auditRowsRaw, error: auditErr } = await supabase
-    .from("billing_audit_log")
-    .select(
-      "id, billing_period_id, billing_line_item_id, event_type, actor_user_id, created_at, details"
-    )
-    .eq("billing_period_id", periodId)
-    .order("created_at", { ascending: false })
-    .limit(PER_SIDE_LIMIT);
-
-  if (auditErr) {
-    return NextResponse.json(
-      { error: `Failed to read audit log: ${auditErr.message}` },
-      { status: 500 }
-    );
-  }
-  const auditRows = (auditRowsRaw ?? []) as unknown as AuditRow[];
-
-  // ── 2. Read payment_events for line items in this period ─────────────────
-  // Join billing_line_items to scope to this period AND to surface
-  // payment_notes + household.display_name for the response.
-  const { data: paymentEventsRaw, error: peErr } = await supabase
-    .from("payment_events")
-    .select(
-      `
-      id, line_item_id, from_status, to_status, source, actor_user_id,
-      raw_payload, at,
-      billing_line_items!inner (
-        billing_period_id,
-        payment_notes,
-        households (
-          display_name
-        )
-      )
-    `
-    )
-    .eq("billing_line_items.billing_period_id", periodId)
-    .order("at", { ascending: false })
-    .limit(PER_SIDE_LIMIT);
-
-  if (peErr) {
-    return NextResponse.json(
-      { error: `Failed to read payment events: ${peErr.message}` },
-      { status: 500 }
-    );
-  }
-  const paymentEvents = (paymentEventsRaw ?? []) as unknown as PaymentEventRow[];
-
-  // ── 3. Resolve household_name for billing_audit_log entries that have a
-  //       live billing_line_item_id (preferred over the snapshot). When the
-  //       line item is hard-deleted, the FK is NULL and we fall back to
-  //       details.household_name (the snapshot kept by the writer).
-  const liveLineItemIds = Array.from(
-    new Set(
-      auditRows
-        .map((r) => r.billing_line_item_id)
-        .filter((v): v is string => Boolean(v))
-    )
-  );
-  const lineItemNameMap = new Map<string, string | null>();
-  if (liveLineItemIds.length > 0) {
-    const { data: lis } = await supabase
-      .from("billing_line_items")
-      .select("id, households(display_name)")
-      .in("id", liveLineItemIds);
-    type LiHHRow = {
-      id: string;
-      households: { display_name: string } | { display_name: string }[] | null;
-    };
-    for (const r of (lis ?? []) as LiHHRow[]) {
-      const hh = r.households;
-      const name = Array.isArray(hh)
-        ? hh[0]?.display_name ?? null
-        : hh?.display_name ?? null;
-      lineItemNameMap.set(r.id, name);
-    }
-  }
-
-  // ── 4. Resolve actor display names via user_directory (RLS-aware). ───────
-  const actorIds = Array.from(
-    new Set(
-      [
-        ...auditRows.map((r) => r.actor_user_id),
-        ...paymentEvents.map((p) => p.actor_user_id),
-      ].filter((v): v is string => Boolean(v))
-    )
-  );
-  const directoryMap = new Map<string, DirectoryRow>();
-  if (actorIds.length > 0) {
-    const { data: dirRows } = await supabase
-      .from("user_directory")
-      .select("user_id, email, first_name, last_name")
-      .in("user_id", actorIds);
-    for (const r of (dirRows ?? []) as DirectoryRow[]) {
-      directoryMap.set(r.user_id, r);
-    }
-  }
-
-  // ── 5. Normalize → BillingAuditLogEntry[] ─────────────────────────────────
-  const entries: BillingAuditLogEntry[] = [];
-
-  for (const a of auditRows) {
-    const detailsObj =
-      a.details && typeof a.details === "object" ? a.details : {};
-    const snapshotName =
-      typeof detailsObj["household_name"] === "string"
-        ? (detailsObj["household_name"] as string)
-        : null;
-    const liveName = a.billing_line_item_id
-      ? lineItemNameMap.get(a.billing_line_item_id) ?? null
-      : null;
-    entries.push({
-      id: `audit:${a.id}`,
-      eventType: a.event_type,
-      actorUserId: a.actor_user_id,
-      actorDisplayName: pickDisplayName(
-        a.actor_user_id ? directoryMap.get(a.actor_user_id) : undefined
-      ),
-      createdAt: a.created_at,
-      billingLineItemId: a.billing_line_item_id,
-      householdName: liveName ?? snapshotName,
-      details: detailsObj,
-    });
-  }
-
-  for (const p of paymentEvents) {
-    // PostgREST may surface the !inner join as an array even though it's
-    // single-row in the DB — defensive coerce mirrors the PATCH /usage
-    // pattern.
-    const bli = Array.isArray(p.billing_line_items)
-      ? p.billing_line_items[0]
-      : p.billing_line_items;
-    const hh = bli?.households;
-    const householdName = Array.isArray(hh)
-      ? hh[0]?.display_name ?? null
-      : hh?.display_name ?? null;
-
-    // Map to BC4's normalized event types.
-    // - source='generate_link' → payment_link_generated (incl. regenerate
-    //   where from === to)
-    // - everything else → payment_status_changed
-    const eventType: BillingAuditLogEntry["eventType"] =
-      p.source === "generate_link"
-        ? "payment_link_generated"
-        : "payment_status_changed";
-
-    const details: Record<string, unknown> = {
-      from: p.from_status,
-      to: p.to_status,
-      source: p.source,
-      raw_payload: p.raw_payload,
-    };
-    if (bli?.payment_notes) details["notes"] = bli.payment_notes;
-
-    entries.push({
-      id: `payment_event:${p.id}`,
-      eventType,
-      actorUserId: p.actor_user_id,
-      actorDisplayName: pickDisplayName(
-        p.actor_user_id ? directoryMap.get(p.actor_user_id) : undefined
-      ),
-      createdAt: p.at,
-      billingLineItemId: p.line_item_id,
-      householdName,
-      details,
-    });
-  }
-
-  // Merge by createdAt DESC.
-  entries.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-
-  return NextResponse.json({ entries });
 }

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -546,7 +546,17 @@ export function BillingTable({
             </span>
           </div>
 
-          <div className="flex gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {/* BC4 (#176): "View history" link — renders on draft AND closed
+                periods (audit trail matters most after close). Always
+                rendered even before any events exist; the destination
+                page owns the empty-state pedagogy. */}
+            <Link
+              href={`/microgrids/${microgridId}/billing/${period.id}/history`}
+              className="text-sm text-muted-foreground underline underline-offset-2 hover:opacity-80"
+            >
+              View history
+            </Link>
             {isDraft && (
               <>
                 <button

--- a/src/components/__tests__/billing-table.test.tsx
+++ b/src/components/__tests__/billing-table.test.tsx
@@ -467,6 +467,43 @@ describe("BillingTable", () => {
     });
   });
 
+  // ── BC4 (#176) — "View history" link in period header ─────────────────────
+
+  it("(BC4) renders 'View history' link in the period header on draft periods", () => {
+    const { container } = render(
+      <Wrapper>
+        <BillingTable {...baseProps} />
+      </Wrapper>
+    );
+    const link = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>("a")
+    ).find((a) => a.textContent?.trim() === "View history");
+    expect(link).toBeDefined();
+    expect(link!.getAttribute("href")).toBe(
+      `/microgrids/mg-1/billing/${period.id}/history`
+    );
+  });
+
+  it("(BC4) renders 'View history' link in the period header on closed periods", () => {
+    const closedPeriod: BillingPeriod = {
+      ...period,
+      status: "closed",
+      closed_at: "2026-04-01T00:00:00Z",
+    };
+    const { container } = render(
+      <Wrapper>
+        <BillingTable {...baseProps} period={closedPeriod} />
+      </Wrapper>
+    );
+    const link = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>("a")
+    ).find((a) => a.textContent?.trim() === "View history");
+    expect(link).toBeDefined();
+    expect(link!.getAttribute("href")).toBe(
+      `/microgrids/mg-1/billing/${closedPeriod.id}/history`
+    );
+  });
+
   it("(f) row-actions kebab still renders when !isPaymentConfigured (gate banner explains the why)", () => {
     // BC2 (#174) — payment-link generate items are HIDDEN inside the menu
     // when !isPaymentConfigured, but the kebab itself still renders so the

--- a/src/components/billing/__tests__/audit-log-list.test.tsx
+++ b/src/components/billing/__tests__/audit-log-list.test.tsx
@@ -1,0 +1,400 @@
+/**
+ * audit-log-list.test.tsx — BC4 #176 list/empty-state/filter/truncation tests.
+ *
+ * Coverage (per ticket AC9):
+ *   - Renders one <li> per entry under <ol aria-label="Audit history">.
+ *   - Each event type from AC4 produces the expected label + summary.
+ *   - Filter by household_id: only matching entries render; <ol> contains
+ *     just those rows; "Show all" link clears the param.
+ *   - Empty state #1 (no entries for period): "No changes recorded yet"
+ *     copy; <ol> NOT rendered.
+ *   - Empty state #2 (no entries after filter): "No changes recorded for X"
+ *     copy + Show all secondary link; <ol> NOT rendered.
+ *   - Truncation notice when entries.length >= 1000.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LocaleProvider } from "@/components/format/locale-context";
+import { AuditLogList } from "../audit-log-list";
+import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <LocaleProvider locale="en-UG" currency="UGX">
+      {children}
+    </LocaleProvider>
+  );
+}
+
+const PERIOD_ID = "660e8400-e29b-41d4-a716-446655441000";
+const MICROGRID_ID = "770e8400-e29b-41d4-a716-446655442000";
+const HH_A = "880e8400-e29b-41d4-a716-446655443001";
+const HH_B = "880e8400-e29b-41d4-a716-446655443002";
+const LI_A = "990e8400-e29b-41d4-a716-446655444001";
+const LI_B = "990e8400-e29b-41d4-a716-446655444002";
+
+const ENTRIES: BillingAuditLogEntry[] = [
+  {
+    id: "audit:00000000-0000-0000-0000-000000000001",
+    eventType: "period_created",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorDisplayName: "Alice Doe",
+    createdAt: "2026-04-25T10:00:00Z",
+    billingLineItemId: null,
+    householdName: null,
+    details: {},
+  },
+  {
+    id: "audit:00000000-0000-0000-0000-000000000002",
+    eventType: "line_item_generated",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorDisplayName: "Alice Doe",
+    createdAt: "2026-04-25T11:00:00Z",
+    billingLineItemId: LI_A,
+    householdName: "HH-A",
+    details: { household_name: "HH-A", new_total_amount: 5000 },
+  },
+  {
+    id: "audit:00000000-0000-0000-0000-000000000003",
+    eventType: "line_item_regenerated",
+    actorUserId: null,
+    actorDisplayName: null,
+    createdAt: "2026-04-25T12:00:00Z",
+    billingLineItemId: LI_B,
+    householdName: "HH-B",
+    details: {
+      household_name: "HH-B",
+      previous_total_amount: 3000,
+      new_total_amount: 4000,
+      previous_reading_source: "edge",
+      new_reading_source: "manual",
+      manual_reason: "Operator estimate",
+      period_was_closed: true,
+    },
+  },
+  {
+    id: "payment_event:00000000-0000-0000-0000-000000000004",
+    eventType: "payment_status_changed",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorDisplayName: "Alice Doe",
+    createdAt: "2026-04-25T13:00:00Z",
+    billingLineItemId: LI_A,
+    householdName: "HH-A",
+    details: { from: "unpaid", to: "paid", source: "manual" },
+  },
+  {
+    id: "payment_event:00000000-0000-0000-0000-000000000005",
+    eventType: "payment_link_generated",
+    actorUserId: null,
+    actorDisplayName: null,
+    createdAt: "2026-04-25T14:00:00Z",
+    billingLineItemId: LI_B,
+    householdName: "HH-B",
+    details: { from: "unpaid", to: "link_generated", source: "generate_link" },
+  },
+];
+
+const LINE_ITEM_TO_HH: Record<string, string> = {
+  [LI_A]: HH_A,
+  [LI_B]: HH_B,
+};
+const HH_NAMES: Record<string, string> = {
+  [HH_A]: "HH-A",
+  [HH_B]: "HH-B",
+};
+
+describe("<AuditLogList> — list rendering", () => {
+  it("renders <ol aria-label='Audit history'> with one <li> per entry", () => {
+    const { container } = render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+
+    const ol = container.querySelector("ol[aria-label='Audit history']");
+    expect(ol).not.toBeNull();
+    const lis = ol!.querySelectorAll("li");
+    expect(lis.length).toBe(ENTRIES.length);
+  });
+
+  it("renders the 6 event-type labels and summaries", () => {
+    render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("Period created")).toBeTruthy();
+    expect(screen.getByText("Bill generated for HH-A")).toBeTruthy();
+    expect(screen.getByText("Bill regenerated for HH-B")).toBeTruthy();
+    expect(screen.getByText("Payment status for HH-A")).toBeTruthy();
+    expect(screen.getByText("Payment link generated for HH-B")).toBeTruthy();
+  });
+
+  it("renders 'post-close revision' chip when details.period_was_closed === true", () => {
+    render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    // Chip text is uppercased via Tailwind `uppercase` class — DOM text
+    // content is the original source ("post-close revision").
+    expect(screen.getByText("post-close revision")).toBeTruthy();
+  });
+
+  it("renders manual_reason as italic muted text", () => {
+    const { container } = render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    const reasonEl = Array.from(
+      container.querySelectorAll(".italic.text-muted-foreground")
+    ).find((el) => el.textContent?.includes("Operator estimate"));
+    expect(reasonEl).toBeDefined();
+  });
+
+  it("renders 3-state actor names (System / Restricted / verbatim)", () => {
+    render(
+      <Wrapper>
+        <AuditLogList
+          entries={[
+            {
+              id: "audit:1",
+              eventType: "period_created",
+              actorUserId: null,
+              actorDisplayName: null,
+              createdAt: "2026-04-25T10:00:00Z",
+              billingLineItemId: null,
+              householdName: null,
+              details: {},
+            },
+            {
+              id: "audit:2",
+              eventType: "period_closed",
+              actorUserId: "33333333-3333-4333-8333-333333333333",
+              actorDisplayName: null,
+              createdAt: "2026-04-25T11:00:00Z",
+              billingLineItemId: null,
+              householdName: null,
+              details: {},
+            },
+            {
+              id: "audit:3",
+              eventType: "period_created",
+              actorUserId: "11111111-1111-4111-8111-111111111111",
+              actorDisplayName: "Alice Doe",
+              createdAt: "2026-04-25T12:00:00Z",
+              billingLineItemId: null,
+              householdName: null,
+              details: {},
+            },
+          ]}
+          lineItemIdToHouseholdId={{}}
+          householdNamesById={{}}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    expect(screen.getByText("System")).toBeTruthy();
+    expect(screen.getByText("Restricted")).toBeTruthy();
+    expect(screen.getByText("Alice Doe")).toBeTruthy();
+  });
+});
+
+// ── Filter by household_id ───────────────────────────────────────────────────
+
+describe("<AuditLogList> — household_id filter", () => {
+  it("only renders entries whose billingLineItemId belongs to the filtered household", () => {
+    const { container } = render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          filterHouseholdId={HH_A}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    const ol = container.querySelector("ol[aria-label='Audit history']");
+    expect(ol).not.toBeNull();
+    const lis = ol!.querySelectorAll("li");
+    // Only entries whose billingLineItemId === LI_A → "Bill generated for
+    // HH-A" + "Payment status for HH-A" = 2.
+    expect(lis.length).toBe(2);
+    expect(screen.getByText("Bill generated for HH-A")).toBeTruthy();
+    expect(screen.getByText("Payment status for HH-A")).toBeTruthy();
+    expect(screen.queryByText("Bill regenerated for HH-B")).toBeNull();
+    expect(screen.queryByText("Payment link generated for HH-B")).toBeNull();
+    // period_created has no billingLineItemId → filtered out.
+    expect(screen.queryByText("Period created")).toBeNull();
+  });
+
+  it("renders the filter banner with a 'Show all' link that clears the query param", () => {
+    const { container } = render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          filterHouseholdId={HH_A}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    const showAllLinks = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>("a")
+    ).filter((a) => a.textContent?.trim() === "Show all");
+    expect(showAllLinks.length).toBeGreaterThan(0);
+    expect(showAllLinks[0].getAttribute("href")).toBe(
+      `/microgrids/${MICROGRID_ID}/billing/${PERIOD_ID}/history`
+    );
+  });
+
+  it("when household_id is unknown, renders 'unknown household' in the banner", () => {
+    render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          filterHouseholdId="ffffffff-ffff-4fff-8fff-ffffffffffff"
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    // The unknown filter id matches no entries → empty-state #2 ("No
+    // changes recorded for unknown household").
+    expect(screen.getByText("No changes recorded for unknown household")).toBeTruthy();
+  });
+});
+
+// ── Empty states ─────────────────────────────────────────────────────────────
+
+describe("<AuditLogList> — empty states", () => {
+  it("renders 'No changes recorded yet' when entries is empty AND no filter", () => {
+    const { container } = render(
+      <Wrapper>
+        <AuditLogList
+          entries={[]}
+          lineItemIdToHouseholdId={{}}
+          householdNamesById={{}}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    expect(screen.getByText("No changes recorded yet")).toBeTruthy();
+    expect(
+      screen.getByText(/This period has no events/i)
+    ).toBeTruthy();
+    // <ol> NOT rendered when there are zero entries.
+    expect(container.querySelector("ol[aria-label='Audit history']")).toBeNull();
+  });
+
+  it("renders 'No changes recorded for {hh}' + Show all secondary when filter narrows to zero", () => {
+    const { container } = render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={{ ...HH_NAMES, "no-entries-for-this-id": "HH-NoOne" }}
+          filterHouseholdId="no-entries-for-this-id"
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    expect(screen.getByText("No changes recorded for HH-NoOne")).toBeTruthy();
+    expect(
+      screen.getByText(/Other households on this period may have entries/i)
+    ).toBeTruthy();
+    // Secondary link to clear the filter.
+    const showAllLinks = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>("a")
+    ).filter((a) => a.textContent?.trim() === "Show all");
+    expect(showAllLinks.length).toBeGreaterThan(0);
+    expect(showAllLinks[0].getAttribute("href")).toBe(
+      `/microgrids/${MICROGRID_ID}/billing/${PERIOD_ID}/history`
+    );
+    // <ol> NOT rendered when filter narrows to zero either.
+    expect(container.querySelector("ol[aria-label='Audit history']")).toBeNull();
+  });
+});
+
+// ── Truncation notice ────────────────────────────────────────────────────────
+
+describe("<AuditLogList> — truncation notice", () => {
+  it("renders 'History may be truncated' when entries.length >= 1000", () => {
+    const big: BillingAuditLogEntry[] = [];
+    for (let i = 0; i < 1000; i++) {
+      big.push({
+        id: `audit:${i}`,
+        eventType: "period_created",
+        actorUserId: null,
+        actorDisplayName: null,
+        createdAt: `2026-04-25T${String(i % 24).padStart(2, "0")}:00:00Z`,
+        billingLineItemId: null,
+        householdName: null,
+        details: {},
+      });
+    }
+    render(
+      <Wrapper>
+        <AuditLogList
+          entries={big}
+          lineItemIdToHouseholdId={{}}
+          householdNamesById={{}}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    expect(screen.getByText("History may be truncated")).toBeTruthy();
+  });
+
+  it("does NOT render the truncation notice when entries.length < 1000", () => {
+    render(
+      <Wrapper>
+        <AuditLogList
+          entries={ENTRIES}
+          lineItemIdToHouseholdId={LINE_ITEM_TO_HH}
+          householdNamesById={HH_NAMES}
+          microgridId={MICROGRID_ID}
+          periodId={PERIOD_ID}
+        />
+      </Wrapper>
+    );
+    expect(screen.queryByText("History may be truncated")).toBeNull();
+  });
+});

--- a/src/components/billing/audit-log-list.tsx
+++ b/src/components/billing/audit-log-list.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+// AuditLogList — renders the BC4 per-period audit history (#176).
+//
+// Receives precomputed entries + an optional `lineItemIdToHouseholdId` map
+// + an optional `filterHouseholdId`. When the filter id is set and resolves
+// to a known household, the list filters client-side by ownership of the
+// entry's billingLineItemId. The page server-component does the household
+// lookup once and passes a string→string map so the client doesn't need
+// to round-trip Supabase.
+//
+// Empty-state branches (per ticket AC6):
+//   - 0 entries for the period (no filter)        → "No changes recorded yet"
+//   - 0 entries after household filter applied    → "No changes recorded for {hh}" + "Show all"
+//   - filter id matched no household in this MG   → banner "unknown household" + same filter path
+// In all empty-state branches the `<ol>` is OMITTED — we never emit an empty list.
+//
+// Truncation notice: when `entries.length >= 1000` (BC1's 500/side worst
+// case), render "History may be truncated — showing the most recent 1000
+// events" above the list. Real pagination is deferred (see ticket Out of
+// Scope).
+
+import * as React from "react";
+import Link from "next/link";
+import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+import { LocalDateTime } from "@/components/format/local-date-time";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Banner } from "@/components/ui/banner";
+import {
+  actorDisplayLabel,
+  humanizeAuditEvent,
+  PostCloseRevisionChip,
+} from "@/lib/billing/audit-humanize";
+
+const TRUNCATION_THRESHOLD = 1000;
+
+export interface AuditLogListProps {
+  entries: BillingAuditLogEntry[];
+  /** lineItemId → householdId map (server-resolved from billing_line_items). */
+  lineItemIdToHouseholdId: Record<string, string>;
+  /** householdId → display_name map (for the "filtered to {name}" banner). */
+  householdNamesById: Record<string, string>;
+  /** When set, only entries whose billingLineItemId belongs to this
+   *  household render. The history page reads this from
+   *  `searchParams.household_id`. */
+  filterHouseholdId?: string;
+  /** For the "Show all" link's href. */
+  microgridId: string;
+  periodId: string;
+}
+
+export function AuditLogList({
+  entries,
+  lineItemIdToHouseholdId,
+  householdNamesById,
+  filterHouseholdId,
+  microgridId,
+  periodId,
+}: AuditLogListProps) {
+  const showAllHref = `/microgrids/${microgridId}/billing/${periodId}/history`;
+
+  // ── Filter (client-side) ───────────────────────────────────────────────
+  const filtered = React.useMemo(() => {
+    if (!filterHouseholdId) return entries;
+    return entries.filter((e) => {
+      if (!e.billingLineItemId) return false;
+      const owner = lineItemIdToHouseholdId[e.billingLineItemId];
+      return owner === filterHouseholdId;
+    });
+  }, [entries, filterHouseholdId, lineItemIdToHouseholdId]);
+
+  const filteredHouseholdName = filterHouseholdId
+    ? householdNamesById[filterHouseholdId] ?? null
+    : null;
+
+  // ── Filter banner ──────────────────────────────────────────────────────
+  const filterBanner = filterHouseholdId ? (
+    <Banner
+      tone="info"
+      title={
+        <>
+          Showing changes for{" "}
+          <strong>{filteredHouseholdName ?? "unknown household"}</strong>
+        </>
+      }
+    >
+      <Link
+        href={showAllHref}
+        className="underline underline-offset-2 hover:opacity-80"
+      >
+        Show all
+      </Link>
+    </Banner>
+  ) : null;
+
+  // ── Empty-state branches ───────────────────────────────────────────────
+  if (filtered.length === 0) {
+    if (filterHouseholdId) {
+      // Filter narrowed to zero. We render a per-filter empty state with
+      // a "Show all" secondary so the user has an escape hatch back to
+      // the unfiltered list.
+      const hhLabel = filteredHouseholdName ?? "unknown household";
+      return (
+        <div className="space-y-4">
+          {filterBanner}
+          <EmptyState
+            eyebrow="Audit history"
+            title={`No changes recorded for ${hhLabel}`}
+            body="Other households on this period may have entries."
+            secondary={
+              <Link
+                href={showAllHref}
+                className="text-sm text-primary underline underline-offset-2 hover:opacity-80"
+              >
+                Show all
+              </Link>
+            }
+          />
+        </div>
+      );
+    }
+    // No filter — period has zero events.
+    return (
+      <EmptyState
+        eyebrow="Audit history"
+        title="No changes recorded yet"
+        body="This period has no events. As you generate bills, close the period, or take payments, entries will appear here."
+      />
+    );
+  }
+
+  // ── Truncation notice ──────────────────────────────────────────────────
+  // BC1 caps at 500 per side; if we hit ~1000 the page may be incomplete.
+  // The notice is informational; pagination is deferred per ticket OOS.
+  const truncated = entries.length >= TRUNCATION_THRESHOLD;
+
+  return (
+    <div className="space-y-4">
+      {filterBanner}
+      {truncated && (
+        <Banner tone="warn" title="History may be truncated">
+          Showing the most recent 1000 events.
+        </Banner>
+      )}
+      <ol
+        aria-label="Audit history"
+        className="space-y-3 [counter-reset:audit-list]"
+      >
+        {filtered.map((entry) => (
+          <AuditLogEntryRow key={entry.id} entry={entry} />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+// ── Per-entry row ─────────────────────────────────────────────────────────
+
+function AuditLogEntryRow({ entry }: { entry: BillingAuditLogEntry }) {
+  const { label, summary, manualReason, postCloseRevision } =
+    humanizeAuditEvent(entry);
+  const actor = actorDisplayLabel(entry);
+
+  return (
+    <li className="rounded-md border border-border bg-card p-3 shadow-elev-1">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+        <LocalDateTime
+          value={entry.createdAt}
+          className="text-xs text-muted-foreground"
+        />
+        <span className="text-xs text-muted-foreground">·</span>
+        <span className="text-xs text-muted-foreground">{actor}</span>
+        <span className="text-xs text-muted-foreground">·</span>
+        <span className="font-medium text-foreground">{label}</span>
+        {postCloseRevision && (
+          <span className="ml-1 inline-flex">
+            <PostCloseRevisionChip />
+          </span>
+        )}
+      </div>
+      {summary && (
+        <div className="mt-1 text-sm text-foreground">{summary}</div>
+      )}
+      {manualReason && (
+        <div className="mt-1 text-xs italic text-muted-foreground">
+          {manualReason}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/format/__tests__/local-date-time.test.tsx
+++ b/src/components/format/__tests__/local-date-time.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * local-date-time.test.tsx — date+time wrapper test (BC4 #176).
+ *
+ * Verifies the pinned Intl options produce consistent output in
+ * en-US and en-GB. We pin `timeZone: "UTC"` is NOT possible from this
+ * test because LocalDateTime hardcodes the opts; instead we pick a
+ * timestamp exactly on the hour (`14:00:00Z`) where the runner's TZ
+ * shouldn't push us over a different display string for the wall-clock
+ * components we care about. We assert on month + year + AM/PM marker
+ * presence rather than exact strings to stay TZ-agnostic.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { LocaleProvider } from "../locale-context";
+import { LocalDateTime } from "../local-date-time";
+
+const TS = "2026-04-25T14:14:00Z";
+
+describe("<LocalDateTime>", () => {
+  it("renders both date AND time portions in en-US", () => {
+    const { container } = render(
+      <LocaleProvider locale="en-US" currency="USD">
+        <LocalDateTime value={TS} />
+      </LocaleProvider>
+    );
+    const text = container.textContent ?? "";
+    // Month (Apr) and year (2026) come from year/month/day opts.
+    expect(text).toContain("Apr");
+    expect(text).toContain("2026");
+    // hour: "2-digit" with en-US default produces AM/PM marker.
+    // Either "AM" or "PM" must appear depending on viewer TZ.
+    expect(text).toMatch(/AM|PM/);
+  });
+
+  it("renders both date AND time portions in en-GB (24h)", () => {
+    const { container } = render(
+      <LocaleProvider locale="en-GB" currency="GBP">
+        <LocalDateTime value={TS} />
+      </LocaleProvider>
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Apr");
+    expect(text).toContain("2026");
+    // en-GB default uses 24h — there should be no AM/PM marker.
+    expect(text).not.toMatch(/AM|PM/);
+  });
+
+  it("does not hand-format the date+time separator (delegates to Intl)", () => {
+    const { container } = render(
+      <LocaleProvider locale="en-US" currency="USD">
+        <LocalDateTime value={TS} />
+      </LocaleProvider>
+    );
+    const text = container.textContent ?? "";
+    // The deliberate decision was to NOT inject " · " — the Intl glue
+    // (typically ", " in en-US) is what users see.
+    expect(text).not.toContain(" · ");
+  });
+});

--- a/src/components/format/local-date-time.tsx
+++ b/src/components/format/local-date-time.tsx
@@ -1,0 +1,31 @@
+// LocalDateTime — date+time wrapper over <LocalDate> (BC4, #176).
+//
+// Why: the audit-history page (BC4) needs a consistent date+time format
+// across all entries. Pinning the Intl options in one place keeps the
+// rendered separator (locale-defined: en-US "Apr 25, 2026, 2:14 PM" vs
+// en-GB "25 Apr 2026, 14:14") consistent and lets future surfaces
+// (e.g. notification timestamps) share the same shape.
+//
+// `<LocalDate>` already accepts `opts: Intl.DateTimeFormatOptions`, so
+// this wrapper just forwards a fixed opts object — no new logic.
+//
+// DO NOT hand-format with " · " or any explicit separator. The whole
+// point of routing through Intl.DateTimeFormat is the locale-aware
+// glue character.
+
+import * as React from "react";
+import { LocalDate, type LocalDateProps } from "./local-date";
+
+const DT_OPTS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+export type LocalDateTimeProps = Omit<LocalDateProps, "opts" | "relative">;
+
+export function LocalDateTime(props: LocalDateTimeProps) {
+  return <LocalDate {...props} opts={DT_OPTS} />;
+}

--- a/src/lib/billing/__tests__/audit-humanize.test.tsx
+++ b/src/lib/billing/__tests__/audit-humanize.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * audit-humanize.test.tsx — unit tests for humanizeAuditEvent + actorDisplayLabel (BC4 #176).
+ *
+ * Coverage (per ticket AC9):
+ *   - 6 event types each produce the expected label + summary shape.
+ *   - 3-state actor naming:
+ *       actorUserId === null                          → "System"
+ *       actorUserId !== null && actorDisplayName null → "Restricted"
+ *       actorDisplayName non-null                     → verbatim
+ *   - line_item_generated with missing household_name AND missing
+ *     entry.householdName → "Unknown household".
+ *   - line_item_regenerated with previous_total_amount === new_total_amount
+ *     → "Total unchanged".
+ *   - line_item_regenerated with previous_reading_source === null → no
+ *     source-change clause.
+ *   - line_item_regenerated with both reading sources non-null and
+ *     differing → source-change clause appended.
+ *   - details.period_was_closed === true → postCloseRevision: true.
+ *   - payment_status_changed with from === null → "Set to {to}".
+ *   - payment_status_changed with details.notes non-empty → italic-muted
+ *     notes line rendered.
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import * as React from "react";
+import {
+  humanizeAuditEvent,
+  actorDisplayLabel,
+} from "../audit-humanize";
+import { LocaleProvider } from "@/components/format/locale-context";
+import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+
+function entry(
+  overrides: Partial<BillingAuditLogEntry> & {
+    eventType: BillingAuditLogEntry["eventType"];
+  }
+): BillingAuditLogEntry {
+  return {
+    id: "audit:00000000-0000-0000-0000-000000000000",
+    actorUserId: null,
+    actorDisplayName: null,
+    createdAt: "2026-04-25T10:00:00Z",
+    billingLineItemId: null,
+    householdName: null,
+    details: {},
+    ...overrides,
+  };
+}
+
+function renderNode(node: React.ReactNode) {
+  // <Currency> needs LocaleProvider; <StatusChip> doesn't but the wrapper
+  // doesn't hurt.
+  return render(
+    <LocaleProvider locale="en-UG" currency="UGX">
+      <>{node}</>
+    </LocaleProvider>
+  );
+}
+
+// ── Per-event-type renderers (6) ────────────────────────────────────────────
+
+describe("humanizeAuditEvent — period_created", () => {
+  it("renders label 'Period created' with no summary", () => {
+    const result = humanizeAuditEvent(entry({ eventType: "period_created" }));
+    expect(result.label).toBe("Period created");
+    expect(result.summary).toBeUndefined();
+    expect(result.postCloseRevision).toBe(false);
+  });
+});
+
+describe("humanizeAuditEvent — period_closed", () => {
+  it("renders label 'Period closed' with no summary", () => {
+    const result = humanizeAuditEvent(entry({ eventType: "period_closed" }));
+    expect(result.label).toBe("Period closed");
+    expect(result.summary).toBeUndefined();
+  });
+});
+
+describe("humanizeAuditEvent — line_item_generated", () => {
+  it("uses entry.householdName + renders 'Total: {amount}' summary", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_generated",
+        householdName: "HH-A",
+        details: { new_total_amount: 5000 },
+      })
+    );
+    expect(result.label).toBe("Bill generated for HH-A");
+    const { container } = renderNode(result.summary);
+    // Currency renders the localized form — for UGX it may be "UGX 5,000"
+    // or similar; we just check the digits land in the DOM.
+    expect(container.textContent ?? "").toContain("5,000");
+    expect((container.textContent ?? "").toLowerCase()).toContain("total");
+  });
+
+  it("falls back to details.household_name when entry.householdName is null", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_generated",
+        householdName: null,
+        details: { household_name: "HH-Snapshot", new_total_amount: 1000 },
+      })
+    );
+    expect(result.label).toBe("Bill generated for HH-Snapshot");
+  });
+
+  it("falls back to 'Unknown household' when both entry.householdName AND details.household_name missing", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_generated",
+        householdName: null,
+        details: { new_total_amount: 0 },
+      })
+    );
+    expect(result.label).toBe("Bill generated for Unknown household");
+  });
+});
+
+describe("humanizeAuditEvent — line_item_regenerated", () => {
+  it("renders 'Total changed from X to Y' when amounts differ", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: 4000,
+          new_total_amount: 5000,
+        },
+      })
+    );
+    expect(result.label).toBe("Bill regenerated for HH-A");
+    const { container } = renderNode(result.summary);
+    expect((container.textContent ?? "").toLowerCase()).toContain("changed from");
+    expect(container.textContent ?? "").toContain("4,000");
+    expect(container.textContent ?? "").toContain("5,000");
+  });
+
+  it("renders 'Total unchanged' when previous_total_amount === new_total_amount", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: 5000,
+          new_total_amount: 5000,
+        },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect(container.textContent ?? "").toContain("Total unchanged");
+  });
+
+  it("renders 'Total unchanged' when previous_total_amount is null (defensive INSERT-path guard)", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: null,
+          new_total_amount: 5000,
+        },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect(container.textContent ?? "").toContain("Total unchanged");
+  });
+
+  it("does NOT append source-change clause when previous_reading_source is null", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: null,
+          new_total_amount: 5000,
+          previous_reading_source: null,
+          new_reading_source: "manual",
+        },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect((container.textContent ?? "").toLowerCase()).not.toContain("source changed from");
+  });
+
+  it("appends 'Source changed from X to Y' clause when both non-null AND differ", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: 4000,
+          new_total_amount: 5000,
+          previous_reading_source: "edge",
+          new_reading_source: "manual",
+        },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect(container.textContent ?? "").toContain("Source changed from");
+    expect(container.textContent ?? "").toContain("edge");
+    expect(container.textContent ?? "").toContain("manual");
+  });
+
+  it("does NOT append source-change clause when previous_reading_source === new_reading_source", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: 4000,
+          new_total_amount: 5000,
+          previous_reading_source: "edge",
+          new_reading_source: "edge",
+        },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect((container.textContent ?? "").toLowerCase()).not.toContain("source changed from");
+  });
+});
+
+describe("humanizeAuditEvent — payment_status_changed", () => {
+  it("renders '{from chip} → {to chip}' summary in normal case", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "payment_status_changed",
+        householdName: "HH-A",
+        details: { from: "unpaid", to: "paid" },
+      })
+    );
+    expect(result.label).toBe("Payment status for HH-A");
+    const { container } = renderNode(result.summary);
+    // both chip labels present
+    expect(container.textContent).toContain("Unpaid");
+    expect(container.textContent).toContain("Paid");
+    expect(container.textContent).toContain("→");
+  });
+
+  it("renders 'Set to {to}' when from === null (initial assignment)", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "payment_status_changed",
+        householdName: "HH-A",
+        details: { from: null, to: "paid" },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect(container.textContent).toContain("Set to");
+    expect(container.textContent).toContain("Paid");
+    // No arrow in the "Set to" branch.
+    expect(container.textContent).not.toContain("→");
+  });
+
+  it("renders italic-muted notes line when details.notes present", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "payment_status_changed",
+        householdName: "HH-A",
+        details: { from: "unpaid", to: "paid", notes: "M-Pesa #123" },
+      })
+    );
+    const { container } = renderNode(result.summary);
+    expect(container.textContent).toContain("M-Pesa #123");
+    // The notes node carries italic + muted classes.
+    const noteEl = container.querySelector("span.italic.text-muted-foreground");
+    expect(noteEl).not.toBeNull();
+  });
+});
+
+describe("humanizeAuditEvent — payment_link_generated", () => {
+  it("renders label only, no summary", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "payment_link_generated",
+        householdName: "HH-A",
+      })
+    );
+    expect(result.label).toBe("Payment link generated for HH-A");
+    expect(result.summary).toBeUndefined();
+  });
+});
+
+// ── Post-close revision flag ─────────────────────────────────────────────────
+
+describe("humanizeAuditEvent — postCloseRevision flag", () => {
+  it("returns postCloseRevision: true when details.period_was_closed === true", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_regenerated",
+        householdName: "HH-A",
+        details: {
+          previous_total_amount: 4000,
+          new_total_amount: 5000,
+          period_was_closed: true,
+        },
+      })
+    );
+    expect(result.postCloseRevision).toBe(true);
+  });
+
+  it("returns postCloseRevision: false when details.period_was_closed missing", () => {
+    const result = humanizeAuditEvent(
+      entry({
+        eventType: "line_item_generated",
+        householdName: "HH-A",
+        details: { new_total_amount: 5000 },
+      })
+    );
+    expect(result.postCloseRevision).toBe(false);
+  });
+});
+
+// ── 3-state actor naming ─────────────────────────────────────────────────────
+
+describe("actorDisplayLabel — 3-state naming", () => {
+  it("returns 'System' when actorUserId === null", () => {
+    const e = entry({
+      eventType: "period_created",
+      actorUserId: null,
+      actorDisplayName: null,
+    });
+    expect(actorDisplayLabel(e)).toBe("System");
+  });
+
+  it("returns 'System' when actorUserId === null even if a display name leaks through", () => {
+    // Defensive: the BC1 fetch helper should never produce this combo, but
+    // the rule is "actorUserId === null wins".
+    const e = entry({
+      eventType: "period_created",
+      actorUserId: null,
+      actorDisplayName: "ghost",
+    });
+    expect(actorDisplayLabel(e)).toBe("System");
+  });
+
+  it("returns 'Restricted' when actorUserId !== null && actorDisplayName === null", () => {
+    const e = entry({
+      eventType: "line_item_generated",
+      actorUserId: "33333333-3333-4333-8333-333333333333",
+      actorDisplayName: null,
+    });
+    expect(actorDisplayLabel(e)).toBe("Restricted");
+  });
+
+  it("returns the verbatim display name when present", () => {
+    const e = entry({
+      eventType: "line_item_generated",
+      actorUserId: "11111111-1111-4111-8111-111111111111",
+      actorDisplayName: "Alice Doe",
+    });
+    expect(actorDisplayLabel(e)).toBe("Alice Doe");
+  });
+});

--- a/src/lib/billing/audit-humanize.tsx
+++ b/src/lib/billing/audit-humanize.tsx
@@ -1,0 +1,245 @@
+/**
+ * audit-humanize.ts — per-event-type renderers for the BC4 audit history (#176).
+ *
+ * Single entry point: `humanizeAuditEvent(entry)` returns
+ *   { label, summary?, manualReason?, postCloseRevision }
+ * — JSX (ReactNode) so `<Currency>` and `<StatusChip>` render inline.
+ *
+ * 6 event types (per the BC1 type module):
+ *   - period_created           → label only.
+ *   - period_closed            → label only.
+ *   - line_item_generated      → label "Bill generated for {hh}", summary "Total: {amount}".
+ *   - line_item_regenerated    → label "Bill regenerated for {hh}", summary "Total changed from {prev} to {new}"
+ *                                 (or "Total unchanged"), optional source-change clause.
+ *   - payment_status_changed   → label "Payment status for {hh}", summary "{from chip} → {to chip}"
+ *                                 (or "Set to {to}" when from === null), optional notes line.
+ *   - payment_link_generated   → label "Payment link generated for {hh}", no summary.
+ *
+ * Actor naming (3-state) is handled by `actorDisplayLabel(entry)` rather
+ * than baked into the per-type renderers — the renderers don't need to
+ * know about actors at all (the list component renders the name beside
+ * the label).
+ */
+
+import * as React from "react";
+import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+import { Currency } from "@/components/format/currency";
+import { StatusChip } from "@/components/ui/status-chip";
+import { Chip } from "@/components/ui/chip";
+
+export type HumanizedAuditEvent = {
+  /** "Bill regenerated for HH-A", "Period closed", etc. May contain JSX. */
+  label: React.ReactNode;
+  /** Optional one-line human summary built from `details`. */
+  summary?: React.ReactNode;
+  /** Optional indented italic muted note (currently `details.manual_reason`). */
+  manualReason?: string;
+  /** True when `details.period_was_closed === true` — list renders a warn chip. */
+  postCloseRevision: boolean;
+};
+
+// ── Actor naming (3-state) ─────────────────────────────────────────────────
+//
+// Per ticket AC3:
+//   - actorUserId === null                                 → "System"
+//     (background job / DB default — no human triggered this)
+//   - actorUserId !== null && actorDisplayName === null    → "Restricted"
+//     (super_admin hidden by user_can_see_user_profile per 00012:71-76;
+//     do NOT use "Unknown" — that misleads org_managers into thinking
+//     the actor is unidentifiable rather than deliberately not-shown)
+//   - actorDisplayName !== null                            → verbatim
+export function actorDisplayLabel(entry: BillingAuditLogEntry): string {
+  if (entry.actorUserId === null) return "System";
+  if (entry.actorDisplayName === null) return "Restricted";
+  return entry.actorDisplayName;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function resolveHouseholdName(entry: BillingAuditLogEntry): string {
+  // AC4: live join (entry.householdName) → snapshot (details.household_name)
+  // → "Unknown household". The fetch helper already collapses live → snapshot
+  // into entry.householdName, but we re-check details defensively.
+  if (entry.householdName) return entry.householdName;
+  const snap = entry.details?.["household_name"];
+  if (typeof snap === "string" && snap.length > 0) return snap;
+  return "Unknown household";
+}
+
+function isPostCloseRevision(entry: BillingAuditLogEntry): boolean {
+  // The DB writer (fn_record_line_item_with_audit) only sets this on
+  // line_item_generated / line_item_regenerated, but checking generically
+  // costs nothing and future-proofs.
+  return entry.details?.["period_was_closed"] === true;
+}
+
+function getNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// ── Per-event-type renderers ───────────────────────────────────────────────
+
+export function humanizeAuditEvent(
+  entry: BillingAuditLogEntry
+): HumanizedAuditEvent {
+  const post = isPostCloseRevision(entry);
+
+  switch (entry.eventType) {
+    case "period_created":
+      return { label: "Period created", postCloseRevision: post };
+
+    case "period_closed":
+      return { label: "Period closed", postCloseRevision: post };
+
+    case "line_item_generated": {
+      const hh = resolveHouseholdName(entry);
+      const newTotal = getNumber(entry.details?.["new_total_amount"]);
+      const summary =
+        newTotal !== null ? (
+          <>
+            Total: <Currency value={newTotal} />
+          </>
+        ) : undefined;
+      return {
+        label: `Bill generated for ${hh}`,
+        summary,
+        manualReason: getString(entry.details?.["manual_reason"]) ?? undefined,
+        postCloseRevision: post,
+      };
+    }
+
+    case "line_item_regenerated": {
+      const hh = resolveHouseholdName(entry);
+      const prevTotal = getNumber(entry.details?.["previous_total_amount"]);
+      const newTotal = getNumber(entry.details?.["new_total_amount"]);
+      const prevSrc = getString(entry.details?.["previous_reading_source"]);
+      const newSrc = getString(entry.details?.["new_reading_source"]);
+
+      // Per ticket AC4:
+      //   - prevTotal === null (INSERT path replayed as regenerate; guard
+      //     even though BC1 INSERT path doesn't write this) → "Total unchanged"
+      //   - prevTotal === newTotal → "Total unchanged"
+      //   - else "Total changed from <prev> to <new>"
+      let totalNode: React.ReactNode;
+      if (prevTotal === null || newTotal === null || prevTotal === newTotal) {
+        totalNode = <>Total unchanged</>;
+      } else {
+        totalNode = (
+          <>
+            Total changed from <Currency value={prevTotal} /> to{" "}
+            <Currency value={newTotal} />
+          </>
+        );
+      }
+
+      // Source-change clause: only when both non-null AND they differ.
+      // Per AC4: when previous_reading_source === null (INSERT path), do
+      // NOT render the clause.
+      let sourceNode: React.ReactNode = null;
+      if (prevSrc !== null && newSrc !== null && prevSrc !== newSrc) {
+        sourceNode = (
+          <>
+            {" · Source changed from "}
+            {prevSrc}
+            {" to "}
+            {newSrc}
+          </>
+        );
+      }
+
+      return {
+        label: `Bill regenerated for ${hh}`,
+        summary: (
+          <>
+            {totalNode}
+            {sourceNode}
+          </>
+        ),
+        manualReason: getString(entry.details?.["manual_reason"]) ?? undefined,
+        postCloseRevision: post,
+      };
+    }
+
+    case "payment_status_changed": {
+      const hh = resolveHouseholdName(entry);
+      const from = getString(entry.details?.["from"]);
+      const to = getString(entry.details?.["to"]);
+      const notes = getString(entry.details?.["notes"]);
+
+      let summary: React.ReactNode;
+      if (from === null && to !== null) {
+        // Initial assignment — no prior status to compare to.
+        summary = (
+          <>
+            Set to{" "}
+            <StatusChip kind="billingLineItemPaymentStatus" status={to} />
+          </>
+        );
+      } else if (to !== null) {
+        // Defensive: if the schema ever surfaces an unknown status string,
+        // <StatusChip> already falls back to a neutral chip + dev warning.
+        summary = (
+          <>
+            <StatusChip
+              kind="billingLineItemPaymentStatus"
+              status={from ?? "unpaid"}
+            />
+            {" → "}
+            <StatusChip kind="billingLineItemPaymentStatus" status={to} />
+          </>
+        );
+      } else {
+        summary = undefined;
+      }
+
+      return {
+        label: `Payment status for ${hh}`,
+        summary: (
+          <>
+            {summary}
+            {notes && (
+              <span className="mt-1 block text-xs italic text-muted-foreground">
+                {notes}
+              </span>
+            )}
+          </>
+        ),
+        postCloseRevision: post,
+      };
+    }
+
+    case "payment_link_generated": {
+      const hh = resolveHouseholdName(entry);
+      return {
+        label: `Payment link generated for ${hh}`,
+        postCloseRevision: post,
+      };
+    }
+
+    default: {
+      // Defensive fallback for an unknown future event type. We keep the
+      // raw eventType string so super_admin debugging still has a foothold.
+      const exhaustive: never = entry.eventType;
+      return {
+        label: (
+          <span className="font-mono text-xs">
+            {(exhaustive as string) || "unknown_event"}
+          </span>
+        ),
+        postCloseRevision: post,
+      };
+    }
+  }
+}
+
+// ── Post-close-revision chip (rendered by the list component) ──────────────
+//
+// Exported so the list can render it next to the event label without
+// importing Chip directly.
+export function PostCloseRevisionChip() {
+  return <Chip tone="warn">post-close revision</Chip>;
+}

--- a/src/lib/billing/audit-log-fetch.ts
+++ b/src/lib/billing/audit-log-fetch.ts
@@ -1,0 +1,300 @@
+/**
+ * audit-log-fetch.ts — shared loader for the period audit log (#176, BC4).
+ *
+ * Lifted verbatim from the BC1 route handler
+ * (`src/app/api/billing-periods/[periodId]/audit-log/route.ts`) so two
+ * surfaces share one implementation:
+ *
+ *   1. The HTTP endpoint (BC1) — `GET /api/billing-periods/[id]/audit-log`
+ *      delegates to `fetchAuditLogEntries`. Existing route tests at
+ *      `route.test.ts` are the behavior contract — DO NOT diverge.
+ *   2. The server-rendered history page (BC4) —
+ *      `src/app/(dashboard)/microgrids/[id]/billing/[periodId]/history/page.tsx`
+ *      calls this directly under the user-bound supabase client. No HTTP
+ *      fetch from a server component (cookie + absolute-URL footgun).
+ *
+ * Behavior preserved (any change here will break the BC1 contract):
+ *   - LIMIT 500 per side (memory-safety guard, NOT pagination).
+ *   - `payment_events.at` aliased into the entry's `createdAt`.
+ *   - `user_directory` join surfaces actor display names; missing rows
+ *     (RLS-hidden super_admin per `user_can_see_user_profile`) → null.
+ *   - `actorDisplayName` = first+last, fallback email, fallback null.
+ *   - Audit IDs prefixed `audit:<uuid>`; payment-event IDs prefixed
+ *     `payment_event:<uuid>` for stable React keys across the union.
+ *   - Audit-row householdName resolution: live join (`billing_line_items
+ *     → households`) preferred over the snapshot in `details.household_name`;
+ *     snapshot used when the line item is hard-deleted (FK NULL).
+ *
+ * The result discriminator mirrors the `unauthorized` / `not-found` /
+ * `error` / `ok` shape the route needs to map to HTTP status codes.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { BillingAuditLogEntry } from "@/lib/types/billing-audit";
+
+const PER_SIDE_LIMIT = 500;
+
+type AuditRow = {
+  id: string;
+  billing_period_id: string;
+  billing_line_item_id: string | null;
+  event_type:
+    | "period_created"
+    | "period_closed"
+    | "line_item_generated"
+    | "line_item_regenerated";
+  actor_user_id: string | null;
+  created_at: string;
+  details: Record<string, unknown> | null;
+};
+
+type PaymentEventRow = {
+  id: string;
+  line_item_id: string;
+  from_status: string | null;
+  to_status: string;
+  source: "ipn" | "manual" | "generate_link";
+  actor_user_id: string | null;
+  raw_payload: Record<string, unknown> | null;
+  at: string;
+  // Joined billing_line_items for line_item → period scoping + payment_notes.
+  billing_line_items: {
+    billing_period_id: string;
+    payment_notes: string | null;
+    households: { display_name: string } | null;
+  } | null;
+};
+
+type DirectoryRow = {
+  user_id: string;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+};
+
+function pickDisplayName(row: DirectoryRow | undefined): string | null {
+  if (!row) return null;
+  const parts = [row.first_name, row.last_name].filter(
+    (s): s is string => typeof s === "string" && s.length > 0
+  );
+  if (parts.length > 0) return parts.join(" ");
+  return row.email ?? null;
+}
+
+export type AuditLogFetchResult =
+  | { kind: "ok"; entries: BillingAuditLogEntry[] }
+  | { kind: "unauthorized" }
+  | { kind: "not_found" }
+  | { kind: "error"; message: string };
+
+/**
+ * Fetch the merged audit log for one billing period under the supplied
+ * (user-bound) supabase client. Caller is responsible for routing the
+ * discriminated result to a 200 / 401 / 404 / 500 response (HTTP) or
+ * to the appropriate page-level rendering branch (server component).
+ */
+export async function fetchAuditLogEntries(
+  // We intentionally use a wide SupabaseClient typing here — the Database
+  // generic on the route's createClient() is unnecessary plumbing for a
+  // helper that only does table selects with explicit column lists.
+  supabase: SupabaseClient,
+  periodId: string
+): Promise<AuditLogFetchResult> {
+  // Explicit auth gate — every other route in this ticket also has it.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { kind: "unauthorized" };
+  }
+
+  // Verify the period exists + caller can see it (RLS gates the query).
+  const { data: period, error: periodErr } = await supabase
+    .from("billing_periods")
+    .select("id")
+    .eq("id", periodId)
+    .maybeSingle<{ id: string }>();
+
+  if (periodErr) {
+    return {
+      kind: "error",
+      message: `Failed to look up billing period: ${periodErr.message}`,
+    };
+  }
+  if (!period) {
+    return { kind: "not_found" };
+  }
+
+  // ── 1. Read billing_audit_log (BC1's table) ───────────────────────────────
+  const { data: auditRowsRaw, error: auditErr } = await supabase
+    .from("billing_audit_log")
+    .select(
+      "id, billing_period_id, billing_line_item_id, event_type, actor_user_id, created_at, details"
+    )
+    .eq("billing_period_id", periodId)
+    .order("created_at", { ascending: false })
+    .limit(PER_SIDE_LIMIT);
+
+  if (auditErr) {
+    return {
+      kind: "error",
+      message: `Failed to read audit log: ${auditErr.message}`,
+    };
+  }
+  const auditRows = (auditRowsRaw ?? []) as unknown as AuditRow[];
+
+  // ── 2. Read payment_events for line items in this period ─────────────────
+  // Join billing_line_items to scope to this period AND to surface
+  // payment_notes + household.display_name for the response.
+  const { data: paymentEventsRaw, error: peErr } = await supabase
+    .from("payment_events")
+    .select(
+      `
+      id, line_item_id, from_status, to_status, source, actor_user_id,
+      raw_payload, at,
+      billing_line_items!inner (
+        billing_period_id,
+        payment_notes,
+        households (
+          display_name
+        )
+      )
+    `
+    )
+    .eq("billing_line_items.billing_period_id", periodId)
+    .order("at", { ascending: false })
+    .limit(PER_SIDE_LIMIT);
+
+  if (peErr) {
+    return {
+      kind: "error",
+      message: `Failed to read payment events: ${peErr.message}`,
+    };
+  }
+  const paymentEvents = (paymentEventsRaw ?? []) as unknown as PaymentEventRow[];
+
+  // ── 3. Resolve household_name for billing_audit_log entries that have a
+  //       live billing_line_item_id (preferred over the snapshot). When the
+  //       line item is hard-deleted, the FK is NULL and we fall back to
+  //       details.household_name (the snapshot kept by the writer).
+  const liveLineItemIds = Array.from(
+    new Set(
+      auditRows
+        .map((r) => r.billing_line_item_id)
+        .filter((v): v is string => Boolean(v))
+    )
+  );
+  const lineItemNameMap = new Map<string, string | null>();
+  if (liveLineItemIds.length > 0) {
+    const { data: lis } = await supabase
+      .from("billing_line_items")
+      .select("id, households(display_name)")
+      .in("id", liveLineItemIds);
+    type LiHHRow = {
+      id: string;
+      households: { display_name: string } | { display_name: string }[] | null;
+    };
+    for (const r of (lis ?? []) as LiHHRow[]) {
+      const hh = r.households;
+      const name = Array.isArray(hh)
+        ? hh[0]?.display_name ?? null
+        : hh?.display_name ?? null;
+      lineItemNameMap.set(r.id, name);
+    }
+  }
+
+  // ── 4. Resolve actor display names via user_directory (RLS-aware). ───────
+  const actorIds = Array.from(
+    new Set(
+      [
+        ...auditRows.map((r) => r.actor_user_id),
+        ...paymentEvents.map((p) => p.actor_user_id),
+      ].filter((v): v is string => Boolean(v))
+    )
+  );
+  const directoryMap = new Map<string, DirectoryRow>();
+  if (actorIds.length > 0) {
+    const { data: dirRows } = await supabase
+      .from("user_directory")
+      .select("user_id, email, first_name, last_name")
+      .in("user_id", actorIds);
+    for (const r of (dirRows ?? []) as DirectoryRow[]) {
+      directoryMap.set(r.user_id, r);
+    }
+  }
+
+  // ── 5. Normalize → BillingAuditLogEntry[] ─────────────────────────────────
+  const entries: BillingAuditLogEntry[] = [];
+
+  for (const a of auditRows) {
+    const detailsObj =
+      a.details && typeof a.details === "object" ? a.details : {};
+    const snapshotName =
+      typeof detailsObj["household_name"] === "string"
+        ? (detailsObj["household_name"] as string)
+        : null;
+    const liveName = a.billing_line_item_id
+      ? lineItemNameMap.get(a.billing_line_item_id) ?? null
+      : null;
+    entries.push({
+      id: `audit:${a.id}`,
+      eventType: a.event_type,
+      actorUserId: a.actor_user_id,
+      actorDisplayName: pickDisplayName(
+        a.actor_user_id ? directoryMap.get(a.actor_user_id) : undefined
+      ),
+      createdAt: a.created_at,
+      billingLineItemId: a.billing_line_item_id,
+      householdName: liveName ?? snapshotName,
+      details: detailsObj,
+    });
+  }
+
+  for (const p of paymentEvents) {
+    // PostgREST may surface the !inner join as an array even though it's
+    // single-row in the DB — defensive coerce mirrors the PATCH /usage
+    // pattern.
+    const bli = Array.isArray(p.billing_line_items)
+      ? p.billing_line_items[0]
+      : p.billing_line_items;
+    const hh = bli?.households;
+    const householdName = Array.isArray(hh)
+      ? hh[0]?.display_name ?? null
+      : hh?.display_name ?? null;
+
+    // Map to BC4's normalized event types.
+    // - source='generate_link' → payment_link_generated (incl. regenerate
+    //   where from === to)
+    // - everything else → payment_status_changed
+    const eventType: BillingAuditLogEntry["eventType"] =
+      p.source === "generate_link"
+        ? "payment_link_generated"
+        : "payment_status_changed";
+
+    const details: Record<string, unknown> = {
+      from: p.from_status,
+      to: p.to_status,
+      source: p.source,
+      raw_payload: p.raw_payload,
+    };
+    if (bli?.payment_notes) details["notes"] = bli.payment_notes;
+
+    entries.push({
+      id: `payment_event:${p.id}`,
+      eventType,
+      actorUserId: p.actor_user_id,
+      actorDisplayName: pickDisplayName(
+        p.actor_user_id ? directoryMap.get(p.actor_user_id) : undefined
+      ),
+      createdAt: p.at,
+      billingLineItemId: p.line_item_id,
+      householdName,
+      details,
+    });
+  }
+
+  // Merge by createdAt DESC.
+  entries.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+
+  return { kind: "ok", entries };
+}


### PR DESCRIPTION
## Summary

New per-period audit history page at \`/microgrids/[id]/billing/[periodId]/history\`.

- **Shared helper** \`src/lib/billing/audit-log-fetch.ts\` extracted from BC1's audit-log route. Returns discriminated \`{kind: 'ok'|'unauthorized'|'not_found'|'error'}\` so the route AND the new server component both use it. **BC1's existing route tests untouched** — behavior contract preserved.
- **Server component** at \`history/page.tsx\` (RLS-scoped via \`createClient()\`, no HTTP self-fetch).
- **Per-event-type renderers** for all 6 BC1 event types (period_created, period_closed, line_item_generated, line_item_regenerated, payment_status_changed, payment_link_generated) in \`audit-humanize.tsx\`.
- **3-state actor naming**: \`actorUserId === null\` → "System"; \`actorUserId !== null && actorDisplayName === null\` → "Restricted" (hidden super_admin per \`user_can_see_user_profile\`); else verbatim.
- **Date+time** via new \`<LocalDateTime>\` wrapper pinning Intl opts \`{year, month, day, hour, minute}\` (no hand-formatted separator).
- **\`<ol aria-label="Audit history">\`** semantics; both empty-state branches omit the \`<ol>\` entirely.
- **"View history" link** in BillingTable period header (always rendered, draft + closed).
- **Truncation notice** when \`entries.length >= 1000\`.
- 40+ new tests across 5 test files.

Closes #176.

## Test plan

- [x] \`npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1175 pass) && npm run build\` — all green; new \`/history\` route in build manifest
- [x] BC1's audit-log route test (9 cases) still passes after refactor
- [x] Reviewer agent walked all 10 ACs — VERDICT: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)