### PR TITLE
Fix billing-period page: user_directory query references nonexistent display_name column

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/__tests__/page.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * billing/[periodId]/page.test.tsx — regression test for the page-level
+ * supabase query.
+ *
+ * Why this exists: an earlier revision asked PostgREST for a non-existent
+ * `user_directory.display_name` column, producing a 500 on every billing
+ * detail page in production. The previous unit test for this surface
+ * (`billing-table.test.tsx`) mocks the `actorByLineItemId` prop directly
+ * — so it never exercises the page loader. TypeScript also can't catch
+ * the bug because `LineItemWithActor` is a hand-written `.returns<>()`
+ * shape that fabricates whatever fields it claims.
+ *
+ * Strategy:
+ *   - Mock @/lib/supabase/server with a per-table dispatcher. The
+ *     `billing_line_items` builder returns rows shaped like the REAL
+ *     `user_directory` view (`first_name`, `last_name`, `email` — NO
+ *     `display_name`).
+ *   - Mock @/components/BillingTable as a stub that serializes the
+ *     `actorByLineItemId` prop into the rendered HTML, so we can
+ *     assert what the page computed for each line item.
+ *   - Render the page server-side and snapshot the captured map.
+ *
+ * Coverage (mirrors `pickDisplayName` in src/lib/billing/audit-log-fetch.ts):
+ *   1. first_name + last_name → "Alejandro Malbet"
+ *   2. first_name only → "Alejandro"
+ *   3. email-only fallback (both names null) → "alejandro@example.com"
+ *   4. null user_directory join (entered_by_user_id IS NULL or RLS-hidden)
+ *      → null actor
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+const MICROGRID_ID = "770e8400-e29b-41d4-a716-446655442000";
+const PERIOD_ID = "660e8400-e29b-41d4-a716-446655441000";
+const LI_FULL = "990e8400-e29b-41d4-a716-446655444001";
+const LI_FIRST_ONLY = "990e8400-e29b-41d4-a716-446655444002";
+const LI_EMAIL_ONLY = "990e8400-e29b-41d4-a716-446655444003";
+const LI_NO_JOIN = "990e8400-e29b-41d4-a716-446655444004";
+
+// Holders we mutate per-test.
+let MOCK_LINE_ITEMS: Array<Record<string, unknown>> = [];
+let LAST_LINE_ITEMS_SELECT = "";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Generic chainable proxy for query chains we don't need to inspect.
+function buildQuery(data: unknown) {
+  function makeChainable(): Record<string, unknown> {
+    return new Proxy({} as Record<string, unknown>, {
+      get(_target, prop) {
+        if (prop === "returns") return () => Promise.resolve({ data, error: null });
+        if (prop === "single" || prop === "maybeSingle")
+          return () => Promise.resolve({ data, error: null });
+        if (prop === "then") {
+          return (resolve: (v: { data: unknown; error: null }) => unknown) =>
+            Promise.resolve({ data, error: null }).then(resolve);
+        }
+        return () => makeChainable();
+      },
+    });
+  }
+  return makeChainable();
+}
+
+// Specialized chain for billing_line_items so we can capture the
+// SELECT string the page sends to PostgREST. This lets us assert that
+// the page does NOT request the nonexistent `display_name` column.
+function buildLineItemsQuery() {
+  const terminal = () =>
+    Promise.resolve({ data: MOCK_LINE_ITEMS, error: null });
+  function makeChainable(): Record<string, unknown> {
+    return new Proxy({} as Record<string, unknown>, {
+      get(_target, prop) {
+        if (prop === "select") {
+          return (sel: string) => {
+            LAST_LINE_ITEMS_SELECT = sel;
+            return makeChainable();
+          };
+        }
+        if (prop === "returns") return terminal;
+        if (prop === "then") {
+          return (resolve: (v: { data: unknown; error: null }) => unknown) =>
+            Promise.resolve({ data: MOCK_LINE_ITEMS, error: null }).then(resolve);
+        }
+        return () => makeChainable();
+      },
+    });
+  }
+  return makeChainable();
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: (table: string) => {
+      if (table === "billing_line_items") return buildLineItemsQuery();
+      if (table === "billing_periods")
+        return buildQuery({ id: PERIOD_ID, microgrid_id: MICROGRID_ID });
+      if (table === "households") return buildQuery([]);
+      if (table === "rate_schedules") return buildQuery(null);
+      if (table === "microgrids")
+        return buildQuery({
+          id: MICROGRID_ID,
+          name: "Test MG",
+          currency: "UGX",
+          communities: { id: "comm-1", payment_provider: null },
+        });
+      // Fallback (e.g. user_roles via currentUserIsSuperAdmin).
+      return buildQuery([]);
+    },
+  }),
+}));
+
+vi.mock("@/lib/hierarchy", () => ({
+  getHierarchyLevels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserIsSuperAdmin: vi.fn().mockResolvedValue(false),
+}));
+
+// Stub the BillingTable so we can read the actor map back out of the
+// rendered HTML. The stub serializes the prop as JSON inside a hidden
+// span — assertions then parse + inspect.
+vi.mock("@/components/BillingTable", () => ({
+  BillingTable: (props: { actorByLineItemId?: Record<string, string | null> }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "billing-table-stub" },
+      React.createElement(
+        "span",
+        { "data-testid": "actor-map" },
+        JSON.stringify(props.actorByLineItemId ?? {})
+      )
+    ),
+}));
+
+vi.mock("@/components/ui/hierarchy-nav", () => ({
+  HierarchyNav: () => null,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+// ── Import page (after mocks) ─────────────────────────────────────────────────
+
+import BillingPeriodDetailPage from "../page";
+
+beforeEach(() => {
+  LAST_LINE_ITEMS_SELECT = "";
+  MOCK_LINE_ITEMS = [
+    {
+      id: LI_FULL,
+      user_directory: {
+        first_name: "Alejandro",
+        last_name: "Malbet",
+        email: "alejandro@example.com",
+      },
+    },
+    {
+      id: LI_FIRST_ONLY,
+      user_directory: {
+        first_name: "Alejandro",
+        last_name: null,
+        email: "alejandro@example.com",
+      },
+    },
+    {
+      id: LI_EMAIL_ONLY,
+      user_directory: {
+        first_name: null,
+        last_name: null,
+        email: "alejandro@example.com",
+      },
+    },
+    {
+      id: LI_NO_JOIN,
+      user_directory: null,
+    },
+  ];
+});
+
+function extractActorMap(html: string): Record<string, string | null> {
+  const m = html.match(
+    /data-testid="actor-map"[^>]*>([^<]*)<\/span>/
+  );
+  if (!m) throw new Error("actor-map span not found in rendered HTML");
+  // Decode HTML-escaped quotes (renderToStaticMarkup turns " into &quot;).
+  const decoded = m[1]
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&");
+  return JSON.parse(decoded);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("BillingPeriodDetailPage — user_directory actor mapping", () => {
+  it("does NOT request the (nonexistent) display_name column", async () => {
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    renderToStaticMarkup(node as React.ReactElement);
+    expect(LAST_LINE_ITEMS_SELECT).not.toContain("display_name");
+    expect(LAST_LINE_ITEMS_SELECT).toContain("first_name");
+    expect(LAST_LINE_ITEMS_SELECT).toContain("last_name");
+    expect(LAST_LINE_ITEMS_SELECT).toContain("email");
+  });
+
+  it("composes first_name + last_name with a space when both present", async () => {
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    const actorMap = extractActorMap(html);
+    expect(actorMap[LI_FULL]).toBe("Alejandro Malbet");
+  });
+
+  it("uses first_name alone when last_name is null", async () => {
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    const actorMap = extractActorMap(html);
+    expect(actorMap[LI_FIRST_ONLY]).toBe("Alejandro");
+  });
+
+  it("falls back to email when both first_name and last_name are null", async () => {
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    const actorMap = extractActorMap(html);
+    expect(actorMap[LI_EMAIL_ONLY]).toBe("alejandro@example.com");
+  });
+
+  it("emits null when the user_directory join is null", async () => {
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    const actorMap = extractActorMap(html);
+    expect(actorMap[LI_NO_JOIN]).toBeNull();
+  });
+});

--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -44,9 +44,16 @@ export default async function BillingPeriodDetailPage({
   };
 
   // BC2 (#174) — line-items query type with the user_directory join
-  // for the entered-by caption.
+  // for the entered-by caption. The `user_directory` view exposes
+  // first_name / last_name / email (no `display_name` column); we
+  // compose the display string client-side via `pickDisplayName`,
+  // mirroring `src/lib/billing/audit-log-fetch.ts:75-82`.
   type LineItemWithActor = BillingLineItem & {
-    user_directory: { display_name: string | null } | null;
+    user_directory: {
+      first_name: string | null;
+      last_name: string | null;
+      email: string | null;
+    } | null;
   };
 
   const [
@@ -68,7 +75,7 @@ export default async function BillingPeriodDetailPage({
     supabase
       .from("billing_line_items")
       .select(
-        "*, payment_status, paid_at, paid_by_user_id, payment_notes, user_directory!entered_by_user_id(display_name)",
+        "*, payment_status, paid_at, paid_by_user_id, payment_notes, user_directory!entered_by_user_id(first_name, last_name, email)",
       )
       .eq("billing_period_id", periodId)
       .returns<LineItemWithActor[]>(),
@@ -192,8 +199,15 @@ export default async function BillingPeriodDetailPage({
   const actorByLineItemId: Record<string, string | null> = {};
   for (const li of lineItemsWithActors) {
     // PostgREST may return the joined row as an object or null.
+    // Mirror `pickDisplayName` from src/lib/billing/audit-log-fetch.ts:75-82:
+    // first_name + last_name (joined with a space), fallback to email,
+    // fallback to null.
     const join = li.user_directory;
-    actorByLineItemId[li.id] = join?.display_name ?? null;
+    const parts = [join?.first_name, join?.last_name].filter(
+      (s): s is string => typeof s === "string" && s.length > 0,
+    );
+    actorByLineItemId[li.id] =
+      parts.length > 0 ? parts.join(" ") : (join?.email ?? null);
   }
   const cleanLineItems: BillingLineItem[] = lineItemsWithActors.map((li) => {
     // Strip the join field so the prop type stays narrow.


### PR DESCRIPTION
## Summary

**Production-breaking BLOCKER caught by the BC-batch holistic post-merge review.**

The page-level Supabase query in \`src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx\` references \`user_directory.display_name\` — a column that doesn't exist. The \`user_directory\` view (defined in migration 00014) has \`email\`, \`first_name\`, \`last_name\` only. PostgREST returns \`42703 column user_directory_1.display_name does not exist\` and every operator opening any billing-period detail page gets a 500.

The bug slipped past 4 rounds of refinement + per-PR review + the implementer's own QA because:
- TypeScript can't catch it: \`LineItemWithActor\` was a hand-written \`.returns<>\` shape that fabricated the \`display_name\` field.
- Tests pass: \`billing-table.test.tsx\` mocks BillingTable's \`actorByLineItemId\` prop directly — never exercises the page-level query.
- The holistic agent caught it by actually running the query against cloud.

## Fix

Mirror the canonical \`pickDisplayName\` helper in \`src/lib/billing/audit-log-fetch.ts:75-82\`:
- SELECT \`user_directory!entered_by_user_id(first_name, last_name, email)\` (the real columns).
- Type \`LineItemWithActor.user_directory\` to match.
- Compose actor name as \`first + last\` joined by space, falling back to \`email\`, then \`null\`.

## Regression guard

New vitest server-component integration test at \`page.test.tsx\` that mocks the supabase response with the REAL \`user_directory\` view shape and asserts:
1. The SELECT string does NOT contain \`display_name\` and DOES contain the three real columns.
2. \`first_name + last_name\` → "Alejandro Malbet"
3. \`first_name\` only → "Alejandro"
4. email-only fallback → email
5. null user_directory join → null actor

This kind of bug (hand-typed \`.returns<>\` shape diverging from the real view columns) is now caught at test time.

## Test plan

- [x] \`npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1202 pass) && npm run build\` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)