### PR TITLE
BC3 polish: optional eyebrow on ConfirmDialog + drop on paid-edge regenerate (#183)

### DIFF
--- a/src/components/billing/__tests__/regenerate-row-dialog.test.tsx
+++ b/src/components/billing/__tests__/regenerate-row-dialog.test.tsx
@@ -207,6 +207,11 @@ describe("RegenerateRowDialog — edge paid path (2b)", () => {
     const diff = document.querySelector('[data-testid="regenerate-preview-diff"]');
     expect(diff?.textContent).toMatch(/\+/); // 22000 - 20000 = +2000
 
+    // #183 — paid-edge dialog passes eyebrow={null}; the neutral-tone
+    // default "Confirm" eyebrow should NOT appear in the dialog header.
+    // ("Regenerate" is the confirm-button label, which still renders.)
+    expect(screen.queryByText("Confirm")).toBeNull();
+
     // /api/billing/generate should NOT have been called yet.
     const generateCalls = fetchMock.mock.calls.filter(
       (c) => c[0] === "/api/billing/generate",

--- a/src/components/billing/regenerate-row-dialog.tsx
+++ b/src/components/billing/regenerate-row-dialog.tsx
@@ -440,6 +440,9 @@ function EdgePaidConfirmDialog(props: RegenerateRowDialogProps) {
       confirmLabel="Regenerate"
       onConfirm={onConfirmFn}
       body={previewBody}
+      // Suppress the neutral-tone "Confirm" eyebrow — the diff body is the
+      // primary visual focus here; the eyebrow would compete with it. See #183.
+      eyebrow={null}
     />
   );
 }

--- a/src/components/ui/__tests__/confirm-dialog.test.tsx
+++ b/src/components/ui/__tests__/confirm-dialog.test.tsx
@@ -188,4 +188,66 @@ describe("ConfirmDialog", () => {
     expect(describedBy).toContain("confirm-dialog-body");
     expect(describedBy).toContain("confirm-dialog-desc");
   });
+
+  // ── #183 optional eyebrow extensions ──────────────────────────────────
+
+  it("(h) eyebrow undefined → renders per-tone default ('Confirm' for neutral, 'Irreversible action' for destructive)", () => {
+    const { unmount } = render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Save and test?"
+        confirmLabel="Save"
+        tone="neutral"
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+    expect(screen.getByText("Confirm")).toBeTruthy();
+    unmount();
+
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete meter?"
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+    expect(screen.getByText("Irreversible action")).toBeTruthy();
+  });
+
+  it("(i) eyebrow='Custom label' → renders the supplied string verbatim", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Save and test?"
+        confirmLabel="Save"
+        tone="neutral"
+        eyebrow="Custom label"
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+    expect(screen.getByText("Custom label")).toBeTruthy();
+    // Default neutral eyebrow must NOT appear when overridden.
+    expect(screen.queryByText("Confirm")).toBeNull();
+  });
+
+  it("(j) eyebrow={null} → no eyebrow node renders (neither default literal appears)", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Regenerate this bill?"
+        confirmLabel="Regenerate"
+        tone="neutral"
+        eyebrow={null}
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+    expect(screen.queryByText("Confirm")).toBeNull();
+    expect(screen.queryByText("Irreversible action")).toBeNull();
+  });
 });

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -63,6 +63,18 @@ export interface ConfirmDialogProps {
     label: string;
     expected: string;
   };
+  /**
+   * Optional eyebrow label rendered above the title. 3-state semantic:
+   *   - `undefined` (default): renders the per-tone default —
+   *     `"Irreversible action"` for destructive, `"Confirm"` for neutral.
+   *   - `string`: renders the supplied string verbatim as the eyebrow.
+   *   - `null`: explicit opt-out — no eyebrow `<span>` is rendered (no
+   *     DOM node, no reserved spacing). Use this when the dialog body
+   *     itself is the primary visual focus and the eyebrow would add
+   *     noise (e.g. BC3 paid-edge regenerate dialog where the diff body
+   *     should be the first thing the operator sees).
+   */
+  eyebrow?: string | null;
 }
 
 type State = "idle" | "loading" | "error";
@@ -82,6 +94,7 @@ export function ConfirmDialog({
   tone,
   onConfirm,
   requireTypedConfirmation,
+  eyebrow,
 }: ConfirmDialogProps) {
   const [state, setState] = React.useState<State>("idle");
   const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
@@ -162,14 +175,24 @@ export function ConfirmDialog({
           />
 
           <div className="px-6 pb-2 pt-5">
-            <span
-              className={cn(
-                "text-[11px] font-semibold uppercase tracking-wide",
-                tone === "destructive" ? "text-destructive" : "text-primary",
-              )}
-            >
-              {tone === "destructive" ? "Irreversible action" : "Confirm"}
-            </span>
+            {/* Eyebrow — 3-state semantic via the `eyebrow` prop:
+                  undefined → per-tone default ("Irreversible action" / "Confirm")
+                  string    → render supplied label
+                  null      → suppress the <span> entirely (no DOM, no spacing) */}
+            {eyebrow !== null && (
+              <span
+                className={cn(
+                  "text-[11px] font-semibold uppercase tracking-wide",
+                  tone === "destructive" ? "text-destructive" : "text-primary",
+                )}
+              >
+                {typeof eyebrow === "string"
+                  ? eyebrow
+                  : tone === "destructive"
+                    ? "Irreversible action"
+                    : "Confirm"}
+              </span>
+            )}
             <Dialog.Title className="mt-1.5 text-xl font-semibold tracking-tight">
               {title}
             </Dialog.Title>


### PR DESCRIPTION
## Summary

Tiny additive primitive change.

- \`<ConfirmDialog>\` accepts new \`eyebrow?: string | null\` prop:
  - \`undefined\` → per-tone default ("Irreversible action" destructive, "Confirm" neutral) — existing behavior preserved
  - String → renders verbatim
  - \`null\` → suppresses entirely (no DOM, no spacing)
- BC3's paid-edge \`<EdgePaidConfirmDialog>\` now passes \`eyebrow={null}\` so the diff/sign/% body is the first thing the operator sees instead of competing with a noisy "Confirm" eyebrow.
- 17 other ConfirmDialog consumers untouched — they retain default behavior.
- 4 new tests (3 in confirm-dialog.test.tsx + 1 negative assertion in the existing 2b "calls preview first…" test).

Closes #183.

## Test plan

- [x] \`npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1205 pass) && npm run build\` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)