### PR TITLE
BC3 polish: surface partial-failure errors in regenerate dialogs + preflight panel (#182)

### DIFF
--- a/src/components/billing/__tests__/preflight-panel.test.tsx
+++ b/src/components/billing/__tests__/preflight-panel.test.tsx
@@ -174,6 +174,361 @@ describe("PreflightPanel — submit body shape", () => {
   });
 });
 
+describe("PreflightPanel — partial-failure result view (BC3 polish #182)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshMock.mockClear();
+  });
+
+  async function fillAndSubmit(onClose: () => void) {
+    const households = [
+      makeHousehold("h-1", "Alice"),
+      makeHousehold("h-2", "Bob"),
+      makeHousehold("h-3", "Carol"),
+    ];
+    const edgeMap = { "h-1": false, "h-2": false, "h-3": false };
+    render(
+      <Wrap>
+        <PreflightPanel
+          open
+          onClose={onClose}
+          billingPeriodId="p-1"
+          households={households}
+          edgeAvailableByHouseholdId={edgeMap}
+        />
+      </Wrap>,
+    );
+    fireEvent.change(screen.getByLabelText(/Start kWh for Alice/i), {
+      target: { value: "100" },
+    });
+    fireEvent.change(screen.getByLabelText(/End kWh for Alice/i), {
+      target: { value: "150" },
+    });
+    fireEvent.change(screen.getByLabelText(/Start kWh for Bob/i), {
+      target: { value: "200" },
+    });
+    fireEvent.change(screen.getByLabelText(/End kWh for Bob/i), {
+      target: { value: "250" },
+    });
+    fireEvent.change(screen.getByLabelText(/Start kWh for Carol/i), {
+      target: { value: "300" },
+    });
+    fireEvent.change(screen.getByLabelText(/End kWh for Carol/i), {
+      target: { value: "350" },
+    });
+    const submitBtn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+  }
+
+  it("all-success: panel calls onClose() (existing behavior preserved)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lineItems: 3, errors: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onClose = vi.fn();
+    await fillAndSubmit(onClose);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(
+      document.querySelector('[data-testid="preflight-panel-result"]'),
+    ).toBeNull();
+    expect(refreshMock).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("partial failure: panel stays open, switches to result view with warn banner + per-code copy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 2,
+          errors: [
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "raw",
+              code: "invalid_manual_reading",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onClose = vi.fn();
+    await fillAndSubmit(onClose);
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-panel-result"]'),
+      ).not.toBeNull(),
+    );
+    // onClose was NOT called.
+    expect(onClose).not.toHaveBeenCalled();
+    // Heading shows partial-success summary.
+    expect(document.body.textContent).toContain("Generated 2 of 3 households");
+    // Per-code copy renders.
+    const list = document.querySelector(
+      '[data-testid="preflight-result-failure-list"]',
+    );
+    expect(list!.textContent).toContain(
+      "Carol has an invalid manual reading.",
+    );
+    // router.refresh fires regardless of partial.
+    expect(refreshMock).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("full failure: panel stays open with destructive banner; heading reads 'Could not generate'", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 0,
+          errors: [
+            {
+              householdId: "h-1",
+              householdName: "Alice",
+              error: "raw1",
+              code: "no_meter_reading",
+            },
+            {
+              householdId: "h-2",
+              householdName: "Bob",
+              error: "raw2",
+              code: "missing_openems_config",
+            },
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "raw3",
+              code: "unmetered_no_manual",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onClose = vi.fn();
+    await fillAndSubmit(onClose);
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-panel-result"]'),
+      ).not.toBeNull(),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain(
+      "Could not generate 3 households",
+    );
+    const items = document.querySelectorAll(
+      '[data-testid="preflight-result-failure-list"] > li',
+    );
+    expect(items.length).toBe(3);
+    // Order preserved (AC7).
+    expect(items[0].textContent).toContain("Alice");
+    expect(items[1].textContent).toContain("Bob");
+    expect(items[2].textContent).toContain("Carol");
+    vi.unstubAllGlobals();
+  });
+
+  it("per-error-code copy smoke: maps unmetered_no_manual, invalid_manual_reading, currently_manual", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 0,
+          errors: [
+            {
+              householdId: "h-1",
+              householdName: "Alice",
+              error: "x",
+              code: "unmetered_no_manual",
+            },
+            {
+              householdId: "h-2",
+              householdName: "Bob",
+              error: "y",
+              code: "invalid_manual_reading",
+            },
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "z",
+              code: "currently_manual",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await fillAndSubmit(vi.fn());
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-panel-result"]'),
+      ).not.toBeNull(),
+    );
+    const text = document.querySelector(
+      '[data-testid="preflight-result-failure-list"]',
+    )!.textContent ?? "";
+    expect(text).toContain(
+      "Alice has no meter and no manual reading provided.",
+    );
+    expect(text).toContain("Bob has an invalid manual reading.");
+    expect(text).toContain(
+      "Carol is set to manual entry — use per-row regenerate.",
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("default fallback: unknown code renders '${name}: ${error}'", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 0,
+          errors: [
+            {
+              householdId: "h-1",
+              householdName: "Alice",
+              error: "Quoted server message",
+              code: "future_code",
+            },
+            {
+              householdId: "h-2",
+              householdName: "Bob",
+              error: "another verbatim",
+              // no code at all
+            },
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "third",
+              code: "no_meter_reading",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await fillAndSubmit(vi.fn());
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-panel-result"]'),
+      ).not.toBeNull(),
+    );
+    const text = document.querySelector(
+      '[data-testid="preflight-result-failure-list"]',
+    )!.textContent ?? "";
+    expect(text).toContain("Alice: Quoted server message");
+    expect(text).toContain("Bob: another verbatim");
+    // Mapped code wins for Carol.
+    expect(text).toContain("Carol has no current meter reading.");
+    vi.unstubAllGlobals();
+  });
+
+  it("truncation: 6 failures → 5 + '+ 1 more'", async () => {
+    const errs = Array.from({ length: 6 }, (_, i) => ({
+      householdId: `h-${i + 1}`,
+      householdName: `Person${i + 1}`,
+      error: "x",
+      code: "no_meter_reading",
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lineItems: 0, errors: errs }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = errs.map((e) =>
+      makeHousehold(e.householdId, e.householdName),
+    );
+    const edgeMap: Record<string, boolean> = {};
+    households.forEach((h) => {
+      edgeMap[h.id] = false;
+    });
+    render(
+      <Wrap>
+        <PreflightPanel
+          open
+          onClose={vi.fn()}
+          billingPeriodId="p-1"
+          households={households}
+          edgeAvailableByHouseholdId={edgeMap}
+        />
+      </Wrap>,
+    );
+    households.forEach((h, i) => {
+      fireEvent.change(
+        screen.getByLabelText(new RegExp(`Start kWh for ${h.display_name}`, "i")),
+        { target: { value: String(i * 10) } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(new RegExp(`End kWh for ${h.display_name}`, "i")),
+        { target: { value: String(i * 10 + 5) } },
+      );
+    });
+    const submitBtn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-panel-result"]'),
+      ).not.toBeNull(),
+    );
+    const items = document.querySelectorAll(
+      '[data-testid="preflight-result-failure-list"] > li',
+    );
+    // 5 displayed + 1 overflow li.
+    expect(items.length).toBe(6);
+    const overflow = document.querySelector(
+      '[data-testid="preflight-result-failure-overflow"]',
+    );
+    expect(overflow!.textContent).toContain("+ 1 more");
+    vi.unstubAllGlobals();
+  });
+
+  it("Close button in result view calls onClose()", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 2,
+          errors: [
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "x",
+              code: "no_meter_reading",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onClose = vi.fn();
+    await fillAndSubmit(onClose);
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-panel-result"]'),
+      ).not.toBeNull(),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    const closeBtn = document.querySelector(
+      '[data-testid="preflight-result-close"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(closeBtn);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+});
+
 describe("PreflightPanel — Generate button label", () => {
   it("reads 'Generate (N households)' regardless of trigger source", () => {
     const households = [makeHousehold("h-1", "Alice"), makeHousehold("h-2", "Bob")];

--- a/src/components/billing/__tests__/regenerate-multi-dialog.test.tsx
+++ b/src/components/billing/__tests__/regenerate-multi-dialog.test.tsx
@@ -253,6 +253,525 @@ describe("RegenerateMultiDialog", () => {
     vi.unstubAllGlobals();
   });
 
+  it("all-success: dialog closes (calls onOpenChange(false)) and parent banner shows success summary", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lineItems: 2, errors: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = [makeHousehold("h-1", "Alice"), makeHousehold("h-2", "Bob")];
+    const lineItems = new Map<string, BillingLineItem>();
+    lineItems.set("h-1", makeLineItem("h-1", "edge", 10000));
+    lineItems.set("h-2", makeLineItem("h-2", "edge", 12000));
+
+    const onOpenChange = vi.fn();
+    const pushParentBanner = vi.fn();
+    const onSuccess = vi.fn();
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={onOpenChange}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={["h-1", "h-2"]}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={pushParentBanner}
+          pushRowBanner={vi.fn()}
+          onSuccess={onSuccess}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 2 households");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    // No result dialog rendered.
+    expect(
+      document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+    ).toBeNull();
+    expect(onSuccess).toHaveBeenCalled();
+    const banner = pushParentBanner.mock.calls.find(
+      (c) => c[0].tone === "info",
+    )?.[0];
+    expect(banner?.message).toContain("Regenerated 2 household");
+    vi.unstubAllGlobals();
+  });
+
+  it("partial-failure (1 of 3 fails, currently_manual): dialog stays open with warn banner + success count + per-row banner", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 2,
+          errors: [
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "Currently set to manual entry — use per-row regenerate.",
+              code: "currently_manual",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = [
+      makeHousehold("h-1", "Alice"),
+      makeHousehold("h-2", "Bob"),
+      makeHousehold("h-3", "Carol"),
+    ];
+    const lineItems = new Map<string, BillingLineItem>();
+    lineItems.set("h-1", makeLineItem("h-1", "edge", 10000));
+    lineItems.set("h-2", makeLineItem("h-2", "edge", 12000));
+    lineItems.set("h-3", makeLineItem("h-3", "edge", 8000));
+
+    const onOpenChange = vi.fn();
+    const pushParentBanner = vi.fn();
+    const pushRowBanner = vi.fn();
+    const onSuccess = vi.fn();
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={onOpenChange}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={["h-1", "h-2", "h-3"]}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={pushParentBanner}
+          pushRowBanner={pushRowBanner}
+          onSuccess={onSuccess}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 3 households");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    // Result dialog appears, ConfirmDialog auto-close did NOT fire.
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+      ).not.toBeNull(),
+    );
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    // Per-code copy renders in the result list.
+    const list = document.querySelector(
+      '[data-testid="regen-multi-result-failure-list"]',
+    );
+    expect(list).not.toBeNull();
+    expect(list!.textContent).toContain("Carol is set to manual entry");
+
+    // Title reflects partial-success summary.
+    expect(document.body.textContent).toContain(
+      "Regenerated 2 of 3 households",
+    );
+
+    // Per-row banner pushed for the failure (AC4).
+    expect(pushRowBanner).toHaveBeenCalledTimes(1);
+    expect(pushRowBanner.mock.calls[0][0].lineItemId).toBe("li-h-3");
+
+    // Success info banner pushed for the 2 that worked.
+    const info = pushParentBanner.mock.calls.find(
+      (c) => c[0].tone === "info",
+    )?.[0];
+    expect(info?.message).toContain("Regenerated 2 household");
+
+    // onSuccess called (partial-success — clear selection).
+    expect(onSuccess).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("full failure (3 of 3 fail): dialog stays open with destructive banner; onSuccess NOT called", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 0,
+          errors: [
+            {
+              householdId: "h-1",
+              householdName: "Alice",
+              error: "no meter reading",
+              code: "no_meter_reading",
+            },
+            {
+              householdId: "h-2",
+              householdName: "Bob",
+              error: "missing config",
+              code: "missing_openems_config",
+            },
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "no household",
+              code: "unknown_household",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = [
+      makeHousehold("h-1", "Alice"),
+      makeHousehold("h-2", "Bob"),
+      makeHousehold("h-3", "Carol"),
+    ];
+    const lineItems = new Map<string, BillingLineItem>();
+    lineItems.set("h-1", makeLineItem("h-1", "edge", 10000));
+    lineItems.set("h-2", makeLineItem("h-2", "edge", 12000));
+    lineItems.set("h-3", makeLineItem("h-3", "edge", 8000));
+
+    const onSuccess = vi.fn();
+    const pushParentBanner = vi.fn();
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={vi.fn()}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={["h-1", "h-2", "h-3"]}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={pushParentBanner}
+          pushRowBanner={vi.fn()}
+          onSuccess={onSuccess}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 3 households");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+      ).not.toBeNull(),
+    );
+
+    // Title for full failure.
+    expect(document.body.textContent).toContain(
+      "Could not regenerate 3 households",
+    );
+
+    // 3 list items (no truncation).
+    const items = document.querySelectorAll(
+      '[data-testid="regen-multi-result-failure-list"] > li',
+    );
+    expect(items.length).toBe(3);
+    expect(
+      document.querySelector(
+        '[data-testid="regen-multi-result-failure-overflow"]',
+      ),
+    ).toBeNull();
+
+    // Order preserved (AC7).
+    expect(items[0].textContent).toContain("Alice");
+    expect(items[1].textContent).toContain("Bob");
+    expect(items[2].textContent).toContain("Carol");
+
+    // No info banner for full failure.
+    const info = pushParentBanner.mock.calls.find(
+      (c) => c[0].tone === "info",
+    );
+    expect(info).toBeUndefined();
+
+    // onSuccess NOT called for full failure (selection retained for retry).
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("truncation: 7 failures → renders 5 + '+ 2 more'", async () => {
+    const errs = Array.from({ length: 7 }, (_, i) => ({
+      householdId: `h-${i + 1}`,
+      householdName: `Person${i + 1}`,
+      error: "no meter reading",
+      code: "no_meter_reading",
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lineItems: 0, errors: errs }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = errs.map((e) => makeHousehold(e.householdId, e.householdName));
+    const lineItems = new Map<string, BillingLineItem>();
+    households.forEach((h) => lineItems.set(h.id, makeLineItem(h.id, "edge", 1000)));
+
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={vi.fn()}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={households.map((h) => h.id)}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={vi.fn()}
+          pushRowBanner={vi.fn()}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 7 households");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+      ).not.toBeNull(),
+    );
+
+    const items = document.querySelectorAll(
+      '[data-testid="regen-multi-result-failure-list"] > li',
+    );
+    // 5 displayed + 1 overflow li = 6 total.
+    expect(items.length).toBe(6);
+    const overflow = document.querySelector(
+      '[data-testid="regen-multi-result-failure-overflow"]',
+    );
+    expect(overflow).not.toBeNull();
+    expect(overflow!.textContent).toContain("+ 2 more");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("per-error-code copy smoke: maps unknown_household, no_meter_reading, missing_openems_config", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 0,
+          errors: [
+            {
+              householdId: "h-1",
+              householdName: "Alice",
+              error: "raw1",
+              code: "unknown_household",
+            },
+            {
+              householdId: "h-2",
+              householdName: "Bob",
+              error: "raw2",
+              code: "no_meter_reading",
+            },
+            {
+              householdId: "h-3",
+              householdName: "Carol",
+              error: "raw3",
+              code: "missing_openems_config",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = [
+      makeHousehold("h-1", "Alice"),
+      makeHousehold("h-2", "Bob"),
+      makeHousehold("h-3", "Carol"),
+    ];
+    const lineItems = new Map<string, BillingLineItem>();
+    households.forEach((h) =>
+      lineItems.set(h.id, makeLineItem(h.id, "edge", 1000)),
+    );
+
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={vi.fn()}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={["h-1", "h-2", "h-3"]}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={vi.fn()}
+          pushRowBanner={vi.fn()}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 3 households");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+      ).not.toBeNull(),
+    );
+
+    const text = document.querySelector(
+      '[data-testid="regen-multi-result-failure-list"]',
+    )!.textContent ?? "";
+    expect(text).toContain("Alice no longer belongs to this microgrid.");
+    expect(text).toContain("Bob has no current meter reading.");
+    expect(text).toContain(
+      "Carol's edge has no OpenEMS connection configured.",
+    );
+    // Verbatim raw strings should NOT appear (per-code mapping wins).
+    expect(text).not.toContain("raw1");
+    expect(text).not.toContain("raw2");
+    expect(text).not.toContain("raw3");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("default fallback: unknown code renders '${name}: ${error}'", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 0,
+          errors: [
+            {
+              householdId: "h-1",
+              householdName: "Alice",
+              error: "Some unmapped server message",
+              code: "future_code",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = [makeHousehold("h-1", "Alice")];
+    const lineItems = new Map<string, BillingLineItem>();
+    lineItems.set("h-1", makeLineItem("h-1", "edge", 10000));
+
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={vi.fn()}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={["h-1"]}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={vi.fn()}
+          pushRowBanner={vi.fn()}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 1 household");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+      ).not.toBeNull(),
+    );
+
+    const text = document.querySelector(
+      '[data-testid="regen-multi-result-failure-list"]',
+    )!.textContent ?? "";
+    expect(text).toContain("Alice: Some unmapped server message");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("Close button in result view calls onOpenChange(false) and does NOT re-fire onSuccess", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          lineItems: 1,
+          errors: [
+            {
+              householdId: "h-2",
+              householdName: "Bob",
+              error: "no meter",
+              code: "no_meter_reading",
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const households = [makeHousehold("h-1", "Alice"), makeHousehold("h-2", "Bob")];
+    const lineItems = new Map<string, BillingLineItem>();
+    lineItems.set("h-1", makeLineItem("h-1", "edge", 10000));
+    lineItems.set("h-2", makeLineItem("h-2", "edge", 12000));
+
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn();
+    render(
+      <Wrap>
+        <RegenerateMultiDialog
+          open
+          onOpenChange={onOpenChange}
+          billingPeriodId="p-1"
+          selectedHouseholdIds={["h-1", "h-2"]}
+          households={households}
+          lineItemsByHouseholdId={lineItems}
+          pushParentBanner={vi.fn()}
+          pushRowBanner={vi.fn()}
+          onSuccess={onSuccess}
+        />
+      </Wrap>,
+    );
+
+    const confirmBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Regenerate 2 households");
+    await act(async () => {
+      fireEvent.click(confirmBtn!);
+    });
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="regen-multi-result-dialog"]'),
+      ).not.toBeNull(),
+    );
+
+    // onSuccess WAS called once (partial-success → clear selection).
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    // Now click Close.
+    const closeBtn = document.querySelector(
+      '[data-testid="regen-multi-result-close"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(closeBtn);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    // onSuccess was NOT called again by the Close button.
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+
   it("currently_manual error display: renders verbatim when server diverged from client snapshot", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/components/billing/error-code-copy.ts
+++ b/src/components/billing/error-code-copy.ts
@@ -1,0 +1,39 @@
+// errorCodeCopy — friendly per-error-code copy for partial/full failures
+// surfaced inside <RegenerateMultiDialog> and <PreflightPanel> result views.
+//
+// Codes mirror `GenerationErrorCode` in `src/lib/billing/generate.ts:80-86`.
+// The route response includes `error.householdName`, so callers should pass
+// that name straight through here — do NOT re-resolve from the `households`
+// prop (it may have drifted from the server's view).
+//
+// Default fallback for unknown / future codes (or missing `code`):
+//   `${name}: ${error}` — uses the route's verbatim `error` string.
+
+import type { GenerationErrorCode } from "@/lib/billing/generate";
+
+export interface PartialFailureError {
+  householdId: string;
+  householdName: string;
+  error: string;
+  code?: string;
+}
+
+export function errorCodeCopy(err: PartialFailureError): string {
+  const name = err.householdName;
+  switch (err.code as GenerationErrorCode | undefined) {
+    case "currently_manual":
+      return `${name} is set to manual entry — use per-row regenerate.`;
+    case "unknown_household":
+      return `${name} no longer belongs to this microgrid.`;
+    case "no_meter_reading":
+      return `${name} has no current meter reading.`;
+    case "missing_openems_config":
+      return `${name}'s edge has no OpenEMS connection configured.`;
+    case "invalid_manual_reading":
+      return `${name} has an invalid manual reading.`;
+    case "unmetered_no_manual":
+      return `${name} has no meter and no manual reading provided.`;
+    default:
+      return `${name}: ${err.error}`;
+  }
+}

--- a/src/components/billing/preflight-panel.tsx
+++ b/src/components/billing/preflight-panel.tsx
@@ -22,6 +22,15 @@
  * On submit: single POST /api/billing/generate with the manualReadings
  * array and NO householdIds filter (the implicit-add semantic in
  * runGenerationFor processes everything).
+ *
+ * View-state machine (BC3 polish #182):
+ *   - `view === 'form'`   → render the form section (default).
+ *   - `view === 'result'` → render a result section showing per-household
+ *     failures + a Close button. Switched into when the response has
+ *     errors.length > 0 (partial OR full failure). Per AC2 the panel is
+ *     NOT a Radix dialog — view-state mutation is applied to the inline
+ *     <section> markup directly. The all-success branch still calls
+ *     `onClose()` (existing behavior preserved).
  */
 
 import * as React from "react";
@@ -29,6 +38,10 @@ import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Banner } from "@/components/ui/banner";
 import { StatusChip } from "@/components/ui/status-chip";
+import {
+  errorCodeCopy,
+  type PartialFailureError,
+} from "@/components/billing/error-code-copy";
 import type { Household } from "@/lib/types/domain";
 
 export interface PreflightPanelProps {
@@ -48,12 +61,20 @@ interface RowFormState {
   overrideEnabled: boolean;
 }
 
+interface ResultState {
+  errors: PartialFailureError[];
+  successCount: number;
+  attemptedCount: number;
+}
+
 const EMPTY_ROW: RowFormState = {
   startKwh: "",
   endKwh: "",
   reason: "",
   overrideEnabled: false,
 };
+
+const MAX_FAILURES_INLINE = 5;
 
 function parseField(raw: string): { ok: true; value: number } | { ok: false } {
   const trimmed = raw.trim();
@@ -80,6 +101,8 @@ export function PreflightPanel(props: PreflightPanelProps) {
   const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
   const [readyExpanded, setReadyExpanded] = React.useState(false);
   const [overrideExpanded, setOverrideExpanded] = React.useState(false);
+  const [view, setView] = React.useState<"form" | "result">("form");
+  const [result, setResult] = React.useState<ResultState | null>(null);
 
   // Reset state when the panel opens.
   React.useEffect(() => {
@@ -89,6 +112,8 @@ export function PreflightPanel(props: PreflightPanelProps) {
       setErrorMsg(null);
       setReadyExpanded(false);
       setOverrideExpanded(false);
+      setView("form");
+      setResult(null);
     }
   }, [open]);
 
@@ -152,22 +177,54 @@ export function PreflightPanel(props: PreflightPanelProps) {
         }),
       });
       const body = (await res.json().catch(() => ({}))) as {
+        lineItems?: number;
         error?: string;
-        errors?: Array<{ householdName: string; error: string }>;
+        errors?: Array<{
+          householdId: string;
+          householdName: string;
+          error: string;
+          code?: string;
+        }>;
       };
       if (!res.ok) {
         setErrorMsg(body.error ?? "Failed to generate");
         setSubmitting(false);
         return;
       }
-      // Surface partial-failure inline (non-blocking — the panel closes).
+      // Always refresh so partial successes appear on the next render.
+      router.refresh();
+
+      const respErrors = body.errors ?? [];
+      if (respErrors.length > 0) {
+        // Partial OR full failure — switch to result view (panel stays open).
+        const successCount = body.lineItems ?? 0;
+        setResult({
+          errors: respErrors,
+          successCount,
+          attemptedCount: totalCount,
+        });
+        setView("result");
+        setSubmitting(false);
+        return;
+      }
+
+      // All-success path — close the panel (existing behavior preserved).
       setSubmitting(false);
       onClose();
-      router.refresh();
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : "Network error");
       setSubmitting(false);
     }
+  }
+
+  // Result-view: replace the form section with the failure summary.
+  if (view === "result" && result) {
+    return (
+      <ResultSection
+        result={result}
+        onClose={onClose}
+      />
+    );
   }
 
   return (
@@ -341,6 +398,75 @@ export function PreflightPanel(props: PreflightPanelProps) {
             </svg>
           )}
           Generate ({totalCount} household{totalCount === 1 ? "" : "s"})
+        </button>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * ResultSection — replaces the form section when view === 'result'.
+ * Per AC2 the panel is not a Radix dialog, so this is just an inline
+ * <section> swap. "Close" calls onClose() — does NOT need to re-fire
+ * any success callback (partial successes already persisted server-side).
+ */
+function ResultSection(props: {
+  result: ResultState;
+  onClose: () => void;
+}) {
+  const { result, onClose } = props;
+  const { errors, successCount, attemptedCount } = result;
+  const isFullFailure = successCount === 0;
+  const tone: "destructive" | "warn" = isFullFailure ? "destructive" : "warn";
+
+  // Preserve API response order (AC7) — do not re-sort.
+  const displayed = errors.slice(0, MAX_FAILURES_INLINE);
+  const overflow = Math.max(0, errors.length - MAX_FAILURES_INLINE);
+
+  const heading = isFullFailure
+    ? `Could not generate ${attemptedCount} household${attemptedCount === 1 ? "" : "s"}`
+    : `Generated ${successCount} of ${attemptedCount} household${attemptedCount === 1 ? "" : "s"}`;
+
+  const bannerTitle = isFullFailure
+    ? `${errors.length} failure${errors.length === 1 ? "" : "s"}`
+    : `${errors.length} household${errors.length === 1 ? "" : "s"} could not be generated`;
+
+  return (
+    <section
+      data-testid="preflight-panel-result"
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-foreground">{heading}</h3>
+      </div>
+
+      <Banner tone={tone} title={bannerTitle}>
+        <ul
+          data-testid="preflight-result-failure-list"
+          className="mt-1 list-disc space-y-1 pl-5"
+        >
+          {displayed.map((err) => (
+            <li key={err.householdId}>{errorCodeCopy(err)}</li>
+          ))}
+          {overflow > 0 && (
+            <li
+              data-testid="preflight-result-failure-overflow"
+              className="font-medium"
+            >
+              + {overflow} more
+            </li>
+          )}
+        </ul>
+      </Banner>
+
+      <div className="mt-4 flex items-center justify-end gap-2 border-t border-border pt-3">
+        <button
+          type="button"
+          data-testid="preflight-result-close"
+          onClick={onClose}
+          className="inline-flex h-8 items-center rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Close
         </button>
       </div>
     </section>

--- a/src/components/billing/regenerate-multi-dialog.tsx
+++ b/src/components/billing/regenerate-multi-dialog.tsx
@@ -13,13 +13,28 @@
  * householdIds (NO manualReadings). Renders inline destructive banner on
  * non-2xx OR if errors[] is non-empty (top-level + per-row banners pushed
  * via parent callbacks).
+ *
+ * View-state machine (BC3 polish #182):
+ *   - `view === 'form'` → render <ConfirmDialog> (existing happy path).
+ *   - `view === 'result'` → render a parallel Radix <Dialog.Root> with an
+ *     inline banner + "Close" button. Switched into when the response has
+ *     errors.length > 0 (partial OR full failure). <ConfirmDialog>'s footer
+ *     cannot host a "Close-only" view, so we render a sibling dialog instead
+ *     (precedent: ManualEntryDialog in regenerate-row-dialog.tsx:564-723).
  */
 
 import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
 import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { Banner } from "@/components/ui/banner";
 import { Currency } from "@/components/format/currency";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { StatusChip } from "@/components/ui/status-chip";
+import {
+  errorCodeCopy,
+  type PartialFailureError,
+} from "@/components/billing/error-code-copy";
 import type { RowBannerEntry } from "@/components/billing/row-banner-stack";
 import type {
   BillingLineItem,
@@ -56,6 +71,13 @@ export interface RegenerateMultiDialogProps {
 
 const ERROR_BANNER_DURATION_MS = 8000;
 const INFO_BANNER_DURATION_MS = 5000;
+const MAX_FAILURES_INLINE = 5;
+
+interface ResultState {
+  errors: PartialFailureError[];
+  successCount: number;
+  attemptedCount: number;
+}
 
 export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
   const {
@@ -70,6 +92,20 @@ export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
     onSuccess,
   } = props;
   const router = useRouter();
+
+  // View-state: 'form' shows the <ConfirmDialog>; 'result' shows a parallel
+  // Radix Dialog with a banner + Close button. The form view auto-closes on
+  // all-success; the result view is shown only when errors.length > 0.
+  const [view, setView] = React.useState<"form" | "result">("form");
+  const [result, setResult] = React.useState<ResultState | null>(null);
+
+  // Reset view-state whenever the dialog re-opens.
+  React.useEffect(() => {
+    if (open) {
+      setView("form");
+      setResult(null);
+    }
+  }, [open]);
 
   // Build the partition — pure derivation from props.
   type Row = {
@@ -141,7 +177,12 @@ export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
     });
     const body = (await res.json().catch(() => ({}))) as {
       lineItems?: number;
-      errors?: Array<{ householdId: string; error: string; code?: string }>;
+      errors?: Array<{
+        householdId: string;
+        householdName: string;
+        error: string;
+        code?: string;
+      }>;
       error?: string;
     };
     if (!res.ok) {
@@ -156,7 +197,7 @@ export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
     }
 
     const respErrors = body.errors ?? [];
-    // Push per-row destructive banners for failures.
+    // Push per-row destructive banners for failures (preserved per AC4).
     const stamp = Date.now();
     for (const err of respErrors) {
       const li = s.lineItemsByHouseholdId.get(err.householdId);
@@ -181,11 +222,60 @@ export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
       });
     }
 
-    s.onSuccess?.();
+    // Always refresh so partial successes appear on the next render.
     s.router.refresh();
+
+    if (respErrors.length > 0) {
+      // Partial OR full failure — switch to result view (keeps dialog open).
+      // For full failure: leave the selection set intact so the user can
+      // retry from the sticky bar (do NOT call onSuccess).
+      // For partial failure: call onSuccess so the parent clears the
+      // selection set — partial successes are persisted on the server, and
+      // re-running the regenerate would no-op for them (or churn audit).
+      if (successCount > 0) {
+        s.onSuccess?.();
+      }
+      setResult({
+        errors: respErrors,
+        successCount,
+        attemptedCount: s.edgeIds.length,
+      });
+      setView("result");
+      // <ConfirmDialog>.handleConfirm calls onOpenChange(false) on a
+      // resolved promise — that would close the wrapper dialog out from
+      // under our result view. Throw to take the catch branch instead;
+      // the next render swaps to <ResultDialog> (view === 'result'), so
+      // the ConfirmDialog unmounts before its own error footer can show
+      // the marker message.
+      throw new Error("__partial_failure__");
+    }
+
+    // All-success path — auto-close + caller's onSuccess.
+    s.onSuccess?.();
   }
 
   const confirmLabel = `Regenerate ${edgeRows.length} household${edgeRows.length === 1 ? "" : "s"}`;
+
+  const onConfirmHandler = allSelectedAreManual
+    ? async () => {
+        throw new Error(
+          "All selected rows are manual — nothing to regenerate.",
+        );
+      }
+    : handleConfirm;
+
+  // Result-view content (rendered when view === 'result').
+  // Always render the parent <Dialog.Root> conditionally so we never have
+  // both dialogs mounted at the same time.
+  if (view === "result" && result) {
+    return (
+      <ResultDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        result={result}
+      />
+    );
+  }
 
   return (
     <ConfirmDialog
@@ -198,15 +288,7 @@ export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
           ? "Regenerate"
           : confirmLabel
       }
-      onConfirm={
-        allSelectedAreManual
-          ? async () => {
-              throw new Error(
-                "All selected rows are manual — nothing to regenerate.",
-              );
-            }
-          : handleConfirm
-      }
+      onConfirm={onConfirmHandler}
       body={
         <div className="space-y-3">
           {edgeRows.length > 0 && (
@@ -292,5 +374,103 @@ export function RegenerateMultiDialog(props: RegenerateMultiDialogProps) {
         </div>
       }
     />
+  );
+}
+
+/**
+ * ResultDialog — parallel Radix Dialog used when the response had
+ * errors.length > 0. Cannot use <ConfirmDialog> — its footer is fixed to
+ * Cancel + Confirm/Retry and cannot host a "Close-only" view.
+ *
+ * Tone:
+ *   - successCount === 0 (full failure)  → destructive banner.
+ *   - successCount > 0  (partial failure) → warn banner + success summary.
+ *
+ * "Close" button calls `onOpenChange(false)`. Does NOT re-fire `onSuccess`.
+ */
+function ResultDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  result: ResultState;
+}) {
+  const { open, onOpenChange, result } = props;
+  const { errors, successCount, attemptedCount } = result;
+  const isFullFailure = successCount === 0;
+  const tone: "destructive" | "warn" = isFullFailure ? "destructive" : "warn";
+
+  // Preserve API response order (AC7) — do not re-sort by code/severity.
+  const displayed = errors.slice(0, MAX_FAILURES_INLINE);
+  const overflow = Math.max(0, errors.length - MAX_FAILURES_INLINE);
+
+  const title = isFullFailure
+    ? `Could not regenerate ${attemptedCount} household${attemptedCount === 1 ? "" : "s"}`
+    : `Regenerated ${successCount} of ${attemptedCount} household${attemptedCount === 1 ? "" : "s"}`;
+
+  const bannerTitle = isFullFailure
+    ? `${errors.length} failure${errors.length === 1 ? "" : "s"}`
+    : `${errors.length} household${errors.length === 1 ? "" : "s"} could not be regenerated`;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-foreground/55" />
+        <Dialog.Content
+          role="alertdialog"
+          aria-modal
+          data-testid="regen-multi-result-dialog"
+          onEscapeKeyDown={() => onOpenChange(false)}
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[460px] max-w-[94%] -translate-x-1/2 -translate-y-1/2",
+            "overflow-hidden rounded-md border border-border bg-card shadow-elev-3 outline-none",
+          )}
+        >
+          <div
+            aria-hidden="true"
+            className={cn(
+              "h-[6px]",
+              isFullFailure ? "bg-destructive" : "bg-warning",
+            )}
+          />
+          <div className="px-6 pb-2 pt-5">
+            <Dialog.Title className="text-xl font-semibold tracking-tight">
+              {title}
+            </Dialog.Title>
+          </div>
+
+          <div className="px-6 pb-1">
+            <Banner tone={tone} title={bannerTitle}>
+              <ul
+                data-testid="regen-multi-result-failure-list"
+                className="mt-1 list-disc space-y-1 pl-5"
+              >
+                {displayed.map((err) => (
+                  <li key={err.householdId}>{errorCodeCopy(err)}</li>
+                ))}
+                {overflow > 0 && (
+                  <li
+                    data-testid="regen-multi-result-failure-overflow"
+                    className="font-medium"
+                  >
+                    + {overflow} more
+                  </li>
+                )}
+              </ul>
+            </Banner>
+          </div>
+
+          <div className="mt-4 flex items-center justify-end gap-2 bg-muted px-6 pb-[18px] pt-[14px]">
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                data-testid="regen-multi-result-close"
+                className="inline-flex h-8 items-center rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Close
+              </button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }


### PR DESCRIPTION
## Summary

Surfaces partial-failure errors in the dialog/panel where the action originated, so operators don't have to hunt for the error in row-level banners after the surface auto-closes.

**Two surfaces had the same bug**: \`<RegenerateMultiDialog>\` (auto-closes on 200 even with non-empty \`errors[]\`) and \`<PreflightPanel>\` (same). Banners ARE pushed to the parent (multi-dialog only — panel doesn't push at all today, out-of-scope), but the operator never sees them in the originating UI.

**Fix**: \`view: 'form' | 'result'\` state machine in both surfaces.
- All-success → existing auto-close + parent banner (preserved).
- Partial failure → keep open, show warning banner listing failed households + success count, "Close" button.
- Full failure → keep open, show destructive banner listing all failures, "Close" button. Selection set retained for retry.

**Critical**: \`<ConfirmDialog>\` cannot host a result view (its \`handleConfirm\` catches throws into its own error footer, not a custom view). Solution: parallel Radix \`<Dialog.Root>\` for the result view in the multi-dialog. Precedent: \`ManualEntryDialog\` in \`regenerate-row-dialog.tsx\`. Throw-marker trick prevents \`<ConfirmDialog>\`'s auto-close from fighting the swap.

**Per-error-code copy** centralized in new \`error-code-copy.ts\` helper:
- \`currently_manual\`, \`unknown_household\`, \`no_meter_reading\`, \`missing_openems_config\`, \`invalid_manual_reading\`, \`unmetered_no_manual\`
- Default fallback for unknown codes: \`{Household}: {error.error}\`
- Uses \`error.householdName\` from route response (no household-prop re-resolution).

Multi-failure ordering: API response order preserved (no re-sort).

**14 new tests** (7 per surface): all 3 branches × 2 surfaces, per-code smoke, truncation 5+"+N more", default-fallback, Close-button cleanup.

Closes #182.

## Test plan

- [x] \`npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1216 pass) && npm run build\` — all green
- [x] Rebased on top of #185 (eyebrow polish) — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)