### PR TITLE
UX5b — Invite email branding + resend invitation (#184)

### DIFF
--- a/src/app/(dashboard)/settings/users/__tests__/users-page-client.test.tsx
+++ b/src/app/(dashboard)/settings/users/__tests__/users-page-client.test.tsx
@@ -1,0 +1,342 @@
+// @vitest-environment jsdom
+/**
+ * UsersPageClient component tests (UX5b / #184).
+ *
+ * No prior tests existed for this component. Coverage:
+ *   - Per-row "Resend" visibility:
+ *       * Visible only on Invited rows (email_confirmed_at == null).
+ *       * Permission-gated:
+ *         - super_admin: always visible on Invited rows.
+ *         - org_manager: only on org_manager rows in their orgs;
+ *                        hidden on super_admin / cross-org / orphan rows.
+ *   - Per-row "Sending…" state isolates correctly when two rows are
+ *     clicked in sequence (the first row's in-flight state does not
+ *     bleed into the second's button label).
+ *   - Banner discriminated union renders the right tone for each kind
+ *     (invite-success, resend-success, rate-limit, error).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { UsersPageClient } from "../users-page-client";
+import type { UserDirectoryRow } from "@/lib/types/domain";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const ORG_A = "aaaaaaaa-aaaa-4000-8000-000000000001";
+const ORG_B = "bbbbbbbb-bbbb-4000-8000-000000000002";
+const CALLER = "11111111-1111-4000-8000-000000000001";
+
+function makeRow(overrides: Partial<UserDirectoryRow>): UserDirectoryRow {
+  return {
+    user_id: "22222222-2222-4000-8000-000000000002",
+    email: "row@example.com",
+    email_confirmed_at: null,
+    last_sign_in_at: null,
+    first_name: "Row",
+    last_name: "User",
+    phone: null,
+    role: "org_manager",
+    scope_type: "org",
+    scope_id: ORG_A,
+    ...overrides,
+  } as UserDirectoryRow;
+}
+
+function rowOf(row: UserDirectoryRow) {
+  // Locate the <tr> that contains this row's email — robust against
+  // table-cell ordering changes.
+  const cell = screen.getByText(row.email!);
+  const tr = cell.closest("tr");
+  if (!tr) throw new Error("row not found");
+  return within(tr);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Visibility ───────────────────────────────────────────────────────
+
+describe("UsersPageClient — Resend visibility (super_admin)", () => {
+  it("shows Resend on Invited rows and hides it on Active rows", () => {
+    const rows = [
+      makeRow({
+        user_id: "aaaaaaaa-1111-4000-8000-000000000001",
+        email: "invited@example.com",
+        email_confirmed_at: null,
+      }),
+      makeRow({
+        user_id: "bbbbbbbb-1111-4000-8000-000000000002",
+        email: "active@example.com",
+        email_confirmed_at: "2026-04-23T00:00:00Z",
+      }),
+    ];
+
+    render(
+      <UsersPageClient
+        rows={rows}
+        orgs={[{ id: ORG_A, name: "Org A" }]}
+        callerRole="super_admin"
+        callerOrgIds={[]}
+        currentUserId={CALLER}
+      />
+    );
+
+    expect(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i })).toBeDefined();
+    expect(
+      rowOf(rows[1]!).queryByRole("button", { name: /^resend$/i })
+    ).toBeNull();
+  });
+});
+
+describe("UsersPageClient — Resend visibility (org_manager)", () => {
+  it("shows Resend on org_manager rows in their org; hides on cross-org, super_admin, and orphan rows", () => {
+    const rows = [
+      // Org_manager in caller's org → SHOWN.
+      makeRow({
+        user_id: "aaaaaaaa-2222-4000-8000-000000000001",
+        email: "ours@example.com",
+        role: "org_manager",
+        scope_type: "org",
+        scope_id: ORG_A,
+        email_confirmed_at: null,
+      }),
+      // Org_manager in a different org → HIDDEN.
+      makeRow({
+        user_id: "bbbbbbbb-2222-4000-8000-000000000002",
+        email: "theirs@example.com",
+        role: "org_manager",
+        scope_type: "org",
+        scope_id: ORG_B,
+        email_confirmed_at: null,
+      }),
+      // Super_admin row → HIDDEN.
+      makeRow({
+        user_id: "cccccccc-2222-4000-8000-000000000003",
+        email: "admin@example.com",
+        role: "super_admin",
+        scope_type: null,
+        scope_id: null,
+        email_confirmed_at: null,
+      }),
+      // Orphan (null role) → HIDDEN.
+      makeRow({
+        user_id: "dddddddd-2222-4000-8000-000000000004",
+        email: "orphan@example.com",
+        role: null,
+        scope_type: null,
+        scope_id: null,
+        email_confirmed_at: null,
+      }),
+    ];
+
+    render(
+      <UsersPageClient
+        rows={rows}
+        orgs={[
+          { id: ORG_A, name: "Org A" },
+          { id: ORG_B, name: "Org B" },
+        ]}
+        callerRole="org_manager"
+        callerOrgIds={[ORG_A]}
+        currentUserId={CALLER}
+      />
+    );
+
+    expect(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i })).toBeDefined();
+    expect(
+      rowOf(rows[1]!).queryByRole("button", { name: /^resend$/i })
+    ).toBeNull();
+    expect(
+      rowOf(rows[2]!).queryByRole("button", { name: /^resend$/i })
+    ).toBeNull();
+    expect(
+      rowOf(rows[3]!).queryByRole("button", { name: /^resend$/i })
+    ).toBeNull();
+  });
+});
+
+// ── Per-row in-flight state isolation ────────────────────────────────
+
+describe("UsersPageClient — per-row in-flight state isolation", () => {
+  it("Sending… state on row A does not bleed into row B (sequential clicks)", async () => {
+    // First fetch resolves on demand so we can observe row A in-flight.
+    let resolveFirst: (v: Response) => void = () => {};
+    const firstPromise = new Promise<Response>((r) => {
+      resolveFirst = r;
+    });
+    let resolveSecond: (v: Response) => void = () => {};
+    const secondPromise = new Promise<Response>((r) => {
+      resolveSecond = r;
+    });
+
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(() => firstPromise)
+      .mockImplementationOnce(() => secondPromise);
+
+    const rows = [
+      makeRow({
+        user_id: "aaaaaaaa-3333-4000-8000-000000000001",
+        email: "a@example.com",
+      }),
+      makeRow({
+        user_id: "bbbbbbbb-3333-4000-8000-000000000002",
+        email: "b@example.com",
+      }),
+    ];
+
+    render(
+      <UsersPageClient
+        rows={rows}
+        orgs={[{ id: ORG_A, name: "Org A" }]}
+        callerRole="super_admin"
+        callerOrgIds={[]}
+        currentUserId={CALLER}
+      />
+    );
+
+    // Click row A → A shows "Sending…", B remains "Resend".
+    fireEvent.click(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i }));
+
+    await waitFor(() => {
+      expect(rowOf(rows[0]!).getByText(/sending/i)).toBeDefined();
+    });
+    expect(rowOf(rows[1]!).getByRole("button", { name: /^resend$/i })).toBeDefined();
+
+    // Resolve A first so its in-flight clears, then click B.
+    resolveFirst(
+      new Response(JSON.stringify({ resent: true }), { status: 200 })
+    );
+
+    await waitFor(() => {
+      expect(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i })).toBeDefined();
+    });
+
+    fireEvent.click(rowOf(rows[1]!).getByRole("button", { name: /^resend$/i }));
+
+    await waitFor(() => {
+      expect(rowOf(rows[1]!).getByText(/sending/i)).toBeDefined();
+    });
+    // A should be back to "Resend" (not stuck on "Sending…").
+    expect(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i })).toBeDefined();
+
+    resolveSecond(
+      new Response(JSON.stringify({ resent: true }), { status: 200 })
+    );
+
+    await waitFor(() => {
+      expect(rowOf(rows[1]!).getByRole("button", { name: /^resend$/i })).toBeDefined();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Banner discriminated union — tone per kind ───────────────────────
+
+describe("UsersPageClient — banner tone per feedback kind", () => {
+  it("renders 'Invitation resent' (success tone) on 200 from row click", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ resent: true }), { status: 200 })
+    );
+
+    const rows = [
+      makeRow({
+        user_id: "aaaaaaaa-4444-4000-8000-000000000001",
+        email: "row@example.com",
+      }),
+    ];
+
+    render(
+      <UsersPageClient
+        rows={rows}
+        orgs={[{ id: ORG_A, name: "Org A" }]}
+        callerRole="super_admin"
+        callerOrgIds={[]}
+        currentUserId={CALLER}
+      />
+    );
+
+    fireEvent.click(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /invitation resent/i })
+      ).toBeDefined();
+    });
+    // The email appears once in the row cell and once in the banner body.
+    expect(screen.getAllByText(/row@example.com/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders the rate-limit banner on 429", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: "rate", code: "rate_limited" }),
+        { status: 429 }
+      )
+    );
+
+    const rows = [
+      makeRow({
+        user_id: "aaaaaaaa-5555-4000-8000-000000000001",
+        email: "rl@example.com",
+      }),
+    ];
+
+    render(
+      <UsersPageClient
+        rows={rows}
+        orgs={[{ id: ORG_A, name: "Org A" }]}
+        callerRole="super_admin"
+        callerOrgIds={[]}
+        currentUserId={CALLER}
+      />
+    );
+
+    fireEvent.click(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/rate limited/i)).toBeDefined();
+    });
+    expect(screen.getByText(/try again in a few minutes/i)).toBeDefined();
+  });
+
+  it("renders the destructive error banner on a 422 with custom message", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Resend failed: boom" }), {
+        status: 422,
+      })
+    );
+
+    const rows = [
+      makeRow({
+        user_id: "aaaaaaaa-6666-4000-8000-000000000001",
+        email: "err@example.com",
+      }),
+    ];
+
+    render(
+      <UsersPageClient
+        rows={rows}
+        orgs={[{ id: ORG_A, name: "Org A" }]}
+        callerRole="super_admin"
+        callerOrgIds={[]}
+        currentUserId={CALLER}
+      />
+    );
+
+    fireEvent.click(rowOf(rows[0]!).getByRole("button", { name: /^resend$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not resend invitation/i)).toBeDefined();
+    });
+    expect(screen.getByText(/resend failed: boom/i)).toBeDefined();
+  });
+});

--- a/src/app/(dashboard)/settings/users/users-page-client.tsx
+++ b/src/app/(dashboard)/settings/users/users-page-client.tsx
@@ -3,18 +3,24 @@
 /**
  * UsersPageClient — client component for Settings > Users.
  *
- * Holds the Invite + Edit dialog state and the recent-invite success
- * banner. Receives pre-resolved row data + caller context from the
- * server component parent.
+ * Holds the Invite + Edit dialog state and the recent-action banner.
+ * Receives pre-resolved row data + caller context from the server
+ * component parent.
+ *
+ * UX5b (#184): added a per-row "Resend" action and a discriminated
+ * `feedback` state replacing the prior `recentInvite: string | null`,
+ * so the banner can render with the correct tone for invite-success /
+ * resend-success / rate-limit / error.
  */
 import * as React from "react";
+import { useRouter } from "next/navigation";
 import { Banner } from "@/components/ui/banner";
 import {
   InviteUserDialog,
   type OrgOption,
 } from "@/components/users/InviteUserDialog";
 import { EditUserDialog } from "@/components/users/EditUserDialog";
-import { SUPER_ADMIN } from "@/lib/roles";
+import { SUPER_ADMIN, ORG_MANAGER, SCOPE_ORG } from "@/lib/roles";
 import type { UserDirectoryRow, UserRole } from "@/lib/types/domain";
 
 export interface UsersPageClientProps {
@@ -25,12 +31,29 @@ export interface UsersPageClientProps {
   currentUserId: string;
 }
 
+/**
+ * Discriminated union for the page-level banner. The `kind` keeps the
+ * UX-tone-to-state mapping in a single place — see render block.
+ */
+type PageFeedback =
+  | { kind: "invite"; email: string }
+  | { kind: "resend"; email: string }
+  | { kind: "rate-limit"; email: string }
+  | { kind: "error"; email: string; message: string };
+
 export function UsersPageClient(props: UsersPageClientProps) {
+  const router = useRouter();
   const [inviteOpen, setInviteOpen] = React.useState(false);
   const [editTarget, setEditTarget] = React.useState<UserDirectoryRow | null>(
     null
   );
-  const [recentInvite, setRecentInvite] = React.useState<string | null>(null);
+  const [feedback, setFeedback] = React.useState<PageFeedback | null>(null);
+
+  // Per-row in-flight resend state. A Set keeps the membership check
+  // O(1) and avoids per-row component state explosion.
+  const [resendingIds, setResendingIds] = React.useState<Set<string>>(
+    () => new Set()
+  );
 
   const orgNameById = React.useMemo(() => {
     const m = new Map<string, string>();
@@ -55,6 +78,31 @@ export function UsersPageClient(props: UsersPageClientProps) {
     return false;
   }
 
+  /**
+   * Mirror the resend-route permission rule (AC1):
+   *   - super_admin: always allowed.
+   *   - org_manager: only when the row is org_manager-scoped to an
+   *     org the caller can access. Orphans (role === null) are hidden
+   *     for org_managers — they would 403 at the route.
+   *
+   * Hidden (not disabled) on Active rows so the action surface only
+   * shows up where it is meaningful.
+   */
+  function canResendFor(row: UserDirectoryRow): boolean {
+    if (!row.user_id) return false;
+    if (row.email_confirmed_at != null) return false; // Active
+    if (props.callerRole === SUPER_ADMIN) return true;
+    if (
+      row.role === ORG_MANAGER &&
+      row.scope_type === SCOPE_ORG &&
+      row.scope_id != null &&
+      props.callerOrgIds.includes(row.scope_id)
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   function roleLabel(role: UserRole | null): string {
     if (role === "super_admin") return "Super admin";
     if (role === "org_manager") return "Org manager";
@@ -71,6 +119,53 @@ export function UsersPageClient(props: UsersPageClientProps) {
     return row.email_confirmed_at == null ? "Invited" : "Active";
   }
 
+  async function handleResendRow(row: UserDirectoryRow) {
+    if (!row.user_id) return;
+    const userId = row.user_id;
+    const email = row.email ?? "";
+    setFeedback(null);
+    setResendingIds((prev) => {
+      const next = new Set(prev);
+      next.add(userId);
+      return next;
+    });
+    try {
+      const res = await fetch(`/api/users/${userId}/resend-invite`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        setFeedback({ kind: "resend", email });
+        router.refresh();
+        return;
+      }
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+      };
+      if (res.status === 429 || data.code === "rate_limited") {
+        setFeedback({ kind: "rate-limit", email });
+        return;
+      }
+      setFeedback({
+        kind: "error",
+        email,
+        message: data.error ?? "Could not resend invitation.",
+      });
+    } catch {
+      setFeedback({
+        kind: "error",
+        email,
+        message: "Network error. Please retry.",
+      });
+    } finally {
+      setResendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(userId);
+        return next;
+      });
+    }
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -83,9 +178,24 @@ export function UsersPageClient(props: UsersPageClientProps) {
         </button>
       </div>
 
-      {recentInvite && (
+      {feedback?.kind === "invite" && (
         <Banner tone="success" title="Invitation sent">
-          Invitation sent to {recentInvite}.
+          Invitation sent to {feedback.email}.
+        </Banner>
+      )}
+      {feedback?.kind === "resend" && (
+        <Banner tone="success" title="Invitation resent">
+          Invitation resent to {feedback.email}.
+        </Banner>
+      )}
+      {feedback?.kind === "rate-limit" && (
+        <Banner tone="warn" title="Rate limited">
+          Too many invitations sent recently. Try again in a few minutes.
+        </Banner>
+      )}
+      {feedback?.kind === "error" && (
+        <Banner tone="destructive" title="Could not resend invitation">
+          {feedback.message}
         </Banner>
       )}
 
@@ -131,42 +241,58 @@ export function UsersPageClient(props: UsersPageClientProps) {
               </tr>
             </thead>
             <tbody>
-              {props.rows.map((row, idx) => (
-                <tr
-                  key={row.user_id ?? row.email ?? `row-${idx}`}
-                  className="border-t border-border"
-                >
-                  <td className="px-4 py-2 text-foreground">
-                    {row.first_name ?? "—"}
-                  </td>
-                  <td className="px-4 py-2 text-foreground">
-                    {row.last_name ?? "—"}
-                  </td>
-                  <td className="px-4 py-2 text-foreground">
-                    {row.email ?? "—"}
-                  </td>
-                  <td className="px-4 py-2 text-foreground">
-                    {row.phone ?? "—"}
-                  </td>
-                  <td className="px-4 py-2 text-foreground">
-                    {roleLabel(row.role)}
-                  </td>
-                  <td className="px-4 py-2 text-foreground">
-                    {scopeLabel(row)}
-                  </td>
-                  <td className="px-4 py-2 text-foreground">
-                    {statusLabel(row)}
-                  </td>
-                  <td className="px-4 py-2 text-right">
-                    <button
-                      onClick={() => setEditTarget(row)}
-                      className="inline-flex h-8 items-center rounded-md border border-border bg-card px-3 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      Edit
-                    </button>
-                  </td>
-                </tr>
-              ))}
+              {props.rows.map((row, idx) => {
+                const showResend = canResendFor(row);
+                const isResending =
+                  row.user_id != null && resendingIds.has(row.user_id);
+                return (
+                  <tr
+                    key={row.user_id ?? row.email ?? `row-${idx}`}
+                    className="border-t border-border"
+                  >
+                    <td className="px-4 py-2 text-foreground">
+                      {row.first_name ?? "—"}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {row.last_name ?? "—"}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {row.email ?? "—"}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {row.phone ?? "—"}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {roleLabel(row.role)}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {scopeLabel(row)}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {statusLabel(row)}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <div className="inline-flex items-center gap-2">
+                        {showResend && (
+                          <button
+                            onClick={() => handleResendRow(row)}
+                            disabled={isResending}
+                            className="inline-flex h-8 items-center rounded-md border border-border bg-card px-3 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed"
+                          >
+                            {isResending ? "Sending…" : "Resend"}
+                          </button>
+                        )}
+                        <button
+                          onClick={() => setEditTarget(row)}
+                          className="inline-flex h-8 items-center rounded-md border border-border bg-card px-3 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          Edit
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -178,7 +304,7 @@ export function UsersPageClient(props: UsersPageClientProps) {
         callerRole={props.callerRole}
         orgs={props.orgs}
         callerOrgIds={props.callerOrgIds}
-        onSuccess={({ email }) => setRecentInvite(email)}
+        onSuccess={({ email }) => setFeedback({ kind: "invite", email })}
       />
 
       {editTarget && editTarget.user_id && (
@@ -195,6 +321,7 @@ export function UsersPageClient(props: UsersPageClientProps) {
             phone: editTarget.phone,
             role: editTarget.role,
             scope_id: editTarget.scope_id,
+            email_confirmed_at: editTarget.email_confirmed_at,
           }}
           callerRole={props.callerRole}
           canChangeRole={canChangeRoleAny}

--- a/src/app/api/users/[id]/resend-invite/__tests__/rls-route.test.ts
+++ b/src/app/api/users/[id]/resend-invite/__tests__/rls-route.test.ts
@@ -1,0 +1,307 @@
+/**
+ * POST /api/users/[id]/resend-invite — RLS-mode integration test
+ * (UX5b / #184).
+ *
+ * Why this exists in addition to route.test.ts:
+ *
+ * The unit suite (route.test.ts) mocks the user-bound Supabase client,
+ * so .from("user_directory")…maybeSingle() returns whatever the test
+ * declares — there is no RLS evaluation. Until 2026-04-24 the route
+ * read `user_roles` directly; that table's SELECT policies grant only
+ * "own row" + super_admin FOR ALL, so an org_manager B trying to
+ * resend an org_manager C in the SAME org silently received NULL and
+ * was 403'd at the orphan branch. Unit tests caught NONE of this
+ * because the mock returned C's row regardless of identity.
+ *
+ * This file mints real JWTs (`rls.helpers.ts`) and runs the route
+ * handler with a real RLS-bound user client, so the visibility helper
+ * `user_can_see_user_profile(user_id)` (the WHERE clause behind the
+ * `user_directory` view) is actually exercised. The service-role
+ * client is mocked at the module level — `auth.admin.inviteUserByEmail`
+ * is stubbed (no real email) and `auth.admin.getUserById` returns a
+ * synthetic unconfirmed user (so the route reaches the invite call
+ * instead of 409'ing on already-confirmed test users).
+ *
+ * Cases covered:
+ *   - super_admin A → resend any user                  → 200
+ *   - org_manager B (same org) → resend org_manager C → 200  ← the BLOCKER
+ *   - org_manager B → resend org_manager D (other org) → 403
+ *   - org_manager B → resend super_admin A             → 403
+ *   - any caller   → resend nonexistent UUID           → 403
+ *
+ * Opt-out: SKIP_RLS_TESTS=1.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  assertEnvironmentReady,
+  shouldSkip,
+  serviceClient,
+  createTestUser,
+  cleanupTestData,
+  type TestUser,
+} from "@/lib/supabase/__tests__/rls.helpers";
+
+// ── Mocks: server client and service client ───────────────────────────
+//
+// `currentTestUser` is swapped per-test via `setCaller(...)`. The mocked
+// `createClient()` returns that user's RLS-bound Supabase client so the
+// route handler executes against a real Postgres instance under the
+// caller's JWT.
+let currentCallerClient: TestUser["client"] | null = null;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => {
+    if (!currentCallerClient) {
+      throw new Error(
+        "[rls-route.test] currentCallerClient not set; call setCaller() in the test"
+      );
+    }
+    return currentCallerClient;
+  },
+}));
+
+// Service-client mock: stub auth.admin.* so we don't actually send mail
+// and so getUserById returns a synthetic unconfirmed user (the real test
+// users created in beforeAll have email_confirmed_at != null and would
+// 409 at the pre-check). The body of `getUserById` reflects whichever
+// user we're targeting — set per test via `setTargetEmail`.
+let mockTargetEmail = "rls-target@test.local";
+let mockTargetUserId = "00000000-0000-0000-0000-000000000000";
+let mockGetUserByIdError: { code?: string; message: string } | null = null;
+const inviteSpy = vi.fn();
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    auth: {
+      admin: {
+        getUserById: vi.fn(async () => ({
+          data: mockGetUserByIdError
+            ? { user: null }
+            : {
+                user: {
+                  id: mockTargetUserId,
+                  email: mockTargetEmail,
+                  email_confirmed_at: null,
+                },
+              },
+          error: mockGetUserByIdError,
+        })),
+        inviteUserByEmail: vi.fn(async (...args: unknown[]) => {
+          inviteSpy(...args);
+          return {
+            data: { user: { id: mockTargetUserId } },
+            error: null,
+          };
+        }),
+      },
+    },
+  }),
+}));
+
+// ── Fixture state ─────────────────────────────────────────────────────
+
+const FIXTURE = {
+  orgX: "ddddeeee-aaaa-4000-8000-000000000001",
+  orgY: "ddddeeee-bbbb-4000-8000-000000000001",
+};
+
+const FIXTURE_EMAILS = [
+  "ux5b-rls-super@test.local",
+  "ux5b-rls-mgr-b@test.local",
+  "ux5b-rls-mgr-c@test.local",
+  "ux5b-rls-mgr-d@test.local",
+];
+
+let userSuper: TestUser;
+let userMgrB: TestUser;
+let userMgrC: TestUser;
+let userMgrD: TestUser;
+
+const NONEXISTENT_UUID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+
+beforeAll(async () => {
+  if (shouldSkip()) return;
+  await assertEnvironmentReady();
+
+  const svc = await serviceClient();
+
+  // Idempotent cleanup before insert.
+  await cleanupTestData({
+    orgIds: [FIXTURE.orgX, FIXTURE.orgY],
+    userEmails: FIXTURE_EMAILS,
+  });
+
+  const { error: orgErr } = await svc.from("organizations").insert([
+    { id: FIXTURE.orgX, name: "UX5b RLS Org X" },
+    { id: FIXTURE.orgY, name: "UX5b RLS Org Y" },
+  ]);
+  if (orgErr) throw new Error(`[fixture] orgs: ${orgErr.message}`);
+
+  [userSuper, userMgrB, userMgrC, userMgrD] = await Promise.all([
+    createTestUser({ email: FIXTURE_EMAILS[0], role: "super_admin" }),
+    createTestUser({
+      email: FIXTURE_EMAILS[1],
+      role: "org_manager",
+      scopeId: FIXTURE.orgX,
+    }),
+    createTestUser({
+      email: FIXTURE_EMAILS[2],
+      role: "org_manager",
+      scopeId: FIXTURE.orgX,
+    }),
+    createTestUser({
+      email: FIXTURE_EMAILS[3],
+      role: "org_manager",
+      scopeId: FIXTURE.orgY,
+    }),
+  ]);
+}, 60_000);
+
+afterAll(async () => {
+  if (shouldSkip()) return;
+  await cleanupTestData({
+    orgIds: [FIXTURE.orgX, FIXTURE.orgY],
+    userEmails: FIXTURE_EMAILS,
+  });
+}, 30_000);
+
+beforeEach(() => {
+  inviteSpy.mockReset();
+  currentCallerClient = null;
+  mockGetUserByIdError = null;
+  mockTargetEmail = "rls-target@test.local";
+  mockTargetUserId = "00000000-0000-0000-0000-000000000000";
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeRequest(id: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/users/${id}/resend-invite`,
+    { method: "POST" }
+  );
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function setCaller(u: TestUser) {
+  currentCallerClient = u.client;
+}
+
+function setTarget(u: TestUser) {
+  mockTargetUserId = u.userId;
+  mockTargetEmail = `synthetic-${u.userId.slice(0, 8)}@test.local`;
+}
+
+function skipIfRequested(): boolean {
+  if (shouldSkip()) {
+    // The harness skips at the file level only when SKIP_RLS_TESTS=1
+    // and the suite-level beforeAll early-returns. Per-test guard is
+    // redundant but matches the pattern in user_directory_view.test.ts.
+    console.log("[rls-route] SKIP_RLS_TESTS=1 — skipping case.");
+    return true;
+  }
+  return false;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("POST /api/users/[id]/resend-invite (RLS mode)", () => {
+  it("super_admin A → resend org_manager C → 200", async () => {
+    if (skipIfRequested()) return;
+    setCaller(userSuper);
+    setTarget(userMgrC);
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(userMgrC.userId), makeContext(userMgrC.userId));
+    expect(res.status).toBe(200);
+    expect(inviteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("org_manager B (same org) → resend org_manager C → 200 (BLOCKER coverage)", async () => {
+    // This is the case the unit-test mock paved over: pre-fix, the route
+    // read `user_roles` directly and B saw NULL for C's row → orphan
+    // branch → 403. With user_directory the visibility helper grants B
+    // visibility on C → org_manager target branch → currentUserCanAccessOrg
+    // succeeds → 200.
+    if (skipIfRequested()) return;
+    setCaller(userMgrB);
+    setTarget(userMgrC);
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(userMgrC.userId), makeContext(userMgrC.userId));
+    expect(res.status).toBe(200);
+    expect(inviteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("org_manager B → resend org_manager D (different org) → 403", async () => {
+    if (skipIfRequested()) return;
+    setCaller(userMgrB);
+    setTarget(userMgrD);
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(userMgrD.userId), makeContext(userMgrD.userId));
+    expect(res.status).toBe(403);
+    expect(inviteSpy).not.toHaveBeenCalled();
+  });
+
+  it("org_manager B → resend super_admin A → 403", async () => {
+    if (skipIfRequested()) return;
+    setCaller(userMgrB);
+    setTarget(userSuper);
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(userSuper.userId), makeContext(userSuper.userId));
+    expect(res.status).toBe(403);
+    expect(inviteSpy).not.toHaveBeenCalled();
+  });
+
+  it("org_manager B → resend nonexistent UUID → 403 (uniform with cross-org)", async () => {
+    // Enumeration defense: invisible-to-caller and doesn't-exist must
+    // be indistinguishable from outside. Both produce 403.
+    if (skipIfRequested()) return;
+    setCaller(userMgrB);
+    // getUserById would return user_not_found if reached, but the route
+    // MUST short-circuit on the visibility miss BEFORE calling it.
+    mockGetUserByIdError = { code: "user_not_found", message: "not found" };
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest(NONEXISTENT_UUID),
+      makeContext(NONEXISTENT_UUID)
+    );
+    expect(res.status).toBe(403);
+    expect(inviteSpy).not.toHaveBeenCalled();
+  });
+
+  it("super_admin A → resend nonexistent UUID → 404 (visibility passes; lookup misses)", async () => {
+    // For super_admin the `user_directory` row is also NULL on a
+    // nonexistent UUID, so the route's "no row + caller is super" branch
+    // proceeds to getUserById, which surfaces 404. This documents the
+    // intentional asymmetry: super_admin gets the canonical 404; everyone
+    // else gets 403.
+    if (skipIfRequested()) return;
+    setCaller(userSuper);
+    mockGetUserByIdError = { code: "user_not_found", message: "not found" };
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest(NONEXISTENT_UUID),
+      makeContext(NONEXISTENT_UUID)
+    );
+    expect(res.status).toBe(404);
+    expect(inviteSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/users/[id]/resend-invite/__tests__/route.test.ts
+++ b/src/app/api/users/[id]/resend-invite/__tests__/route.test.ts
@@ -1,0 +1,467 @@
+/**
+ * POST /api/users/[id]/resend-invite — route handler unit tests
+ * (UX5b / #184).
+ *
+ * Mocks Supabase user-bound + service clients. Covers (mirroring AC1
+ * Steps A→G):
+ *   - 200: happy path (super_admin → org_manager target).
+ *   - 401: no caller session.
+ *   - 403: org_manager → super_admin target.
+ *   - 403: org_manager → cross-org org_manager target.
+ *   - 403: org_manager → orphan target (no role row).
+ *   - 404: target not found in auth.users (lookup AFTER permission has passed).
+ *   - 409: pre-check email_confirmed_at IS NOT NULL.
+ *   - 409: race — GoTrue returns email_exists.
+ *   - 429: rate-limit by error.code.
+ *   - 429: rate-limit by message-text fallback.
+ *   - 422: any other GoTrue error.
+ *   - Ordering: when permission would 403 AND target also doesn't
+ *     exist, the route MUST 403 (permission-before-lookup).
+ *   - 400: invalid UUID in path.
+ *
+ * The two-client pattern is mocked via vi.mock() with mutable handles
+ * the tests reset in beforeEach.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+// Caller user (auth.getUser result).
+let mockCaller: { id: string; email?: string } | null = null;
+
+// Mock for the user-bound client `.from("user_directory").select(...).eq(...).maybeSingle()`
+// Returns the target's CURRENT row (or null when invisible/absent). The
+// route was migrated from `user_roles` → `user_directory` because the
+// former's RLS policies block org_manager → org_manager-in-same-org reads;
+// the view's WHERE filter (`user_can_see_user_profile(user_id)`) is the
+// canonical visibility gate. A visible orphan surfaces as a row with
+// NULL role/scope columns (LEFT JOIN miss on user_roles).
+let mockTargetRoleRow: {
+  role: "super_admin" | "org_manager" | null;
+  scope_type: "org" | null;
+  scope_id: string | null;
+} | null = null;
+
+// Roles for the caller (used by access.ts helpers via the same mock from()).
+let mockCallerRoles: Array<{
+  role: "super_admin" | "org_manager";
+  scope_type: "org" | null;
+  scope_id: string | null;
+}> = [];
+
+// Mock for service-client svc.auth.admin.getUserById
+let mockGetUserByIdResult: {
+  data: { user: { id: string; email: string; email_confirmed_at: string | null } | null };
+  error: { code?: string; message: string } | null;
+} = { data: { user: null }, error: { code: "user_not_found", message: "not found" } };
+
+// Mock for service-client svc.auth.admin.inviteUserByEmail
+let mockInviteResult: {
+  data: { user: { id: string } | null };
+  error: { code?: string; message: string } | null;
+} = { data: { user: null }, error: null };
+
+// Spy capturing the inviteUserByEmail args for shape assertions.
+const inviteUserByEmailSpy = vi.fn();
+
+// User-bound client `.from('user_profiles')` and `.from('organizations')`
+// chains used by buildInviteDataPayload — return permissive defaults.
+function userClientFromImpl(table: string) {
+  if (table === "user_profiles") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: vi.fn(async () => ({
+            data: { first_name: "Test", last_name: "Caller" },
+            error: null,
+          })),
+        }),
+      }),
+    };
+  }
+  if (table === "organizations") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: vi.fn(async () => ({
+            data: { name: "Test Org" },
+            error: null,
+          })),
+        }),
+      }),
+    };
+  }
+  if (table === "user_directory") {
+    // Target lookup. `eq("user_id", targetId).maybeSingle()`.
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: vi.fn(async () => ({
+            data: mockTargetRoleRow,
+            error: null,
+          })),
+        }),
+      }),
+    };
+  }
+  if (table === "user_roles") {
+    // After the route migration, only access.ts's `getCurrentUserRoles`
+    // (caller-roles fetch) reads user_roles via the user-bound client.
+    // The chain is `select("*").eq("user_id", caller.id).returns()`.
+    return {
+      select: () => ({
+        eq: () => ({
+          returns: () =>
+            Promise.resolve({ data: mockCallerRoles, error: null }),
+        }),
+      }),
+    };
+  }
+  throw new Error(`Unexpected table in userClient: ${table}`);
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: vi.fn(userClientFromImpl),
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: mockCaller },
+        error: null,
+      })),
+    },
+  }),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    auth: {
+      admin: {
+        getUserById: vi.fn(async () => mockGetUserByIdResult),
+        inviteUserByEmail: vi.fn(async (...args: unknown[]) => {
+          inviteUserByEmailSpy(...args);
+          return mockInviteResult;
+        }),
+      },
+    },
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const CALLER_UUID = "11111111-1111-4000-8000-000000000001";
+const TARGET_UUID = "22222222-2222-4000-8000-000000000002";
+const ORG_A = "aaaaaaaa-aaaa-4000-8000-000000000001";
+const ORG_B = "bbbbbbbb-bbbb-4000-8000-000000000002";
+
+function makeRequest(id: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/users/${id}/resend-invite`,
+    { method: "POST" }
+  );
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inviteUserByEmailSpy.mockReset();
+  mockCaller = { id: CALLER_UUID, email: "caller@example.com" };
+  mockCallerRoles = [];
+  mockTargetRoleRow = null;
+  mockGetUserByIdResult = {
+    data: { user: null },
+    error: { code: "user_not_found", message: "not found" },
+  };
+  mockInviteResult = { data: { user: { id: TARGET_UUID } }, error: null };
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("POST /api/users/[id]/resend-invite", () => {
+  // ── 400: invalid UUID ─────────────────────────────────────────────
+  it("returns 400 for a malformed UUID in the path", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest("not-a-uuid"), makeContext("not-a-uuid"));
+    expect(res.status).toBe(400);
+  });
+
+  // ── 401: no session ──────────────────────────────────────────────
+  it("returns 401 when no caller session is present", async () => {
+    mockCaller = null;
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/auth/i);
+  });
+
+  // ── 403: org_manager → super_admin target ───────────────────────
+  it("returns 403 when org_manager attempts to resend a super_admin", async () => {
+    mockCallerRoles = [{ role: "org_manager", scope_type: "org", scope_id: ORG_A }];
+    mockTargetRoleRow = { role: "super_admin", scope_type: null, scope_id: null };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(403);
+  });
+
+  // ── 403: org_manager → cross-org org_manager ────────────────────
+  it("returns 403 when org_manager attempts to resend an org_manager scoped to a different org", async () => {
+    mockCallerRoles = [{ role: "org_manager", scope_type: "org", scope_id: ORG_A }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_B };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(403);
+  });
+
+  // ── 403: org_manager → orphan (no role row) ─────────────────────
+  // Either the target genuinely has no role row, OR RLS hid it. Uniform 403.
+  it("returns 403 when org_manager hits an orphan target (null role row)", async () => {
+    mockCallerRoles = [{ role: "org_manager", scope_type: "org", scope_id: ORG_A }];
+    mockTargetRoleRow = null;
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(403);
+  });
+
+  // ── Permission-before-lookup ordering ──────────────────────────
+  // A non-existent target combined with insufficient permission MUST 403,
+  // not 404. This prevents an attacker from probing UUIDs via 404s.
+  it("returns 403 (NOT 404) when target doesn't exist AND caller lacks permission", async () => {
+    mockCallerRoles = [{ role: "org_manager", scope_type: "org", scope_id: ORG_A }];
+    mockTargetRoleRow = null; // target has no role row OR RLS-hidden
+    // getUserById would return user_not_found if reached, but the route
+    // MUST short-circuit on the permission failure before calling it.
+    mockGetUserByIdResult = {
+      data: { user: null },
+      error: { code: "user_not_found", message: "not found" },
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(403);
+  });
+
+  // ── 404: missing auth user (only after permission has passed) ──
+  it("returns 404 when the target user does not exist in auth.users (super_admin caller)", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = null; // orphan path, super_admin allowed
+    mockGetUserByIdResult = {
+      data: { user: null },
+      error: { code: "user_not_found", message: "not found" },
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when getUserById returns null user with no error code", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = null;
+    mockGetUserByIdResult = { data: { user: null }, error: null };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(404);
+  });
+
+  // ── 409: already accepted (pre-check) ──────────────────────────
+  it("returns 409 when the target has already accepted (email_confirmed_at not null)", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "target@example.com",
+          email_confirmed_at: "2026-04-24T00:00:00Z",
+        },
+      },
+      error: null,
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toMatch(/already accepted/i);
+    expect(inviteUserByEmailSpy).not.toHaveBeenCalled();
+  });
+
+  // ── 409: race — GoTrue returns email_exists ────────────────────
+  it("returns 409 when GoTrue races on email_exists (target confirmed mid-flight)", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "target@example.com",
+          email_confirmed_at: null,
+        },
+      },
+      error: null,
+    };
+    mockInviteResult = {
+      data: { user: null },
+      error: { code: "email_exists", message: "already registered" },
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toMatch(/already accepted/i);
+  });
+
+  // ── 429: rate-limit by error.code ──────────────────────────────
+  it("returns 429 with code: rate_limited when GoTrue surfaces over_email_send_rate_limit", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "target@example.com",
+          email_confirmed_at: null,
+        },
+      },
+      error: null,
+    };
+    mockInviteResult = {
+      data: { user: null },
+      error: {
+        code: "over_email_send_rate_limit",
+        message: "rate limit exceeded",
+      },
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.code).toBe("rate_limited");
+    expect(json.error).toMatch(/try again/i);
+  });
+
+  // ── 429: rate-limit by message-text fallback (no code) ─────────
+  it("returns 429 when older SDK omits code but message contains 'rate limit'", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "target@example.com",
+          email_confirmed_at: null,
+        },
+      },
+      error: null,
+    };
+    mockInviteResult = {
+      data: { user: null },
+      error: { message: "Email rate limit reached" }, // no code
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.code).toBe("rate_limited");
+  });
+
+  // ── 422: other GoTrue error ────────────────────────────────────
+  it("returns 422 for any other GoTrue error", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "target@example.com",
+          email_confirmed_at: null,
+        },
+      },
+      error: null,
+    };
+    mockInviteResult = {
+      data: { user: null },
+      error: { code: "unexpected_failure", message: "something else" },
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toMatch(/Resend failed/i);
+  });
+
+  // ── 200: happy path (super_admin → org_manager target) ────────
+  it("returns 200 { resent: true } and forwards data payload to GoTrue", async () => {
+    mockCallerRoles = [{ role: "super_admin", scope_type: null, scope_id: null }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "target@example.com",
+          email_confirmed_at: null,
+        },
+      },
+      error: null,
+    };
+    mockInviteResult = {
+      data: { user: { id: TARGET_UUID } },
+      error: null,
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.resent).toBe(true);
+
+    // Verify the data payload was forwarded with the expected shape.
+    expect(inviteUserByEmailSpy).toHaveBeenCalledTimes(1);
+    const [emailArg, optsArg] = inviteUserByEmailSpy.mock.calls[0]!;
+    expect(emailArg).toBe("target@example.com");
+    expect(optsArg).toMatchObject({
+      data: {
+        invited_by_name: expect.any(String),
+        org_name: "Test Org",
+        role_label: "an organization manager",
+        app_name: "Metering & Billing Engine",
+      },
+    });
+  });
+
+  // ── 200: org_manager resending an org_manager in their org ──────
+  it("allows org_manager to resend an org_manager in their org", async () => {
+    mockCallerRoles = [{ role: "org_manager", scope_type: "org", scope_id: ORG_A }];
+    mockTargetRoleRow = { role: "org_manager", scope_type: "org", scope_id: ORG_A };
+    mockGetUserByIdResult = {
+      data: {
+        user: {
+          id: TARGET_UUID,
+          email: "peer@example.com",
+          email_confirmed_at: null,
+        },
+      },
+      error: null,
+    };
+    mockInviteResult = {
+      data: { user: { id: TARGET_UUID } },
+      error: null,
+    };
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(TARGET_UUID), makeContext(TARGET_UUID));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/users/[id]/resend-invite/route.ts
+++ b/src/app/api/users/[id]/resend-invite/route.ts
@@ -1,0 +1,259 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import {
+  currentUserIsSuperAdmin,
+  currentUserCanAccessOrg,
+} from "@/lib/auth/access";
+import { SUPER_ADMIN, ORG_MANAGER, SCOPE_ORG } from "@/lib/roles";
+import { buildInviteDataPayload } from "@/lib/auth/invite-data-payload";
+import type { UserRole, RoleScopeType } from "@/lib/types/domain";
+
+/**
+ * POST /api/users/[id]/resend-invite — re-issue an invitation email
+ * for an existing-but-unconfirmed user (UX5b / #184).
+ *
+ * Two-client pattern (mirrors POST /api/users/invite):
+ *   userClient = createClient()         → permission checks (RLS-honoring).
+ *   svc        = createServiceClient()  → svc.auth.admin.* ops only.
+ *
+ * Security ordering — permission BEFORE target lookup. Probing UUIDs
+ * via this endpoint must produce uniform 403 for invisible rows so
+ * an attacker cannot distinguish "exists but you can't resend" from
+ * "doesn't exist":
+ *
+ *   Step A — caller authentication.
+ *           userClient.auth.getUser() → 401 if no session.
+ *
+ *   Step B — resolve target's CURRENT role row via the user_directory
+ *           VIEW (user-bound client). The view's WHERE clause calls
+ *           `user_can_see_user_profile(user_id)` so RLS-equivalent
+ *           visibility is enforced uniformly: invisible row → uniform
+ *           403, never "not found". Reading directly from `user_roles`
+ *           would NOT work for org_manager → org_manager-in-same-org
+ *           because no `user_roles` SELECT policy grants cross-user
+ *           reads (only "own row" + super_admin FOR ALL).
+ *
+ *           Orphans surface as a row whose `role` column is NULL (LEFT
+ *           JOIN miss). The visibility helper still gates them: an
+ *           orphan is only visible to the orphan-target itself OR a
+ *           super_admin. Caller-side we still require super_admin to
+ *           proceed on a NULL-role row.
+ *
+ *   Step C — caller permission against TARGET's role row.
+ *           super_admin target → caller must be super_admin.
+ *           org_manager target → caller must pass currentUserCanAccessOrg.
+ *
+ *   Step D — target user lookup via svc.auth.admin.getUserById.
+ *           Both error.code === 'user_not_found' AND !data.user → 404.
+ *
+ *   Step E — pre-check email_confirmed_at IS NOT NULL → 409
+ *           "User has already accepted their invitation."
+ *
+ *   Step F — build the data payload (shared helper) reflecting the
+ *           target's CURRENT role/scope (architect decision: invite
+ *           reflects current state, not the original).
+ *
+ *   Step G — svc.auth.admin.inviteUserByEmail(email, { data }).
+ *           - 'over_email_send_rate_limit' (or message-text fallback) → 429.
+ *           - 'email_exists' (race: user confirmed between pre-check and
+ *             GoTrue call) → 409 with the same shape as the pre-check.
+ *           - any other error → 422.
+ *
+ * Returns 200 { resent: true } on success. Idempotent at the API
+ * layer; GoTrue rate-limits internally.
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface CurrentRoleRow {
+  role: UserRole | null;
+  scope_type: RoleScopeType | null;
+  scope_id: string | null;
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id: targetId } = await params;
+
+  if (!UUID_RE.test(targetId)) {
+    return NextResponse.json(
+      { error: "Invalid user id — expected UUID." },
+      { status: 400 }
+    );
+  }
+
+  const userClient = await createClient();
+
+  // ── Step A: authenticate caller ────────────────────────────────────
+  const {
+    data: { user: caller },
+  } = await userClient.auth.getUser();
+  if (!caller) {
+    return NextResponse.json(
+      { error: "Authentication required." },
+      { status: 401 }
+    );
+  }
+
+  // ── Step B: resolve target's CURRENT role row via user_directory ───
+  //
+  // user_directory is a VIEW (00014_user_directory_view.sql) that
+  // joins auth.users LEFT user_profiles LEFT user_roles, gated by
+  // `WHERE user_can_see_user_profile(au.id)`. The helper is
+  // SECURITY DEFINER and reads `auth.uid()` from the caller's JWT —
+  // it returns true iff the caller is the target, is a super_admin,
+  // OR shares an org-scoped manager role with the target. So a row
+  // returned here is guaranteed visible to the caller; a NULL row
+  // means "doesn't exist OR you can't see it" — uniform 403 (the
+  // enumeration-defense rule the route docstring describes).
+  //
+  // We deliberately do NOT read `user_roles` directly: that table's
+  // SELECT policies only grant "own row" + super_admin FOR ALL, so
+  // an org_manager B trying to resend an org_manager C in the SAME
+  // org would get a NULL row and be 403'd — even though both the
+  // RLS helper and the rest of the app correctly consider C visible
+  // to B. The view is the single source of truth for "can A see B".
+  const { data: targetRoleRow } = await userClient
+    .from("user_directory")
+    .select("role, scope_type, scope_id")
+    .eq("user_id", targetId)
+    .maybeSingle<CurrentRoleRow>();
+
+  // ── Step C: caller permission against TARGET's role ────────────────
+  const callerIsSuper = await currentUserIsSuperAdmin(userClient);
+
+  if (!targetRoleRow) {
+    // Either the target doesn't exist OR is invisible to this caller.
+    // Uniform 403 (existence-leak hardening). Super_admin sees all
+    // rows via the view, so a NULL here for super_admin truly means
+    // "doesn't exist" — but we still 403 here to keep one branch;
+    // the canonical 404 surfaces at Step D via getUserById.
+    if (!callerIsSuper) {
+      return NextResponse.json(
+        { error: "You do not have permission to resend this invitation." },
+        { status: 403 }
+      );
+    }
+    // super_admin proceeds; getUserById will produce the canonical 404
+    // if the auth user is genuinely absent.
+  } else if (targetRoleRow.role == null) {
+    // Visible row with NULL role = orphan (LEFT JOIN miss on user_roles).
+    // Only a super_admin can recover an orphan — everyone else 403.
+    if (!callerIsSuper) {
+      return NextResponse.json(
+        { error: "You do not have permission to resend this invitation." },
+        { status: 403 }
+      );
+    }
+  } else if (targetRoleRow.role === SUPER_ADMIN) {
+    if (!callerIsSuper) {
+      return NextResponse.json(
+        { error: "You do not have permission to resend this invitation." },
+        { status: 403 }
+      );
+    }
+  } else if (targetRoleRow.role === ORG_MANAGER) {
+    if (
+      targetRoleRow.scope_type !== SCOPE_ORG ||
+      !targetRoleRow.scope_id ||
+      !(await currentUserCanAccessOrg(userClient, targetRoleRow.scope_id))
+    ) {
+      return NextResponse.json(
+        { error: "You do not have permission to resend this invitation." },
+        { status: 403 }
+      );
+    }
+  } else {
+    // Unknown role enum value (future-proofing). Reject conservatively.
+    return NextResponse.json(
+      { error: "You do not have permission to resend this invitation." },
+      { status: 403 }
+    );
+  }
+
+  // ── Step D: target user lookup (after permission has passed) ───────
+  const svc = createServiceClient();
+  const lookup = await svc.auth.admin.getUserById(targetId);
+  const lookupErrCode = (lookup.error as { code?: string } | null)?.code;
+  if (lookupErrCode === "user_not_found" || !lookup.data?.user) {
+    return NextResponse.json({ error: "User not found." }, { status: 404 });
+  }
+  const targetUser = lookup.data.user;
+  const targetEmail = targetUser.email;
+  if (!targetEmail) {
+    // Defensive — auth.users rows always have email for invite-flow
+    // users, but the SDK type permits undefined.
+    return NextResponse.json(
+      { error: "Target user has no email on record." },
+      { status: 422 }
+    );
+  }
+
+  // ── Step E: pre-check already-confirmed ────────────────────────────
+  if (targetUser.email_confirmed_at != null) {
+    return NextResponse.json(
+      { error: "User has already accepted their invitation." },
+      { status: 409 }
+    );
+  }
+
+  // ── Step F: build data payload reflecting CURRENT role/scope ──────
+  //
+  // For orphans (no role row), we still pass app_name + a generic role
+  // label so the template renders consistently. invited_by_name and
+  // org_name are populated when applicable.
+  const data = await buildInviteDataPayload({
+    caller,
+    targetRole: targetRoleRow?.role ?? ORG_MANAGER, // orphan fallback
+    targetOrgId: targetRoleRow?.scope_id ?? null,
+    supabase: userClient,
+  });
+
+  // ── Step G: re-issue the invite ────────────────────────────────────
+  const inviteRes = await svc.auth.admin.inviteUserByEmail(targetEmail, {
+    data,
+  });
+
+  if (inviteRes.error) {
+    const errCode = (inviteRes.error as { code?: string }).code;
+    const msg = inviteRes.error.message?.toLowerCase() ?? "";
+
+    // Rate-limit detection: code first, then message-text fallback for
+    // older GoTrue/SDK versions that don't set `code`.
+    const isRateLimited =
+      errCode === "over_email_send_rate_limit" ||
+      msg.includes("over_email_send_rate_limit") ||
+      msg.includes("rate limit") ||
+      msg.includes("too many requests");
+    if (isRateLimited) {
+      return NextResponse.json(
+        {
+          error:
+            "Too many invitations sent recently. Try again in a few minutes.",
+          code: "rate_limited",
+        },
+        { status: 429 }
+      );
+    }
+
+    // Race: target was confirmed between our pre-check and GoTrue's
+    // call. Surface the same shape as the pre-check.
+    if (errCode === "email_exists") {
+      return NextResponse.json(
+        { error: "User has already accepted their invitation." },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: `Resend failed: ${inviteRes.error.message}` },
+      { status: 422 }
+    );
+  }
+
+  return NextResponse.json({ resent: true }, { status: 200 });
+}

--- a/src/app/api/users/invite/__tests__/route.test.ts
+++ b/src/app/api/users/invite/__tests__/route.test.ts
@@ -1,0 +1,255 @@
+/**
+ * POST /api/users/invite — route handler tests (UX5b / #184).
+ *
+ * No prior test suite existed for the invite route. This file covers
+ * the happy paths + the new AC2 contract (data payload forwarded to
+ * inviteUserByEmail).
+ *
+ * Mocks: Supabase user-bound + service-role clients, including the
+ * fn_finalize_user_invitation RPC.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+let mockCaller: { id: string; email?: string } | null = null;
+let mockCallerRoles: Array<{
+  role: "super_admin" | "org_manager";
+  scope_type: "org" | null;
+  scope_id: string | null;
+}> = [];
+let mockRpcResult: { error: { code?: string; message: string } | null } = {
+  error: null,
+};
+let mockInviteResult: {
+  data: { user: { id: string } | null };
+  error: { code?: string; message: string } | null;
+} = {
+  data: { user: { id: "00000000-0000-4000-8000-000000000099" } },
+  error: null,
+};
+
+const inviteUserByEmailSpy = vi.fn();
+const rpcSpy = vi.fn();
+
+function userClientFromImpl(table: string) {
+  if (table === "user_profiles") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: vi.fn(async () => ({
+            data: { first_name: "Inviter", last_name: "Name" },
+            error: null,
+          })),
+        }),
+      }),
+    };
+  }
+  if (table === "organizations") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: vi.fn(async () => ({
+            data: { name: "Test Org" },
+            error: null,
+          })),
+        }),
+      }),
+    };
+  }
+  if (table === "user_roles") {
+    return {
+      select: () => ({
+        eq: () => ({
+          returns: () =>
+            Promise.resolve({ data: mockCallerRoles, error: null }),
+        }),
+      }),
+    };
+  }
+  throw new Error(`Unexpected table in userClient: ${table}`);
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: vi.fn(userClientFromImpl),
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: mockCaller },
+        error: null,
+      })),
+    },
+    rpc: vi.fn(async (...args: unknown[]) => {
+      rpcSpy(...args);
+      return mockRpcResult;
+    }),
+  }),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    auth: {
+      admin: {
+        inviteUserByEmail: vi.fn(async (...args: unknown[]) => {
+          inviteUserByEmailSpy(...args);
+          return mockInviteResult;
+        }),
+        listUsers: vi.fn(async () => ({
+          data: { users: [] },
+          error: null,
+        })),
+        deleteUser: vi.fn(async () => ({ error: null })),
+      },
+    },
+    from: vi.fn(() => {
+      throw new Error(
+        "service client `.from(...)` should not be called in invite happy paths"
+      );
+    }),
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const CALLER_UUID = "11111111-1111-4000-8000-000000000001";
+const ORG_A = "aaaaaaaa-aaaa-4000-8000-000000000001";
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/users/invite", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inviteUserByEmailSpy.mockReset();
+  rpcSpy.mockReset();
+  mockCaller = { id: CALLER_UUID, email: "caller@example.com" };
+  mockRpcResult = { error: null };
+  mockInviteResult = {
+    data: { user: { id: "00000000-0000-4000-8000-000000000099" } },
+    error: null,
+  };
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("POST /api/users/invite", () => {
+  // ── Happy path: super_admin caller, org_manager invitee ──────────
+  it("super_admin invites an org_manager → 201 + data payload forwarded", async () => {
+    mockCallerRoles = [
+      { role: "super_admin", scope_type: null, scope_id: null },
+    ];
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        email: "newuser@example.com",
+        first_name: "New",
+        last_name: "User",
+        role: "org_manager",
+        scope_id: ORG_A,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(inviteUserByEmailSpy).toHaveBeenCalledTimes(1);
+    const [emailArg, optsArg] = inviteUserByEmailSpy.mock.calls[0]!;
+    expect(emailArg).toBe("newuser@example.com");
+    expect(optsArg).toMatchObject({
+      data: {
+        invited_by_name: "Inviter Name",
+        org_name: "Test Org",
+        role_label: "an organization manager",
+        app_name: "Metering & Billing Engine",
+      },
+    });
+  });
+
+  // ── Happy path: super_admin caller, super_admin invitee ───────────
+  it("super_admin invites a super_admin → 201 + data payload omits org_name", async () => {
+    mockCallerRoles = [
+      { role: "super_admin", scope_type: null, scope_id: null },
+    ];
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        email: "peer-admin@example.com",
+        role: "super_admin",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(inviteUserByEmailSpy).toHaveBeenCalledTimes(1);
+    const [, optsArg] = inviteUserByEmailSpy.mock.calls[0]!;
+    const payload = (optsArg as { data: Record<string, unknown> }).data;
+    expect(payload.role_label).toBe("a super administrator");
+    expect(payload.app_name).toBe("Metering & Billing Engine");
+    // org_name MUST be omitted for super_admin invites (Go template
+    // `{{ if .Data.org_name }}` semantics).
+    expect("org_name" in payload).toBe(false);
+  });
+
+  // ── Happy path: org_manager caller, org_manager invitee ───────────
+  it("org_manager invites an org_manager into their own org → 201", async () => {
+    mockCallerRoles = [
+      { role: "org_manager", scope_type: "org", scope_id: ORG_A },
+    ];
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        email: "new-org-mgr@example.com",
+        role: "org_manager",
+        scope_id: ORG_A,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const [, optsArg] = inviteUserByEmailSpy.mock.calls[0]!;
+    const payload = (optsArg as { data: Record<string, unknown> }).data;
+    expect(payload.org_name).toBe("Test Org");
+    expect(payload.role_label).toBe("an organization manager");
+  });
+
+  // ── 422: validation — invalid email ──────────────────────────────
+  it("returns 422 on invalid email", async () => {
+    mockCallerRoles = [
+      { role: "super_admin", scope_type: null, scope_id: null },
+    ];
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        email: "not-an-email",
+        role: "org_manager",
+        scope_id: ORG_A,
+      })
+    );
+
+    expect(res.status).toBe(422);
+    expect(inviteUserByEmailSpy).not.toHaveBeenCalled();
+  });
+
+  // ── 403: org_manager attempting super_admin invite ───────────────
+  it("returns 403 when org_manager attempts super_admin invite", async () => {
+    mockCallerRoles = [
+      { role: "org_manager", scope_type: "org", scope_id: ORG_A },
+    ];
+
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        email: "would-be-admin@example.com",
+        role: "super_admin",
+      })
+    );
+
+    expect(res.status).toBe(403);
+    expect(inviteUserByEmailSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/users/invite/route.ts
+++ b/src/app/api/users/invite/route.ts
@@ -7,6 +7,7 @@ import {
   currentUserCanAccessOrg,
 } from "@/lib/auth/access";
 import { SUPER_ADMIN, ORG_MANAGER } from "@/lib/roles";
+import { buildInviteDataPayload } from "@/lib/auth/invite-data-payload";
 import type { UserRole } from "@/lib/types/domain";
 
 /**
@@ -141,9 +142,35 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // ── Step 2: invite via GoTrue admin API ──────────────────────────────
+  //
+  // The `data` payload (UX5b / #184) is forwarded to the email template
+  // so the rendered invitation includes the inviter name, org name, and
+  // a humanized role label. GoTrue persists this on
+  // auth.users.raw_user_meta_data — see invite-data-payload.ts.
+  const {
+    data: { user: caller },
+  } = await userClient.auth.getUser();
+  if (!caller) {
+    // Should not happen — RLS in the perm checks above already requires
+    // an authenticated session — but guard for type-narrowing.
+    return NextResponse.json(
+      { error: "Authentication required." },
+      { status: 401 }
+    );
+  }
+
+  const inviteData = await buildInviteDataPayload({
+    caller,
+    targetRole: role,
+    targetOrgId: scopeId,
+    supabase: userClient,
+  });
+
   const svc = createServiceClient();
 
-  const inviteRes = await svc.auth.admin.inviteUserByEmail(email);
+  const inviteRes = await svc.auth.admin.inviteUserByEmail(email, {
+    data: inviteData,
+  });
   let targetUserId: string | null = null;
 
   if (inviteRes.error) {

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -44,6 +44,12 @@ export interface EditUserDialogProps {
     phone: string | null;
     role: UserRole | null;
     scope_id: string | null;
+    /**
+     * NULL when the invited user has not yet accepted (status "Invited"),
+     * non-null timestamp once accepted (status "Active"). The Resend
+     * invitation button (UX5b / #184) only renders when this is null.
+     */
+    email_confirmed_at: string | null;
   };
   callerRole: "super_admin" | "org_manager";
   canChangeRole: boolean;
@@ -72,6 +78,19 @@ export function EditUserDialog(props: EditUserDialogProps) {
   const [submitting, setSubmitting] = React.useState(false);
   const [confirmOpen, setConfirmOpen] = React.useState(false);
 
+  // Resend-invitation state (UX5b / #184). Mirrors the
+  // `submitting`/`topError` pattern used by the profile/role PATCH flow
+  // so the dialog has a single, consistent async-state shape.
+  type ResendFeedback =
+    | { kind: "success" }
+    | { kind: "rate-limit" }
+    | { kind: "error"; message: string };
+  const [resending, setResending] = React.useState(false);
+  const [resendFeedback, setResendFeedback] =
+    React.useState<ResendFeedback | null>(null);
+
+  const showResend = t.email_confirmed_at == null;
+
   React.useEffect(() => {
     if (props.open) {
       setFirstName(t.first_name ?? "");
@@ -83,6 +102,8 @@ export function EditUserDialog(props: EditUserDialogProps) {
       setTopError(null);
       setSubmitting(false);
       setConfirmOpen(false);
+      setResending(false);
+      setResendFeedback(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.open, t.user_id]);
@@ -180,6 +201,42 @@ export function EditUserDialog(props: EditUserDialogProps) {
     props.onSuccess?.();
     router.refresh();
     props.onOpenChange(false);
+  }
+
+  // Resend invitation handler (UX5b / #184). Stays in the dialog (no
+  // dismissal) so the operator gets explicit in-context confirmation
+  // via an inline <Banner>.
+  async function handleResend() {
+    setResending(true);
+    setResendFeedback(null);
+    try {
+      const res = await fetch(`/api/users/${t.user_id}/resend-invite`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        setResendFeedback({ kind: "success" });
+        return;
+      }
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+      };
+      if (res.status === 429 || data.code === "rate_limited") {
+        setResendFeedback({ kind: "rate-limit" });
+        return;
+      }
+      setResendFeedback({
+        kind: "error",
+        message: data.error ?? "Could not resend invitation.",
+      });
+    } catch {
+      setResendFeedback({
+        kind: "error",
+        message: "Network error. Please retry.",
+      });
+    } finally {
+      setResending(false);
+    }
   }
 
   return (
@@ -343,6 +400,51 @@ export function EditUserDialog(props: EditUserDialogProps) {
                       </div>
                     )}
                   </div>
+                </div>
+              )}
+
+              {/* Resend invitation (UX5b / #184) — only when status is "Invited".
+                  Positioned ABOVE the destructive Revoke action so the
+                  constructive option is reached first. */}
+              {showResend && (
+                <div className="border-t border-border pt-4">
+                  {resendFeedback?.kind === "success" && (
+                    <div className="mb-3">
+                      <Banner tone="success" title="Invitation resent">
+                        Invitation resent to {t.email}.
+                      </Banner>
+                    </div>
+                  )}
+                  {resendFeedback?.kind === "rate-limit" && (
+                    <div className="mb-3">
+                      <Banner tone="warn" title="Rate limited">
+                        Too many invitations sent recently. Try again in a
+                        few minutes.
+                      </Banner>
+                    </div>
+                  )}
+                  {resendFeedback?.kind === "error" && (
+                    <div className="mb-3">
+                      <Banner
+                        tone="destructive"
+                        title="Could not resend invitation"
+                      >
+                        {resendFeedback.message}
+                      </Banner>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleResend}
+                    disabled={resending}
+                    className="inline-flex h-8 items-center rounded-md border border-border bg-card px-3.5 text-[13px] font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed"
+                  >
+                    {resending ? "Sending…" : "Resend invitation"}
+                  </button>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Re-issues the magic-link email. The previous link is
+                    superseded.
+                  </p>
                 </div>
               )}
 

--- a/src/components/users/__tests__/EditUserDialog.test.tsx
+++ b/src/components/users/__tests__/EditUserDialog.test.tsx
@@ -1,15 +1,22 @@
 // @vitest-environment jsdom
 /**
- * EditUserDialog component tests (UX5 / #79).
+ * EditUserDialog component tests (UX5 / #79; UX5b / #184).
  *
  * Covers:
  *   - Profile section always renders; email is read-only.
  *   - Role section is hidden when canChangeRole = false.
  *   - Revoke button is hidden when canRevoke = false.
  *   - Clicking Revoke opens the ConfirmDialog.
+ *   - Resend invitation (UX5b):
+ *       * Hidden when target.email_confirmed_at is non-null (Active).
+ *       * Visible when target.email_confirmed_at is null (Invited).
+ *       * Click POSTs to /api/users/[id]/resend-invite.
+ *       * Success surfaces the success Banner.
+ *       * 429 surfaces the rate-limit Banner.
+ *       * Banner resets when the dialog re-opens.
  */
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { EditUserDialog } from "../EditUserDialog";
 
 vi.mock("next/navigation", () => ({
@@ -18,7 +25,11 @@ vi.mock("next/navigation", () => ({
 
 const ORG_A = "aaaaaaaa-aaaa-4000-8000-000000000001";
 
-function baseTarget() {
+function baseTarget(overrides: Partial<ReturnType<typeof rawTarget>> = {}) {
+  return { ...rawTarget(), ...overrides };
+}
+
+function rawTarget() {
   return {
     user_id: "11111111-1111-4000-8000-000000000001",
     email: "alice@nfe.local",
@@ -27,6 +38,7 @@ function baseTarget() {
     phone: "",
     role: "org_manager" as const,
     scope_id: ORG_A,
+    email_confirmed_at: null as string | null,
   };
 }
 
@@ -125,5 +137,205 @@ describe("EditUserDialog — render", () => {
     // with label "Revoke access" — two buttons with that accessible name now
     // exist. The confirm-dialog title "Revoke access?" is distinct.
     expect(screen.getByText(/revoke access\?/i)).toBeDefined();
+  });
+});
+
+describe("EditUserDialog — resend invitation (UX5b / #184)", () => {
+  it("hides Resend when the target is Active (email_confirmed_at non-null)", () => {
+    render(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget({ email_confirmed_at: "2026-04-23T00:00:00Z" })}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /resend invitation/i })
+    ).toBeNull();
+  });
+
+  it("shows Resend when the target is Invited (email_confirmed_at null)", () => {
+    render(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /resend invitation/i })
+    ).toBeDefined();
+  });
+
+  it("POSTs to /api/users/[id]/resend-invite and surfaces success banner", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ resent: true }), { status: 200 })
+    );
+
+    render(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    const resendBtn = screen.getByRole("button", { name: /resend invitation/i });
+    fireEvent.click(resendBtn);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "/api/users/11111111-1111-4000-8000-000000000001/resend-invite"
+    );
+    expect((init as RequestInit).method).toBe("POST");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /invitation resent/i })
+      ).toBeDefined();
+    });
+    expect(screen.getByText(/alice@nfe.local/)).toBeDefined();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("surfaces a rate-limit banner on 429", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: "rate", code: "rate_limited" }),
+        { status: 429 }
+      )
+    );
+
+    render(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /resend invitation/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/rate limited/i)).toBeDefined();
+    });
+    expect(screen.getByText(/try again in a few minutes/i)).toBeDefined();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("surfaces a destructive banner on other errors (422)", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Resend failed: boom" }), {
+        status: 422,
+      })
+    );
+
+    render(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /resend invitation/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not resend invitation/i)).toBeDefined();
+    });
+    expect(screen.getByText(/resend failed: boom/i)).toBeDefined();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("clears any previous resend banner when the dialog re-opens", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ resent: true }), { status: 200 })
+    );
+
+    const { rerender } = render(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /resend invitation/i })
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /invitation resent/i })
+      ).toBeDefined()
+    );
+
+    // Close dialog.
+    rerender(
+      <EditUserDialog
+        open={false}
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    // Re-open — banner should be gone.
+    rerender(
+      <EditUserDialog
+        open
+        onOpenChange={() => {}}
+        target={baseTarget()}
+        callerRole="super_admin"
+        canChangeRole
+        canRevoke
+        orgs={orgList()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /invitation resent/i })
+      ).toBeNull();
+    });
+
+    fetchSpy.mockRestore();
   });
 });

--- a/src/lib/auth/__tests__/invite-data-payload.test.ts
+++ b/src/lib/auth/__tests__/invite-data-payload.test.ts
@@ -1,0 +1,235 @@
+/**
+ * invite-data-payload.test.ts — shared payload-builder unit tests
+ * (UX5b / #184).
+ *
+ * The helper produces the `data` object passed to
+ * `auth.admin.inviteUserByEmail`. Critical contract:
+ *   - null/empty `org_name` and `invited_by_name` are OMITTED from the
+ *     returned object (NOT sent as null) so Go's text/template
+ *     `{{ if .Data.field }}` branches resolve correctly.
+ *   - `app_name` and `role_label` are always present.
+ *   - For super_admin targets, `org_name` is omitted entirely.
+ *   - Caller name resolution: `first_name + ' ' + last_name` trimmed,
+ *     fallback to caller email when both are NULL/empty.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+import { buildInviteDataPayload } from "../invite-data-payload";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeCaller(overrides: Partial<User> = {}): User {
+  return {
+    id: "11111111-1111-4000-8000-000000000001",
+    email: "caller@example.com",
+    aud: "authenticated",
+    app_metadata: {},
+    user_metadata: {},
+    created_at: "2026-04-23T00:00:00Z",
+    ...overrides,
+  } as User;
+}
+
+/**
+ * Build a minimal SupabaseClient mock that returns canned values for
+ * the two queries the helper performs:
+ *   - .from('user_profiles').select(...).eq(...).maybeSingle() → callerProfile
+ *   - .from('organizations').select(...).eq(...).maybeSingle() → orgRow
+ */
+function makeSupabaseMock(opts: {
+  callerProfile?: { first_name: string | null; last_name: string | null } | null;
+  callerProfileError?: { message: string } | null;
+  orgRow?: { name: string } | null;
+  orgRowError?: { message: string } | null;
+}): SupabaseClient {
+  const fromImpl = vi.fn((table: string) => {
+    if (table === "user_profiles") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: vi.fn(async () => ({
+              data: opts.callerProfile ?? null,
+              error: opts.callerProfileError ?? null,
+            })),
+          }),
+        }),
+      };
+    }
+    if (table === "organizations") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: vi.fn(async () => ({
+              data: opts.orgRow ?? null,
+              error: opts.orgRowError ?? null,
+            })),
+          }),
+        }),
+      };
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  });
+  return { from: fromImpl } as unknown as SupabaseClient;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("buildInviteDataPayload", () => {
+  it("super_admin caller inviting org_manager: includes invited_by_name + org_name", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: "Alejandro", last_name: "Malbet" },
+      orgRow: { name: "NorthFork Energy" },
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller(),
+      targetRole: "org_manager",
+      targetOrgId: "aaaaaaaa-aaaa-4000-8000-000000000001",
+      supabase,
+    });
+
+    expect(data).toEqual({
+      invited_by_name: "Alejandro Malbet",
+      org_name: "NorthFork Energy",
+      role_label: "an organization manager",
+      app_name: "Metering & Billing Engine",
+    });
+  });
+
+  it("super_admin caller inviting super_admin: omits org_name entirely", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: "Alejandro", last_name: "Malbet" },
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller(),
+      targetRole: "super_admin",
+      targetOrgId: null,
+      supabase,
+    });
+
+    // org_name MUST NOT be a key on the object — Go template `{{ if .Data.org_name }}`
+    // semantics rely on the field being absent, not present-with-null.
+    expect("org_name" in data).toBe(false);
+    expect(data).toEqual({
+      invited_by_name: "Alejandro Malbet",
+      role_label: "a super administrator",
+      app_name: "Metering & Billing Engine",
+    });
+  });
+
+  it("falls back to caller email when both first_name and last_name are NULL", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: null, last_name: null },
+      orgRow: { name: "NorthFork Energy" },
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller({ email: "fallback@example.com" }),
+      targetRole: "org_manager",
+      targetOrgId: "aaaaaaaa-aaaa-4000-8000-000000000001",
+      supabase,
+    });
+
+    expect(data.invited_by_name).toBe("fallback@example.com");
+  });
+
+  it("falls back to caller email when names are empty strings (whitespace)", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: "  ", last_name: "" },
+      orgRow: { name: "NorthFork Energy" },
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller({ email: "fallback@example.com" }),
+      targetRole: "org_manager",
+      targetOrgId: "aaaaaaaa-aaaa-4000-8000-000000000001",
+      supabase,
+    });
+
+    expect(data.invited_by_name).toBe("fallback@example.com");
+  });
+
+  it("trims composed name when only one of first/last is set", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: "Alejandro", last_name: null },
+      orgRow: { name: "NorthFork Energy" },
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller(),
+      targetRole: "org_manager",
+      targetOrgId: "aaaaaaaa-aaaa-4000-8000-000000000001",
+      supabase,
+    });
+
+    expect(data.invited_by_name).toBe("Alejandro");
+  });
+
+  it("omits invited_by_name when caller has no profile AND no email", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: null,
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller({ email: undefined }),
+      targetRole: "super_admin",
+      targetOrgId: null,
+      supabase,
+    });
+
+    expect("invited_by_name" in data).toBe(false);
+    expect(data).toEqual({
+      role_label: "a super administrator",
+      app_name: "Metering & Billing Engine",
+    });
+  });
+
+  it("omits org_name when org lookup returns null (RLS-hidden org)", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: "Alejandro", last_name: "Malbet" },
+      orgRow: null,
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller(),
+      targetRole: "org_manager",
+      targetOrgId: "aaaaaaaa-aaaa-4000-8000-000000000001",
+      supabase,
+    });
+
+    expect("org_name" in data).toBe(false);
+  });
+
+  it("omits org_name when targetOrgId is null for an org_manager target", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: { first_name: "Alejandro", last_name: "Malbet" },
+      orgRow: { name: "Should not be looked up" },
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller(),
+      targetRole: "org_manager",
+      targetOrgId: null,
+      supabase,
+    });
+
+    expect("org_name" in data).toBe(false);
+  });
+
+  it("always returns role_label and app_name (required fields)", async () => {
+    const supabase = makeSupabaseMock({
+      callerProfile: null,
+    });
+
+    const data = await buildInviteDataPayload({
+      caller: makeCaller({ email: undefined }),
+      targetRole: "org_manager",
+      targetOrgId: null,
+      supabase,
+    });
+
+    expect(data.role_label).toBe("an organization manager");
+    expect(data.app_name).toBe("Metering & Billing Engine");
+  });
+});

--- a/src/lib/auth/invite-data-payload.ts
+++ b/src/lib/auth/invite-data-payload.ts
@@ -1,0 +1,140 @@
+import "server-only";
+
+/**
+ * invite-data-payload.ts — shared helper to build the `data` payload
+ * passed to `auth.admin.inviteUserByEmail` (UX5b / #184).
+ *
+ * The Supabase email template renders rich content (inviter name, org
+ * name, role label, app name) by reading `{{ .Data.field }}` template
+ * variables. GoTrue forwards anything we put in `data` through to the
+ * template AND persists it on `auth.users.raw_user_meta_data`
+ * (`user_metadata` alias) — see GoTrueAdminApi.ts:141-165.
+ *
+ * Architectural decisions (see ticket #184 Dev Notes):
+ *
+ *   - `null`/empty `org_name` and `invited_by_name` are OMITTED from
+ *     the returned object (NOT sent as JSON null) so the template's
+ *     `{{ if .Data.field }}` branches resolve correctly. Go's
+ *     text/template treats null as "set" — only absence falls through
+ *     to the else branch.
+ *
+ *   - `org_name` is omitted entirely for super_admin invites (no org
+ *     scope by definition).
+ *
+ *   - Caller name resolution: trimmed `first_name + ' ' + last_name`
+ *     from `user_profiles`; fallback to caller email when both names
+ *     are NULL/empty.
+ *
+ *   - Org name resolution uses the user-bound supabase client (RLS
+ *     gates visibility — defense-in-depth: if the caller cannot see
+ *     the org, the route's permission check would have already 403'd).
+ *
+ *   - `app_name` is hardcoded `'Metering & Billing Engine'`. The
+ *     payload field exists for forward-compat (per-tenant template
+ *     branding); no override UI in MVP.
+ *
+ * Used by:
+ *   - POST /api/users/invite
+ *   - POST /api/users/[id]/resend-invite
+ */
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+import { SUPER_ADMIN, ORG_MANAGER } from "@/lib/roles";
+import type { UserRole } from "@/lib/types/domain";
+
+const APP_NAME = "Metering & Billing Engine";
+
+export interface InviteDataPayload {
+  invited_by_name?: string;
+  org_name?: string;
+  role_label: string;
+  app_name: string;
+}
+
+export interface BuildInviteDataPayloadParams {
+  /** The authenticated caller (must have a non-null email). */
+  caller: User;
+  /** The role being assigned (or current role on resend). */
+  targetRole: UserRole;
+  /** The org id when targetRole === 'org_manager'; null/omit for super_admin. */
+  targetOrgId?: string | null;
+  /** User-bound supabase client (RLS-honoring, for caller name + org name lookups). */
+  supabase: SupabaseClient;
+}
+
+/**
+ * Build the `data` payload for `auth.admin.inviteUserByEmail`.
+ *
+ * Returns an object with only the populated keys — null/empty values
+ * are OMITTED (not sent as JSON null) so Go template `{{ if .Data.x }}`
+ * branches resolve correctly.
+ */
+export async function buildInviteDataPayload(
+  params: BuildInviteDataPayloadParams
+): Promise<InviteDataPayload> {
+  const { caller, targetRole, targetOrgId, supabase } = params;
+
+  // ── Caller name (single round trip). ──
+  const invitedByName = await resolveCallerName(supabase, caller);
+
+  // ── Org name (org_manager target only). ──
+  let orgName: string | null = null;
+  if (targetRole === ORG_MANAGER && targetOrgId) {
+    orgName = await resolveOrgName(supabase, targetOrgId);
+  }
+
+  // ── Role label (humanized). ──
+  const roleLabel = humanizeRoleLabel(targetRole);
+
+  // Build payload — omit null/empty fields entirely.
+  const payload: InviteDataPayload = {
+    role_label: roleLabel,
+    app_name: APP_NAME,
+  };
+  if (invitedByName) payload.invited_by_name = invitedByName;
+  if (orgName) payload.org_name = orgName;
+  return payload;
+}
+
+// ── Internals ─────────────────────────────────────────────────────────
+
+async function resolveCallerName(
+  supabase: SupabaseClient,
+  caller: User
+): Promise<string> {
+  const { data } = await supabase
+    .from("user_profiles")
+    .select("first_name, last_name")
+    .eq("user_id", caller.id)
+    .maybeSingle<{ first_name: string | null; last_name: string | null }>();
+
+  const first = (data?.first_name ?? "").trim();
+  const last = (data?.last_name ?? "").trim();
+  const composed = `${first} ${last}`.trim();
+  if (composed) return composed;
+  // Fallback to email — auth.User.email is non-null in practice for
+  // invite/resend callers (they're authenticated session users), but
+  // the type allows undefined so guard.
+  return caller.email ?? "";
+}
+
+async function resolveOrgName(
+  supabase: SupabaseClient,
+  orgId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("organizations")
+    .select("name")
+    .eq("id", orgId)
+    .maybeSingle<{ name: string }>();
+
+  if (error || !data) return null;
+  const trimmed = data.name?.trim();
+  return trimmed || null;
+}
+
+function humanizeRoleLabel(role: UserRole): string {
+  if (role === SUPER_ADMIN) return "a super administrator";
+  if (role === ORG_MANAGER) return "an organization manager";
+  // Future-proof: any unknown role enum value falls back to its raw token.
+  return role;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
             "src/lib/supabase/__tests__/payment_state_machine.test.ts",
             "src/lib/supabase/__tests__/billing_audit_log.test.ts",
             "src/lib/__tests__/invite-user-rpc.test.ts",
+            "src/app/api/users/[id]/resend-invite/__tests__/rls-route.test.ts",
           ],
           environment: "node",
           fileParallelism: false,
@@ -61,6 +62,11 @@ export default defineConfig({
           name: "app",
           // Server-component tests (node environment) co-located with page files.
           include: ["src/app/**/*.test.{ts,tsx}"],
+          // Exclude RLS-mode integration tests that live under src/app — they
+          // run in the `rls` project (live local Supabase, sequential).
+          exclude: [
+            "src/app/api/users/[id]/resend-invite/__tests__/rls-route.test.ts",
+          ],
           environment: "node",
         },
       },


### PR DESCRIPTION
## Summary

Two surfaces, one ticket — the resend route and the rich-content `data` payload are tightly coupled (operator wants the same template render whether the email is the original invite or a resend).

**New: \`POST /api/users/[id]/resend-invite\`** with security-hardened ordering to prevent UUID enumeration:
- Step A: \`getUser\` → 401 if no auth.
- Step B: read target via \`user_directory\` view (the view enforces \`user_can_see_user_profile\` — invisible rows return \`null\` which routes to a uniform 403, NOT 404).
- Step C: permission check (\`currentUserCanAccessOrg\` for org_manager target; \`currentUserIsSuperAdmin\` for super_admin target).
- Step D: \`auth.admin.getUserById\` → 404 ONLY after permission passes (so 404 vs 403 doesn't leak existence).
- Pre-check \`email_confirmed_at IS NOT NULL\` → 409 \"User has already accepted their invitation.\"
- Two-client pattern: user-bound for permission, service-role for \`auth.admin.*\` ops only.
- Rate-limit handling: \`over_email_send_rate_limit\` → 429 \`code: \"rate_limited\"\`.
- Race handling: \`email_exists\` → 409.
- Other errors → 422.

**Branding**: both invite routes now pass a \`data\` payload (\`invited_by_name\`, \`org_name?\`, \`role_label\`, \`app_name\`) via shared \`buildInviteDataPayload\` helper. Omits null fields so the template's \`{{ if .Data.field }}\` branches work correctly. Email subject + body templates pinned in runbook at \`mbe-docs/docs/operational-runbooks/invite-email-template.md\` (sibling repo, NOT in this PR — operator pastes after merge).

**UI**:
- \`<EditUserDialog>\` gets a \"Resend invitation\" button (above Revoke; visible only when \`email_confirmed_at == null\`). Inline \`<Banner>\` for success / 429 (warn) / destructive errors. Resets on dialog re-open.
- Per-row Resend action in \`<UsersTable>\` (permission-gated visibility; \`Set<string>\` for in-flight tracking).
- \`recentInvite: string | null\` replaced with discriminated union \`feedback: {kind: 'invite' | 'resend', email} | null\` rendered via tone-per-kind banner.
- \`target.email_confirmed_at\` plumbed from page client through to the dialog.

**Reviewer caught a BLOCKER** (RLS on \`user_roles\` is super_admin-only — same-org org_managers would have been blanket-403'd). Fix: switched lookup from \`user_roles\` → \`user_directory\` view (which enforces visibility via \`user_can_see_user_profile\`). Added an RLS-mode integration test that mints real JWTs and exercises the route under super_admin / same-org org_manager / cross-org / super_admin-target / nonexistent-UUID contexts — exactly the matrix that catches this class of bug.

**Tests**: 47 new across 5 files — resend route (15 unit + 5 RLS), invite route (5 — new file), EditUserDialog (6), users-page-client (6 — new file), invite-data-payload helper (9).

Closes #184.

## Test plan

- [x] \`npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1266 pass) && npm run build\` — all green
- [x] Reviewer agent walked all 7 ACs + ran security audit — found BLOCKER (cross-org RLS); fix-agent addressed it; reviewer's recommended RLS integration test added.

## Deployment step (operator, post-merge)

Paste the email subject + body from \`mbe-docs/docs/operational-runbooks/invite-email-template.md\` into Supabase Dashboard → Authentication → Email Templates → Invite user, on the cloud dev project (\`tztbmsxxjjsryuvoyqji\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)