### PR TITLE
UX5d — Forgot-password flow: /forgot-password + /reset-password (#190)

### DIFF
--- a/src/app/forgot-password/__tests__/page.test.tsx
+++ b/src/app/forgot-password/__tests__/page.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+/**
+ * ForgotPasswordPage tests (UX5d / #190).
+ *
+ * Coverage (per AC9 of #190):
+ *   - Renders email input + submit button.
+ *   - Submit calls supabase.auth.resetPasswordForEmail with
+ *     `{ redirectTo: '<origin>/reset-password' }`.
+ *   - Success state renders identical copy regardless of email
+ *     existence (enumeration defense — both mock-200 cases assert
+ *     same output text for known + unknown emails).
+ *   - 429 / over_email_send_rate_limit error renders the
+ *     "Too many reset attempts" banner.
+ *   - Generic error renders the generic banner; error.message is NOT
+ *     echoed to the UI.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+const resetPasswordForEmailSpy = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      resetPasswordForEmail: (...args: unknown[]) =>
+        resetPasswordForEmailSpy(...args),
+    },
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetPasswordForEmailSpy.mockReset();
+  // jsdom defaults window.location.origin to http://localhost:3000.
+});
+
+async function loadPage() {
+  vi.resetModules();
+  const mod = await import("../page");
+  return mod.default;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("ForgotPasswordPage", () => {
+  it("renders email input + submit button", async () => {
+    const ForgotPasswordPage = await loadPage();
+    render(<ForgotPasswordPage />);
+
+    expect(screen.getByLabelText(/email/i)).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /send reset link/i })
+    ).toBeDefined();
+  });
+
+  it("calls resetPasswordForEmail with redirectTo='${origin}/reset-password' on submit", async () => {
+    resetPasswordForEmailSpy.mockResolvedValue({ data: {}, error: null });
+    const ForgotPasswordPage = await loadPage();
+    render(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /send reset link/i })
+    );
+
+    await waitFor(() => {
+      expect(resetPasswordForEmailSpy).toHaveBeenCalledWith(
+        "user@example.com",
+        { redirectTo: `${window.location.origin}/reset-password` }
+      );
+    });
+  });
+
+  it("renders the same success copy for a known email (enumeration defense)", async () => {
+    resetPasswordForEmailSpy.mockResolvedValue({ data: {}, error: null });
+    const ForgotPasswordPage = await loadPage();
+    render(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "known@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /send reset link/i })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /check your inbox/i })
+      ).toBeDefined();
+    });
+    expect(screen.getByText(/if an account exists for/i)).toBeDefined();
+    expect(screen.getByText(/known@example.com/i)).toBeDefined();
+  });
+
+  it("renders the same success copy for an unknown email (enumeration defense)", async () => {
+    // Supabase returns a 200 (success-shaped response) even for emails
+    // that don't have an account. Mock that and assert the UI is
+    // identical to the known-email case.
+    resetPasswordForEmailSpy.mockResolvedValue({ data: {}, error: null });
+    const ForgotPasswordPage = await loadPage();
+    render(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "nobody-here@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /send reset link/i })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /check your inbox/i })
+      ).toBeDefined();
+    });
+    // Same conditional copy — does NOT confirm whether the account exists.
+    expect(screen.getByText(/if an account exists for/i)).toBeDefined();
+    expect(screen.getByText(/nobody-here@example.com/i)).toBeDefined();
+  });
+
+  it("renders the rate-limit banner on 429 / over_email_send_rate_limit", async () => {
+    resetPasswordForEmailSpy.mockResolvedValue({
+      data: {},
+      error: {
+        message: "Email rate limit exceeded",
+        status: 429,
+        code: "over_email_send_rate_limit",
+      },
+    });
+    const ForgotPasswordPage = await loadPage();
+    render(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /send reset link/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/too many reset attempts/i)).toBeDefined();
+    });
+    // Form is still rendered (user can retry later).
+    expect(
+      screen.getByRole("button", { name: /send reset link/i })
+    ).toBeDefined();
+    // Internal error message must NOT leak to the UI.
+    expect(screen.queryByText(/email rate limit exceeded/i)).toBeNull();
+  });
+
+  it("renders a generic error banner without echoing error.message", async () => {
+    // Suppress the diagnostic console.error for this test.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    resetPasswordForEmailSpy.mockResolvedValue({
+      data: {},
+      error: {
+        message: "internal-only-detail-DO-NOT-LEAK",
+        status: 500,
+      },
+    });
+    const ForgotPasswordPage = await loadPage();
+    render(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /send reset link/i })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/something went wrong\. please try again/i)
+      ).toBeDefined();
+    });
+    // Internal error message must NOT leak to the UI.
+    expect(
+      screen.queryByText(/internal-only-detail-DO-NOT-LEAK/)
+    ).toBeNull();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+/**
+ * /forgot-password — password-reset request page (UX5d / #190).
+ *
+ * Reached by users clicking "Forgot password?" on /login. Submits an
+ * email address; the Supabase server emits a recovery email whose
+ * `{{ .ConfirmationURL }}` lands the user on /reset-password with a
+ * `?token_hash=…&type=recovery` query string.
+ *
+ * Email-enumeration defense (AC2 + AC7 of #190):
+ *   - Success copy is identical regardless of whether the email exists.
+ *     ("If an account exists for {email}, we've sent a password-reset
+ *     link.") — phrased as a conditional, never confirms existence.
+ *   - Rate-limit error (HTTP 429 / `over_email_send_rate_limit`) shows a
+ *     generic banner with no timing detail.
+ *   - Generic errors show "Something went wrong. Please try again." —
+ *     `error.message` is logged to console but NOT echoed to the UI
+ *     (self-hosted Supabase tiers can leak existence via error.message).
+ *
+ * Per-call redirectTo (AC2 of #190; matches UX5c's per-call pattern):
+ *   - `redirectTo: ${window.location.origin}/reset-password` — no global
+ *     Site URL change, no server-side `resolveOrigin` helper. The origin
+ *     read at call time is correct in the recipient's browser context.
+ */
+import * as React from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { Banner } from "@/components/ui/banner";
+import { Input } from "@/components/ui/input";
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; email: string }
+  | { kind: "error"; tone: "rate_limit" | "generic" };
+
+const RATE_LIMIT_MESSAGE =
+  "Too many reset attempts. Please wait a few minutes and try again.";
+const GENERIC_ERROR_MESSAGE = "Something went wrong. Please try again.";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = React.useState("");
+  const [phase, setPhase] = React.useState<Phase>({ kind: "idle" });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (phase.kind === "submitting") return;
+    if (!email) return;
+
+    setPhase({ kind: "submitting" });
+    const supabase = createClient();
+    const redirectTo = `${window.location.origin}/reset-password`;
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo,
+    });
+
+    if (error) {
+      // Rate-limit detection: GoTrue surfaces 429 with code
+      // `over_email_send_rate_limit` for both invite resends (UX5b)
+      // and recovery emails (UX5d).
+      const status = (error as { status?: number }).status;
+      const code = (error as { code?: string }).code;
+      const isRateLimit =
+        status === 429 || code === "over_email_send_rate_limit";
+      // Diagnostic for operators; never echoed to the UI
+      // (enumeration vector on self-hosted tiers).
+      console.error("resetPasswordForEmail failed:", error.message);
+      setPhase({
+        kind: "error",
+        tone: isRateLimit ? "rate_limit" : "generic",
+      });
+      return;
+    }
+
+    setPhase({ kind: "success", email });
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted px-4">
+      <div className="w-full max-w-md rounded-md border border-border bg-card p-8 shadow-sm">
+        {phase.kind === "success" ? (
+          <div className="space-y-4">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+              Check your inbox
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              If an account exists for{" "}
+              <span className="font-medium text-foreground">{phase.email}</span>
+              , we&apos;ve sent a password-reset link. Check your inbox.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                href="/login"
+                className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+                Forgot your password?
+              </h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Enter your email address and we&apos;ll send you a link to
+                reset your password.
+              </p>
+            </div>
+
+            {phase.kind === "error" && (
+              <Banner
+                tone="destructive"
+                title={
+                  phase.tone === "rate_limit"
+                    ? "Too many attempts"
+                    : "Could not send reset email"
+                }
+              >
+                {phase.tone === "rate_limit"
+                  ? RATE_LIMIT_MESSAGE
+                  : GENERIC_ERROR_MESSAGE}
+              </Banner>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+              <div>
+                <label
+                  htmlFor="forgot-password-email"
+                  className="mb-1 block text-xs font-medium text-muted-foreground"
+                >
+                  Email
+                </label>
+                <Input
+                  id="forgot-password-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={phase.kind === "submitting"}
+                  autoComplete="email"
+                  required
+                  placeholder="you@example.com"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={phase.kind === "submitting" || !email}
+                className="inline-flex h-9 w-full items-center justify-center rounded-md border border-primary bg-primary px-3.5 text-sm font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {phase.kind === "submitting"
+                  ? "Sending…"
+                  : "Send reset link"}
+              </button>
+            </form>
+
+            <p className="text-sm text-muted-foreground">
+              <Link
+                href="/login"
+                className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/__tests__/page.test.tsx
+++ b/src/app/login/__tests__/page.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+/**
+ * LoginPage tests (UX5d / #190 — link addition only).
+ *
+ * Coverage (per AC9 of #190):
+ *   - "Forgot password?" link is visible and points to /forgot-password.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      signInWithPassword: vi.fn(),
+    },
+  }),
+}));
+
+describe("LoginPage", () => {
+  it("renders a 'Forgot password?' link to /forgot-password", async () => {
+    const { default: LoginPage } = await import("../page");
+    render(<LoginPage />);
+
+    const link = screen.getByRole("link", { name: /forgot password/i });
+    expect(link).toBeDefined();
+    expect(link.getAttribute("href")).toBe("/forgot-password");
+  });
+});

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
@@ -72,6 +73,14 @@ export default function LoginPage() {
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               placeholder="Your password"
             />
+            <div className="mt-2 flex justify-end">
+              <Link
+                href="/forgot-password"
+                className="text-sm text-blue-600 hover:text-blue-700"
+              >
+                Forgot password?
+              </Link>
+            </div>
           </div>
           {error && (
             <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">

--- a/src/app/reset-password/__tests__/page.test.tsx
+++ b/src/app/reset-password/__tests__/page.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+/**
+ * ResetPasswordPage tests (UX5d / #190).
+ *
+ * Coverage (per AC9 of #190):
+ *   - Error state when token_hash is missing.
+ *   - Error state when type is missing or != "recovery" (e.g. invite link).
+ *   - Error state when ?error_description is present.
+ *   - Calls verifyOtp({ token_hash, type: "recovery" }) on mount with
+ *     both params; renders the password form on success.
+ *   - Error state when verifyOtp returns an error (expired/invalid).
+ *   - Error state when verifyOtp succeeds but getUser() returns no user.
+ *   - Strips ?token_hash from the URL via router.replace on success.
+ *   - Successful submit calls supabase.auth.updateUser({ password })
+ *     and redirects to "/".
+ *   - Submit error renders the destructive Banner from SetPasswordForm.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+let mockSearchParams: URLSearchParams;
+
+const pushSpy = vi.fn();
+const replaceSpy = vi.fn();
+const refreshSpy = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushSpy,
+    replace: replaceSpy,
+    refresh: refreshSpy,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+const verifyOtpSpy = vi.fn();
+const getUserSpy = vi.fn();
+const updateUserSpy = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      verifyOtp: (...args: unknown[]) => verifyOtpSpy(...args),
+      getUser: (...args: unknown[]) => getUserSpy(...args),
+      updateUser: (...args: unknown[]) => updateUserSpy(...args),
+    },
+  }),
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const TOKEN_HASH = "abcdef1234567890";
+
+function setSearchParams(query: Record<string, string>) {
+  mockSearchParams = new URLSearchParams(query);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pushSpy.mockReset();
+  replaceSpy.mockReset();
+  refreshSpy.mockReset();
+  verifyOtpSpy.mockReset();
+  getUserSpy.mockReset();
+  updateUserSpy.mockReset();
+  mockSearchParams = new URLSearchParams();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("ResetPasswordPage", () => {
+  it("renders error state when token_hash is missing", async () => {
+    setSearchParams({ type: "recovery" });
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/reset link problem/i)).toBeDefined();
+    });
+    expect(verifyOtpSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders error state when type is missing", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH });
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/reset link problem/i)).toBeDefined();
+    });
+    expect(verifyOtpSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders error state when type is not 'recovery' (e.g. invite link)", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH, type: "invite" });
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/reset link problem/i)).toBeDefined();
+    });
+    expect(verifyOtpSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders error state when ?error_description is present", async () => {
+    setSearchParams({
+      token_hash: TOKEN_HASH,
+      type: "recovery",
+      error_description: "Token expired",
+    });
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/reset link problem/i)).toBeDefined();
+    });
+    expect(verifyOtpSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls verifyOtp with token_hash + type:'recovery' and renders the password form on success", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH, type: "recovery" });
+    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
+    getUserSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" } },
+      error: null,
+    });
+
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => {
+      expect(verifyOtpSpy).toHaveBeenCalledWith({
+        token_hash: TOKEN_HASH,
+        type: "recovery",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/reset your password/i)).toBeDefined();
+    });
+    // URL strip side-effect.
+    expect(replaceSpy).toHaveBeenCalledWith("/reset-password");
+  });
+
+  it("renders error state when verifyOtp returns an error", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH, type: "recovery" });
+    verifyOtpSpy.mockResolvedValue({
+      data: {},
+      error: { message: "expired_token" },
+    });
+
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/expired or has already been used/i)
+      ).toBeDefined();
+    });
+  });
+
+  it("renders error state when verifyOtp succeeds but getUser returns no user", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH, type: "recovery" });
+    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
+    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/expired or has already been used/i)
+      ).toBeDefined();
+    });
+  });
+
+  it("calls updateUser with the new password and redirects to / on submit success", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH, type: "recovery" });
+    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
+    getUserSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" } },
+      error: null,
+    });
+    updateUserSpy.mockResolvedValue({ data: {}, error: null });
+
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/reset your password/i)).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: "longenough1" },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: "longenough1" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /update password and sign in/i })
+    );
+
+    await waitFor(() => {
+      expect(updateUserSpy).toHaveBeenCalledWith({ password: "longenough1" });
+    });
+    expect(pushSpy).toHaveBeenCalledWith("/");
+    expect(refreshSpy).toHaveBeenCalled();
+  });
+
+  it("renders a destructive Banner when updateUser fails", async () => {
+    setSearchParams({ token_hash: TOKEN_HASH, type: "recovery" });
+    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
+    getUserSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" } },
+      error: null,
+    });
+    updateUserSpy.mockResolvedValue({
+      data: {},
+      error: { message: "Password too weak" },
+    });
+
+    const { default: ResetPasswordPage } = await import("../page");
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/reset your password/i)).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: "longenough1" },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: "longenough1" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /update password and sign in/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/password too weak/i)).toBeDefined();
+    });
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+/**
+ * /reset-password — password-recovery landing page (UX5d / #190).
+ *
+ * Reached by users clicking the "Reset password" link in the branded
+ * recovery email. Supabase expands `{{ .ConfirmationURL }}` to
+ * `${redirectTo}?token_hash=<hash>&type=recovery&redirect_to=…` for
+ * this project's auth flow.
+ *
+ * Mirrors UX5c's /accept-invite structurally (#189) — same `verifyOtp`
+ * primitive, only the `type` literal differs.
+ *
+ * Flow:
+ *   1. Read `token_hash` + `type` from the URL query string.
+ *      - Validate `type === "recovery"`. Surface error state on mismatch
+ *        or `?error=…`/`?error_description=…` from GoTrue.
+ *   2. Call `supabase.auth.verifyOtp({ token_hash, type: "recovery" })`.
+ *      - Wrong primitive for server-issued recovery emails is
+ *        `exchangeCodeForSession` (PKCE) — that requires a code-verifier
+ *        cookie set by the ORIGINATING browser; recipient who clicked
+ *        the email link has no such cookie, so PKCE throws
+ *        AuthPKCECodeVerifierMissingError. UX5c R2 verified this.
+ *      - `verifyOtp` is stateless on the client, which means a user
+ *        can forward a reset link from one machine to another and the
+ *        recipient still completes the flow (cross-browser positive
+ *        behaviour).
+ *   3. After verifyOtp succeeds, the SDK installs session cookies
+ *      automatically. Strip token_hash + type from the URL via
+ *      router.replace so a refresh doesn't try to re-verify a now-
+ *      spent token.
+ *   4. Defensively confirm getUser() returns a user before rendering
+ *      the form.
+ *   5. <SetPasswordForm onSubmit> calls supabase.auth.updateUser —
+ *      this page owns the SDK call so the form stays reusable across
+ *      both invite and recovery flows.
+ *   6. On success, router.push("/") + router.refresh() so the
+ *      dashboard renders against the freshly-installed session.
+ */
+import * as React from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { SetPasswordForm } from "@/components/auth/set-password-form";
+import { Banner } from "@/components/ui/banner";
+
+type Phase =
+  | { kind: "verifying" }
+  | { kind: "ready" }
+  | { kind: "error"; message: string };
+
+const ERROR_INVALID_LINK =
+  "This password-reset link is invalid or expired. Request a new one.";
+const ERROR_EXPIRED_OR_USED =
+  "This password-reset link has expired or has already been used. Request a new one.";
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [phase, setPhase] = React.useState<Phase>({ kind: "verifying" });
+  // Single-shot guard — React Strict Mode double-mounts effects in
+  // development and we MUST NOT call verifyOtp twice (the second call
+  // would race the now-spent token_hash and surface a false error).
+  const verifyStartedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (verifyStartedRef.current) return;
+    verifyStartedRef.current = true;
+
+    const tokenHash = searchParams.get("token_hash");
+    const type = searchParams.get("type");
+    const errorDescription =
+      searchParams.get("error_description") || searchParams.get("error");
+
+    if (errorDescription) {
+      setPhase({ kind: "error", message: ERROR_INVALID_LINK });
+      return;
+    }
+
+    if (!tokenHash || type !== "recovery") {
+      setPhase({ kind: "error", message: ERROR_INVALID_LINK });
+      return;
+    }
+
+    const supabase = createClient();
+
+    void (async () => {
+      const { error } = await supabase.auth.verifyOtp({
+        token_hash: tokenHash,
+        type: "recovery",
+      });
+      if (error) {
+        setPhase({ kind: "error", message: ERROR_EXPIRED_OR_USED });
+        return;
+      }
+      // Defensive: confirm a session was installed. verifyOtp returns
+      // success but the session may be absent if cookies failed to
+      // persist — surface the standard error in that edge case.
+      const { data: userData } = await supabase.auth.getUser();
+      if (!userData.user) {
+        setPhase({ kind: "error", message: ERROR_EXPIRED_OR_USED });
+        return;
+      }
+      // Strip the token_hash + type from the URL so a refresh doesn't
+      // try to re-verify a now-spent token.
+      router.replace("/reset-password");
+      setPhase({ kind: "ready" });
+    })();
+  }, [router, searchParams]);
+
+  async function handleSetPassword(password: string): Promise<void> {
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      // SetPasswordForm surfaces the thrown message in its top-level
+      // <Banner tone="destructive">.
+      throw new Error(error.message || "Could not set password.");
+    }
+    router.push("/");
+    router.refresh();
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted px-4">
+      <div className="w-full max-w-md rounded-md border border-border bg-card p-8 shadow-sm">
+        {phase.kind === "verifying" && (
+          <div className="text-center" role="status" aria-live="polite">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Verifying your reset link…
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              One moment while we confirm your password-reset link.
+            </p>
+          </div>
+        )}
+
+        {phase.kind === "error" && (
+          <div className="space-y-4">
+            <Banner tone="destructive" title="Reset link problem">
+              {phase.message}
+            </Banner>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                href="/forgot-password"
+                className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Back to forgot password
+              </Link>
+            </p>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                href="/login"
+                className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        )}
+
+        {phase.kind === "ready" && (
+          <SetPasswordForm
+            title="Reset your password"
+            subtitle="Choose a new password for your account."
+            submitLabel="Update password and sign in"
+            onSubmit={handleSetPassword}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/middleware.test.ts
+++ b/src/lib/__tests__/middleware.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Middleware tests (UX5d / #190).
+ *
+ * Coverage (per AC8 + AC9 of #190):
+ *   - Unauthenticated GET on /forgot-password is NOT redirected to /login.
+ *   - Unauthenticated GET on /reset-password is NOT redirected to /login.
+ *   - Public-paths check still allows /login and /accept-invite (UX5c).
+ *   - Unauthenticated GET on a private path (/dashboard) IS redirected.
+ *
+ * Located in src/lib/__tests__ so it runs under the `lib` vitest
+ * project (vitest.config.ts only globs src/lib, src/components, and
+ * src/app).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock @supabase/ssr so getUser() resolves to a deterministic value.
+const getUserMock = vi.fn();
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: {
+      getUser: getUserMock,
+    },
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUserMock.mockReset();
+  // Provide minimal env for the middleware to construct a client.
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+});
+
+async function loadMiddleware() {
+  vi.resetModules();
+  return (await import("../../middleware")).middleware;
+}
+
+function makeRequest(pathname: string) {
+  return new NextRequest(`http://localhost${pathname}`);
+}
+
+describe("middleware PUBLIC_PATHS", () => {
+  it("allows unauthenticated GET on /forgot-password (no redirect)", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/forgot-password"));
+
+    // Pass-through (NextResponse.next), not a redirect to /login.
+    expect(res.headers.get("location")).toBeNull();
+    expect(res.status).toBe(200);
+  });
+
+  it("allows unauthenticated GET on /reset-password (no redirect)", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/reset-password"));
+
+    expect(res.headers.get("location")).toBeNull();
+    expect(res.status).toBe(200);
+  });
+
+  it("allows unauthenticated GET on /login (regression)", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/login"));
+
+    expect(res.headers.get("location")).toBeNull();
+    expect(res.status).toBe(200);
+  });
+
+  it("allows unauthenticated GET on /accept-invite (regression — UX5c)", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/accept-invite"));
+
+    expect(res.headers.get("location")).toBeNull();
+    expect(res.status).toBe(200);
+  });
+
+  it("redirects unauthenticated GET on a private path to /login", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/dashboard"));
+
+    // NextResponse.redirect sets a 3xx and a Location header.
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(res.status).toBeLessThan(400);
+    expect(res.headers.get("location")).toMatch(/\/login$/);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,16 @@ import { NextResponse, type NextRequest } from "next/server";
 // Paths that don't require an authenticated session. `/accept-invite`
 // is reached unauthenticated by users clicking the invite-email link
 // — verifyOtp on the page installs the session cookie (UX5c / #189).
-const PUBLIC_PATHS = ["/login", "/accept-invite"];
+// `/forgot-password` is the request side of the password-recovery flow;
+// `/reset-password` is the consumption side reached by the recovery
+// email link — verifyOtp on that page installs the session cookie
+// (UX5d / #190).
+const PUBLIC_PATHS = [
+  "/login",
+  "/accept-invite",
+  "/forgot-password",
+  "/reset-password",
+];
 
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({


### PR DESCRIPTION
## Summary

Mirrors UX5c (#189) structurally — same `verifyOtp({ token_hash, type })` primitive but with `type: "recovery"` instead of `"invite"`. Reuses `<SetPasswordForm>` (UX5c's extraction) verbatim.

- **"Forgot password?" link on `/login`** — right-aligned below password input. /login styling NOT migrated (out of scope per refinement).
- **`/forgot-password/page.tsx`** — email input + submit. Calls `resetPasswordForEmail(email, { redirectTo: '${window.location.origin}/reset-password' })`. **Email-enumeration defense**: identical success copy regardless of whether the email exists ("If an account exists for {email}…"). 429 (`over_email_send_rate_limit`) maps to a generic message — no timing leak. NEVER echoes `error.message` to UI.
- **`/reset-password/page.tsx`** — mirrors `/accept-invite`. Reads `?token_hash=…&type=recovery`, validates `type === "recovery"` (rejects mistaken invite links client-side before SDK call), `verifyOtp`, defensive `getUser()`, strips spent params via `router.replace`. Renders `<SetPasswordForm submitLabel="Update password and sign in">`. Cross-browser link forwarding works (verifyOtp stateless). Errors map to "This reset link is invalid or expired."
- **Middleware** — `PUBLIC_PATHS` extended with `/forgot-password` + `/reset-password`.
- **Reset email template runbook** at `mbe-docs/docs/operational-runbooks/reset-password-email-template.md` (sibling repo, NOT committed). Uses `{{ .ConfirmationURL }}`. NO `.Data` (recovery emails don't get the data payload).

**21 new tests** — 6 forgot-password (incl. enumeration defense + 429), 9 reset-password (verifyOtp flow happy + sad), 1 login (link visible + href), 5 middleware (4 public paths pass-through + 1 protected redirects).

Closes #190.

## ⚠ Pre-merge operator steps

1. **Confirm Supabase Dashboard → Authentication → URL Configuration → Additional Redirect URLs** allowlist covers:
   - `https://metering-billing-engine.vercel.app/reset-password`
   - `https://metering-billing-engine.vercel.app/*` (wildcard for preview branches)
   - `http://localhost:3000/reset-password` (local dev)
   
   Per memory, redirect URLs were widened on 2026-04-25 to cover preview + localhost; should already be in place.

2. **Paste the reset-password email template** from `~/Projects/energy-iot/mbe-docs/docs/operational-runbooks/reset-password-email-template.md` into Supabase Dashboard → Authentication → Email Templates → Reset password (cloud project `tztbmsxxjjsryuvoyqji`).

## Test plan

- [x] `npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1304 pass) && npm run build` — all green
- [x] Reviewer agent walked all 9 ACs + ran security audit + enumeration-defense check — VERDICT: APPROVE (zero blockers, two NITs noted as acceptable trade-offs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)