### PR TITLE
Payment config: allow org_manager to manage their own communities (#196)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/payment/__tests__/payment-shell.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/__tests__/payment-shell.test.tsx
@@ -1,13 +1,13 @@
 // @vitest-environment jsdom
 /**
- * PaymentShell tests (#119).
+ * PaymentShell tests (#119, #196).
  *
  * Covers:
- *  1. Empty state (super_admin): "Connect Pesapal" card + coming-soon footnote
- *  2. Empty state (org_manager): info banner, no form
- *  3. Configured state (super_admin): chip, masked secret, Test again,
+ *  1. Empty state (canEdit=true): "Connect Pesapal" card + coming-soon footnote
+ *  2. Empty state (canEdit=false): info banner, no form
+ *  3. Configured state (canEdit=true): chip, masked secret, Test again,
  *     Reconfigure buttons visible
- *  4. Configured state (org_manager): no Reconfigure/Test again, read-only
+ *  4. Configured state (canEdit=false): no Reconfigure/Test again, read-only
  *     banner, secret renders "—"
  *  5. Reconfigure form opens with existing consumer_key + blank secret +
  *     sandbox toggle initialized from stored value
@@ -79,13 +79,13 @@ afterEach(() => {
 // ─── Empty state ─────────────────────────────────────────────────────────
 
 describe("PaymentShell — empty state", () => {
-  it("(1) super_admin sees Connect Pesapal card + coming-soon footnote", () => {
+  it("(1) canEdit=true sees Connect Pesapal card + coming-soon footnote", () => {
     render(
       <PaymentShell
         community={BASE_COMMUNITY}
         health="not_configured"
         secretLast4={null}
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     expect(
@@ -94,13 +94,13 @@ describe("PaymentShell — empty state", () => {
     expect(screen.getByText(/more providers/i)).toBeDefined();
   });
 
-  it("(2) org_manager sees info banner, no Connect button", () => {
+  it("(2) canEdit=false sees info banner, no Connect button", () => {
     render(
       <PaymentShell
         community={BASE_COMMUNITY}
         health="not_configured"
         secretLast4={null}
-        isSuperAdmin={false}
+        canEdit={false}
       />,
     );
     expect(
@@ -113,13 +113,13 @@ describe("PaymentShell — empty state", () => {
 // ─── Configured state ────────────────────────────────────────────────────
 
 describe("PaymentShell — configured state", () => {
-  it("(3) super_admin: chip, masked secret, Test again + Reconfigure visible", () => {
+  it("(3) canEdit=true: chip, masked secret, Test again + Reconfigure visible", () => {
     const { container } = render(
       <PaymentShell
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     expect(container.textContent).toContain("Healthy");
@@ -128,30 +128,32 @@ describe("PaymentShell — configured state", () => {
     expect(screen.getByRole("button", { name: /reconfigure/i })).toBeDefined();
   });
 
-  it("(4) org_manager: read-only banner, no Reconfigure/Test, secret '—'", () => {
+  it("(4) canEdit=false: read-only banner, no Reconfigure/Test, secret '—'", () => {
     const { container } = render(
       <PaymentShell
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4={null}
-        isSuperAdmin={false}
+        canEdit={false}
       />,
     );
     expect(screen.queryByRole("button", { name: /reconfigure/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /test again/i })).toBeNull();
     expect(
-      screen.getByText(/only super admins can update payment credentials/i),
+      screen.getByText(
+        /you don.?t have permission to update this community.?s payment configuration/i,
+      ),
     ).toBeDefined();
     expect(container.textContent).toContain("—");
   });
 
-  it("(4b) super_admin: callback URL + truncated ipn_id rendered (#121)", () => {
+  it("(4b) canEdit=true: callback URL + truncated ipn_id rendered (#121)", () => {
     const { container } = render(
       <PaymentShell
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     expect(container.textContent).toContain("IPN callback URL");
@@ -166,20 +168,20 @@ describe("PaymentShell — configured state", () => {
     );
   });
 
-  it("(4c) org_manager does not see callback URL / ipn_id (super_admin gated)", () => {
+  it("(4c) canEdit=false does not see callback URL / ipn_id (gated)", () => {
     const { container } = render(
       <PaymentShell
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4={null}
-        isSuperAdmin={false}
+        canEdit={false}
       />,
     );
     expect(container.textContent).not.toContain("IPN callback URL");
     expect(container.textContent).not.toContain("Registered IPN id");
   });
 
-  it("(4d) super_admin sees 'Not registered yet' hint when ipn_id is missing", () => {
+  it("(4d) canEdit=true sees 'Not registered yet' hint when ipn_id is missing", () => {
     const { container } = render(
       <PaymentShell
         community={{
@@ -188,7 +190,7 @@ describe("PaymentShell — configured state", () => {
         }}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     expect(container.textContent).toContain("Not registered yet");
@@ -204,7 +206,7 @@ describe("PaymentShell — reconfigure flow", () => {
         community={{ ...CONFIGURED_COMMUNITY, config: { ...CONFIGURED_COMMUNITY.config, sandbox: true } }}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
@@ -261,7 +263,7 @@ describe("PaymentShell — Save & test outcomes", () => {
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
@@ -292,7 +294,7 @@ describe("PaymentShell — Save & test outcomes", () => {
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
@@ -318,7 +320,7 @@ describe("PaymentShell — Save & test outcomes", () => {
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
@@ -343,7 +345,7 @@ describe("PaymentShell — secret-preserve", () => {
         community={CONFIGURED_COMMUNITY}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
@@ -374,7 +376,7 @@ describe("PaymentShell — sandbox toggle", () => {
         }}
         health="healthy"
         secretLast4="9xYZ"
-        isSuperAdmin={true}
+        canEdit={true}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));

--- a/src/app/(dashboard)/communities/[id]/payment/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/page.tsx
@@ -2,21 +2,24 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import {
   currentUserCanAccessCommunity,
-  currentUserIsSuperAdmin,
+  currentUserCanAccessOrg,
 } from "@/lib/auth/access";
 import { derivePaymentHealth } from "./health";
 import { PaymentShell } from "./payment-shell";
 
 /**
- * /communities/[id]/payment — Payment configuration (#119).
+ * /communities/[id]/payment — Payment configuration (#119, #196).
  *
  * Server component fetches:
  *   1. Community row (name + payment_* columns).
- *   2. Permission flags (canAccessCommunity, isSuperAdmin).
- *   3. Decrypted secret last-4 — super_admin only. We call
- *      fn_get_community_payment_secret which returns NULL for org_manager
- *      (even on their own community), then compute `secret.slice(-4)`
- *      SERVER-SIDE. The plaintext secret NEVER crosses to the client.
+ *   2. Permission flags (canAccessCommunity for visibility, canEdit for the
+ *      Save / Reconfigure / Test-again surface). canEdit is true for
+ *      super_admin OR org_manager scoped to this community's parent org.
+ *   3. Decrypted secret last-4 — visible to anyone with edit permission. We
+ *      call fn_get_community_payment_secret (per migration 00030 widens the
+ *      decrypt gate to org_managers of the parent org), then compute
+ *      `secret.slice(-4)` SERVER-SIDE. The plaintext secret NEVER crosses
+ *      to the client.
  *
  * The server component passes everything as props to `<PaymentShell>` which
  * owns mode state (empty / configured / editing), form state, and the
@@ -34,16 +37,15 @@ export default async function PaymentPage({
   const canAccess = await currentUserCanAccessCommunity(supabase, id);
   if (!canAccess) notFound();
 
-  const isSuperAdmin = await currentUserIsSuperAdmin(supabase);
-
   const { data: community, error: commErr } = await supabase
     .from("communities")
     .select(
-      "id, name, payment_provider, payment_provider_config, payment_last_configured_at",
+      "id, org_id, name, payment_provider, payment_provider_config, payment_last_configured_at",
     )
     .eq("id", id)
     .maybeSingle<{
       id: string;
+      org_id: string;
       name: string;
       payment_provider: "pesapal" | null;
       payment_provider_config: unknown;
@@ -52,11 +54,17 @@ export default async function PaymentPage({
 
   if (commErr || !community) notFound();
 
-  // Mirrors openems-backend/page.tsx:81-89. `fn_get_community_payment_secret`
-  // returns NULL for non-super_admin per migration 00020 truth table, so the
-  // secretLast4 prop is NULL for org_manager (UI renders "—").
+  // canEdit needs community.org_id, so this derivation must follow the
+  // community fetch. True for super_admin OR org_manager scoped to this
+  // community's parent org (#196).
+  const canEdit = await currentUserCanAccessOrg(supabase, community.org_id);
+
+  // `fn_get_community_payment_secret` (migration 00030 truth table): returns
+  // plaintext for super_admin OR org_manager-of-parent-org OR service_role,
+  // NULL otherwise. We mirror the gate here so the secretLast4 prop is only
+  // computed when the caller can edit (UI renders "—" when canEdit=false).
   let secretLast4: string | null = null;
-  if (community.payment_provider === "pesapal" && isSuperAdmin) {
+  if (community.payment_provider === "pesapal" && canEdit) {
     const { data: secret } = await supabase.rpc(
       "fn_get_community_payment_secret",
       { _community_id: id },
@@ -113,8 +121,9 @@ export default async function PaymentPage({
   });
 
   // Server-derived public callback URL surfaced in the configured-mode panel
-  // (super_admin only) for operator visibility — matches the URL Save & test
-  // registers with Pesapal. Always recomputed; never persisted client-side.
+  // (visible to anyone with edit permission) for operator visibility — matches
+  // the URL Save & test registers with Pesapal. Always recomputed; never
+  // persisted client-side.
   const callbackBase = (
     process.env.NEXT_PUBLIC_PAYMENT_CALLBACK_URL ?? ""
   )
@@ -135,7 +144,7 @@ export default async function PaymentPage({
         }}
         health={health}
         secretLast4={secretLast4}
-        isSuperAdmin={isSuperAdmin}
+        canEdit={canEdit}
       />
     </div>
   );

--- a/src/app/(dashboard)/communities/[id]/payment/payment-shell.tsx
+++ b/src/app/(dashboard)/communities/[id]/payment/payment-shell.tsx
@@ -8,7 +8,9 @@
 //   - Save & test promise + result banner state
 //
 // Data flow:
-//   Server component passes (community, health, secretLast4, isSuperAdmin).
+//   Server component passes (community, health, secretLast4, canEdit).
+//   `canEdit` is true for super_admin OR org_manager scoped to this
+//   community's parent org (#196).
 //   On Save/Test success → router.refresh() so the layout + page re-fetch
 //   health + last-configured timestamp.
 //
@@ -57,7 +59,7 @@ export type PaymentShellProps = {
   community: CommunityProps;
   health: PaymentHealth;
   secretLast4: string | null;
-  isSuperAdmin: boolean;
+  canEdit: boolean;
 };
 
 type SaveOutcome =
@@ -71,7 +73,7 @@ type SaveOutcome =
   | { kind: "generic_error"; message: string };
 
 export function PaymentShell(props: PaymentShellProps) {
-  const { community, health, secretLast4, isSuperAdmin } = props;
+  const { community, health, secretLast4, canEdit } = props;
   const router = useRouter();
 
   const initialMode: "empty" | "configured" =
@@ -271,13 +273,13 @@ export function PaymentShell(props: PaymentShellProps) {
 
   // Empty state
   if (mode === "empty" && !isEditing) {
-    if (!isSuperAdmin) {
+    if (!canEdit) {
       return (
         <div className="space-y-4">
           {header}
           <Banner tone="info" title="Not configured yet">
             This community hasn&apos;t been connected to a payment provider yet.
-            Ask a super admin to configure it.
+            Ask a super admin or your org&apos;s manager to configure it.
           </Banner>
         </div>
       );
@@ -361,7 +363,7 @@ export function PaymentShell(props: PaymentShellProps) {
                 {community.config.base_url || "—"}
               </p>
             </div>
-            {isSuperAdmin && (
+            {canEdit && (
               <>
                 <div>
                   <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -409,7 +411,7 @@ export function PaymentShell(props: PaymentShellProps) {
                 No Save & test has run yet.
               </p>
             )}
-            {isSuperAdmin && (
+            {canEdit && (
               <button
                 type="button"
                 onClick={handleTestAgain}
@@ -422,7 +424,7 @@ export function PaymentShell(props: PaymentShellProps) {
           </div>
         </div>
 
-        {isSuperAdmin && !isEditing && (
+        {canEdit && !isEditing && (
           <div className="mt-5 flex justify-end">
             <button
               type="button"
@@ -555,10 +557,11 @@ export function PaymentShell(props: PaymentShellProps) {
     <div className="space-y-4">
       {header}
 
-      {!isSuperAdmin && mode === "configured" && (
+      {!canEdit && mode === "configured" && (
         <Banner tone="info" title="Read-only view">
-          Only super admins can update Payment credentials. Contact your
-          administrator to request changes.
+          You don&apos;t have permission to update this community&apos;s payment
+          configuration. Contact a super admin or your org&apos;s manager to
+          request changes.
         </Banner>
       )}
 

--- a/src/app/api/billing-line-items/[lineItemId]/url/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/route.ts
@@ -9,10 +9,10 @@
  *   lineItem → billing_period → microgrid → community (provider config)
  *
  * Permission:
- *   Both super_admin AND org_manager may trigger link generation. Only super_admin
- *   (or service_role) can decrypt the provider secret via
- *   fn_get_community_payment_secret; an org_manager of the owning community
- *   will receive a 403 from getCommunityPaymentConfig with PAYMENT_FORBIDDEN.
+ *   super_admin, service_role, OR org_manager-of-owning-community can decrypt
+ *   the provider secret via fn_get_community_payment_secret (#196). An
+ *   org_manager of a DIFFERENT org will receive a 403 from
+ *   getCommunityPaymentConfig with PAYMENT_FORBIDDEN.
  *
  * Response:
  *   200 → { redirectUrl, orderTrackingId, merchantReference }
@@ -144,9 +144,9 @@ export async function POST(
     actorUserId = null;
   }
 
-  // 2. Permission gate. org_manager + super_admin both allowed; secret access
-  //    is filtered by fn_get_community_payment_secret (org_manager → null →
-  //    PAYMENT_FORBIDDEN below).
+  // 2. Permission gate. super_admin + org_manager-of-owning-org both allowed;
+  //    cross-org callers are filtered by fn_get_community_payment_secret
+  //    (cross-org org_manager → null → PAYMENT_FORBIDDEN below) (#196).
   if (!(await currentUserCanAccessMicrogrid(supabase, microgridId))) {
     return NextResponse.json(
       { error: "Billing line item not found.", reason: "not_found" },

--- a/src/app/api/communities/[id]/payment/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/payment/__tests__/route.test.ts
@@ -1,10 +1,10 @@
 /**
- * PUT /api/communities/[id]/payment — unit tests (#119 AC-ROUTE-*).
+ * PUT /api/communities/[id]/payment — unit tests (#119 AC-ROUTE-*, #196).
  *
  * Supabase + auth helpers + PesapalClient are mocked. Covers:
  *   (1) Happy path (new config) → 200, encrypts secret, writes all 4 columns
  *   (2) Happy path (reconfigure w/ blank secret) → secret-preserve skips encrypt
- *   (3) Permission: non-super_admin (org_manager) → 403
+ *   (3) Permission: org_manager-of-parent-org → 200 (widened in #196)
  *   (4) Permission: cannot access org → 403
  *   (5) RLS-hidden / missing community → 404
  *   (6) Pesapal auth fail → 503 { reason: "auth_failed" }, no DB write
@@ -12,6 +12,11 @@
  *   (8) Malformed body → 400
  *   (9) First-configuration with blank secret → 400
  *  (10) base_url is server-derived from sandbox (NOT taken from body)
+ *
+ * Note: anon → 401 is enforced by `src/middleware.ts:57-64` for any /api/*
+ * path; this unit test mounts the route handler directly so middleware does
+ * not run. The DB-level NULL-for-anon defense-in-depth is covered by the
+ * fn_get_community_payment_secret RLS test in `rls.test.ts`.
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
@@ -53,11 +58,9 @@ vi.mock("@/lib/payments/pesapal/client", async () => {
 });
 
 let canAccessOrgReturn = true;
-let isSuperAdminReturn = true;
 
 vi.mock("@/lib/auth/access", () => ({
   currentUserCanAccessOrg: async () => canAccessOrgReturn,
-  currentUserIsSuperAdmin: async () => isSuperAdminReturn,
 }));
 
 // ─── Supabase mock — sequenced from() handlers, shared mockRpc ─────────────
@@ -109,7 +112,6 @@ describe("PUT /api/communities/[id]/payment", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     canAccessOrgReturn = true;
-    isSuperAdminReturn = true;
     communitySelectResp = {
       data: {
         id: COMMUNITY_ID,
@@ -242,10 +244,12 @@ describe("PUT /api/communities/[id]/payment", () => {
     ).toBe("ipn-fresh-guid");
   });
 
-  // ─── (3) org_manager → 403 ─────────────────────────────────────────────
-  it("(3) non-super_admin → 403 before any DB write", async () => {
-    isSuperAdminReturn = false;
-
+  // ─── (3) org_manager-of-parent-org → 200 (widened in #196) ─────────────
+  it("(3) org_manager-of-parent-org (canAccessOrg=true) → 200 happy path", async () => {
+    // Same setup as case (1) — canAccessOrgReturn defaults to true. This
+    // mirrors the post-#196 behavior where any caller satisfying
+    // currentUserCanAccessOrg can save the config (no separate super_admin
+    // gate). The route never calls currentUserIsSuperAdmin anymore.
     const { PUT } = await import("../route");
     const res = await PUT(
       makePutRequest({
@@ -255,9 +259,9 @@ describe("PUT /api/communities/[id]/payment", () => {
       }),
       { params: Promise.resolve({ id: COMMUNITY_ID }) },
     );
-    expect(res.status).toBe(403);
-    expect(getAccessTokenMock).not.toHaveBeenCalled();
-    expect(updatePayloadCapture).toBeNull();
+    expect(res.status).toBe(200);
+    expect(getAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(updatePayloadCapture).toBeTruthy();
   });
 
   // ─── (4) cross-org → 403 ───────────────────────────────────────────────

--- a/src/app/api/communities/[id]/payment/route.ts
+++ b/src/app/api/communities/[id]/payment/route.ts
@@ -1,17 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import {
-  currentUserCanAccessOrg,
-  currentUserIsSuperAdmin,
-} from "@/lib/auth/access";
+import { currentUserCanAccessOrg } from "@/lib/auth/access";
 import { PesapalClient } from "@/lib/payments/pesapal/client";
 import { PesapalError } from "@/lib/payments/pesapal/errors";
 import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
 
 /**
- * PUT /api/communities/[id]/payment — Save & test payment-provider config (#119, #121).
+ * PUT /api/communities/[id]/payment — Save & test payment-provider config (#119, #121, #196).
  *
- * Body shape (super_admin only):
+ * Body shape:
  *   {
  *     provider: 'pesapal',
  *     config: { consumer_key: string, sandbox: boolean },
@@ -22,15 +19,15 @@ import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
  * from the `sandbox` boolean so the JSONB stays canonical and typo'd URLs
  * can never reach the DB.
  *
- * Execution order (post-#121):
+ * Execution order (post-#121, gate widened in #196):
  *
  *   1. UUID check on [id] → 400 on malformed.
  *   2. JSON parse + manual shape validation → 400 on malformed body.
  *   3. Resolve the community's org_id (and existing payment_*_encrypted column)
  *      with a single row read. RLS hidden or missing → 404 (don't leak).
- *   4. Permission gate: currentUserCanAccessOrg(org_id) AND
- *      currentUserIsSuperAdmin. Either missing → 403. super_admin gate is the
- *      primary rule; org access is defense-in-depth.
+ *   4. Permission gate: currentUserCanAccessOrg(org_id) — true for super_admin
+ *      OR for org_manager scoped to the community's parent org. Either
+ *      missing → 403. Mirrors the SQL helper `user_can_access_org`.
  *   5. Secret-preserve gate: if the body's secret_access_key is blank/absent
  *      AND an existing payment_provider_secret_encrypted row is non-NULL,
  *      preserve it. Otherwise require a non-empty secret → 400.
@@ -155,20 +152,12 @@ export async function PUT(
     return NextResponse.json({ error: "Community not found." }, { status: 404 });
   }
 
-  // Permission — super_admin gate is the primary rule; org access
-  // is defense-in-depth (super_admins always pass currentUserCanAccessOrg).
+  // Permission — currentUserCanAccessOrg returns true for super_admin OR for
+  // org_manager scoped to this community's parent org (#196). Cross-org
+  // org_managers and unscoped users are rejected here.
   if (!(await currentUserCanAccessOrg(supabase, community.org_id))) {
     return NextResponse.json(
       { error: "You do not have permission to configure this community." },
-      { status: 403 },
-    );
-  }
-  if (!(await currentUserIsSuperAdmin(supabase))) {
-    return NextResponse.json(
-      {
-        error:
-          "Only super admins can update Payment credentials.",
-      },
       { status: 403 },
     );
   }

--- a/src/lib/payments/config.ts
+++ b/src/lib/payments/config.ts
@@ -18,9 +18,10 @@ import type { PesapalConfig } from "./pesapal/types";
  * Throws:
  *   - `PaymentError('PAYMENT_INVALID_CONFIG', 500)` — stored config is
  *     malformed / partial (shape doesn't match provider contract).
- *   - `PaymentError('PAYMENT_FORBIDDEN', 403)` — caller is an org_manager
- *     (not super_admin, not service_role) trying to decrypt a payment secret;
- *     `fn_get_community_payment_secret` returned NULL.
+ *   - `PaymentError('PAYMENT_FORBIDDEN', 403)` — caller is an org_manager of
+ *     a DIFFERENT org than the community (not super_admin, not service_role,
+ *     not org_manager-of-parent-org) trying to decrypt a payment secret;
+ *     `fn_get_community_payment_secret` returned NULL (#196).
  *
  * Mirrors `src/lib/openems/config.ts`. Authorization semantics are identical:
  * RLS on `communities` filters cross-org rows; the SECURITY-DEFINER helper
@@ -71,7 +72,7 @@ export async function getCommunityPaymentConfig(
 
     if (!secret) {
       throw new PaymentError(
-        "Only super admins can generate payment links for this community, because they are the only role that can decrypt the provider secret. Ask a super admin.",
+        "You don't have permission to generate payment links for this community. Ask a super admin or your org's manager.",
         "PAYMENT_FORBIDDEN",
         403,
       );

--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -25,13 +25,14 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { type SupabaseClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import {
   assertEnvironmentReady,
   shouldSkip,
   serviceClient,
   createTestUser,
   cleanupTestData,
+  LOCAL_SUPABASE_URL,
   type TestUser,
 } from "./rls.helpers";
 
@@ -1714,9 +1715,13 @@ describe("RLS: OpenEMS Backend (#101)", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════
-// RLS: Community payment provider (#115)
+// RLS: Community payment provider (#115, #196)
 // Exercises the fn_get_community_payment_secret truth table + encryption
 // round-trip via fn_ems_encrypt_secret (shared DEK).
+//
+// Post-#196: org_managers scoped to the community's parent org now receive
+// the plaintext secret (previously redacted to NULL). Cross-org callers
+// continue to receive NULL via the user_can_access_org gate.
 // ══════════════════════════════════════════════════════════════════════════
 
 describe("RLS: Community payment provider (#115)", () => {
@@ -1801,7 +1806,7 @@ describe("RLS: Community payment provider (#115)", () => {
       expect(data).toBeNull();
     });
 
-    it("org_manager (owner org) gets NULL — redacted", async () => {
+    it("org_manager (owner org) gets plaintext (#196 — widened)", async () => {
       if (skipIfRequested()) return;
       await setupPaymentConfig();
       try {
@@ -1810,13 +1815,27 @@ describe("RLS: Community payment provider (#115)", () => {
           { _community_id: FIXTURE.communityA }
         );
         expect(error).toBeNull();
-        expect(data).toBeNull();
+        expect(data).toBe(PAYMENT_SECRET_PLAINTEXT);
       } finally {
         await clearPaymentConfig();
       }
     });
 
-    it("org_manager (different org) gets NULL — redacted by helper", async () => {
+    it("org_manager (owner org) gets NULL when secret is not set (#196)", async () => {
+      if (skipIfRequested()) return;
+      // Setup with provider null (no secret) — org_manager can read the
+      // community row via RLS but the function returns NULL because there
+      // is no ciphertext to decrypt. Distinct from "no permission".
+      await clearPaymentConfig();
+      const { data, error } = await userA.client.rpc(
+        "fn_get_community_payment_secret",
+        { _community_id: FIXTURE.communityA }
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("org_manager (different org) gets NULL — blocked by user_can_access_org gate", async () => {
       if (skipIfRequested()) return;
       await setupPaymentConfig();
       try {
@@ -1852,6 +1871,32 @@ describe("RLS: Community payment provider (#115)", () => {
       await setupPaymentConfig();
       try {
         const { data, error } = await userC.client.rpc(
+          "fn_get_community_payment_secret",
+          { _community_id: FIXTURE.communityA }
+        );
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+      } finally {
+        await clearPaymentConfig();
+      }
+    });
+
+    it("anon (no Authorization header) gets NULL — DB-level defense-in-depth (#196)", async () => {
+      if (skipIfRequested()) return;
+      await setupPaymentConfig();
+      try {
+        // Anon client: anon key only, no user JWT. PostgREST evaluates
+        // auth.uid() = NULL and auth.role() = 'anon'; the function's
+        // permission gate (service_role OR user_can_access_org) returns
+        // false, so the function returns NULL. This guards the route as
+        // defense-in-depth even though src/middleware.ts:57-64 already
+        // 401s anon /api/* requests upstream.
+        const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+        if (!anonKey) throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY not set");
+        const anonClient = createClient(LOCAL_SUPABASE_URL, anonKey, {
+          auth: { persistSession: false, autoRefreshToken: false },
+        });
+        const { data, error } = await anonClient.rpc(
           "fn_get_community_payment_secret",
           { _community_id: FIXTURE.communityA }
         );

--- a/supabase/migrations/00030_payment_secret_org_manager.sql
+++ b/supabase/migrations/00030_payment_secret_org_manager.sql
@@ -1,0 +1,89 @@
+-- 00030_payment_secret_org_manager.sql
+-- Widen fn_get_community_payment_secret to org_manager-of-parent-org (#196).
+--
+-- ── Summary ──────────────────────────────────────────────────────────────
+--
+-- The original definition (00020) gated decryption to super_admin /
+-- service_role only. Operationally, an org_manager owning a community in a
+-- different org needs to configure and rotate that community's payment
+-- provider without pinging a super_admin every time. This migration replaces
+-- the function body so org_managers scoped to the community's parent org
+-- also get the plaintext secret.
+--
+-- Authorization is delegated to `user_can_access_org` (00002_rls.sql:57-73),
+-- which already short-circuits to true for super_admins (00002_rls.sql:65)
+-- — there is no need to call `is_super_admin()` again in this body.
+-- `service_role` bypass is preserved for cron / IPN handler call sites.
+--
+-- ── New truth table ──────────────────────────────────────────────────────
+--
+--   | Caller context                                              | Return     |
+--   |-------------------------------------------------------------|------------|
+--   | is_super_admin() = true, secret set                         | plaintext  |
+--   | is_super_admin() = true, secret NULL                        | NULL       |
+--   | service_role                                                | plaintext  |
+--   | org_manager (community's parent org), secret set            | plaintext  |  <-- NEW
+--   | org_manager (community's parent org), secret NULL           | NULL       |
+--   | org_manager (different org)                                 | NULL       |
+--   | community not found / hard-deleted                          | NULL       |
+--   | anon / unauthenticated                                      | NULL       |
+--
+-- ── Probing-resistance ───────────────────────────────────────────────────
+--
+-- The lookup-then-gate ordering preserves the property documented at
+-- 00020:103-106: NULL is returned uniformly for "row missing" AND for
+-- "no permission", so an unauthorized caller cannot probe for row existence
+-- via timing or distinguishable return values.
+--
+-- ── Signature & grants ───────────────────────────────────────────────────
+--
+-- Signature unchanged: `fn_get_community_payment_secret(_community_id UUID)
+-- RETURNS TEXT`. `CREATE OR REPLACE` preserves existing privileges in
+-- Postgres ≥ 14, but we re-issue GRANT EXECUTE TO authenticated, service_role
+-- defensively to mirror the 00018 / 00020 patterns.
+
+CREATE OR REPLACE FUNCTION fn_get_community_payment_secret(_community_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_org_id UUID;
+  v_ciphertext BYTEA;
+BEGIN
+  -- Lookup org_id + ciphertext in a single read.
+  SELECT org_id, payment_provider_secret_encrypted
+    INTO v_org_id, v_ciphertext
+    FROM communities
+    WHERE id = _community_id
+    LIMIT 1;
+
+  -- Row missing → NULL (uniform with redaction; non-authorized callers
+  -- cannot probe for row existence).
+  IF v_org_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Permission gate. user_can_access_org already short-circuits
+  -- is_super_admin() → true (00002_rls.sql:65), so an explicit
+  -- is_super_admin() check would be redundant. service_role bypass is
+  -- preserved for the cron / IPN handler call sites.
+  IF NOT (auth.role() = 'service_role' OR user_can_access_org(v_org_id)) THEN
+    RETURN NULL;
+  END IF;
+
+  IF v_ciphertext IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN fn_ems_decrypt_secret(v_ciphertext);
+END;
+$$;
+
+-- Defensive re-grant. CREATE OR REPLACE preserves privileges, but mirroring
+-- the pattern from 00018 / 00020 keeps the grant explicit at the migration
+-- boundary in case the function was dropped + recreated by a future change.
+GRANT EXECUTE ON FUNCTION fn_get_community_payment_secret(UUID)
+  TO authenticated, service_role;


### PR DESCRIPTION
## Summary

Widens the Pesapal payment configuration surface from super_admin-only to **super_admin OR org_manager-of-the-community's-parent-org**. Three gates deleted in three layers:

- **DB** — new migration 00030 replaces `fn_get_community_payment_secret` body with collapsed `auth.role()='service_role' OR user_can_access_org(v_org_id)`. `user_can_access_org` short-circuits super_admin per `00002_rls.sql:65`, so no redundant `is_super_admin()` call. Lookup-then-gate order: org_id + ciphertext fetched in single SELECT, missing row returns NULL safely, permission then plaintext.
- **API** — `PUT /api/communities/[id]/payment` already had a correctly-scoped `currentUserCanAccessOrg(community.org_id)` gate at line 160 (post-refinement discovery). The redundant `currentUserIsSuperAdmin` block at lines 166-174 + its unused import + 3 stale comment blocks deleted. Existing line-160 gate stays.
- **UI** — `isSuperAdmin` → `canEdit` derived from `currentUserCanAccessOrg(community.org_id)` in `page.tsx`. 8 consumer sites in `payment-shell.tsx` renamed. Read-only banner copy generalized to "Ask a super admin or your org's manager".

**Stale comments + error strings cleaned up in downstream callers** (caught at refinement R2):
- `billing-line-items/[lineItemId]/url/route.ts` (docblock + inline gate comment).
- `lib/payments/config.ts` (PAYMENT_FORBIDDEN JSDoc + user-facing error string "Only super admins…" → "Ask a super admin or your org's manager.").

**Existing RLS test FLIPPED in place** (caught at R2): `rls.test.ts:1804` previously asserted `org_manager (owner org) → NULL (redacted)`; now asserts `→ plaintext`. Two new defense-in-depth cases added (NULL when secret unset; NULL for anon).

## Security audit

- ✅ Cross-org leak protected: route uses RLS-scoped client for community fetch → cross-org rows return 404 before gate.
- ✅ DB function: lookup-then-gate ordering; no early plaintext paths; `SECURITY DEFINER` + `SET search_path` preserved.
- ✅ Audit log: `logSaveTest` records `actor_user_id` from `getUser()` — org_manager actions are observable.
- ✅ IPN registration is per-community via that community's own Pesapal credentials — no cross-org impact.
- ✅ Sandbox toggle (#121) gated behind canEdit; org_manager already controls credentials so toggle is no new privilege.

## Test plan

- [x] `npm run lint && npx tsc --noEmit && SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test (1350 pass) && npm run build` — all green
- [x] Reviewer agent walked all 7 ACs + ran security audit — VERDICT: APPROVE (zero blockers; one cosmetic NIT noted)

## Pre-merge step

After merge, **apply migration 00030 to cloud** (the operator runs `psql … -f supabase/migrations/00030_payment_secret_org_manager.sql` against `tztbmsxxjjsryuvoyqji`) — same pattern as prior session migrations. Until then, the DB function still rejects org_managers; only the UI/route widening is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)