### PR TITLE
Fix: org_manager can create microgrids — RLS WITH CHECK now uses parent column (#198)

### DIFF
--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -174,11 +174,13 @@ beforeAll(async () => {
       id: FIXTURE.householdA,
       microgrid_id: FIXTURE.microgridA,
       display_name: "Household A",
+      primary_phone: "+256700000001",
     },
     {
       id: FIXTURE.householdB,
       microgrid_id: FIXTURE.microgridB,
       display_name: "Household B",
+      primary_phone: "+256700000002",
     },
   ]);
   if (hhError) throw new Error(`[fixture] households: ${hhError.message}`);
@@ -499,6 +501,36 @@ describe("RLS: microgrids", () => {
       name: "Unauthorized Microgrid",
       currency: "UGX",
     });
+  });
+
+  it("User A (org_manager of Org A) CAN INSERT a microgrid under Community A", async () => {
+    if (skipIfRequested()) return;
+
+    // Regression guard for #198: WITH CHECK on the microgrids policy used
+    // to dereference the new row's own id (which doesn't exist at INSERT
+    // time inside a STABLE helper's snapshot), making this insert fail
+    // with 42501 for org_managers. Migration 00031 repoints the policy at
+    // community_id (a parent-pointing column) so this now succeeds.
+    const { data, error } = await userA.client
+      .from("microgrids")
+      .insert({
+        community_id: FIXTURE.communityA,
+        name: "rls-test-own-microgrid",
+        currency: "UGX",
+      })
+      .select("id");
+
+    // RLS should permit this; clean up via service client (NOT userA.client)
+    // — matches the edges positive-INSERT pattern at :1104-1106.
+    if (data && data.length > 0) {
+      const svc = await serviceClient();
+      await svc.from("microgrids").delete().eq("id", data[0].id);
+    }
+
+    const isRlsError =
+      error?.code === "42501" ||
+      (error?.message ?? "").includes("row-level security");
+    expect(isRlsError, `unexpected RLS error: ${error?.message}`).toBe(false);
   });
 });
 
@@ -1063,6 +1095,81 @@ describe("RLS helper functions", () => {
         _microgrid_id: FIXTURE.microgridA,
       });
       expect(result).toBe(false);
+    });
+  });
+
+  describe("user_can_access_community(_community_id)", () => {
+    it("returns true for User A on Community A (own org)", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userA.client, "user_can_access_community", {
+        _community_id: FIXTURE.communityA,
+      });
+      expect(result).toBe(true);
+    });
+
+    it("returns false for User A on Community B (cross-org)", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userA.client, "user_can_access_community", {
+        _community_id: FIXTURE.communityB,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("returns false for User C (no role) on Community A", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userC.client, "user_can_access_community", {
+        _community_id: FIXTURE.communityA,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("returns false for User C (no role) on Community B", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userC.client, "user_can_access_community", {
+        _community_id: FIXTURE.communityB,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("returns true for User D (super_admin) on any community", async () => {
+      if (skipIfRequested()) return;
+      const [resultA, resultB] = await Promise.all([
+        callRpc(userD.client, "user_can_access_community", {
+          _community_id: FIXTURE.communityA,
+        }),
+        callRpc(userD.client, "user_can_access_community", {
+          _community_id: FIXTURE.communityB,
+        }),
+      ]);
+      expect(resultA).toBe(true);
+      expect(resultB).toBe(true);
+    });
+
+    // NULL contract — locks the super_admin short-circuit so a future
+    // "optimize away the subselect" refactor cannot regress.
+    // PostgREST coerces JSON null to SQL NULL.
+    it("NULL contract: returns false for User A on null _community_id", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userA.client, "user_can_access_community", {
+        _community_id: null,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("NULL contract: returns false for User C (no role) on null _community_id", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userC.client, "user_can_access_community", {
+        _community_id: null,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("NULL contract: returns true for User D (super_admin) on null _community_id", async () => {
+      if (skipIfRequested()) return;
+      const result = await callRpc(userD.client, "user_can_access_community", {
+        _community_id: null,
+      });
+      expect(result).toBe(true);
     });
   });
 });

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -1064,6 +1064,10 @@ export type Database = {
         }
       }
       is_super_admin: { Args: never; Returns: boolean }
+      user_can_access_community: {
+        Args: { _community_id: string }
+        Returns: boolean
+      }
       user_can_access_microgrid: {
         Args: { _microgrid_id: string }
         Returns: boolean

--- a/supabase/migrations/00031_microgrid_rls_insert_fix.sql
+++ b/supabase/migrations/00031_microgrid_rls_insert_fix.sql
@@ -1,0 +1,50 @@
+-- 00031_microgrid_rls_insert_fix.sql
+-- Fix: org_manager cannot INSERT microgrids because the existing
+-- "Authorized users can access microgrids" policy resolves access via the
+-- target row's own id (microgrids → communities → org_id) — but on INSERT
+-- the SECURITY-DEFINER STABLE helper's snapshot does not see the pending
+-- new row, so the resolved org_id is NULL and user_can_access_org(NULL)
+-- returns false for non-super_admins. (Super_admins pass via the
+-- is_super_admin() short-circuit, which is why the bug went unnoticed.)
+--
+-- Fix: introduce user_can_access_community(_community_id) which delegates
+-- to user_can_access_org() via communities.org_id (a row that already
+-- exists at INSERT time), then point the microgrids policy at the new
+-- row's community_id (a parent-pointing column), mirroring the pattern
+-- used by every other table policy.
+--
+-- Scope: targeted fix. user_can_access_microgrid() is unchanged and
+-- continues to back SELECT/UPDATE/DELETE on existing microgrid rows
+-- elsewhere in the schema. Body refactor of user_can_access_microgrid is
+-- explicitly out of scope (file a separate ticket).
+
+-- ── Helper: user_can_access_community ───────────────────────────────────
+-- Mirrors user_can_access_microgrid (00002_rls.sql:77-90): SECURITY
+-- DEFINER, STABLE, search_path pinned. Owned by postgres so it bypasses
+-- RLS when reading communities/user_roles via user_can_access_org.
+CREATE OR REPLACE FUNCTION user_can_access_community(_community_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT user_can_access_org((
+    SELECT org_id FROM communities WHERE id = _community_id
+  ));
+$$;
+
+-- ── Repoint the microgrids policy at the parent column ──────────────────
+-- DROP+CREATE matches the codebase convention (no other migration uses
+-- ALTER POLICY). IF EXISTS is mandatory for re-run safety: cloud deploys
+-- are manual via psql per CLAUDE.md, and re-running this migration must
+-- not error.
+--
+-- Policy name MUST remain byte-identical to the existing string —
+-- monitoring + rollback procedures depend on it.
+DROP POLICY IF EXISTS "Authorized users can access microgrids" ON microgrids;
+
+CREATE POLICY "Authorized users can access microgrids"
+  ON microgrids FOR ALL
+  USING (user_can_access_community(community_id))
+  WITH CHECK (user_can_access_community(community_id));


### PR DESCRIPTION
Closes #198

## Summary
- Migration `00031_microgrid_rls_insert_fix.sql` introduces `user_can_access_community(_community_id UUID)` SECURITY DEFINER STABLE helper, then drops + recreates the `microgrids` RLS policy to use `community_id` (the parent column on the new row) in both `USING` and `WITH CHECK`. Eliminates the self-lookup that blocked org_manager INSERTs because the STABLE function couldn't see the row being inserted.
- Adds positive RLS test (org_manager CAN INSERT microgrid into own community) + helper-direct describe block with 8 strict assertions including NULL contract.
- Fixture repair: `households` rows in `rls.test.ts` get `primary_phone` (migration `00024` made the column NOT NULL but the fixture was never updated, blocking the entire RLS suite).

## Why
Aaron (org_manager scoped to NFE org) hit "Could not save — Not authorized to add microgrids to this community." when trying to add a microgrid. Diagnosis: the original policy `WITH CHECK (user_can_access_microgrid(id))` passed `NEW.id` to a function that joined back to `microgrids` looking for the row — which doesn't exist yet during INSERT, so the join returned NULL and `user_can_access_org(NULL)` returned false for non-super_admin. Super_admins passed via the `is_super_admin()` short-circuit, which is why the bug went unnoticed in admin-only testing. Every other table's policy uses a parent-pointing column; only `microgrids` referenced its own `id`.

## Test plan
- [x] `npm test -- rls.test.ts` — 109 tests pass; new positive INSERT + 8 helper-direct assertions all pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (`✓ Compiled successfully`)
- [ ] Operator follow-up: apply migration to cloud Supabase `tztbmsxxjjsryuvoyqji`, run AC #9 pre-checks/post-checks, sign in as `aaron@kisakye.ug` and create a microgrid in an NFE community
- [ ] Operator follow-up: negative regression — Aaron POST `/api/microgrids` with cross-org `community_id` → expect 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)