### PR TITLE
Inline device discovery + meter pick in Add Household wizard (#200)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/households/households-section.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/households-section.tsx
@@ -19,6 +19,12 @@ import {
 // primary_consumption_meter assignment (UX2 requirement) in a single
 // atomic RPC call.
 
+type WizardEdge = {
+  id: string;
+  name: string;
+  openems_edge_id: string;
+};
+
 type Props = {
   microgridId: string;
   households: Household[];
@@ -28,6 +34,10 @@ type Props = {
   /** Enriched device list for the per-row billing-device <select>. */
   billingDevices?: BillingDeviceOption[];
   canManage?: boolean;
+  /** #200: edges on this microgrid (used by the wizard's inline discovery). */
+  edges?: WizardEdge[];
+  /** #200: edges that have NO consumption_meter device yet. */
+  edgeIdsWithoutConsumptionMeter?: string[];
 };
 
 export function HouseholdsSection({
@@ -38,6 +48,8 @@ export function HouseholdsSection({
   availableMeters,
   billingDevices,
   canManage = false,
+  edges = [],
+  edgeIdsWithoutConsumptionMeter = [],
 }: Props) {
   const [wizardOpen, setWizardOpen] = React.useState(false);
 
@@ -67,6 +79,8 @@ export function HouseholdsSection({
         microgridId={microgridId}
         availableMeters={availableMeters}
         edgesSetupHref={`/microgrids/${microgridId}/setup/edges`}
+        edges={edges}
+        edgeIdsWithoutConsumptionMeter={edgeIdsWithoutConsumptionMeter}
       />
 
       <HouseholdTable

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/page.tsx
@@ -61,7 +61,7 @@ export default async function SetupHouseholdsPage({
       .eq("role", "primary_consumption_meter"),
     supabase
       .from("edges")
-      .select("id, name")
+      .select("id, name, openems_edge_id")
       .eq("microgrid_id", id),
   ]);
 
@@ -93,6 +93,24 @@ export default async function SetupHouseholdsPage({
   const edgeNameById = new Map<string, string>(
     (edgesForMg ?? []).map((e) => [e.id, e.name ?? ""])
   );
+
+  // #200: edges that have NO consumption_meter device yet, used by the
+  // wizard's inline DiscoverMeterInline default-edge picker.
+  const edgesWithConsumptionMeter = new Set<string>(
+    (devices ?? [])
+      .filter((d) => d.device_type === "consumption_meter")
+      .map((d) => d.edge_id)
+  );
+  const edgeIdsWithoutConsumptionMeter: string[] = (edgesForMg ?? [])
+    .filter((e) => !edgesWithConsumptionMeter.has(e.id))
+    .map((e) => e.id);
+
+  // Edges shaped for `<DiscoverMeterInline>` (id + name + openems_edge_id).
+  const wizardEdges = (edgesForMg ?? []).map((e) => ({
+    id: e.id,
+    name: e.name ?? "",
+    openems_edge_id: e.openems_edge_id ?? "",
+  }));
 
   // The wizard call site still filters out devices that are already linked
   // (StepMeter expects only assignable meters). DeviceSelect (used by the
@@ -161,6 +179,8 @@ export default async function SetupHouseholdsPage({
         availableMeters={availableMeters}
         billingDevices={billingDevices}
         canManage={canManage}
+        edges={wizardEdges}
+        edgeIdsWithoutConsumptionMeter={edgeIdsWithoutConsumptionMeter}
       />
     </>
   );

--- a/src/app/api/edges/[id]/discover-devices/__tests__/route.test.ts
+++ b/src/app/api/edges/[id]/discover-devices/__tests__/route.test.ts
@@ -7,7 +7,7 @@
  *   (c) Bad UUID → 400
  *   (d) Edge not found → 404
  *   (e) Cross-microgrid edge (canAccessMicrogrid false) → 404
- *   (f) org_manager caller → 403
+ *   (f) org_manager who can access the microgrid → 200 (post-#200 widening)
  *   (g) Microgrid unconfigured → 409 reason: "not_configured"
  *   (h) OPENEMS_FORBIDDEN from config → 403 reason: "forbidden"
  *   (i) getEdgesStatus throws OPENEMS_AUTH_FAILED → 503 reason: "auth_failed"
@@ -196,18 +196,31 @@ describe("GET /api/edges/[id]/discover-devices", () => {
     expect(res.status).toBe(404);
   });
 
-  // (f) org_manager caller → 403
-  it("(f) returns 403 when caller is not super_admin", async () => {
+  // (f) org_manager who can access the microgrid → 200 (post-#200 widening).
+  // The super_admin gate was removed; permission is now decided by
+  // currentUserCanAccessMicrogrid + fn_get_ems_secret, both of which accept
+  // org_managers scoped to the microgrid's parent org. The 403 surface is
+  // now exclusive to OPENEMS_FORBIDDEN (case (h)).
+  it("(f) returns 200 for org_manager who can access the microgrid", async () => {
     isSuperAdminReturn = false;
+    canAccessMicrogridReturn = true;
+    getMicrogridEmsConfigMock.mockResolvedValue(defaultEmsConfig);
     registerEdgeLookup(true);
+    registerDedupQuery([]);
+
+    getEdgesStatusMock.mockResolvedValue([{ edgeId: OPENEMS_EDGE_ID, online: true }]);
+    getEdgeConfigMock.mockResolvedValue(singleComponentConfig);
 
     const { GET } = await import("../route");
     const res = await GET(makeReq(), {
       params: Promise.resolve({ id: EDGE_DB_ID }),
     });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.error).toContain("super admin");
+    expect(json.edgeId).toBe(OPENEMS_EDGE_ID);
+    expect(json.online).toBe(true);
+    expect(json.devices).toHaveLength(1);
+    expect(json.devices[0].componentId).toBe("meter0");
   });
 
   // (g) Microgrid unconfigured → 409

--- a/src/app/api/edges/[id]/discover-devices/route.ts
+++ b/src/app/api/edges/[id]/discover-devices/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { currentUserIsSuperAdmin, currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
 import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { getMicrogridEmsConfig } from "@/lib/openems/config";
 import { classifyDeviceType } from "@/lib/openems/classify";
@@ -89,18 +89,13 @@ export async function GET(
     );
   }
 
-  // Super-admin gate: getMicrogridEmsConfig throws OPENEMS_FORBIDDEN for
-  // org_managers on cloud_aws (fn_get_ems_secret returns NULL). Gate here
-  // explicitly so the caller gets a clean 403 rather than an opaque backend
-  // config error.
-  if (!(await currentUserIsSuperAdmin(supabase))) {
-    return NextResponse.json(
-      { error: "Only super admins can discover devices for this edge." },
-      { status: 403 }
-    );
-  }
-
   // Resolve per-microgrid OpenEMS config.
+  // Post-#200: fn_get_ems_secret was widened to return plaintext to
+  // org_managers of the microgrid's parent org (00032), so the previous
+  // super_admin-only gate at this position has been removed. Cross-org
+  // callers are still rejected — currentUserCanAccessMicrogrid above filters
+  // them, and any residual OPENEMS_FORBIDDEN from getMicrogridEmsConfig is
+  // surfaced as 403 by the catch block below.
   let emsConfig;
   try {
     emsConfig = await getMicrogridEmsConfig(supabase, edge.microgrid_id);

--- a/src/components/forms/DiscoverMeterInline.tsx
+++ b/src/components/forms/DiscoverMeterInline.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+/**
+ * DiscoverMeterInline — single-pick consumption-meter discovery for the
+ * Add-Household wizard's Step 3 (#200).
+ *
+ * Distinct from `<DiscoverDevices>` (the multi-pick edge-detail surface):
+ *   - single-pick RadioGroup (one meter at a time)
+ *   - filters discovery results to consumption_meter only
+ *   - persists via POST /api/devices, then hands the saved device back to
+ *     the wizard via `onDevicePersisted` so the parent can append it to
+ *     `availableMeters` and auto-select it
+ *   - errors are owned + rendered inline (no `onError` callback)
+ *   - both fetches are guarded by a single AbortController so that an
+ *     in-flight request doesn't leak results into a re-mounted instance
+ *     (the wizard re-mounts on `state.no_meter` toggle via `key={…}`)
+ *
+ * Component contract (per ticket #200 Dev Notes):
+ *   {
+ *     edges: { id, name, openems_edge_id }[];
+ *     edgeIdsWithoutConsumptionMeter: string[];
+ *     microgridId: string;
+ *     onDevicePersisted: (device: AvailableMeter) => void;
+ *   }
+ */
+
+import * as React from "react";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { DiscoveredDevice, EdgeDiscoveryResponse } from "@/lib/openems/types";
+import type { AvailableMeter } from "@/components/forms/HouseholdWizard";
+
+export type DiscoverMeterInlineEdge = {
+  id: string;
+  name: string;
+  openems_edge_id: string;
+};
+
+type Props = {
+  edges: DiscoverMeterInlineEdge[];
+  edgeIdsWithoutConsumptionMeter: string[];
+  /** Reserved for future per-microgrid scoping; not used in current contract. */
+  microgridId: string;
+  /** Called after POST /api/devices succeeds; parent appends + auto-selects. */
+  onDevicePersisted: (device: AvailableMeter) => void;
+};
+
+type Phase = "idle" | "discovering" | "ready" | "saving";
+
+/**
+ * Sort edges by (name, id) ascending — name first, id as a deterministic
+ * tie-break for collidable names.
+ */
+function sortEdges(edges: DiscoverMeterInlineEdge[]): DiscoverMeterInlineEdge[] {
+  return [...edges].sort((a, b) => {
+    const n = a.name.localeCompare(b.name);
+    return n !== 0 ? n : a.id.localeCompare(b.id);
+  });
+}
+
+/**
+ * Default-edge selector. Pre-selects the first edge in
+ * `edgeIdsWithoutConsumptionMeter` sorted by (name, id) ascending; falls
+ * back to the alphabetically first edge by (name, id) if every edge already
+ * has at least one consumption_meter.
+ */
+function pickDefaultEdgeId(
+  sortedEdges: DiscoverMeterInlineEdge[],
+  edgeIdsWithoutConsumptionMeter: string[]
+): string | null {
+  if (sortedEdges.length === 0) return null;
+  const withoutSet = new Set(edgeIdsWithoutConsumptionMeter);
+  const firstWithout = sortedEdges.find((e) => withoutSet.has(e.id));
+  return firstWithout?.id ?? sortedEdges[0].id;
+}
+
+export function DiscoverMeterInline({
+  edges,
+  edgeIdsWithoutConsumptionMeter,
+  onDevicePersisted,
+}: Props) {
+  const sortedEdges = React.useMemo(() => sortEdges(edges), [edges]);
+
+  const [pickedEdgeId, setPickedEdgeId] = React.useState<string>(
+    () => pickDefaultEdgeId(sortedEdges, edgeIdsWithoutConsumptionMeter) ?? ""
+  );
+  const [phase, setPhase] = React.useState<Phase>("idle");
+  const [discovered, setDiscovered] = React.useState<DiscoveredDevice[]>([]);
+  const [edgeOnline, setEdgeOnline] = React.useState<boolean>(true);
+  const [pickedComponentId, setPickedComponentId] = React.useState<string>("");
+  const [editedName, setEditedName] = React.useState<string>("");
+  const [discoverError, setDiscoverError] = React.useState<string | null>(null);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+
+  // One AbortController guards both GET /discover-devices and POST /api/devices.
+  // Cleanup aborts on unmount; the wizard re-mounts this component via
+  // `key={state.no_meter}` whenever the user toggles the manual-billing
+  // checkbox, so the unmount path is the canonical "cancel pending fetches"
+  // signal.
+  const abortRef = React.useRef<AbortController | null>(null);
+  React.useEffect(() => {
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    return () => {
+      ctrl.abort();
+      abortRef.current = null;
+    };
+  }, []);
+
+  const pickedEdge = sortedEdges.find((e) => e.id === pickedEdgeId) ?? null;
+
+  // Filter discovery results to consumption_meter not yet linked.
+  // The `openemsChannelAddress !== null` check is dropped per ticket #200:
+  // channelAddressFor() always returns non-null for consumption_meter, so
+  // the predicate is redundant.
+  const candidates = React.useMemo(
+    () =>
+      discovered.filter(
+        (d) => d.suggestedDeviceType === "consumption_meter" && d.alreadyAdded !== true
+      ),
+    [discovered]
+  );
+
+  const handleDiscover = React.useCallback(async () => {
+    if (!pickedEdge) return;
+    setPhase("discovering");
+    setDiscoverError(null);
+    setSaveError(null);
+    setDiscovered([]);
+    setPickedComponentId("");
+    setEditedName("");
+    setEdgeOnline(true);
+
+    try {
+      const res = await fetch(
+        `/api/edges/${encodeURIComponent(pickedEdge.id)}/discover-devices`,
+        { signal: abortRef.current?.signal }
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setDiscoverError(
+          body.error ?? `Discovery failed (HTTP ${res.status}).`
+        );
+        setPhase("idle");
+        return;
+      }
+      const data = (await res.json()) as EdgeDiscoveryResponse;
+      setEdgeOnline(data.online);
+      setDiscovered(data.devices ?? []);
+      setPhase("ready");
+    } catch (err) {
+      if ((err as { name?: string } | undefined)?.name === "AbortError") return;
+      setDiscoverError(
+        "Could not reach the server. Check your network connection."
+      );
+      setPhase("idle");
+    }
+  }, [pickedEdge]);
+
+  const handlePick = React.useCallback(
+    (componentId: string) => {
+      setPickedComponentId(componentId);
+      const candidate = candidates.find((d) => d.componentId === componentId);
+      if (candidate) {
+        setEditedName(candidate.alias || candidate.componentId);
+      }
+      setSaveError(null);
+    },
+    [candidates]
+  );
+
+  const handleSave = React.useCallback(async () => {
+    if (!pickedEdge) return;
+    const candidate = candidates.find((d) => d.componentId === pickedComponentId);
+    if (!candidate) return;
+    setSaveError(null);
+    setPhase("saving");
+
+    try {
+      const res = await fetch("/api/devices", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          edgeId: pickedEdge.id,
+          devices: [
+            {
+              componentId: candidate.componentId,
+              factoryId: candidate.factoryId,
+              deviceType: "consumption_meter",
+              name: editedName.trim() || candidate.alias || candidate.componentId,
+            },
+          ],
+        }),
+        signal: abortRef.current?.signal,
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setSaveError(
+          body.error ??
+            `Could not save the device (HTTP ${res.status}). Your selection is preserved — please retry.`
+        );
+        setPhase("ready");
+        return;
+      }
+
+      const data = (await res.json()) as {
+        saved: Array<{
+          id: string;
+          name: string;
+          device_type: string;
+          openems_component_id: string | null;
+        }>;
+      };
+      const saved = data.saved?.[0];
+      if (!saved) {
+        setSaveError("Server did not return the saved device. Please retry.");
+        setPhase("ready");
+        return;
+      }
+
+      // Construct the AvailableMeter from the picked-edge object in scope —
+      // POST /api/devices does not return edge_id / edge_name. Freshly-saved
+      // devices are never linked, so linked_household_name is null.
+      const newMeter: AvailableMeter = {
+        id: saved.id,
+        name: saved.name,
+        device_type: saved.device_type as AvailableMeter["device_type"],
+        edge_id: pickedEdge.id,
+        edge_name: pickedEdge.name,
+        linked_household_name: null,
+      };
+
+      onDevicePersisted(newMeter);
+      // Reset the inline pick UI so re-discovery starts clean. Phase goes
+      // back to 'ready' rather than 'idle' because the discovery list is
+      // still relevant; the saved component will appear `alreadyAdded:true`
+      // on the next discover.
+      setPickedComponentId("");
+      setEditedName("");
+      setPhase("ready");
+    } catch (err) {
+      if ((err as { name?: string } | undefined)?.name === "AbortError") return;
+      setSaveError(
+        "Network error while saving. Your selection is preserved — please retry."
+      );
+      setPhase("ready");
+    }
+  }, [pickedEdge, candidates, pickedComponentId, editedName, onDevicePersisted]);
+
+  if (sortedEdges.length === 0) {
+    return null;
+  }
+
+  const isDiscovering = phase === "discovering";
+  const isSaving = phase === "saving";
+  const showResults = phase === "ready" || phase === "saving";
+
+  return (
+    <section
+      aria-label="Discover meters on an edge"
+      className="space-y-3 rounded-md border border-border bg-card p-3"
+    >
+      <header className="flex items-center justify-between gap-3">
+        <h4 className="text-sm font-semibold text-foreground">
+          Discover meters on an edge
+        </h4>
+      </header>
+      <p className="text-xs text-muted-foreground">
+        Scan an edge for new consumption meters and link one directly to this
+        household — no need to leave the wizard.
+      </p>
+
+      {/* Edge picker. Collapses to a static label when there's exactly one. */}
+      {sortedEdges.length === 1 ? (
+        <div className="text-sm text-foreground">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+            Edge:
+          </span>{" "}
+          {sortedEdges[0].name}
+        </div>
+      ) : (
+        <div>
+          <label
+            htmlFor="dmi-edge-select"
+            className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Edge
+          </label>
+          <Select
+            value={pickedEdgeId}
+            onValueChange={(v) => {
+              setPickedEdgeId(v);
+              setDiscovered([]);
+              setPickedComponentId("");
+              setEditedName("");
+              setDiscoverError(null);
+              setSaveError(null);
+              setPhase("idle");
+            }}
+          >
+            <SelectTrigger id="dmi-edge-select">
+              <SelectValue placeholder="Pick an edge" />
+            </SelectTrigger>
+            <SelectContent>
+              {sortedEdges.map((e) => (
+                <SelectItem key={e.id} value={e.id}>
+                  {e.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleDiscover}
+          disabled={!pickedEdge || isDiscovering || isSaving}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isDiscovering ? "Scanning…" : "Discover meters"}
+        </button>
+      </div>
+
+      {discoverError && (
+        <div className="rounded-md bg-destructive-muted p-3 text-sm text-destructive-fg">
+          {discoverError}
+          <button
+            type="button"
+            onClick={handleDiscover}
+            className="ml-2 underline hover:no-underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {showResults && !edgeOnline && (
+        <div className="rounded-md bg-warning-muted p-3 text-sm text-warning-fg">
+          Edge is offline — retry when it reconnects.
+        </div>
+      )}
+
+      {showResults && edgeOnline && candidates.length === 0 && (
+        <p className="rounded-md border border-border bg-muted p-3 text-sm text-muted-foreground">
+          No new consumption meters on this edge. Make sure the edge is online
+          and has components configured.
+        </p>
+      )}
+
+      {showResults && candidates.length > 0 && (
+        <div className="space-y-3">
+          <RadioGroup
+            value={pickedComponentId}
+            onValueChange={handlePick}
+            aria-label="Discovered consumption meters"
+            className="gap-2"
+          >
+            {candidates.map((c) => {
+              const id = `dmi-cand-${c.componentId}`;
+              return (
+                <label
+                  key={c.componentId}
+                  htmlFor={id}
+                  className="flex cursor-pointer items-start gap-3 rounded-md border border-border bg-card p-3 hover:bg-muted"
+                >
+                  <RadioGroupItem id={id} value={c.componentId} className="mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-foreground">
+                      {c.alias || c.componentId}
+                    </div>
+                    <div className="font-mono text-xs text-muted-foreground">
+                      {c.componentId}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {c.factoryId}
+                    </div>
+                  </div>
+                </label>
+              );
+            })}
+          </RadioGroup>
+
+          {pickedComponentId && (
+            <div className="space-y-2 rounded-md border border-border bg-muted p-3">
+              <div>
+                <label
+                  htmlFor="dmi-name"
+                  className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Device name
+                </label>
+                <Input
+                  id="dmi-name"
+                  type="text"
+                  value={editedName}
+                  onChange={(e) => setEditedName(e.target.value)}
+                  placeholder="Device name"
+                />
+              </div>
+              {saveError && (
+                <div className="rounded-md bg-destructive-muted p-2 text-xs text-destructive-fg">
+                  {saveError}
+                </div>
+              )}
+              <div className="flex items-center justify-end">
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={isSaving || !editedName.trim()}
+                  className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isSaving ? "Saving…" : "Save & select"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -35,6 +35,10 @@ import { StatusChip } from "@/components/ui/status-chip";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { humanReadable } from "@/lib/openems/device-descriptions";
 import type { DeviceType } from "@/lib/types/domain";
+import {
+  DiscoverMeterInline,
+  type DiscoverMeterInlineEdge,
+} from "@/components/forms/DiscoverMeterInline";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -65,6 +69,17 @@ export interface HouseholdWizardProps {
   availableMeters: AvailableMeter[];
   /** Route to the edges discovery page — surfaced in the empty-state banner. */
   edgesSetupHref: string;
+  /**
+   * Edges on this microgrid (#200). Used by `<DiscoverMeterInline>` for the
+   * inline edge picker + discovery scope.
+   */
+  edges?: DiscoverMeterInlineEdge[];
+  /**
+   * IDs of edges on this microgrid that have NO `consumption_meter` device
+   * yet (#200). Used to default-pre-select the most-likely edge in the
+   * inline discovery section.
+   */
+  edgeIdsWithoutConsumptionMeter?: string[];
 }
 
 type Step = 1 | 2 | 3 | 4;
@@ -172,8 +187,10 @@ export function HouseholdWizard({
   open,
   onOpenChange,
   microgridId,
-  availableMeters,
+  availableMeters: availableMetersProp,
   edgesSetupHref,
+  edges = [],
+  edgeIdsWithoutConsumptionMeter = [],
 }: HouseholdWizardProps) {
   const router = useRouter();
 
@@ -183,6 +200,12 @@ export function HouseholdWizard({
   const [submitting, setSubmitting] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<string | null>(null);
   const [confirmCancelOpen, setConfirmCancelOpen] = React.useState(false);
+  // #200: `availableMeters` is a prop seeded from the server, but inline
+  // discovery (DiscoverMeterInline) appends new meters mid-flow. Promote
+  // to local state so all reads see the augmented list.
+  const [availableMeters, setAvailableMeters] = React.useState<AvailableMeter[]>(
+    availableMetersProp
+  );
 
   // Refs for focus management — each step's first required/focusable field.
   const step1FirstFieldRef = React.useRef<HTMLInputElement>(null);
@@ -201,8 +224,41 @@ export function HouseholdWizard({
       setSubmitting(false);
       setSubmitError(null);
       setConfirmCancelOpen(false);
+      // #200: re-seed availableMeters from the prop so any in-flight
+      // appended-via-discovery devices from a prior open are dropped on
+      // re-open. The prop itself is refreshed by router.refresh() after
+      // a successful save in the parent server component.
+      setAvailableMeters(availableMetersProp);
     }
-  }, [open]);
+  }, [open, availableMetersProp]);
+
+  // #200: handle a freshly persisted device from inline discovery.
+  // Update ordering rationale (per ticket #200 AC #11):
+  //   1. setAvailableMeters → dedup + append → immediate UI feedback.
+  //   2. setState → set device_id to the new meter's id → also auto-batched.
+  //   3. router.refresh() → fire-and-forget, syncs server-rendered ancestors
+  //      (HouseholdTable's billingDevices, primaryDeviceAssignments).
+  //
+  // React 18 auto-batches setState calls in event handlers AND across
+  // awaited boundaries when fired in the same post-await tick. No
+  // `flushSync` or `unstable_batchedUpdates` is needed — do NOT add one
+  // here.
+  const handleDevicePersisted = React.useCallback(
+    (newMeter: AvailableMeter) => {
+      setAvailableMeters((prev) => {
+        const existing = prev.find((m) => m.id === newMeter.id);
+        if (existing) {
+          // Already in the list — keep existing entry (preserve ordering),
+          // don't reorder on re-pick.
+          return prev;
+        }
+        return [...prev, newMeter];
+      });
+      setState((prev) => ({ ...prev, device_id: newMeter.id }));
+      router.refresh();
+    },
+    [router]
+  );
 
   // Focus management — on every step change, move focus to the first
   // focusable field of the new step. Run in a layout effect so the element
@@ -420,6 +476,10 @@ export function HouseholdWizard({
                   meters={availableMeters}
                   edgesSetupHref={edgesSetupHref}
                   disabled={submitting}
+                  edges={edges}
+                  edgeIdsWithoutConsumptionMeter={edgeIdsWithoutConsumptionMeter}
+                  microgridId={microgridId}
+                  onDevicePersisted={handleDevicePersisted}
                 />
               )}
               {step === 4 && (
@@ -828,6 +888,10 @@ function StepMeter({
   meters,
   edgesSetupHref,
   disabled,
+  edges,
+  edgeIdsWithoutConsumptionMeter,
+  microgridId,
+  onDevicePersisted,
 }: {
   state: FormState;
   update: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
@@ -836,6 +900,10 @@ function StepMeter({
   meters: AvailableMeter[];
   edgesSetupHref: string;
   disabled: boolean;
+  edges: DiscoverMeterInlineEdge[];
+  edgeIdsWithoutConsumptionMeter: string[];
+  microgridId: string;
+  onDevicePersisted: (device: AvailableMeter) => void;
 }) {
   // #158: top-of-step "no meter" checkbox. When checked we clear device_id
   // defensively so an accidental prior pick doesn't leak into the submit
@@ -874,7 +942,31 @@ function StepMeter({
           Without a meter, you&apos;ll enter usage manually each period. You
           can link a meter later from the household&apos;s edit dialog.
         </div>
-      ) : meters.length === 0 ? (
+      ) : (
+        <>
+          {/*
+            #200 inline discovery section. Always visible (empty + non-empty
+            cases both show it); suppressed only when state.no_meter is
+            true via the outer ternary above.
+
+            `key={state.no_meter}` re-mounts on toggle so any in-flight
+            internal state (current pick, scan results, fetch errors) is
+            reset. The component's internal AbortController also aborts
+            pending fetches on unmount.
+          */}
+          {edges.length > 0 && (
+            <DiscoverMeterInline
+              key={String(state.no_meter)}
+              edges={edges}
+              edgeIdsWithoutConsumptionMeter={edgeIdsWithoutConsumptionMeter}
+              microgridId={microgridId}
+              onDevicePersisted={onDevicePersisted}
+            />
+          )}
+        </>
+      )}
+
+      {state.no_meter ? null : meters.length === 0 ? (
         <div className="space-y-3">
           <Banner
             tone="warn"

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -215,7 +215,13 @@ export function HouseholdWizard({
   const step3FirstFieldRef = React.useRef<HTMLButtonElement | HTMLInputElement | null>(null);
   const step4FirstElementRef = React.useRef<HTMLButtonElement>(null);
 
-  // Reset wizard state when opened.
+  // Reset wizard state when `open` flips false → true (entering a fresh
+  // wizard session). Split out from the prop-resync effect below: keeping
+  // `availableMetersProp` as a dep here would wipe the user's in-progress
+  // form state every time the parent server component re-renders with a
+  // new array reference (e.g. after `router.refresh()` from
+  // `handleDevicePersisted`). Two effects let prop refreshes update the
+  // local meter list without touching step/state/visited.
   React.useEffect(() => {
     if (open) {
       setStep(1);
@@ -226,11 +232,33 @@ export function HouseholdWizard({
       setConfirmCancelOpen(false);
       // #200: re-seed availableMeters from the prop so any in-flight
       // appended-via-discovery devices from a prior open are dropped on
-      // re-open. The prop itself is refreshed by router.refresh() after
-      // a successful save in the parent server component.
+      // re-open.
       setAvailableMeters(availableMetersProp);
     }
-  }, [open, availableMetersProp]);
+    // Intentionally only depend on `open` — we want this to run on the
+    // open transition, not on prop changes mid-flow. The prop is read at
+    // open time to seed `availableMeters`; subsequent prop refreshes are
+    // handled by the dedicated effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // #200: re-sync local availableMeters when the parent server component
+  // hands us a new prop reference (e.g. after `router.refresh()`).
+  // Dedupes against in-flight inline-discovery appends so we don't drop
+  // freshly persisted devices that haven't yet appeared in the prop.
+  React.useEffect(() => {
+    if (!open) return;
+    setAvailableMeters((prev) => {
+      const byId = new Map(availableMetersProp.map((m) => [m.id, m]));
+      // Append any locally-known meters that aren't in the new prop yet.
+      for (const m of prev) {
+        if (!byId.has(m.id)) {
+          byId.set(m.id, m);
+        }
+      }
+      return Array.from(byId.values());
+    });
+  }, [availableMetersProp, open]);
 
   // #200: handle a freshly persisted device from inline discovery.
   // Update ordering rationale (per ticket #200 AC #11):

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -24,9 +24,13 @@ import {
   type AvailableMeter,
 } from "../HouseholdWizard";
 
-// Mock next/navigation
+// Mock next/navigation. `refreshHandler` is module-scoped so individual
+// tests can swap in a side-effecting refresh (e.g. to simulate the parent
+// server component re-rendering with a new `availableMeters` prop) — this
+// is what the #200 regression test for the reset-effect bug needs.
+let refreshHandler: () => void = () => {};
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ refresh: vi.fn() }),
+  useRouter: () => ({ refresh: () => refreshHandler() }),
 }));
 
 // Polyfill ResizeObserver — required by Radix RadioGroup
@@ -94,6 +98,8 @@ describe("HouseholdWizard", () => {
 
   beforeEach(() => {
     fetchMock = vi.spyOn(globalThis, "fetch");
+    // Reset router.refresh side-effect between tests.
+    refreshHandler = () => {};
   });
 
   afterEach(() => {
@@ -1060,6 +1066,133 @@ describe("HouseholdWizard", () => {
       expect(
         screen.getByRole("button", { name: /^Discover meters$/i })
       ).toBeDefined();
+    });
+
+    /**
+     * #200 regression: when `handleDevicePersisted` calls `router.refresh()`
+     * after a successful inline-discover save, the parent server component
+     * re-renders with a new `availableMeters` prop reference. The reset
+     * effect MUST NOT fire on that prop change — it would wipe step state
+     * and the user's typed values back to step 1. This test wraps the
+     * wizard in a controlled parent that mutates the prop reference inside
+     * `router.refresh()`, simulating the production re-render path that
+     * the prior `vi.fn()` no-op mock missed.
+     */
+    it("router.refresh after inline-persist preserves step + form state (regression for reset-on-prop-change)", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([consumptionMeter("meter9", "M9")])],
+        devices: [
+          {
+            ok: true,
+            status: 200,
+            jsonBody: {
+              saved: [
+                {
+                  id: "dev-new",
+                  name: "M9",
+                  device_type: "consumption_meter",
+                  openems_component_id: "meter9",
+                },
+              ],
+            },
+          },
+        ],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      // Controlled wrapper: lets the test mutate the `availableMeters`
+      // prop reference from inside `router.refresh()`, mimicking how a
+      // server-component parent re-renders after `router.refresh()`.
+      function Wrapper() {
+        const [meters, setMeters] = React.useState<AvailableMeter[]>([]);
+        // Hook the test-scoped refresh handler to push a new prop ref.
+        React.useEffect(() => {
+          refreshHandler = () => {
+            // New array reference (would be returned by the server
+            // component on its next render after the device was saved).
+            setMeters([
+              {
+                id: "dev-new",
+                name: "M9",
+                device_type: "consumption_meter",
+                edge_id: "edge-1",
+                edge_name: "Metering Pi",
+                linked_household_name: null,
+              },
+            ]);
+          };
+          return () => {
+            refreshHandler = () => {};
+          };
+        }, []);
+        return (
+          <HouseholdWizard
+            open
+            onOpenChange={() => {}}
+            microgridId={MICROGRID_ID}
+            availableMeters={meters}
+            edgesSetupHref={`/microgrids/${MICROGRID_ID}/setup/edges`}
+            edges={[EDGE_1]}
+            edgeIdsWithoutConsumptionMeter={[EDGE_1.id]}
+          />
+        );
+      }
+
+      render(<Wrapper />);
+
+      // Step 1 — fill display name + phone
+      fillDisplayName("My Household");
+      fillPhone("+256700000111");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Step 2 — wait for step 2 fields, then advance
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Step 3 — discover & save flow that triggers router.refresh()
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+      await waitFor(() => expect(screen.getByText("M9")).toBeDefined());
+      const candidateRadios = screen.getAllByRole("radio");
+      fireEvent.click(candidateRadios[0]);
+      fireEvent.click(screen.getByRole("button", { name: /Save & select/i }));
+
+      // After persist, the wrapper's refreshHandler fires, replacing the
+      // `availableMeters` prop with a brand-new array. Pre-fix, this
+      // wiped state back to step 1.
+      await waitFor(() => {
+        const radios = screen.getAllByRole("radio");
+        const checked = radios.filter(
+          (r) => r.getAttribute("aria-checked") === "true"
+        );
+        expect(checked.length).toBeGreaterThanOrEqual(1);
+      });
+
+      // Still on step 3 — the Create button is the step-4 advance, so its
+      // absence is the proof we are NOT on step 4 either; combined with the
+      // step-3-only Discover panel still in the DOM, we are on step 3.
+      expect(
+        screen.queryByRole("button", { name: /Create household/i })
+      ).toBeNull();
+      // Step 1 and Step 2 fields must NOT be visible (we'd see them if
+      // the wizard had snapped back to step 1).
+      expect(screen.queryByLabelText(/^Display name/i)).toBeNull();
+      expect(screen.queryByLabelText(/Address line 1/i)).toBeNull();
+
+      // Advance to step 4 — preserved values must show in the review.
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /Create household/i })
+        ).toBeDefined()
+      );
+      // Display name and phone preserved on the review panel.
+      expect(screen.getByText("My Household")).toBeDefined();
+      expect(screen.getByText("+256700000111")).toBeDefined();
     });
 
     it("multi-edge: picker renders both edges; default-selects first edge in edgeIdsWithoutConsumptionMeter by (name, id)", async () => {

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 /**
- * HouseholdWizard component tests (UX2 / #74 + #146).
+ * HouseholdWizard component tests (UX2 / #74 + #146 + #200).
  *
  * Covers:
  *   (a) 4-step transitions (1 → 2 → 3 → 4) work with Next
@@ -13,6 +13,7 @@
  *   (h) #146 — Step 2 renders 5 new address fields
  *   (i) #146 — Step 4 review displays new address fields
  *   (j) #146 — submit payload includes new address fields
+ *   (k) #200 — inline DiscoverMeterInline integration in Step 3
  */
 
 import * as React from "react";
@@ -658,6 +659,432 @@ describe("HouseholdWizard", () => {
 
       // And the confirm dialog should NOT be shown
       expect(screen.queryByText(/Discard unsaved household/i)).toBeNull();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // (k) #200 — inline DiscoverMeterInline integration
+  // URL-dispatching mock pattern: two endpoints
+  //   /api/edges/<id>/discover-devices  →  GET — discovery
+  //   /api/devices                       →  POST — persist single meter
+  //   /api/households/with-meter         →  POST — wizard submit
+  // ──────────────────────────────────────────────────────────────────────
+  describe("(k) #200 inline discovery", () => {
+    const EDGE_1 = {
+      id: "edge-1",
+      name: "Metering Pi",
+      openems_edge_id: "edge1",
+    };
+    const EDGE_2 = {
+      id: "edge-2",
+      name: "Aux Edge",
+      openems_edge_id: "edge2",
+    };
+
+    /**
+     * Build a fetch mock that dispatches by URL substring. Each endpoint
+     * has a queue of responses; the first call to the matching URL pops
+     * the head of the queue.
+     */
+    type Resp = { ok: boolean; status: number; jsonBody: unknown };
+    function makeUrlDispatcher(
+      handlers: Record<
+        "discover" | "devices" | "household",
+        Resp[] | ((url: string) => Resp)
+      >
+    ) {
+      const counts = { discover: 0, devices: 0, household: 0 };
+      const impl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        const route = url.includes("/discover-devices")
+          ? "discover"
+          : url.includes("/api/devices")
+          ? "devices"
+          : url.includes("/api/households/with-meter")
+          ? "household"
+          : null;
+        if (!route) {
+          throw new Error(`Unhandled fetch URL: ${url}`);
+        }
+        counts[route]++;
+        const handler = handlers[route];
+        const r =
+          typeof handler === "function" ? handler(url) : handler.shift();
+        if (!r) {
+          throw new Error(`No mock response queued for ${route} at ${url}`);
+        }
+        return {
+          ok: r.ok,
+          status: r.status,
+          json: async () => r.jsonBody,
+        } as Response;
+      });
+      return { impl, counts };
+    }
+
+    function discoveryResponse(devices: object[], online = true) {
+      return {
+        ok: true,
+        status: 200,
+        jsonBody: {
+          edgeId: "edge1",
+          online,
+          devices,
+        },
+      };
+    }
+
+    function consumptionMeter(
+      componentId: string,
+      alias = "Discovered Meter"
+    ) {
+      return {
+        componentId,
+        factoryId: "io.openems.impl.meter.consumption.ConsumptionMeter",
+        alias,
+        nature: "io.openems.edge.meter.api.ElectricityMeter",
+        openemsChannelAddress: `${componentId}/ActiveConsumptionEnergy`,
+        suggestedDeviceType: "consumption_meter",
+        alreadyAdded: false,
+      };
+    }
+
+    it("renders the discovery section with edge1 pre-selected (single-edge collapses to label)", async () => {
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      // navigate to step 3
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Discovery section visible
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Discover meters on an edge/i)
+        ).toBeDefined()
+      );
+      // Single-edge label shows the name (not a Select)
+      expect(screen.getByText(/Metering Pi/i)).toBeDefined();
+      // Discover button visible
+      expect(
+        screen.getByRole("button", { name: /Discover meters/i })
+      ).toBeDefined();
+    });
+
+    it("happy path: discover → pick → save → meter appears + auto-selected, step stays on 3", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([consumptionMeter("meter9", "M9")])],
+        devices: [
+          {
+            ok: true,
+            status: 200,
+            jsonBody: {
+              saved: [
+                {
+                  id: "dev-new",
+                  name: "M9",
+                  device_type: "consumption_meter",
+                  openems_component_id: "meter9",
+                },
+              ],
+            },
+          },
+        ],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Click Discover
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+
+      // Wait for the candidate radio to render
+      await waitFor(() =>
+        expect(screen.getByText("M9")).toBeDefined()
+      );
+      // Pick the candidate
+      const candidateRadios = screen.getAllByRole("radio");
+      // The first radio in the wizard's own RadioGroup may not exist (no
+      // available meters yet) — DiscoverMeterInline owns the only group.
+      fireEvent.click(candidateRadios[0]);
+
+      // Save & select
+      fireEvent.click(screen.getByRole("button", { name: /Save & select/i }));
+
+      // The new meter should now appear in the wizard's own RadioGroup —
+      // identified by the meter name "M9". It is also auto-selected.
+      await waitFor(() => {
+        const radios = screen.getAllByRole("radio");
+        // After append, the radio list should include the new meter card.
+        const checked = radios.filter(
+          (r) => r.getAttribute("aria-checked") === "true"
+        );
+        expect(checked.length).toBeGreaterThanOrEqual(1);
+      });
+
+      // Still on step 3 (Next button is the visible advance, not Create)
+      expect(
+        screen.queryByRole("button", { name: /Create household/i })
+      ).toBeNull();
+      // Next is enabled
+      const next = screen.getByRole("button", { name: /^Next$/ });
+      expect(next).toHaveProperty("disabled", false);
+    });
+
+    it("empty discovery (no consumption meters after filter) renders the no-meters message", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([])],
+        devices: [],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+      await waitFor(() =>
+        expect(
+          screen.getByText(/No new consumption meters on this edge/i)
+        ).toBeDefined()
+      );
+    });
+
+    it("offline edge response renders the offline notice", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([], false)],
+        devices: [],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Edge is offline — retry when it reconnects/i)
+        ).toBeDefined()
+      );
+    });
+
+    it("network error renders Retry; clicking it re-fires the GET", async () => {
+      let calls = 0;
+      const impl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/discover-devices")) {
+          calls++;
+          if (calls === 1) {
+            throw new Error("network down");
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              edgeId: "edge1",
+              online: true,
+              devices: [],
+            }),
+          } as Response;
+        }
+        throw new Error(`Unhandled URL: ${url}`);
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+      const retry = await screen.findByRole("button", { name: /^Retry$/i });
+      fireEvent.click(retry);
+
+      await waitFor(() => expect(calls).toBe(2));
+    });
+
+    it("POST /api/devices 500 → renders inline error, preserves the user's pick", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([consumptionMeter("meterX", "MX")])],
+        devices: [
+          {
+            ok: false,
+            status: 500,
+            jsonBody: { error: "Could not save device" },
+          },
+        ],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+      await waitFor(() =>
+        expect(screen.getByText("MX")).toBeDefined()
+      );
+      const candidateRadio = screen.getAllByRole("radio")[0];
+      fireEvent.click(candidateRadio);
+      fireEvent.click(screen.getByRole("button", { name: /Save & select/i }));
+
+      // Inline error visible
+      await waitFor(() =>
+        expect(screen.getByText(/Could not save device/i)).toBeDefined()
+      );
+
+      // Pick is preserved — radio is still in the document AND the editable
+      // name input is still rendered (it lives inside the picked-section
+      // panel).
+      expect(screen.getByDisplayValue("MX")).toBeDefined();
+      // Wizard still on step 3 (no Create household button)
+      expect(
+        screen.queryByRole("button", { name: /Create household/i })
+      ).toBeNull();
+    });
+
+    it("toggling no_meter ON hides discovery section; OFF re-shows in idle phase", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([])],
+        devices: [],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // Initially the discovery section is visible.
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Discover meters on an edge/i)
+        ).toBeDefined()
+      );
+
+      // Toggle no_meter ON — section disappears.
+      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+      fireEvent.click(checkbox);
+      expect(checkbox.checked).toBe(true);
+      await waitFor(() =>
+        expect(
+          screen.queryByText(/Discover meters on an edge/i)
+        ).toBeNull()
+      );
+
+      // Toggle OFF — section reappears in idle phase (no scan results).
+      fireEvent.click(checkbox);
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Discover meters on an edge/i)
+        ).toBeDefined()
+      );
+      // The discover button is in idle ("Discover meters", not "Scanning…")
+      expect(
+        screen.getByRole("button", { name: /^Discover meters$/i })
+      ).toBeDefined();
+    });
+
+    it("multi-edge: picker renders both edges; default-selects first edge in edgeIdsWithoutConsumptionMeter by (name, id)", async () => {
+      // Edge naming: "Aux Edge" (a) < "Metering Pi" (m).
+      // Both are in edgeIdsWithoutConsumptionMeter — alphabetical first
+      // by name is Aux Edge.
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1, EDGE_2],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id, EDGE_2.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+      // The Select trigger displays the picked edge's name.
+      // Aux Edge sorts first alphabetically by name.
+      await waitFor(() => {
+        const trigger = screen.getByRole("combobox");
+        expect(trigger.textContent).toContain("Aux Edge");
+      });
     });
   });
 });

--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -1762,7 +1762,7 @@ describe("RLS: OpenEMS Backend (#101)", () => {
       expect(data).toBeNull();
     });
 
-    it("org_manager (owner org) gets NULL — redacted", async () => {
+    it("org_manager (owner org) gets plaintext (post-#200 widening)", async () => {
       if (skipIfRequested()) return;
       await setupCloudAwsConfig();
       try {
@@ -1770,7 +1770,7 @@ describe("RLS: OpenEMS Backend (#101)", () => {
           _microgrid_id: FIXTURE.microgridA,
         });
         expect(error).toBeNull();
-        expect(data).toBeNull();
+        expect(data).toBe(SECRET_PLAINTEXT);
       } finally {
         await clearCloudAwsConfig();
       }

--- a/supabase/migrations/00032_ems_secret_org_manager.sql
+++ b/supabase/migrations/00032_ems_secret_org_manager.sql
@@ -1,0 +1,85 @@
+-- 00032_ems_secret_org_manager.sql
+-- Widen fn_get_ems_secret to org_manager-of-microgrid's-parent-org (#200).
+--
+-- ── Summary ──────────────────────────────────────────────────────────────
+--
+-- The original definition (00018) gated decryption to super_admin /
+-- service_role only. Operationally, an org_manager onboarding a household
+-- needs inline device-discovery from within the Add-Household wizard, which
+-- routes through `getMicrogridEmsConfig` → `fn_get_ems_secret`. Without
+-- widening, the wizard's discovery path returns NULL → opaque backend
+-- config error for the org_manager persona that motivates the surface.
+--
+-- This migration replaces the function body so org_managers who can access
+-- the microgrid (via `user_can_access_microgrid`) also receive the
+-- plaintext secret. The function signature is unchanged
+-- (`fn_get_ems_secret(_microgrid_id UUID) RETURNS TEXT`).
+--
+-- ── New truth table (supersedes the 00018:297-305 comment semantically;
+--    the 00018 comment is left intact for historical accuracy) ──────────
+--
+--   | Caller context                                              | Return     |
+--   |-------------------------------------------------------------|------------|
+--   | super_admin                                                 | plaintext  |
+--   | super_admin, secret NULL                                    | NULL       |
+--   | service_role                                                | plaintext  |
+--   | org_manager (microgrid's parent org), secret set            | plaintext  |  <-- NEW
+--   | org_manager (microgrid's parent org), secret NULL           | NULL       |
+--   | org_manager (different org)                                 | NULL       |
+--   | microgrid not found / hard-deleted                          | NULL       |
+--   | anon / unauthenticated                                      | NULL       |
+--
+-- ── Probing-resistance ──────────────────────────────────────────────────
+--
+-- Gate-first preserves the original 00018 ordering. `user_can_access_microgrid`
+-- returns false for non-existent microgrids (community → org_id resolves to
+-- NULL → `user_can_access_org(NULL)` is false), so 'row missing' and 'no
+-- permission' both return NULL with no timing leak.
+--
+-- `is_super_admin()` short-circuits inside `user_can_access_org` (per
+-- 00002_rls.sql:65), so super_admins continue to receive plaintext via the
+-- gate without an explicit `is_super_admin()` check in this body.
+--
+-- ── Signature & grants ──────────────────────────────────────────────────
+--
+-- Signature unchanged. `CREATE OR REPLACE` preserves existing privileges in
+-- Postgres ≥ 14, but we re-issue GRANT EXECUTE TO authenticated, service_role
+-- defensively to mirror the 00018 / 00020 / 00030 patterns.
+
+CREATE OR REPLACE FUNCTION fn_get_ems_secret(_microgrid_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_ciphertext BYTEA;
+BEGIN
+  -- Permission gate. service_role bypasses for server-side internal paths
+  -- (Discover/readings pipeline). user_can_access_microgrid short-circuits
+  -- to true for super_admin and for org_managers scoped to the microgrid's
+  -- parent org (via communities → org_id).
+  IF NOT (auth.role() = 'service_role' OR user_can_access_microgrid(_microgrid_id)) THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT ems_aws_secret_access_key_encrypted INTO v_ciphertext
+    FROM microgrids
+    WHERE id = _microgrid_id
+    LIMIT 1;
+
+  IF v_ciphertext IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN fn_ems_decrypt_secret(v_ciphertext);
+END;
+$$;
+
+-- Defensive re-grant. CREATE OR REPLACE preserves privileges, but mirroring
+-- the pattern from 00018 / 00020 / 00030 keeps the grant explicit at the
+-- migration boundary in case the function was dropped + recreated by a
+-- future change.
+GRANT EXECUTE ON FUNCTION fn_get_ems_secret(UUID)
+  TO authenticated, service_role;


### PR DESCRIPTION
Closes #200

## Summary
- New `DiscoverMeterInline` component embedded in Step 3 of the Add Household wizard. Org_managers can now discover meters on a specific edge and pick one inline — no more bailing out to Setup > Edges > [edgeId].
- Migration `00032_ems_secret_org_manager.sql` widens `fn_get_ems_secret` to org_manager-of-microgrid (mirrors the `00030_payment_secret_org_manager.sql` pattern). Removes the super_admin-only gate from `GET /api/edges/[id]/discover-devices` — the underlying RLS via `currentUserCanAccessMicrogrid` is the authoritative permission check.
- Wizard form state now survives `router.refresh()` after inline-persist: split the previously-combined reset effect so the `EMPTY_STATE` reset only fires on `open` transitions, while prop-driven `availableMeters` sync runs separately and dedupes by id.

## Why
Aaron deleted a household, deleted `edge1`, re-added `edge1` (with 0 devices because edge create does NOT auto-discover), tried to add a new household and hit "No available meters" with a generic "Go to Setup > Edges" CTA. Inline discovery folds the discover → save → pick flow into the wizard so the entrepreneur stays in context. Widening `fn_get_ems_secret` is the prerequisite — without it, org_managers could never reach the discovery API.

## Test plan
- [x] `npm test` — `HouseholdWizard.test.tsx` 28/28 (9 new wizard cases + 1 regression test for `router.refresh` survival), `discover-devices/route.test.ts` 11/11 (case (f) inverted to org_manager 200), `rls.test.ts` 109/109 (org_manager-owner-org row inverted to plaintext).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] `npm run db:types` — zero diff (`fn_get_ems_secret` signature unchanged).
- [ ] Operator follow-up: apply migration `00032` to cloud Supabase `tztbmsxxjjsryuvoyqji` via psql; verify `pg_get_functiondef('fn_get_ems_secret(uuid)'::regprocedure)` references `user_can_access_microgrid`.
- [ ] Operator follow-up: sign in as `aaron@kisakye.ug` (org_manager) → Kisakye microgrid → Setup > Households → Add household → Step 3 → discovery section visible with `edge1` pre-selected → Discover → pick consumption meter → Save & select → meter auto-selected → Next → Review → Submit → household created.
- [ ] Operator follow-up: cross-org regression — `aaron@kisakye.ug` calling discover-devices on a non-NFE edge continues to return 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)