### PR TITLE
PDF2 — Community Setup → Invoice tab + logo upload + preview (#204)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/__tests__/community-subnav.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/__tests__/community-subnav.test.tsx
@@ -1,20 +1,24 @@
 // @vitest-environment jsdom
 /**
- * CommunitySubNav tests (#119 AC-NAV-*).
+ * CommunitySubNav tests (#119 AC-NAV-*, extended in #204 / PDF2 AC-7).
  *
  * Covers:
  *   - Renders Overview + Payment tabs
  *   - Active-tab derivation via usePathname (longest-prefix match on /payment)
  *   - Payment tab chip renders when paymentHealth prop supplied
+ *   - Invoice tab visibility gated by `showInvoiceTab` prop (#204)
+ *   - Active-tab derivation includes /invoice when shown (#204)
+ *   - ArrowRight cycling covers Invoice tab when shown (#204)
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 let mockPathname = "/communities/comm-abc";
+const routerPushMock = vi.fn();
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: routerPushMock }),
 }));
 
 import { CommunitySubNav } from "../community-subnav";
@@ -62,5 +66,58 @@ describe("CommunitySubNav", () => {
     expect(container.textContent).not.toContain("Healthy");
     expect(container.textContent).not.toContain("Stale");
     expect(container.textContent).not.toContain("Not connected");
+  });
+
+  // ── PDF2 (#204) — Invoice tab tests ────────────────────────────────────
+
+  it("(#204) Invoice tab is NOT rendered when showInvoiceTab is omitted (default false)", () => {
+    mockPathname = "/communities/comm-abc";
+    render(<CommunitySubNav communityId="comm-abc" />);
+    expect(screen.queryByRole("tab", { name: /invoice/i })).toBeNull();
+  });
+
+  it("(#204) Invoice tab IS rendered when showInvoiceTab=true", () => {
+    mockPathname = "/communities/comm-abc";
+    render(
+      <CommunitySubNav communityId="comm-abc" showInvoiceTab={true} />,
+    );
+    expect(screen.getByRole("tab", { name: /invoice/i })).toBeDefined();
+  });
+
+  it("(#204) Invoice tab is active on /communities/[id]/invoice", () => {
+    mockPathname = "/communities/comm-abc/invoice";
+    render(
+      <CommunitySubNav communityId="comm-abc" showInvoiceTab={true} />,
+    );
+    const invoiceTab = screen.getByRole("tab", { name: /invoice/i });
+    expect(invoiceTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("(#204) ArrowRight cycles through 3 tabs when Invoice is shown", () => {
+    mockPathname = "/communities/comm-abc";
+    routerPushMock.mockClear();
+    render(
+      <CommunitySubNav communityId="comm-abc" showInvoiceTab={true} />,
+    );
+    const overview = screen.getByRole("tab", { name: /overview/i });
+    overview.focus();
+
+    // Overview → Payment.
+    fireEvent.keyDown(overview, { key: "ArrowRight" });
+    expect(routerPushMock).toHaveBeenLastCalledWith(
+      "/communities/comm-abc/payment",
+    );
+
+    // Payment → Invoice.
+    const payment = screen.getByRole("tab", { name: /payment/i });
+    fireEvent.keyDown(payment, { key: "ArrowRight" });
+    expect(routerPushMock).toHaveBeenLastCalledWith(
+      "/communities/comm-abc/invoice",
+    );
+
+    // Invoice → Overview (cycle).
+    const invoice = screen.getByRole("tab", { name: /invoice/i });
+    fireEvent.keyDown(invoice, { key: "ArrowRight" });
+    expect(routerPushMock).toHaveBeenLastCalledWith("/communities/comm-abc");
   });
 });

--- a/src/app/(dashboard)/communities/[id]/community-subnav.tsx
+++ b/src/app/(dashboard)/communities/[id]/community-subnav.tsx
@@ -29,6 +29,11 @@ const TABS: SubTab[] = [
   { label: "Payment", segment: "payment" },
 ];
 
+// Invoice tab is appended to the visible-tabs array conditionally based on
+// the `showInvoiceTab` prop — see PDF2 (#204). Hidden, not just disabled, when
+// the caller is not org_manager-of-parent-org / super_admin.
+const INVOICE_TAB: SubTab = { label: "Invoice", segment: "invoice" };
+
 export type PaymentChipData = {
   status: PaymentHealth;
   lastConfiguredAt: string | null;
@@ -58,21 +63,34 @@ function tooltipFor(data: PaymentChipData): string | null {
 export function CommunitySubNav({
   communityId,
   paymentHealth,
+  showInvoiceTab = false,
 }: {
   communityId: string;
   paymentHealth?: PaymentChipData;
+  /**
+   * When true, append the Invoice tab to the sub-nav (#204 / PDF2). Defaults
+   * to false so existing callers (and tests that mount the component without
+   * the prop) keep their 2-tab shape unchanged.
+   */
+  showInvoiceTab?: boolean;
 }) {
   const pathname = usePathname();
   const router = useRouter();
   const base = `/communities/${communityId}`;
   const tabRefs = useRef<Array<HTMLAnchorElement | null>>([]);
 
+  // Build the visible-tabs array from props rather than mutating the module
+  // constant. Keyboard cycling (ArrowLeft/Right + Home/End) derives `last`
+  // from `visibleTabs.length` so the cycle covers Invoice when present.
+  const visibleTabs: SubTab[] = showInvoiceTab ? [...TABS, INVOICE_TAB] : TABS;
+
   // Active-tab resolution:
+  //   - Invoice tab wins when pathname starts with `${base}/invoice`
   //   - Payment tab wins when pathname starts with `${base}/payment`
   //   - Otherwise Overview (default / exact-match).
   const activeIndex = (() => {
-    for (let i = 0; i < TABS.length; i++) {
-      const t = TABS[i];
+    for (let i = 0; i < visibleTabs.length; i++) {
+      const t = visibleTabs[i];
       if (t.segment === "") continue;
       if (pathname.startsWith(`${base}/${t.segment}`)) return i;
     }
@@ -84,7 +102,7 @@ export function CommunitySubNav({
   }
 
   function onKeyDown(e: KeyboardEvent<HTMLAnchorElement>, current: number) {
-    const last = TABS.length - 1;
+    const last = visibleTabs.length - 1;
     let next = current;
     switch (e.key) {
       case "ArrowRight":
@@ -105,7 +123,7 @@ export function CommunitySubNav({
     e.preventDefault();
     const el = tabRefs.current[next];
     el?.focus();
-    router.push(hrefFor(TABS[next]));
+    router.push(hrefFor(visibleTabs[next]));
   }
 
   return (
@@ -114,7 +132,7 @@ export function CommunitySubNav({
       aria-label="Community sections"
       className="inline-flex w-fit gap-1 rounded-lg bg-muted p-1"
     >
-      {TABS.map((tab, i) => {
+      {visibleTabs.map((tab, i) => {
         const isActive = i === activeIndex;
         const chipData = tab.segment === "payment" ? paymentHealth : undefined;
         return (

--- a/src/app/(dashboard)/communities/[id]/invoice/__tests__/color-input.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/__tests__/color-input.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+/**
+ * ColorInput — integration tests (#204 / PDF2 AC-7).
+ *
+ * Verifies:
+ *   - Hex sanitisation: uppercase input → lowercase storage; whitespace
+ *     stripped; bad hex on blur reverts to last valid value.
+ *   - Bidirectional binding: typing valid hex updates parent; clicking the
+ *     swatch updates the text input.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ColorInput } from "../color-input";
+
+describe("ColorInput", () => {
+  it("uppercase input is normalised to lowercase on blur", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ColorInput
+        id="primary"
+        label="Primary"
+        value="#163a5f"
+        onChange={onChange}
+        defaultValue="#163a5f"
+      />,
+    );
+    const text = container.querySelector("#primary") as HTMLInputElement;
+    fireEvent.change(text, { target: { value: "#ABCDEF" } });
+    fireEvent.blur(text);
+    expect(onChange).toHaveBeenLastCalledWith("#abcdef");
+  });
+
+  it("whitespace is stripped on blur", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ColorInput
+        id="primary"
+        label="Primary"
+        value="#163a5f"
+        onChange={onChange}
+        defaultValue="#163a5f"
+      />,
+    );
+    const text = container.querySelector("#primary") as HTMLInputElement;
+    fireEvent.change(text, { target: { value: "  #abcdef  " } });
+    fireEvent.blur(text);
+    expect(onChange).toHaveBeenLastCalledWith("#abcdef");
+  });
+
+  it("bad hex on blur reverts to the last valid value (does NOT push up)", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ColorInput
+        id="primary"
+        label="Primary"
+        value="#163a5f"
+        onChange={onChange}
+        defaultValue="#163a5f"
+      />,
+    );
+    const text = container.querySelector("#primary") as HTMLInputElement;
+    fireEvent.change(text, { target: { value: "garbage" } });
+    fireEvent.blur(text);
+    // onChange should NOT have been called with the garbage value.
+    const calls = onChange.mock.calls.map((c) => c[0]);
+    expect(calls.every((v) => v !== "garbage")).toBe(true);
+    // Text input reverts to the previously-valid value.
+    expect(text.value).toBe("#163a5f");
+  });
+
+  it("swatch change updates the parent (lowercase hex)", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ColorInput
+        id="primary"
+        label="Primary"
+        value="#163a5f"
+        onChange={onChange}
+        defaultValue="#163a5f"
+      />,
+    );
+    const swatch = container.querySelector(
+      "#primary-swatch",
+    ) as HTMLInputElement;
+    fireEvent.change(swatch, { target: { value: "#FF00AA" } });
+    expect(onChange).toHaveBeenLastCalledWith("#ff00aa");
+  });
+
+  it("invalid persisted value falls back to defaultValue for the swatch", () => {
+    const { container } = render(
+      <ColorInput
+        id="primary"
+        label="Primary"
+        value="garbage"
+        onChange={vi.fn()}
+        defaultValue="#163a5f"
+      />,
+    );
+    const swatch = container.querySelector(
+      "#primary-swatch",
+    ) as HTMLInputElement;
+    expect(swatch.value).toBe("#163a5f");
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/invoice/__tests__/invoice-shell.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/__tests__/invoice-shell.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/**
+ * InvoiceShell — component snapshot tests (#204 / PDF2 AC-7).
+ *
+ * Mounts the shell in three states (empty, partially-filled, fully-filled)
+ * and snapshots the rendered DOM. Vitest + jsdom + @testing-library/react.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+import { InvoiceShell } from "../invoice-shell";
+
+describe("InvoiceShell — three-state snapshots", () => {
+  beforeEach(() => {
+    // No-op: useRouter is mocked above.
+  });
+
+  it("(1) empty config renders the prefilled defaults + missing-prefix banner", () => {
+    const { container } = render(
+      <InvoiceShell
+        communityId="comm-abc"
+        communityName="Sample Community"
+        initialConfig={{}}
+        initialPrefix={null}
+        initialSignedThumbnailUrl={null}
+      />,
+    );
+    // Defaults are present.
+    expect(container.textContent).toContain("Configure Sample Community");
+    // Missing-prefix banner.
+    expect(container.textContent).toContain("Invoice prefix not set");
+    // Sections.
+    expect(container.textContent).toContain("Identity");
+    expect(container.textContent).toContain("Seller Details");
+    expect(container.textContent).toContain("Branding");
+    expect(container.textContent).toContain("Payment");
+    expect(container.textContent).toContain("Tax");
+    expect(container.textContent).toContain("Notice copy");
+  });
+
+  it("(2) partially-filled config (prefix + identity only)", () => {
+    const { container } = render(
+      <InvoiceShell
+        communityId="comm-abc"
+        communityName="Sample Community"
+        initialConfig={{
+          seller: { legal_name: "Acme Co" },
+        }}
+        initialPrefix="ACME"
+        initialSignedThumbnailUrl={null}
+      />,
+    );
+    // Missing-prefix banner is gone.
+    expect(container.textContent).not.toContain("Invoice prefix not set");
+    // Prefix is in the input.
+    const prefixInput = container.querySelector(
+      "input#invoice-prefix",
+    ) as HTMLInputElement | null;
+    expect(prefixInput?.value).toBe("ACME");
+  });
+
+  it("(3) fully-filled config (all sections populated)", () => {
+    const { container } = render(
+      <InvoiceShell
+        communityId="comm-abc"
+        communityName="Sample Community"
+        initialConfig={{
+          seller: {
+            legal_name: "Acme Co",
+            trade_name: "Acme",
+            tax_ids: [{ label: "TIN", value: "1234567890" }],
+            address_lines: ["123 Main St", "Kampala, Uganda"],
+            contact_email: "billing@acme.test",
+            contact_phone: "+256700000000",
+          },
+          branding: {
+            logo_storage_path: "comm-abc/logo.png",
+            tagline: "Customer Energy Bill",
+            primary_color: "#163a5f",
+            accent_color: "#2f7d32",
+            whatsapp_number: "+256700000000",
+            document_title: "Bill",
+          },
+          payment: { due_days_after_issue: 14 },
+          tax: { show_section: true, category_label: "VAT @ 18%", rate_pct: 18 },
+          notices: {
+            vat_text: "VAT registered",
+            payment_instructions_text: "Pay via mobile money.",
+            signature_disclaimer: "No signature required.",
+          },
+        }}
+        initialPrefix="ACME"
+        initialSignedThumbnailUrl="https://example.com/signed.png"
+      />,
+    );
+    // Form values live in input.value, not textContent. Verify the
+    // population via the actual input elements.
+    const legalNameInput = container.querySelector(
+      "#legal-name",
+    ) as HTMLInputElement | null;
+    expect(legalNameInput?.value).toBe("Acme Co");
+    const tradeNameInput = container.querySelector(
+      "#trade-name",
+    ) as HTMLInputElement | null;
+    expect(tradeNameInput?.value).toBe("Acme");
+    const dueDaysInput = container.querySelector(
+      "#due-days",
+    ) as HTMLInputElement | null;
+    expect(dueDaysInput?.value).toBe("14");
+    // Persisted thumbnail src is rendered via <img>.
+    const thumbImg = container.querySelector(
+      'img[alt="Current logo"]',
+    ) as HTMLImageElement | null;
+    expect(thumbImg?.getAttribute("src")).toBe("https://example.com/signed.png");
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/invoice/__tests__/list-editor.test.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/__tests__/list-editor.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+/**
+ * ListEditor — integration tests (#204 / PDF2 AC-7).
+ *
+ * Verifies:
+ *   - Add row appends a new row built by `emptyRow()`.
+ *   - Remove row deletes by index.
+ *   - Up/Down reorder preserves data (no clobber).
+ *   - Max-rows guard prevents adding beyond the limit.
+ *   - Empty-state CTA shows when rows.length === 0.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { ListEditor } from "../list-editor";
+
+function makeStringEditor(rows: string[], onChange: (next: string[]) => void) {
+  return (
+    <ListEditor<string>
+      rows={rows}
+      onChange={onChange}
+      renderRow={(row, _i, update) => (
+        <input
+          aria-label="row"
+          value={row}
+          onChange={(e) => update(e.target.value)}
+        />
+      )}
+      emptyRow={() => ""}
+      maxRows={3}
+      addLabel="Add row"
+    />
+  );
+}
+
+describe("ListEditor", () => {
+  it("renders empty-state CTA when rows is empty", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor([], onChange));
+    const cta = screen.getByRole("button", { name: /add row/i });
+    expect(cta).toBeDefined();
+  });
+
+  it("Add appends a new row built by emptyRow()", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b"], onChange));
+    fireEvent.click(screen.getByRole("button", { name: /add row/i }));
+    expect(onChange).toHaveBeenCalledWith(["a", "b", ""]);
+  });
+
+  it("Remove deletes by index", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b", "c"], onChange));
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove row/i,
+    });
+    fireEvent.click(removeButtons[1]); // Remove "b".
+    expect(onChange).toHaveBeenCalledWith(["a", "c"]);
+  });
+
+  it("Up reorder preserves data", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b", "c"], onChange));
+    const upButtons = screen.getAllByRole("button", { name: /move row \d+ up/i });
+    fireEvent.click(upButtons[1]); // Move "b" up.
+    expect(onChange).toHaveBeenCalledWith(["b", "a", "c"]);
+  });
+
+  it("Down reorder preserves data", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b", "c"], onChange));
+    const downButtons = screen.getAllByRole("button", {
+      name: /move row \d+ down/i,
+    });
+    fireEvent.click(downButtons[0]); // Move "a" down.
+    expect(onChange).toHaveBeenCalledWith(["b", "a", "c"]);
+  });
+
+  it("max-rows guard disables Add at the limit", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b", "c"], onChange));
+    const addButton = screen.getByRole("button", { name: /add row/i });
+    expect(addButton.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("Up at row 0 is disabled (boundary)", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b"], onChange));
+    const upButtons = screen.getAllByRole("button", { name: /move row \d+ up/i });
+    expect(upButtons[0].hasAttribute("disabled")).toBe(true);
+  });
+
+  it("Down at last row is disabled (boundary)", () => {
+    const onChange = vi.fn();
+    render(makeStringEditor(["a", "b"], onChange));
+    const downButtons = screen.getAllByRole("button", {
+      name: /move row \d+ down/i,
+    });
+    expect(downButtons[downButtons.length - 1].hasAttribute("disabled")).toBe(
+      true,
+    );
+  });
+});

--- a/src/app/(dashboard)/communities/[id]/invoice/color-input.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/color-input.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * color-input.tsx — Native `<input type="color">` swatch + paired hex text
+ * input (#204 / PDF2).
+ *
+ * Why a paired text input:
+ *   - `<input type="color">` has spotty screen-reader support; the text input
+ *     is the SR-accessible affordance.
+ *   - Allows operators to paste a hex value from a brand guide.
+ *
+ * Bidirectional binding contract:
+ *   - Typing a valid hex in the text input updates the swatch.
+ *   - Picking a colour from the swatch updates the text input (lowercase).
+ *
+ * Sanitisation:
+ *   - Internal value is always lowercase `#rrggbb`.
+ *   - Whitespace is trimmed on text-input blur.
+ *   - Invalid hex while typing renders the swatch with the previous valid
+ *     value (the swatch falls back to `#000000` on a malformed `value`
+ *     attribute, so we only forward a valid hex into it).
+ *
+ * Validation feedback is left to the parent shell — this primitive just
+ * sanitises on blur and reports up via `onChange`.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const HEX_RE = /^#[0-9a-f]{6}$/;
+
+export type ColorInputProps = {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  /** Default to fall back to when the user clears the input. */
+  defaultValue: string;
+  /** Optional helper text rendered below the input pair. */
+  description?: string;
+  disabled?: boolean;
+};
+
+export function ColorInput({
+  id,
+  label,
+  value,
+  onChange,
+  defaultValue,
+  description,
+  disabled = false,
+}: ColorInputProps) {
+  // Local text-input state lets the operator type freely; we only push
+  // sanitised values up to the parent.
+  const [draft, setDraft] = React.useState(value);
+
+  React.useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const sanitisedSwatchValue = HEX_RE.test(value) ? value : defaultValue;
+
+  function handleSwatchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const next = e.target.value.toLowerCase();
+    setDraft(next);
+    onChange(next);
+  }
+
+  function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setDraft(e.target.value);
+    // Only push up if the typed value is valid hex — otherwise the swatch
+    // would silently reset to #000000 mid-typing.
+    const candidate = e.target.value.trim().toLowerCase();
+    if (HEX_RE.test(candidate)) {
+      onChange(candidate);
+    }
+  }
+
+  function handleTextBlur() {
+    const candidate = draft.trim().toLowerCase();
+    if (HEX_RE.test(candidate)) {
+      setDraft(candidate);
+      onChange(candidate);
+    } else {
+      // Invalid hex on blur — revert to the last valid value.
+      setDraft(value);
+    }
+  }
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-xs font-medium text-foreground"
+      >
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          id={`${id}-swatch`}
+          type="color"
+          aria-label={`${label} colour swatch`}
+          value={sanitisedSwatchValue}
+          onChange={handleSwatchChange}
+          disabled={disabled}
+          className={cn(
+            "h-9 w-12 cursor-pointer rounded-md border border-border bg-card",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+        />
+        <input
+          id={id}
+          type="text"
+          inputMode="text"
+          autoComplete="off"
+          spellCheck={false}
+          value={draft}
+          onChange={handleTextChange}
+          onBlur={handleTextBlur}
+          disabled={disabled}
+          aria-label={`${label} hex value`}
+          className={cn(
+            "flex h-9 w-32 rounded-md border border-border bg-card px-3 py-1 font-mono text-xs text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+        />
+      </div>
+      {description && (
+        <p className="mt-1 text-[11px] text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/invoice/invoice-shell.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/invoice-shell.tsx
@@ -1,0 +1,807 @@
+"use client";
+
+/**
+ * invoice-shell.tsx — Client shell for the community Invoice tab (#204 / PDF2).
+ *
+ * Owns:
+ *   - Form state (controlled — useState; no react-hook-form, mirrors the
+ *     Payment-shell precedent).
+ *   - Logo-staging state (drafted path + signed thumbnail URL until next save).
+ *   - Submit handler (PATCH /api/communities/[id]/invoice-config).
+ *   - Preview-button click flow (Pattern A — fetch + blob + popup window).
+ *
+ * Click-flow rationale (preview button — Pattern A): we open `about:blank`
+ * synchronously inside the click handler (popup blockers reject async opens),
+ * then POST to the preview route, then set the popup's location to a blob
+ * URL. Pattern B (hidden form submit) was rejected because the route's
+ * permission gate operates on JSON, and accepting both content-types is
+ * extra surface area.
+ *
+ * Default-value semantics (#204 R5): when `invoice_config` is empty (`{}`),
+ * we pre-fill the form with sensible defaults (sourced from PDF1a's Zod
+ * schema defaults). These defaults are EDITABLE, not placeholder — the first
+ * save persists the full populated JSONB.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  parseInvoiceConfig,
+  type InvoiceConfig,
+} from "@/lib/invoices/config-schema";
+import { ColorInput } from "./color-input";
+import { ListEditor } from "./list-editor";
+import {
+  LogoUploadControl,
+  type LogoUploadResult,
+} from "./logo-upload-control";
+
+// ── Defaults ────────────────────────────────────────────────────────────────
+//
+// Sourced from PLAN.md's "default config" reference + AC #2 default-value
+// section. Mirror the Zod schema's expectations so the first PATCH from a
+// fresh form always passes validation.
+
+const DEFAULT_PRIMARY_COLOR = "#163a5f";
+const DEFAULT_ACCENT_COLOR = "#2f7d32";
+const DEFAULT_DUE_DAYS = 8;
+const DEFAULT_TAX_RATE = 18;
+const DEFAULT_TAX_LABEL = "VAT @ 18%";
+
+type FormState = {
+  invoice_prefix: string;
+  // Identity
+  document_title: "Invoice" | "Bill" | "Receipt";
+  // Seller
+  legal_name: string;
+  trade_name: string;
+  tax_ids: { label: string; value: string }[];
+  address_lines: string[];
+  contact_email: string;
+  contact_phone: string;
+  // Branding
+  tagline: string;
+  primary_color: string;
+  accent_color: string;
+  whatsapp_number: string;
+  logo_storage_path: string | null;
+  // Payment
+  due_days_after_issue: number;
+  // Tax
+  tax_show_section: boolean;
+  tax_category_label: string;
+  tax_rate_pct: number;
+  // Notices
+  vat_text: string;
+  payment_instructions_text: string;
+  signature_disclaimer: string;
+};
+
+function buildInitialState(
+  config: InvoiceConfig,
+  prefix: string | null,
+): FormState {
+  const branding = config.branding ?? {};
+  const seller = config.seller ?? { legal_name: "" };
+  const payment = config.payment;
+  const tax = config.tax ?? {};
+  const notices = config.notices ?? {};
+
+  return {
+    invoice_prefix: prefix ?? "",
+    document_title:
+      branding.document_title === "Bill" || branding.document_title === "Receipt"
+        ? branding.document_title
+        : "Invoice",
+    legal_name: seller.legal_name ?? "",
+    trade_name: seller.trade_name ?? "",
+    tax_ids: seller.tax_ids ? [...seller.tax_ids] : [],
+    address_lines: seller.address_lines ? [...seller.address_lines] : [],
+    contact_email: seller.contact_email ?? "",
+    contact_phone: seller.contact_phone ?? "",
+    tagline: branding.tagline ?? "",
+    primary_color: branding.primary_color ?? DEFAULT_PRIMARY_COLOR,
+    accent_color: branding.accent_color ?? DEFAULT_ACCENT_COLOR,
+    whatsapp_number: branding.whatsapp_number ?? "",
+    logo_storage_path: branding.logo_storage_path ?? null,
+    due_days_after_issue: payment?.due_days_after_issue ?? DEFAULT_DUE_DAYS,
+    tax_show_section: tax.show_section ?? true,
+    tax_category_label: tax.category_label ?? DEFAULT_TAX_LABEL,
+    tax_rate_pct: tax.rate_pct ?? DEFAULT_TAX_RATE,
+    vat_text: notices.vat_text ?? "",
+    payment_instructions_text: notices.payment_instructions_text ?? "",
+    signature_disclaimer: notices.signature_disclaimer ?? "",
+  };
+}
+
+function buildPayload(state: FormState): {
+  invoice_prefix: string | null;
+  invoice_config: InvoiceConfig;
+} {
+  const seller: NonNullable<InvoiceConfig["seller"]> = {
+    legal_name: state.legal_name.trim(),
+  };
+  if (state.trade_name.trim()) seller.trade_name = state.trade_name.trim();
+  if (state.tax_ids.length > 0) {
+    seller.tax_ids = state.tax_ids
+      .map((t) => ({ label: t.label.trim(), value: t.value.trim() }))
+      .filter((t) => t.label && t.value);
+  }
+  if (state.address_lines.length > 0) {
+    seller.address_lines = state.address_lines
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  }
+  if (state.contact_email.trim()) {
+    seller.contact_email = state.contact_email.trim();
+  }
+  if (state.contact_phone.trim()) {
+    seller.contact_phone = state.contact_phone.trim();
+  }
+
+  const branding: NonNullable<InvoiceConfig["branding"]> = {};
+  if (state.logo_storage_path) {
+    branding.logo_storage_path = state.logo_storage_path;
+  }
+  if (state.tagline.trim()) branding.tagline = state.tagline.trim();
+  branding.primary_color = state.primary_color;
+  branding.accent_color = state.accent_color;
+  if (state.whatsapp_number.trim()) {
+    branding.whatsapp_number = state.whatsapp_number.trim();
+  }
+  branding.document_title = state.document_title;
+
+  const config: InvoiceConfig = {
+    seller: seller.legal_name ? seller : undefined,
+    branding,
+    payment: { due_days_after_issue: state.due_days_after_issue },
+    tax: {
+      show_section: state.tax_show_section,
+      category_label: state.tax_category_label.trim() || DEFAULT_TAX_LABEL,
+      rate_pct: state.tax_rate_pct,
+    },
+    notices: {
+      vat_text: state.vat_text.trim() || null,
+      payment_instructions_text:
+        state.payment_instructions_text.trim() || null,
+      signature_disclaimer: state.signature_disclaimer.trim() || null,
+    },
+  };
+
+  // Strip undefined keys so the JSONB stays canonical.
+  if (!config.seller) delete config.seller;
+
+  return {
+    invoice_prefix: state.invoice_prefix.trim()
+      ? state.invoice_prefix.trim()
+      : null,
+    invoice_config: config,
+  };
+}
+
+export type InvoiceShellProps = {
+  communityId: string;
+  communityName: string;
+  initialConfig: InvoiceConfig;
+  initialPrefix: string | null;
+  initialSignedThumbnailUrl: string | null;
+};
+
+export function InvoiceShell({
+  communityId,
+  communityName,
+  initialConfig,
+  initialPrefix,
+  initialSignedThumbnailUrl,
+}: InvoiceShellProps) {
+  const router = useRouter();
+  const [state, setState] = React.useState<FormState>(() =>
+    buildInitialState(initialConfig, initialPrefix),
+  );
+  const [signedThumbnailUrl, setSignedThumbnailUrl] = React.useState<
+    string | null
+  >(initialSignedThumbnailUrl);
+  const [saving, setSaving] = React.useState(false);
+  const [previewing, setPreviewing] = React.useState(false);
+  const [outcome, setOutcome] = React.useState<
+    | null
+    | { kind: "success"; message: string }
+    | { kind: "error"; message: string; fields?: Record<string, unknown> }
+  >(null);
+  const [showNotices, setShowNotices] = React.useState(false);
+
+  // Cross-field rule (#204 R5 / PDF1a Zod): when the rate is set to 0, auto-
+  // toggle Show tax section to false. Mirrors the schema's invariant.
+  React.useEffect(() => {
+    if (state.tax_rate_pct === 0 && state.tax_show_section) {
+      setState((s) => ({ ...s, tax_show_section: false }));
+    }
+  }, [state.tax_rate_pct, state.tax_show_section]);
+
+  function patch<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setState((s) => ({ ...s, [key]: value }));
+  }
+
+  function handleLogoUploaded(result: LogoUploadResult) {
+    setState((s) => ({ ...s, logo_storage_path: result.logo_storage_path }));
+    setSignedThumbnailUrl(result.signed_thumbnail_url || null);
+  }
+
+  function handleLogoRemove() {
+    // Clear the form-state path; the storage object is intentionally left
+    // orphaned for MVP (architect R6 cleanup is a future ticket).
+    setState((s) => ({ ...s, logo_storage_path: null }));
+    setSignedThumbnailUrl(null);
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setOutcome(null);
+    setSaving(true);
+    try {
+      const payload = buildPayload(state);
+
+      // Client-side Zod pre-flight — catches obvious errors without a server
+      // round-trip and normalises the JSONB shape.
+      try {
+        parseInvoiceConfig(payload.invoice_config);
+      } catch (err) {
+        setOutcome({
+          kind: "error",
+          message:
+            err instanceof Error
+              ? err.message
+              : "Invoice configuration is invalid.",
+        });
+        setSaving(false);
+        return;
+      }
+
+      const res = await fetch(
+        `/api/communities/${communityId}/invoice-config`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      const json = (await res.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+
+      if (res.status === 200) {
+        setOutcome({
+          kind: "success",
+          message: "Invoice settings saved.",
+        });
+        router.refresh();
+        return;
+      }
+
+      setOutcome({
+        kind: "error",
+        message:
+          (typeof json.error === "string" && json.error) ||
+          "Failed to save invoice settings.",
+        fields:
+          json.fields && typeof json.fields === "object"
+            ? (json.fields as Record<string, unknown>)
+            : undefined,
+      });
+    } catch {
+      setOutcome({
+        kind: "error",
+        message: "Network error — please try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePreview() {
+    if (previewing) return;
+    setPreviewing(true);
+    setOutcome(null);
+
+    // Pattern A — open the popup synchronously inside the click handler so
+    // popup blockers don't reject it.
+    const popup = window.open("about:blank", "_blank");
+
+    try {
+      const payload = buildPayload(state);
+      const res = await fetch(
+        `/api/communities/${communityId}/invoice-preview`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >;
+        setOutcome({
+          kind: "error",
+          message:
+            (typeof json.error === "string" && json.error) ||
+            `Preview failed (HTTP ${res.status}).`,
+        });
+        if (popup) popup.close();
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      if (popup) {
+        popup.location.href = url;
+      } else {
+        // Popup blocked — fall back to navigating the current tab. The
+        // operator should re-enable popups for the best experience.
+        window.location.href = url;
+      }
+    } catch {
+      setOutcome({
+        kind: "error",
+        message: "Network error during preview generation.",
+      });
+      if (popup) popup.close();
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  const showPrefixWarning = !state.invoice_prefix.trim();
+
+  return (
+    <form onSubmit={handleSave} className="space-y-6">
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Invoice
+        </p>
+        <h3 className="text-lg font-semibold text-foreground">
+          Configure {communityName}&apos;s invoice template
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Branding, seller details, and tax/payment copy that appear on every
+          PDF bill for this community.
+        </p>
+      </div>
+
+      {/* Section: Identity */}
+      <Section title="Identity">
+        <Field
+          id="invoice-prefix"
+          label="Invoice prefix"
+          description="Used in invoice numbers, e.g. NFE-2026-00421. 2-8 uppercase letters or digits."
+        >
+          <Input
+            id="invoice-prefix"
+            type="text"
+            value={state.invoice_prefix}
+            onChange={(e) => patch("invoice_prefix", e.target.value.toUpperCase())}
+            placeholder="NFE"
+            autoComplete="off"
+            spellCheck={false}
+            className="font-mono"
+          />
+        </Field>
+
+        <Field id="document-title" label="Document title">
+          <Select
+            value={state.document_title}
+            onValueChange={(v) =>
+              patch("document_title", v as FormState["document_title"])
+            }
+          >
+            <SelectTrigger id="document-title">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Invoice">Invoice</SelectItem>
+              <SelectItem value="Bill">Bill</SelectItem>
+              <SelectItem value="Receipt">Receipt</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+      </Section>
+
+      {/* Section: Seller Details */}
+      <Section title="Seller Details">
+        <Field
+          id="legal-name"
+          label="Legal name"
+          description="Required when other invoice config fields are set. Falls back to the org name if empty."
+        >
+          <Input
+            id="legal-name"
+            type="text"
+            value={state.legal_name}
+            onChange={(e) => patch("legal_name", e.target.value)}
+          />
+        </Field>
+
+        <Field
+          id="trade-name"
+          label="Trade name"
+          description="Optional — falls back to legal name."
+        >
+          <Input
+            id="trade-name"
+            type="text"
+            value={state.trade_name}
+            onChange={(e) => patch("trade_name", e.target.value)}
+          />
+        </Field>
+
+        <Field id="tax-ids" label="Tax IDs">
+          <ListEditor<{ label: string; value: string }>
+            rows={state.tax_ids}
+            onChange={(rows) => patch("tax_ids", rows)}
+            renderRow={(row, _i, update) => (
+              <div className="grid grid-cols-2 gap-2">
+                <Input
+                  type="text"
+                  value={row.label}
+                  onChange={(e) => update({ ...row, label: e.target.value })}
+                  placeholder="Label (e.g. TIN)"
+                  aria-label="Tax ID label"
+                />
+                <Input
+                  type="text"
+                  value={row.value}
+                  onChange={(e) => update({ ...row, value: e.target.value })}
+                  placeholder="Value"
+                  aria-label="Tax ID value"
+                />
+              </div>
+            )}
+            emptyRow={() => ({ label: "", value: "" })}
+            maxRows={4}
+            addLabel="Add tax ID"
+            emptyCopy="No tax IDs configured."
+          />
+        </Field>
+
+        <Field id="address-lines" label="Address lines">
+          <ListEditor<string>
+            rows={state.address_lines}
+            onChange={(rows) => patch("address_lines", rows)}
+            renderRow={(row, _i, update) => (
+              <Input
+                type="text"
+                value={row}
+                onChange={(e) => update(e.target.value)}
+                placeholder="Street, city, country…"
+                aria-label="Address line"
+              />
+            )}
+            emptyRow={() => ""}
+            maxRows={6}
+            addLabel="Add address line"
+            emptyCopy="No address lines configured."
+          />
+        </Field>
+
+        <Field id="contact-email" label="Contact email">
+          <Input
+            id="contact-email"
+            type="email"
+            value={state.contact_email}
+            onChange={(e) => patch("contact_email", e.target.value)}
+          />
+        </Field>
+
+        <Field
+          id="contact-phone"
+          label="Contact phone"
+          description="Used as a fallback for the WhatsApp link if the WhatsApp number is empty."
+        >
+          <Input
+            id="contact-phone"
+            type="tel"
+            value={state.contact_phone}
+            onChange={(e) => patch("contact_phone", e.target.value)}
+          />
+        </Field>
+      </Section>
+
+      {/* Section: Branding */}
+      <Section title="Branding">
+        <Field id="tagline" label="Tagline">
+          <Input
+            id="tagline"
+            type="text"
+            value={state.tagline}
+            onChange={(e) => patch("tagline", e.target.value)}
+            placeholder="Customer Energy Bill"
+          />
+        </Field>
+
+        <ColorInput
+          id="primary-color"
+          label="Primary colour"
+          value={state.primary_color}
+          onChange={(v) => patch("primary_color", v)}
+          defaultValue={DEFAULT_PRIMARY_COLOR}
+          description="Used for the document header and accents."
+        />
+
+        <ColorInput
+          id="accent-color"
+          label="Accent colour"
+          value={state.accent_color}
+          onChange={(v) => patch("accent_color", v)}
+          defaultValue={DEFAULT_ACCENT_COLOR}
+          description="Used for highlighted totals and action chips."
+        />
+
+        <Field
+          id="whatsapp-number"
+          label="WhatsApp number"
+          description="Optional — overrides the contact phone for the WhatsApp link."
+        >
+          <Input
+            id="whatsapp-number"
+            type="tel"
+            value={state.whatsapp_number}
+            onChange={(e) => patch("whatsapp_number", e.target.value)}
+          />
+        </Field>
+
+        <Field id="logo" label="Logo">
+          <LogoUploadControl
+            communityId={communityId}
+            currentLogoPath={state.logo_storage_path}
+            currentSignedThumbnailUrl={signedThumbnailUrl}
+            onUploaded={handleLogoUploaded}
+            onRemove={handleLogoRemove}
+          />
+        </Field>
+      </Section>
+
+      {/* Section: Payment */}
+      <Section title="Payment">
+        <Field
+          id="due-days"
+          label="Days until due"
+          description="Number of days after issue when the bill becomes due (1-60)."
+        >
+          <Input
+            id="due-days"
+            type="number"
+            min={1}
+            max={60}
+            value={state.due_days_after_issue}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              patch(
+                "due_days_after_issue",
+                Number.isFinite(n) ? Math.max(1, Math.min(60, n)) : DEFAULT_DUE_DAYS,
+              );
+            }}
+            className="w-24"
+          />
+        </Field>
+      </Section>
+
+      {/* Section: Tax */}
+      <Section title="Tax">
+        <div>
+          <label className="inline-flex cursor-pointer items-center gap-2">
+            <input
+              type="checkbox"
+              checked={state.tax_show_section}
+              onChange={(e) => patch("tax_show_section", e.target.checked)}
+              disabled={state.tax_rate_pct === 0}
+              className="h-4 w-4 rounded border-border text-primary focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <span className="text-xs text-foreground">
+              Show tax section on bills
+            </span>
+          </label>
+          {state.tax_rate_pct === 0 && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Tax section is hidden when the rate is 0%.
+            </p>
+          )}
+        </div>
+
+        <Field id="tax-category-label" label="Tax category label">
+          <Input
+            id="tax-category-label"
+            type="text"
+            value={state.tax_category_label}
+            onChange={(e) => patch("tax_category_label", e.target.value)}
+            disabled={!state.tax_show_section}
+          />
+        </Field>
+
+        <Field id="tax-rate-pct" label="Tax rate %">
+          <Input
+            id="tax-rate-pct"
+            type="number"
+            min={0}
+            max={30}
+            value={state.tax_rate_pct}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              patch(
+                "tax_rate_pct",
+                Number.isFinite(n) ? Math.max(0, Math.min(30, n)) : 0,
+              );
+            }}
+            disabled={!state.tax_show_section && state.tax_rate_pct === 0}
+            className="w-24"
+          />
+        </Field>
+      </Section>
+
+      {/* Section: Notice Copy (collapsible) */}
+      <Section
+        title="Notice copy"
+        collapsible
+        collapsed={!showNotices}
+        onToggle={() => setShowNotices((v) => !v)}
+      >
+        {showNotices && (
+          <>
+            <Field
+              id="vat-text"
+              label="VAT notice"
+              description="Optional — renderer falls back to the default VAT explanation."
+            >
+              <textarea
+                id="vat-text"
+                value={state.vat_text}
+                onChange={(e) => patch("vat_text", e.target.value)}
+                rows={2}
+                className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </Field>
+            <Field
+              id="payment-instructions-text"
+              label="Payment instructions"
+              description="Optional — renderer falls back to default payment instructions."
+            >
+              <textarea
+                id="payment-instructions-text"
+                value={state.payment_instructions_text}
+                onChange={(e) =>
+                  patch("payment_instructions_text", e.target.value)
+                }
+                rows={3}
+                className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </Field>
+            <Field
+              id="signature-disclaimer"
+              label="Signature disclaimer"
+              description="Optional — renderer defaults to “Computer generated, valid without signature.”"
+            >
+              <textarea
+                id="signature-disclaimer"
+                value={state.signature_disclaimer}
+                onChange={(e) => patch("signature_disclaimer", e.target.value)}
+                rows={2}
+                className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </Field>
+          </>
+        )}
+      </Section>
+
+      {showPrefixWarning && (
+        <Banner tone="warn" title="Invoice prefix not set">
+          Invoice prefix is required to download bills as PDFs — bills cannot
+          be generated until you set this.
+        </Banner>
+      )}
+
+      {outcome?.kind === "success" && (
+        <Banner tone="success" title="Saved">
+          {outcome.message}
+        </Banner>
+      )}
+
+      {outcome?.kind === "error" && (
+        <Banner tone="destructive" title="Could not save">
+          {outcome.message}
+        </Banner>
+      )}
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={handlePreview}
+          disabled={previewing}
+          className="rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {previewing ? "Generating preview…" : "Preview bill"}
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          aria-busy={saving}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Internal layout primitives ────────────────────────────────────────────
+
+function Section({
+  title,
+  children,
+  collapsible = false,
+  collapsed = false,
+  onToggle,
+}: {
+  title: string;
+  children: React.ReactNode;
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
+}) {
+  return (
+    <section className="rounded-md border border-border bg-card p-5 shadow-elev-1">
+      <div className="mb-4 flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-foreground">{title}</h4>
+        {collapsible && (
+          <button
+            type="button"
+            onClick={onToggle}
+            className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted"
+            aria-expanded={!collapsed}
+          >
+            {collapsed ? "Show" : "Hide"}
+          </button>
+        )}
+      </div>
+      <div className="space-y-4">{children}</div>
+    </section>
+  );
+}
+
+function Field({
+  id,
+  label,
+  description,
+  children,
+}: {
+  id: string;
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-xs font-medium text-foreground"
+      >
+        {label}
+      </label>
+      {children}
+      {description && (
+        <p className="mt-1 text-[11px] text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/invoice/list-editor.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/list-editor.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * list-editor.tsx — Generic add/remove + up/down reorder editor (#204 / PDF2).
+ *
+ * Used by the Tax IDs section (label/value pair rows, max 4) and the Address
+ * Lines section (single string rows, max 6). The renderProp pattern keeps
+ * row markup at the call site — the editor only owns the array shape +
+ * controls.
+ *
+ * A11y:
+ *   - Each row controls (Up/Down/Remove) are real `<button>` elements with
+ *     visible labels on the focused state.
+ *   - Disabled at boundaries (Up at row 0, Down at last row).
+ *   - The Add button is disabled at the max-rows guard.
+ *
+ * Out of scope (refinement R5): drag-and-drop reorder. At N≤6 the up/down
+ * arrows are sufficient and have full keyboard support.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type ListEditorProps<T> = {
+  rows: T[];
+  onChange: (next: T[]) => void;
+  /** Render the editable controls for a single row. */
+  renderRow: (row: T, index: number, update: (next: T) => void) => React.ReactNode;
+  /** Build a fresh empty row when the operator clicks "Add". */
+  emptyRow: () => T;
+  /** Maximum number of rows the editor will allow (inclusive). */
+  maxRows: number;
+  /** Singular label for the Add button (e.g. "Add tax ID"). */
+  addLabel: string;
+  /** Optional empty-state copy when the list has zero rows. */
+  emptyCopy?: string;
+};
+
+export function ListEditor<T>({
+  rows,
+  onChange,
+  renderRow,
+  emptyRow,
+  maxRows,
+  addLabel,
+  emptyCopy,
+}: ListEditorProps<T>) {
+  function handleAdd() {
+    if (rows.length >= maxRows) return;
+    onChange([...rows, emptyRow()]);
+  }
+
+  function handleRemove(index: number) {
+    onChange(rows.filter((_, i) => i !== index));
+  }
+
+  function handleMove(index: number, direction: "up" | "down") {
+    const swap = direction === "up" ? index - 1 : index + 1;
+    if (swap < 0 || swap >= rows.length) return;
+    const next = [...rows];
+    [next[index], next[swap]] = [next[swap], next[index]];
+    onChange(next);
+  }
+
+  function handleUpdate(index: number, value: T) {
+    const next = [...rows];
+    next[index] = value;
+    onChange(next);
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-2">
+        {emptyCopy && (
+          <p className="text-[11px] text-muted-foreground">{emptyCopy}</p>
+        )}
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="rounded-md border border-dashed border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted"
+        >
+          + {addLabel}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          className="flex items-start gap-2 rounded-md border border-border bg-card p-2"
+        >
+          <div className="flex-1">
+            {renderRow(row, i, (next) => handleUpdate(i, next))}
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <button
+              type="button"
+              onClick={() => handleMove(i, "up")}
+              disabled={i === 0}
+              aria-label={`Move row ${i + 1} up`}
+              title="Move up"
+              className={cn(
+                "rounded-md border border-border bg-card px-2 py-1 text-xs text-foreground hover:bg-muted",
+                "disabled:cursor-not-allowed disabled:opacity-40",
+              )}
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => handleMove(i, "down")}
+              disabled={i === rows.length - 1}
+              aria-label={`Move row ${i + 1} down`}
+              title="Move down"
+              className={cn(
+                "rounded-md border border-border bg-card px-2 py-1 text-xs text-foreground hover:bg-muted",
+                "disabled:cursor-not-allowed disabled:opacity-40",
+              )}
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              onClick={() => handleRemove(i)}
+              aria-label={`Remove row ${i + 1}`}
+              title="Remove"
+              className="rounded-md border border-border bg-card px-2 py-1 text-xs text-destructive-fg hover:bg-destructive-muted"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAdd}
+        disabled={rows.length >= maxRows}
+        className={cn(
+          "rounded-md border border-dashed border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+        )}
+      >
+        + {addLabel}
+      </button>
+      {rows.length >= maxRows && (
+        <p className="text-[11px] text-muted-foreground">
+          Maximum of {maxRows} rows reached.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/invoice/logo-upload-control.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/logo-upload-control.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+/**
+ * logo-upload-control.tsx — Drag-drop / file-picker logo uploader (#204 / PDF2).
+ *
+ * Drag-drop is implemented with native HTML5 events (`onDragOver`, `onDrop`)
+ * — NO library. The fallback file picker is a hidden `<input type="file">`
+ * triggered by clicking (or pressing Enter/Space on) the dropzone.
+ *
+ * Client-side validation (defense-in-depth — the server also re-validates):
+ *   - MIME: image/png, image/jpeg, image/svg+xml.
+ *   - Size: ≤ 500 KB (the bucket caps at 1 MiB; 500 KB keeps deploy/preview
+ *     bundles small).
+ *
+ * Preview: `URL.createObjectURL()` blob URI rendered inline before the
+ * upload click. We revoke the blob URL on unmount and on successful upload.
+ *
+ * In-flight guard: the Upload button disables while a previous request is
+ * pending — prevents double-fire orphans in storage.
+ *
+ * A11y: dropzone is `tabIndex={0}` with Enter/Space triggering the file
+ * picker (mirroring click). Mouse-only dropzones are an a11y bug.
+ */
+
+import * as React from "react";
+import { Banner } from "@/components/ui/banner";
+import { cn } from "@/lib/utils";
+
+const ACCEPTED_MIME = "image/png,image/jpeg,image/svg+xml";
+const ALLOWED_MIME_SET = new Set<string>([
+  "image/png",
+  "image/jpeg",
+  "image/svg+xml",
+]);
+
+const CLIENT_MAX_BYTES = 500 * 1024; // 500 KB.
+
+export type LogoUploadResult = {
+  logo_storage_path: string;
+  signed_thumbnail_url: string;
+};
+
+export type LogoUploadControlProps = {
+  communityId: string;
+  /** Current persisted-or-staged logo path (drives the "Remove" button). */
+  currentLogoPath: string | null;
+  /** Signed URL to render the persisted thumbnail, when available. */
+  currentSignedThumbnailUrl: string | null;
+  /** Called after a successful upload so the form-state path can be staged. */
+  onUploaded: (result: LogoUploadResult) => void;
+  /** Clears the form-state path; does NOT delete the storage object. */
+  onRemove: () => void;
+};
+
+export function LogoUploadControl({
+  communityId,
+  currentLogoPath,
+  currentSignedThumbnailUrl,
+  onUploaded,
+  onRemove,
+}: LogoUploadControlProps) {
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const [draftFile, setDraftFile] = React.useState<File | null>(null);
+  const [draftPreviewUrl, setDraftPreviewUrl] = React.useState<string | null>(
+    null,
+  );
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [uploading, setUploading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Revoke the blob URL on unmount or when replaced — prevents leak.
+  React.useEffect(() => {
+    return () => {
+      if (draftPreviewUrl) URL.revokeObjectURL(draftPreviewUrl);
+    };
+  }, [draftPreviewUrl]);
+
+  function clearDraft() {
+    if (draftPreviewUrl) URL.revokeObjectURL(draftPreviewUrl);
+    setDraftFile(null);
+    setDraftPreviewUrl(null);
+  }
+
+  function handleSelect(file: File) {
+    setError(null);
+    if (!ALLOWED_MIME_SET.has(file.type)) {
+      setError("Unsupported file type. Use PNG, JPG, or SVG.");
+      return;
+    }
+    if (file.size > CLIENT_MAX_BYTES) {
+      setError(
+        `File is too large (${Math.round(file.size / 1024)} KB). Maximum 500 KB.`,
+      );
+      return;
+    }
+    if (draftPreviewUrl) URL.revokeObjectURL(draftPreviewUrl);
+    setDraftFile(file);
+    setDraftPreviewUrl(URL.createObjectURL(file));
+  }
+
+  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleSelect(file);
+    // Reset the input so the same filename can be re-selected.
+    e.target.value = "";
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleSelect(file);
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setIsDragging(true);
+  }
+
+  function handleDragLeave() {
+    setIsDragging(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      fileInputRef.current?.click();
+    }
+  }
+
+  async function handleUpload() {
+    if (!draftFile) return;
+    setUploading(true);
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", draftFile);
+      const res = await fetch(`/api/communities/${communityId}/invoice-logo`, {
+        method: "POST",
+        body: fd,
+      });
+      const json = (await res.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+      if (!res.ok) {
+        setError(
+          (typeof json.error === "string" && json.error) ||
+            "Upload failed. Try again.",
+        );
+        return;
+      }
+      const path = typeof json.logo_storage_path === "string"
+        ? json.logo_storage_path
+        : "";
+      const signedUrl = typeof json.signed_thumbnail_url === "string"
+        ? json.signed_thumbnail_url
+        : "";
+      if (!path) {
+        setError("Upload returned no storage path. Try again.");
+        return;
+      }
+      onUploaded({ logo_storage_path: path, signed_thumbnail_url: signedUrl });
+      clearDraft();
+    } catch {
+      setError("Network error during upload. Try again.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  const persistedThumbnailSrc =
+    !draftPreviewUrl && currentSignedThumbnailUrl
+      ? currentSignedThumbnailUrl
+      : null;
+
+  return (
+    <div className="space-y-3">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Drop a logo file here, or press Enter to browse"
+        onClick={() => fileInputRef.current?.click()}
+        onKeyDown={handleKeyDown}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={cn(
+          "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed bg-card p-6 text-center transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          isDragging
+            ? "border-primary bg-muted"
+            : "border-border hover:bg-muted",
+        )}
+      >
+        {draftPreviewUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={draftPreviewUrl}
+            alt="Logo preview"
+            className="max-h-24 max-w-full object-contain"
+          />
+        ) : persistedThumbnailSrc ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={persistedThumbnailSrc}
+            alt="Current logo"
+            className="max-h-24 max-w-full object-contain"
+          />
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Drag a logo here or click to browse (PNG, JPG, SVG, up to 500 KB)
+          </p>
+        )}
+        {(draftPreviewUrl || persistedThumbnailSrc) && (
+          <p className="text-[11px] text-muted-foreground">
+            {draftPreviewUrl
+              ? `Selected: ${draftFile?.name ?? "file"} — click Upload to save`
+              : currentLogoPath
+                ? "Current logo (signed URL — refreshes on next save)"
+                : ""}
+          </p>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_MIME}
+          onChange={handleFileInput}
+          className="sr-only"
+          aria-hidden="true"
+          tabIndex={-1}
+        />
+      </div>
+
+      {error && (
+        <Banner tone="destructive" title="Upload error">
+          {error}
+        </Banner>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={handleUpload}
+          disabled={!draftFile || uploading}
+          className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {uploading ? "Uploading…" : "Upload"}
+        </button>
+        {draftFile && !uploading && (
+          <button
+            type="button"
+            onClick={clearDraft}
+            className="rounded-md px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+          >
+            Cancel selection
+          </button>
+        )}
+        {currentLogoPath && !draftFile && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-destructive-fg hover:bg-destructive-muted"
+          >
+            Remove logo
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/invoice/page.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/page.tsx
@@ -1,0 +1,98 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import {
+  currentUserCanAccessCommunity,
+  currentUserCanAccessOrg,
+} from "@/lib/auth/access";
+import type { InvoiceConfig } from "@/lib/invoices/config-schema";
+import { InvoiceShell } from "./invoice-shell";
+
+/**
+ * /communities/[id]/invoice — Invoice configuration tab (#204 / PDF2).
+ *
+ * Defense-in-depth pattern (matches the layout's hidden-tab behaviour with a
+ * 404):
+ *   - 404 if the user can't read the community (RLS-hidden / non-existent).
+ *   - 404 if the user can read but not edit (read-but-not-edit user). Don't
+ *     render an empty form or a "you can't edit" message — match the
+ *     hidden-tab semantics with a 404.
+ *
+ * Loads the persisted `invoice_config` JSONB + `invoice_prefix` column +
+ * generates a 5-minute signed thumbnail URL when a logo is set, and passes
+ * everything to `<InvoiceShell>` (client). The signed URL is generated via
+ * the service-role client because the bucket is private and the operator's
+ * browser session can't SELECT directly without a signed URL.
+ */
+
+const SIGNED_THUMBNAIL_TTL_SECONDS = 300;
+
+export default async function InvoicePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // Read gate (404 if hidden — don't leak existence).
+  const canAccess = await currentUserCanAccessCommunity(supabase, id);
+  if (!canAccess) notFound();
+
+  const { data: community, error: commErr } = await supabase
+    .from("communities")
+    .select("id, org_id, name, invoice_config, invoice_prefix")
+    .eq("id", id)
+    .maybeSingle<{
+      id: string;
+      org_id: string;
+      name: string;
+      invoice_config: unknown;
+      invoice_prefix: string | null;
+    }>();
+
+  if (commErr || !community) notFound();
+
+  // Edit gate (404 for read-but-not-edit users, matching the hidden-tab
+  // semantics). A bookmarked URL still 404s for cross-org.
+  const canEdit = await currentUserCanAccessOrg(supabase, community.org_id);
+  if (!canEdit) notFound();
+
+  // Normalize invoice_config — empty `{}` is the column default.
+  const persistedConfig: InvoiceConfig =
+    community.invoice_config &&
+    typeof community.invoice_config === "object" &&
+    !Array.isArray(community.invoice_config)
+      ? (community.invoice_config as InvoiceConfig)
+      : {};
+
+  // Generate a 5-minute signed thumbnail URL when a logo is persisted.
+  let signedThumbnailUrl: string | null = null;
+  const persistedLogoPath =
+    persistedConfig.branding?.logo_storage_path ?? null;
+  if (persistedLogoPath) {
+    try {
+      const service = createServiceClient();
+      const { data: signed } = await service.storage
+        .from("invoice-logos")
+        .createSignedUrl(persistedLogoPath, SIGNED_THUMBNAIL_TTL_SECONDS);
+      signedThumbnailUrl = signed?.signedUrl ?? null;
+    } catch {
+      // Signed-URL generation failure is non-fatal — the form falls back to
+      // showing the path text and the operator can re-upload if needed.
+      signedThumbnailUrl = null;
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <InvoiceShell
+        communityId={community.id}
+        communityName={community.name}
+        initialConfig={persistedConfig}
+        initialPrefix={community.invoice_prefix}
+        initialSignedThumbnailUrl={signedThumbnailUrl}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/communities/[id]/layout.tsx
+++ b/src/app/(dashboard)/communities/[id]/layout.tsx
@@ -1,6 +1,9 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { currentUserCanAccessCommunity } from "@/lib/auth/access";
+import {
+  currentUserCanAccessCommunity,
+  currentUserCanAccessOrg,
+} from "@/lib/auth/access";
 import { CommunitySubNav, type PaymentChipData } from "./community-subnav";
 import { derivePaymentHealth } from "./payment/health";
 import { timeAgo } from "@/lib/time-ago";
@@ -33,17 +36,28 @@ export default async function CommunityLayout({
   const { data: community } = await supabase
     .from("communities")
     .select(
-      "id, name, payment_provider, payment_last_configured_at",
+      "id, org_id, name, payment_provider, payment_last_configured_at",
     )
     .eq("id", id)
     .maybeSingle<{
       id: string;
+      org_id: string;
       name: string;
       payment_provider: "pesapal" | null;
       payment_last_configured_at: string | null;
     }>();
 
   if (!community) notFound();
+
+  // Invoice-tab visibility is the *edit* gate (super_admin OR org_manager
+  // scoped to this community's parent org), independent of `canAccess` (the
+  // read gate). Hidden, not just disabled, when false. Mirrors the Payment
+  // route's permission gate (#196). Two round-trips here are acceptable for
+  // simplicity — the helper isn't cached today (see PDF2 R3 dev notes).
+  const canEditInvoice = await currentUserCanAccessOrg(
+    supabase,
+    community.org_id,
+  );
 
   // Phase B (#157): the `failing` health state is emitted when this
   // community has at least one payment_events row with `to_status='failed'`
@@ -95,7 +109,11 @@ export default async function CommunityLayout({
   return (
     <div>
       <div className="mb-4">
-        <CommunitySubNav communityId={community.id} paymentHealth={chipData} />
+        <CommunitySubNav
+          communityId={community.id}
+          paymentHealth={chipData}
+          showInvoiceTab={canEditInvoice}
+        />
       </div>
       {children}
     </div>

--- a/src/app/api/communities/[id]/invoice-config/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/invoice-config/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+/**
+ * PATCH /api/communities/[id]/invoice-config — unit tests (#204 / PDF2 AC-7).
+ *
+ * Supabase + auth helpers are mocked. Covers:
+ *   (1) Happy path → 200, persists invoice_prefix + invoice_config
+ *   (2) Empty invoice_prefix (null) is accepted — column allows NULL
+ *   (3) Invalid hex color (Zod) → 400
+ *   (4) Invalid invoice_prefix regex → 400
+ *   (5) Cross-org caller → 403
+ *   (6) RLS-hidden / missing community → 404 (also covers no-session)
+ *   (7) Malformed JSON body → 400
+ *   (8) Malformed UUID → 400
+ *   (9) revalidatePath called on success
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const COMMUNITY_ID = "550e8400-e29b-41d4-a716-446655440010";
+const ORG_ID = "550e8400-e29b-41d4-a716-446655440020";
+
+const mockRevalidatePath = vi.fn();
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+let canAccessOrgReturn = true;
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessOrg: async () => canAccessOrgReturn,
+}));
+
+let communitySelectResp: { data: unknown; error: unknown } = {
+  data: {
+    id: COMMUNITY_ID,
+    org_id: ORG_ID,
+    invoice_config: {},
+    invoice_prefix: null,
+  },
+  error: null,
+};
+let updateError: unknown = null;
+let updatePayloadCapture: Record<string, unknown> | null = null;
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+function makePatchRequest(body: unknown, id = COMMUNITY_ID): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/communities/${id}/invoice-config`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const VALID_BODY = {
+  invoice_prefix: "NFE",
+  invoice_config: {
+    seller: { legal_name: "Acme Co" },
+    branding: {
+      primary_color: "#163a5f",
+      accent_color: "#2f7d32",
+      document_title: "Invoice",
+    },
+    payment: { due_days_after_issue: 8 },
+    tax: { show_section: true, category_label: "VAT @ 18%", rate_pct: 18 },
+    notices: {
+      vat_text: null,
+      payment_instructions_text: null,
+      signature_disclaimer: null,
+    },
+  },
+};
+
+describe("PATCH /api/communities/[id]/invoice-config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessOrgReturn = true;
+    communitySelectResp = {
+      data: {
+        id: COMMUNITY_ID,
+        org_id: ORG_ID,
+        invoice_config: {},
+        invoice_prefix: null,
+      },
+      error: null,
+    };
+    updateError = null;
+    updatePayloadCapture = null;
+
+    mockFrom.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve(communitySelectResp),
+        }),
+      }),
+      update: (payload: Record<string, unknown>) => {
+        updatePayloadCapture = payload;
+        return {
+          eq: () => Promise.resolve({ error: updateError }),
+        };
+      },
+    }));
+  });
+
+  it("(1) happy path → 200, persists prefix + config", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("success");
+    expect(updatePayloadCapture).toBeTruthy();
+    expect(updatePayloadCapture!.invoice_prefix).toBe("NFE");
+    expect(
+      (updatePayloadCapture!.invoice_config as Record<string, unknown>).branding,
+    ).toMatchObject({ primary_color: "#163a5f" });
+  });
+
+  it("(2) null invoice_prefix is accepted (column allows NULL)", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest({ ...VALID_BODY, invoice_prefix: null }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect(updatePayloadCapture!.invoice_prefix).toBeNull();
+  });
+
+  it("(3) invalid hex color → 400 (Zod field error)", async () => {
+    const { PATCH } = await import("../route");
+    const badBody = {
+      ...VALID_BODY,
+      invoice_config: {
+        ...VALID_BODY.invoice_config,
+        branding: { primary_color: "not-a-hex" },
+      },
+    };
+    const res = await PATCH(makePatchRequest(badBody), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.fields).toBeDefined();
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  it("(4) invalid invoice_prefix regex → 400", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makePatchRequest({ ...VALID_BODY, invoice_prefix: "lowercase" }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.fields).toMatchObject({ invoice_prefix: "invalid-format" });
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  it("(5) cross-org caller → 403", async () => {
+    canAccessOrgReturn = false;
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(403);
+    expect(updatePayloadCapture).toBeNull();
+  });
+
+  it("(6) RLS-hidden / missing community → 404", async () => {
+    communitySelectResp = { data: null, error: null };
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("(7) malformed JSON body → 400", async () => {
+    const { PATCH } = await import("../route");
+    const req = new NextRequest(
+      `http://localhost/api/communities/${COMMUNITY_ID}/invoice-config`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: "not-json",
+      },
+    );
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("(8) malformed UUID → 400", async () => {
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest(VALID_BODY, "not-a-uuid"), {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("(9) revalidatePath('/communities/[id]', 'layout') called on success", async () => {
+    const { PATCH } = await import("../route");
+    await PATCH(makePatchRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      `/communities/${COMMUNITY_ID}`,
+      "layout",
+    );
+  });
+});

--- a/src/app/api/communities/[id]/invoice-config/route.ts
+++ b/src/app/api/communities/[id]/invoice-config/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { currentUserCanAccessOrg } from "@/lib/auth/access";
+import {
+  parseInvoiceConfig,
+  INVOICE_PREFIX_RE,
+} from "@/lib/invoices/config-schema";
+
+/**
+ * PATCH /api/communities/[id]/invoice-config — Save invoice settings (#204 / PDF2).
+ *
+ * Why a separate sub-route (not extending PATCH /api/communities/[id]):
+ *   - Different permission gate: invoice-config requires
+ *     `currentUserCanAccessOrg` (org_manager-of-parent-org / super_admin)
+ *     while the parent route uses `currentUserCanAccessCommunity`.
+ *   - Different validation path (Zod via `parseInvoiceConfig` vs a hand-rolled
+ *     allow-list).
+ *   - Clean rollback boundary if the PDF workstream needs a partial revert.
+ *
+ * Why PATCH (not PUT like Payment):
+ *   - Matches the org-update precedent at `src/app/api/organizations/[id]/route.ts`.
+ *   - Signals partial-resource semantics on the parent `communities` row.
+ *   - Payment's PUT is the codebase outlier; don't mirror it blindly.
+ *
+ * Body shape:
+ *   {
+ *     invoice_prefix: string | null,    // null → DB column NULL (allowed by 00033)
+ *     invoice_config: InvoiceConfig,    // Zod-validated JSONB
+ *   }
+ *
+ * Permission-check ordering (mirrors UX5b #184 + #196):
+ *   1. UUID check on [id] → 400.
+ *   2. JSON parse the body → 400.
+ *   3. Row read via user-bound client → NULL → 404 (don't leak existence).
+ *   4. `currentUserCanAccessOrg(community.org_id)` → false → 403.
+ *   5. Two-step body validation:
+ *      (a) `parseInvoiceConfig(body.invoice_config)` (Zod).
+ *      (b) Manual prefix check: null OR INVOICE_PREFIX_RE — invoice_prefix
+ *          column is nullable, but `parseInvoiceUpdate` from PDF1a forbids
+ *          null on the prefix. We allow null here per AC #3.
+ *   6. UPDATE both columns. On success: revalidatePath + 200 { status: "success" }.
+ *
+ * Errors return `{ error: string, fields?: { invoice_config?: ..., invoice_prefix?: string } }`
+ * for client-side field-level error surfacing.
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: communityId } = await params;
+
+  // (1) UUID parse.
+  if (!UUID_RE.test(communityId)) {
+    return NextResponse.json(
+      { error: "Invalid community id — expected UUID." },
+      { status: 400 },
+    );
+  }
+
+  // (2) JSON parse.
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  // (3) Row read — RLS-hidden / missing → 404 (don't leak via 403).
+  const { data: community, error: commErr } = await supabase
+    .from("communities")
+    .select("id, org_id, invoice_config, invoice_prefix")
+    .eq("id", communityId)
+    .maybeSingle<{
+      id: string;
+      org_id: string;
+      invoice_config: unknown;
+      invoice_prefix: string | null;
+    }>();
+
+  if (commErr) {
+    return NextResponse.json(
+      { error: `Failed to read community: ${commErr.message}` },
+      { status: 500 },
+    );
+  }
+  if (!community) {
+    return NextResponse.json(
+      { error: "Community not found." },
+      { status: 404 },
+    );
+  }
+
+  // (4) Permission — currentUserCanAccessOrg returns true for super_admin OR
+  // org_manager scoped to this community's parent org (#196).
+  if (!(await currentUserCanAccessOrg(supabase, community.org_id))) {
+    return NextResponse.json(
+      {
+        error:
+          "You do not have permission to update this community's invoice settings.",
+      },
+      { status: 403 },
+    );
+  }
+
+  // (5) Body shape + validation.
+  if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return NextResponse.json(
+      { error: "Request body must be an object." },
+      { status: 400 },
+    );
+  }
+  const body = rawBody as Record<string, unknown>;
+
+  // (5a) Invoice prefix — null OR a string matching INVOICE_PREFIX_RE.
+  // Hand-rolled (not via Zod's parseInvoiceUpdate) because that schema forbids
+  // null; the column allows null, the form allows clearing → null persists.
+  let invoicePrefix: string | null;
+  if (body.invoice_prefix === null) {
+    invoicePrefix = null;
+  } else if (typeof body.invoice_prefix === "string") {
+    if (!INVOICE_PREFIX_RE.test(body.invoice_prefix)) {
+      return NextResponse.json(
+        {
+          error:
+            "Invoice prefix must be 2-8 uppercase letters or digits (e.g. NFE, ACME01).",
+          fields: { invoice_prefix: "invalid-format" },
+        },
+        { status: 400 },
+      );
+    }
+    invoicePrefix = body.invoice_prefix;
+  } else {
+    return NextResponse.json(
+      {
+        error: "invoice_prefix must be a string or null.",
+        fields: { invoice_prefix: "wrong-type" },
+      },
+      { status: 400 },
+    );
+  }
+
+  // (5b) Invoice config — Zod via parseInvoiceConfig.
+  let invoiceConfig;
+  try {
+    invoiceConfig = parseInvoiceConfig(body.invoice_config);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of err.issues) {
+        const path = issue.path.join(".");
+        if (path) fieldErrors[path] = issue.message;
+      }
+      return NextResponse.json(
+        {
+          error:
+            "Invoice configuration is invalid. See the highlighted fields.",
+          fields: { invoice_config: fieldErrors },
+        },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Invoice configuration is invalid." },
+      { status: 400 },
+    );
+  }
+
+  // (6) UPDATE.
+  const { error: updateErr } = await supabase
+    .from("communities")
+    .update({
+      invoice_prefix: invoicePrefix,
+      invoice_config: invoiceConfig,
+    })
+    .eq("id", communityId);
+
+  if (updateErr) {
+    if (
+      updateErr.code === "42501" ||
+      updateErr.message?.includes("row-level security")
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "You do not have permission to update this community's invoice settings.",
+        },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json(
+      { error: `Failed to update invoice settings: ${updateErr.message}` },
+      { status: 500 },
+    );
+  }
+
+  // Bust the layout cache so the sub-nav + child pages re-fetch.
+  revalidatePath(`/communities/${communityId}`, "layout");
+
+  return NextResponse.json({ status: "success" }, { status: 200 });
+}

--- a/src/app/api/communities/[id]/invoice-logo/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/invoice-logo/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+/**
+ * POST /api/communities/[id]/invoice-logo — unit tests (#204 / PDF2 AC-7).
+ *
+ * Mocks Supabase + service-role storage + auth. Covers:
+ *   (1) Happy path → 200, returns logo_storage_path + signed_thumbnail_url
+ *   (2) Oversized file (>1 MB server cap) → 400
+ *   (3) Wrong MIME → 400
+ *   (4) Missing `file` field → 400
+ *   (5) Cross-org → 403, NO upload attempted
+ *   (6) RLS-hidden / missing community → 404
+ *   (7) Malformed UUID → 400
+ *   (8) Storage path uses {community.id}/{timestamp}-{uuid}.{ext} shape
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Set the env var BEFORE importing the route module — `service.ts` enforces
+// this at module-load.
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "service-role-test-key";
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://localhost:54321";
+
+const COMMUNITY_ID = "550e8400-e29b-41d4-a716-446655440010";
+const ORG_ID = "550e8400-e29b-41d4-a716-446655440020";
+
+let canAccessOrgReturn = true;
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessOrg: async () => canAccessOrgReturn,
+}));
+
+let communitySelectResp: { data: unknown; error: unknown } = {
+  data: { id: COMMUNITY_ID, org_id: ORG_ID },
+  error: null,
+};
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+const uploadMock = vi.fn();
+const createSignedUrlMock = vi.fn();
+const storageFromMock = vi.fn(() => ({
+  upload: uploadMock,
+  createSignedUrl: createSignedUrlMock,
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    storage: { from: storageFromMock },
+  }),
+}));
+
+function makePostRequest(formData: FormData, id = COMMUNITY_ID): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/communities/${id}/invoice-logo`,
+    {
+      method: "POST",
+      body: formData,
+    },
+  );
+}
+
+function pngBlob(byteSize = 1024): Blob {
+  const bytes = new Uint8Array(byteSize);
+  // PNG magic header — not strictly required (server only checks file.type)
+  // but useful for reader-friendliness.
+  bytes[0] = 0x89;
+  bytes[1] = 0x50;
+  bytes[2] = 0x4e;
+  bytes[3] = 0x47;
+  return new Blob([bytes], { type: "image/png" });
+}
+
+describe("POST /api/communities/[id]/invoice-logo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessOrgReturn = true;
+    communitySelectResp = {
+      data: { id: COMMUNITY_ID, org_id: ORG_ID },
+      error: null,
+    };
+
+    mockFrom.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve(communitySelectResp),
+        }),
+      }),
+    }));
+
+    uploadMock.mockResolvedValue({
+      data: { path: `${COMMUNITY_ID}/file.png` },
+      error: null,
+    });
+    createSignedUrlMock.mockResolvedValue({
+      data: {
+        signedUrl: "https://storage.example.com/signed-thumb-url",
+      },
+      error: null,
+    });
+  });
+
+  it("(1) happy path → 200 with logo_storage_path + signed_thumbnail_url", async () => {
+    const fd = new FormData();
+    fd.append("file", new File([pngBlob()], "logo.png", { type: "image/png" }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.logo_storage_path).toBeTypeOf("string");
+    expect(body.logo_storage_path).toMatch(
+      new RegExp(`^${COMMUNITY_ID}/\\d+-[0-9a-f-]+\\.png$`),
+    );
+    expect(body.signed_thumbnail_url).toBe(
+      "https://storage.example.com/signed-thumb-url",
+    );
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("(2) oversized file (>1 MB) → 400", async () => {
+    const fd = new FormData();
+    const oversized = new Blob([new Uint8Array(2 * 1024 * 1024)], {
+      type: "image/png",
+    });
+    fd.append("file", new File([oversized], "big.png", { type: "image/png" }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("(3) wrong MIME → 400", async () => {
+    const fd = new FormData();
+    fd.append(
+      "file",
+      new File([new Blob(["abc"])], "doc.txt", { type: "text/plain" }),
+    );
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("(4) missing file field → 400", async () => {
+    const fd = new FormData();
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("(5) cross-org → 403 and NO upload attempted (permission-FIRST)", async () => {
+    canAccessOrgReturn = false;
+    const fd = new FormData();
+    fd.append("file", new File([pngBlob()], "logo.png", { type: "image/png" }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(403);
+    // The route must reject BEFORE touching storage.
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("(6) RLS-hidden / missing community → 404", async () => {
+    communitySelectResp = { data: null, error: null };
+    const fd = new FormData();
+    fd.append("file", new File([pngBlob()], "logo.png", { type: "image/png" }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("(7) malformed UUID → 400", async () => {
+    const fd = new FormData();
+    fd.append("file", new File([pngBlob()], "logo.png", { type: "image/png" }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd, "not-a-uuid"), {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("(8) storage path follows {community}/{timestamp}-{uuid}.{ext} shape", async () => {
+    const fd = new FormData();
+    fd.append("file", new File([pngBlob()], "logo.png", { type: "image/png" }));
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(fd), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(200);
+    const uploadCall = uploadMock.mock.calls[0];
+    const storagePath = uploadCall[0] as string;
+    expect(storagePath.startsWith(`${COMMUNITY_ID}/`)).toBe(true);
+    expect(storagePath).toMatch(
+      new RegExp(`^${COMMUNITY_ID}/\\d+-[0-9a-f-]+\\.png$`),
+    );
+  });
+});

--- a/src/app/api/communities/[id]/invoice-logo/route.ts
+++ b/src/app/api/communities/[id]/invoice-logo/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { currentUserCanAccessOrg } from "@/lib/auth/access";
+
+/**
+ * POST /api/communities/[id]/invoice-logo — Upload an invoice-logo image (#204 / PDF2).
+ *
+ * Permission-FIRST execution order. We read the community row + verify the
+ * caller can edit BEFORE reading the multipart body — this guards against an
+ * unauthorised caller streaming a megabyte of bytes into our function. The
+ * storage write goes via `createServiceClient()` (bypasses RLS), so this
+ * route's permission gate IS the only authorisation barrier; the
+ * `storage.objects` RLS policies in 00033 are defense-in-depth for the
+ * operator-preview SELECT path.
+ *
+ * SVG XSS scope-out (#204 R5): SVGs are accepted, NOT sanitised. They are
+ * rasterised by `@react-pdf/renderer` (no script execution) and previewed via
+ * the operator's authenticated browser session. **Implementer constraint:
+ * never wire a public, unauthenticated endpoint that returns the raw bytes
+ * from `invoice-logos`** — that's the only place XSS would reactivate.
+ *
+ * Server-side defense-in-depth on size: 1 MB cap (UI enforces 500 KB tighter
+ * client-side). The bucket also caps at 1 MiB in 00033.
+ *
+ * Path schema: `{community.id}/{Date.now()}-{crypto.randomUUID()}.{ext}`.
+ * `crypto.randomUUID()` is cryptographically random; collision is effectively
+ * impossible. `Date.now()` keeps file lists chronologically ordered when
+ * listed by the operator UI.
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1 MB server-side cap.
+
+const ALLOWED_MIME = new Set<string>([
+  "image/png",
+  "image/jpeg",
+  "image/svg+xml",
+]);
+
+const EXT_BY_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/svg+xml": "svg",
+};
+
+const SIGNED_URL_TTL_SECONDS = 300; // 5 minutes for the thumbnail handoff.
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: communityId } = await params;
+
+  // (1) UUID parse.
+  if (!UUID_RE.test(communityId)) {
+    return NextResponse.json(
+      { error: "Invalid community id — expected UUID." },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+
+  // (2) Row read — RLS-hidden / missing → 404. Don't leak existence via 403.
+  const { data: community, error: commErr } = await supabase
+    .from("communities")
+    .select("id, org_id")
+    .eq("id", communityId)
+    .maybeSingle<{ id: string; org_id: string }>();
+
+  if (commErr) {
+    return NextResponse.json(
+      { error: `Failed to read community: ${commErr.message}` },
+      { status: 500 },
+    );
+  }
+  if (!community) {
+    return NextResponse.json(
+      { error: "Community not found." },
+      { status: 404 },
+    );
+  }
+
+  // (3) Permission BEFORE body read.
+  if (!(await currentUserCanAccessOrg(supabase, community.org_id))) {
+    return NextResponse.json(
+      {
+        error:
+          "You do not have permission to upload a logo for this community.",
+      },
+      { status: 403 },
+    );
+  }
+
+  // (4) Multipart body parse — Next.js 15 native FormData.
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid multipart form body." },
+      { status: 400 },
+    );
+  }
+
+  const file = formData.get("file");
+  if (!file || typeof file === "string") {
+    return NextResponse.json(
+      { error: "Missing `file` field in multipart form." },
+      { status: 400 },
+    );
+  }
+
+  // file is a Web `File` instance.
+  const mime = file.type;
+  if (!ALLOWED_MIME.has(mime)) {
+    return NextResponse.json(
+      {
+        error:
+          "Unsupported file type. Allowed: image/png, image/jpeg, image/svg+xml.",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return NextResponse.json(
+      { error: "File too large. Maximum size is 1 MB." },
+      { status: 400 },
+    );
+  }
+
+  // (5) Build the storage path: relative to the bucket, no leading slash.
+  const ext = EXT_BY_MIME[mime] ?? "bin";
+  const storagePath = `${community.id}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+
+  // (6) Service-role upload (bypasses RLS — the route IS the gate).
+  const service = createServiceClient();
+  const fileBytes = await file.arrayBuffer();
+
+  const uploadResult = await service.storage
+    .from("invoice-logos")
+    .upload(storagePath, fileBytes, {
+      contentType: mime,
+      upsert: false,
+    });
+
+  if (uploadResult.error) {
+    return NextResponse.json(
+      {
+        error: `Failed to upload logo: ${uploadResult.error.message}`,
+      },
+      { status: 500 },
+    );
+  }
+
+  // (7) Generate a 5-minute signed URL so the form can swap the thumbnail
+  // immediately without a second round-trip.
+  const signedResult = await service.storage
+    .from("invoice-logos")
+    .createSignedUrl(storagePath, SIGNED_URL_TTL_SECONDS);
+
+  const signedThumbnailUrl = signedResult.data?.signedUrl ?? "";
+
+  return NextResponse.json(
+    {
+      logo_storage_path: storagePath,
+      signed_thumbnail_url: signedThumbnailUrl,
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/communities/[id]/invoice-preview/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/invoice-preview/__tests__/route.test.ts
@@ -1,0 +1,231 @@
+/**
+ * POST /api/communities/[id]/invoice-preview — unit tests (#204 / PDF2 AC-7).
+ *
+ * The renderer (PDF1b #203) is not yet on origin/main; this route ships with
+ * a `renderInvoicePdfStub` that throws — the route catches and returns 503
+ * `{ error: 'Preview unavailable until PDF1b...' }`. After PDF1b lands and
+ * the stub is removed, swap the 503-stub assertions for PDF-stream
+ * assertions per the AC.
+ *
+ * Coverage today (with the stub):
+ *   (1) Happy path body validation → 503 (stubbed renderer)
+ *   (2) 403 for cross-org caller — no renderer call
+ *   (3) 404 for RLS-hidden / missing community
+ *   (4) 400 for malformed UUID / JSON / Zod validation
+ *   (5) Permission gate runs BEFORE rendering (renderer NOT invoked on 403/404)
+ *   (6) Preview does NOT call fn_next_invoice_number (RPC count = 0)
+ *   (7) Empty invoice_prefix yields PREVIEW-{year}-PREVIEW invoice number
+ *      (verified via the helper unit test below — renderer is stubbed here)
+ *   (8) No-microgrid path uses the synthetic 1-tier rate schedule
+ *      (verified via the helper unit test below — renderer is stubbed here)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "service-role-test-key";
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://localhost:54321";
+
+const COMMUNITY_ID = "550e8400-e29b-41d4-a716-446655440010";
+const ORG_ID = "550e8400-e29b-41d4-a716-446655440020";
+
+let canAccessOrgReturn = true;
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessOrg: async () => canAccessOrgReturn,
+}));
+
+let communitySelectResp: { data: unknown; error: unknown } = {
+  data: { id: COMMUNITY_ID, org_id: ORG_ID, name: "Sample Community" },
+  error: null,
+};
+let organizationSelectResp: { data: unknown; error: unknown } = {
+  data: { id: ORG_ID, name: "Sample Org" },
+  error: null,
+};
+let microgridSelectResp: { data: unknown; error: unknown } = {
+  data: null,
+  error: null,
+};
+let rateScheduleSelectResp: { data: unknown; error: unknown } = {
+  data: null,
+  error: null,
+};
+
+const mockFrom = vi.fn();
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom, rpc: mockRpc }),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    storage: {
+      from: () => ({
+        createSignedUrl: () =>
+          Promise.resolve({ data: { signedUrl: "" }, error: null }),
+      }),
+    },
+  }),
+}));
+
+const VALID_BODY = {
+  invoice_prefix: "NFE",
+  invoice_config: {
+    seller: { legal_name: "Acme Co" },
+    branding: { primary_color: "#163a5f", accent_color: "#2f7d32" },
+    payment: { due_days_after_issue: 8 },
+    tax: { show_section: true, category_label: "VAT @ 18%", rate_pct: 18 },
+  },
+};
+
+function makeRequest(body: unknown, id = COMMUNITY_ID): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/communities/${id}/invoice-preview`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe("POST /api/communities/[id]/invoice-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessOrgReturn = true;
+
+    communitySelectResp = {
+      data: { id: COMMUNITY_ID, org_id: ORG_ID, name: "Sample Community" },
+      error: null,
+    };
+    organizationSelectResp = {
+      data: { id: ORG_ID, name: "Sample Org" },
+      error: null,
+    };
+    microgridSelectResp = { data: null, error: null };
+    rateScheduleSelectResp = { data: null, error: null };
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "communities") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve(communitySelectResp),
+            }),
+          }),
+        };
+      }
+      if (table === "organizations") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve(organizationSelectResp),
+            }),
+          }),
+        };
+      }
+      if (table === "microgrids") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => ({
+                limit: () => ({
+                  maybeSingle: () => Promise.resolve(microgridSelectResp),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "rate_schedules") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => ({
+                limit: () => ({
+                  maybeSingle: () => Promise.resolve(rateScheduleSelectResp),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    mockRpc.mockResolvedValue({ data: null, error: null });
+  });
+
+  it("(1) renderer-stub still gated → 503 { error } until PDF1b lands", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toContain("PDF1b");
+  });
+
+  it("(2) cross-org → 403 (renderer NOT invoked)", async () => {
+    canAccessOrgReturn = false;
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("(3) RLS-hidden / missing community → 404", async () => {
+    communitySelectResp = { data: null, error: null };
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("(4) malformed UUID → 400", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest(VALID_BODY, "not-a-uuid"), {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("(4b) malformed JSON body → 400", async () => {
+    const req = new NextRequest(
+      `http://localhost/api/communities/${COMMUNITY_ID}/invoice-preview`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not-json",
+      },
+    );
+    const { POST } = await import("../route");
+    const res = await POST(req, {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("(4c) invalid Zod body → 400", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest({
+        invoice_prefix: "NFE",
+        invoice_config: { branding: { primary_color: "not-a-hex" } },
+      }),
+      { params: Promise.resolve({ id: COMMUNITY_ID }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("(6) preview does NOT call fn_next_invoice_number", async () => {
+    const { POST } = await import("../route");
+    await POST(makeRequest(VALID_BODY), {
+      params: Promise.resolve({ id: COMMUNITY_ID }),
+    });
+    const rpcNames = mockRpc.mock.calls.map((c) => c[0]);
+    expect(rpcNames).not.toContain("fn_next_invoice_number");
+  });
+});

--- a/src/app/api/communities/[id]/invoice-preview/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/invoice-preview/__tests__/route.test.ts
@@ -1,23 +1,17 @@
 /**
  * POST /api/communities/[id]/invoice-preview — unit tests (#204 / PDF2 AC-7).
  *
- * The renderer (PDF1b #203) is not yet on origin/main; this route ships with
- * a `renderInvoicePdfStub` that throws — the route catches and returns 503
- * `{ error: 'Preview unavailable until PDF1b...' }`. After PDF1b lands and
- * the stub is removed, swap the 503-stub assertions for PDF-stream
- * assertions per the AC.
- *
- * Coverage today (with the stub):
- *   (1) Happy path body validation → 503 (stubbed renderer)
+ * Coverage:
+ *   (1) Happy path → 200 PDF stream with `Content-Disposition: inline`
  *   (2) 403 for cross-org caller — no renderer call
  *   (3) 404 for RLS-hidden / missing community
  *   (4) 400 for malformed UUID / JSON / Zod validation
  *   (5) Permission gate runs BEFORE rendering (renderer NOT invoked on 403/404)
  *   (6) Preview does NOT call fn_next_invoice_number (RPC count = 0)
  *   (7) Empty invoice_prefix yields PREVIEW-{year}-PREVIEW invoice number
- *      (verified via the helper unit test below — renderer is stubbed here)
+ *      (verified via the helper unit test below)
  *   (8) No-microgrid path uses the synthetic 1-tier rate schedule
- *      (verified via the helper unit test below — renderer is stubbed here)
+ *      (verified via the helper unit test below)
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -66,6 +60,16 @@ vi.mock("@/lib/supabase/service", () => ({
       }),
     },
   }),
+}));
+
+// Mock the renderer to return a tiny fake PDF buffer. The renderer is exercised
+// end-to-end in PDF1b's own test suite (#203 / src/lib/invoices/__tests__/render.test.ts).
+const FAKE_PDF_BYTES = Buffer.from("%PDF-1.7\nfake-preview-bytes\n%%EOF\n");
+const renderMock = vi.fn<(input: unknown) => Promise<Buffer>>(
+  async () => FAKE_PDF_BYTES,
+);
+vi.mock("@/lib/invoices/render", () => ({
+  renderInvoicePdf: (input: unknown) => renderMock(input),
 }));
 
 const VALID_BODY = {
@@ -156,14 +160,25 @@ describe("POST /api/communities/[id]/invoice-preview", () => {
     mockRpc.mockResolvedValue({ data: null, error: null });
   });
 
-  it("(1) renderer-stub still gated → 503 { error } until PDF1b lands", async () => {
+  it("(1) happy path → 200 PDF stream with inline disposition", async () => {
     const { POST } = await import("../route");
     const res = await POST(makeRequest(VALID_BODY), {
       params: Promise.resolve({ id: COMMUNITY_ID }),
     });
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.error).toContain("PDF1b");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+    expect(res.headers.get("Content-Disposition")).toBe(
+      'inline; filename="preview.pdf"',
+    );
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(renderMock).toHaveBeenCalledOnce();
+    // Sanity-check that the renderer received the synthetic-input shape.
+    const firstCall = renderMock.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const passed = firstCall![0] as Record<string, unknown>;
+    expect(passed.paymentRedirectUrl).toBe(
+      "https://example.com/preview-payment",
+    );
   });
 
   it("(2) cross-org → 403 (renderer NOT invoked)", async () => {

--- a/src/app/api/communities/[id]/invoice-preview/route.ts
+++ b/src/app/api/communities/[id]/invoice-preview/route.ts
@@ -11,6 +11,7 @@ import {
   assembleSyntheticPreviewInput,
   type PreviewRateSchedule,
 } from "@/lib/invoices/preview-input";
+import { renderInvoicePdf } from "@/lib/invoices/render";
 
 /**
  * POST /api/communities/[id]/invoice-preview — Render a synthetic preview PDF
@@ -43,20 +44,6 @@ import {
  *
  * Returns: PDF stream with `Content-Disposition: inline; filename="preview.pdf"`
  * — distinct from PDF1b's `attachment` (downloaded bills).
- *
- * ──────────────────────────────────────────────────────────────────────────
- *  PARALLEL DEPENDENCY: PDF1b (#203) ships `renderInvoicePdf` from
- *  `src/lib/invoices/render.tsx`. This route was implemented in parallel; the
- *  renderer import is gated behind a runtime stub returning 503 until #203
- *  merges. After #203 lands and this branch rebases on origin/main:
- *
- *    1. Replace the `renderInvoicePdfStub` import below with:
- *       `import { renderInvoicePdf } from '@/lib/invoices/render';`
- *    2. Delete the `renderInvoicePdfStub` declaration.
- *    3. Re-run `npm test` and `npm run build` to confirm the integration.
- *
- *  The reviewer MUST flag this comment if it survives merge.
- * ──────────────────────────────────────────────────────────────────────────
  */
 
 const UUID_RE =
@@ -65,14 +52,6 @@ const UUID_RE =
 const PREVIEW_PAYMENT_REDIRECT_URL = "https://example.com/preview-payment";
 
 const SIGNED_LOGO_TTL_SECONDS = 60;
-
-// TEMP STUB — remove once #203 (PDF1b) lands. The signature mirrors PDF1b's
-// renderer spec from mbe-docs/docs/tickets/pdf-invoices/PDF1b-renderer-and-pdf-endpoint.md.
-async function renderInvoicePdfStub(_input: unknown): Promise<Buffer> {
-  throw new Error(
-    "renderInvoicePdf is not yet available in this build (depends on PDF1b #203).",
-  );
-}
 
 export async function POST(
   request: NextRequest,
@@ -280,7 +259,7 @@ export async function POST(
   // (10) Render. Returns 503 until PDF1b lands and the stub is removed.
   let pdfBuffer: Buffer;
   try {
-    pdfBuffer = await renderInvoicePdfStub({
+    pdfBuffer = await renderInvoicePdf({
       ...baseInput,
       logoBytes,
       paymentRedirectUrl: PREVIEW_PAYMENT_REDIRECT_URL,
@@ -289,10 +268,10 @@ export async function POST(
     return NextResponse.json(
       {
         error:
-          "Preview unavailable until PDF1b (#203) lands. " +
-          (err instanceof Error ? err.message : ""),
+          "Failed to render preview: " +
+          (err instanceof Error ? err.message : "unknown error"),
       },
-      { status: 503 },
+      { status: 500 },
     );
   }
 

--- a/src/app/api/communities/[id]/invoice-preview/route.ts
+++ b/src/app/api/communities/[id]/invoice-preview/route.ts
@@ -1,0 +1,307 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { currentUserCanAccessOrg } from "@/lib/auth/access";
+import {
+  parseInvoiceConfig,
+  INVOICE_PREFIX_RE,
+} from "@/lib/invoices/config-schema";
+import {
+  assembleSyntheticPreviewInput,
+  type PreviewRateSchedule,
+} from "@/lib/invoices/preview-input";
+
+/**
+ * POST /api/communities/[id]/invoice-preview — Render a synthetic preview PDF
+ * (#204 / PDF2 AC #5).
+ *
+ * Click-flow chosen: Pattern A (fetch + blob). The client opens
+ * `window.open('about:blank')` synchronously inside the click handler, then
+ * POSTs to this route, then sets the popup's `location` to the blob URL.
+ *
+ * Permission gate identical to the PATCH config route — UUID → row read →
+ * 404 → `currentUserCanAccessOrg` → 403. The synthetic preview must NOT be a
+ * public endpoint.
+ *
+ * Body shape (mirrors the PATCH body — the form passes its in-memory state):
+ *   {
+ *     invoice_prefix: string | null,
+ *     invoice_config: InvoiceConfig,
+ *   }
+ *
+ * Synthesised content:
+ *   - `paymentRedirectUrl = 'https://example.com/preview-payment'` — fake URL
+ *     so the Payment Information card always renders. The link 404s if
+ *     clicked; acceptable for branding-feedback preview.
+ *   - `invoiceNumber = '${invoice_prefix || 'PREVIEW'}-{year}-PREVIEW'` —
+ *     does NOT call `fn_next_invoice_number()`.
+ *   - `logoBytes` — fetched via service-role signed URL (60s TTL) when the
+ *     posted config has a `branding.logo_storage_path`; null otherwise.
+ *   - `ratesSchedule` — fetched from the community's first microgrid; falls
+ *     back to a synthetic 1-tier schedule when none exists yet.
+ *
+ * Returns: PDF stream with `Content-Disposition: inline; filename="preview.pdf"`
+ * — distinct from PDF1b's `attachment` (downloaded bills).
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ *  PARALLEL DEPENDENCY: PDF1b (#203) ships `renderInvoicePdf` from
+ *  `src/lib/invoices/render.tsx`. This route was implemented in parallel; the
+ *  renderer import is gated behind a runtime stub returning 503 until #203
+ *  merges. After #203 lands and this branch rebases on origin/main:
+ *
+ *    1. Replace the `renderInvoicePdfStub` import below with:
+ *       `import { renderInvoicePdf } from '@/lib/invoices/render';`
+ *    2. Delete the `renderInvoicePdfStub` declaration.
+ *    3. Re-run `npm test` and `npm run build` to confirm the integration.
+ *
+ *  The reviewer MUST flag this comment if it survives merge.
+ * ──────────────────────────────────────────────────────────────────────────
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const PREVIEW_PAYMENT_REDIRECT_URL = "https://example.com/preview-payment";
+
+const SIGNED_LOGO_TTL_SECONDS = 60;
+
+// TEMP STUB — remove once #203 (PDF1b) lands. The signature mirrors PDF1b's
+// renderer spec from mbe-docs/docs/tickets/pdf-invoices/PDF1b-renderer-and-pdf-endpoint.md.
+async function renderInvoicePdfStub(_input: unknown): Promise<Buffer> {
+  throw new Error(
+    "renderInvoicePdf is not yet available in this build (depends on PDF1b #203).",
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: communityId } = await params;
+
+  // (1) UUID parse.
+  if (!UUID_RE.test(communityId)) {
+    return NextResponse.json(
+      { error: "Invalid community id — expected UUID." },
+      { status: 400 },
+    );
+  }
+
+  // (2) JSON parse.
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  // (3) Row read — RLS-hidden / missing → 404.
+  const { data: community, error: commErr } = await supabase
+    .from("communities")
+    .select("id, org_id, name")
+    .eq("id", communityId)
+    .maybeSingle<{ id: string; org_id: string; name: string }>();
+
+  if (commErr) {
+    return NextResponse.json(
+      { error: `Failed to read community: ${commErr.message}` },
+      { status: 500 },
+    );
+  }
+  if (!community) {
+    return NextResponse.json(
+      { error: "Community not found." },
+      { status: 404 },
+    );
+  }
+
+  // (4) Permission.
+  if (!(await currentUserCanAccessOrg(supabase, community.org_id))) {
+    return NextResponse.json(
+      {
+        error:
+          "You do not have permission to preview invoices for this community.",
+      },
+      { status: 403 },
+    );
+  }
+
+  // (5) Body shape + Zod validation (defense-in-depth — the operator's form
+  // already validates client-side, but a malformed body here would crash the
+  // renderer with an opaque error).
+  if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return NextResponse.json(
+      { error: "Request body must be an object." },
+      { status: 400 },
+    );
+  }
+  const body = rawBody as Record<string, unknown>;
+
+  let invoicePrefix: string | null;
+  if (body.invoice_prefix === null) {
+    invoicePrefix = null;
+  } else if (typeof body.invoice_prefix === "string") {
+    if (
+      body.invoice_prefix.length > 0 &&
+      !INVOICE_PREFIX_RE.test(body.invoice_prefix)
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Invoice prefix must be 2-8 uppercase letters or digits (e.g. NFE, ACME01).",
+        },
+        { status: 400 },
+      );
+    }
+    invoicePrefix = body.invoice_prefix.length > 0 ? body.invoice_prefix : null;
+  } else {
+    return NextResponse.json(
+      { error: "invoice_prefix must be a string or null." },
+      { status: 400 },
+    );
+  }
+
+  let invoiceConfig;
+  try {
+    invoiceConfig = parseInvoiceConfig(body.invoice_config);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error:
+            "Invoice configuration is invalid. Save your changes to see the field errors.",
+        },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Invoice configuration is invalid." },
+      { status: 400 },
+    );
+  }
+
+  // (6) Resolve organization name (renderer's seller fallback).
+  const { data: organization } = await supabase
+    .from("organizations")
+    .select("id, name")
+    .eq("id", community.org_id)
+    .maybeSingle<{ id: string; name: string }>();
+
+  if (!organization) {
+    return NextResponse.json(
+      { error: "Could not resolve parent organization for this community." },
+      { status: 500 },
+    );
+  }
+
+  // (7) Resolve a real rate schedule from the first microgrid; fall back to
+  // a synthetic 1-tier schedule when none exists yet (operator is configuring
+  // invoice settings before any microgrids are added).
+  const { data: microgrid } = await supabase
+    .from("microgrids")
+    .select("id")
+    .eq("community_id", community.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle<{ id: string }>();
+
+  let ratesSchedule: PreviewRateSchedule | null = null;
+  if (microgrid) {
+    const { data: schedule } = await supabase
+      .from("rate_schedules")
+      .select(
+        "id, microgrid_id, tiers, service_charge, service_charge_description, tax_rate",
+      )
+      .eq("microgrid_id", microgrid.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<{
+        id: string;
+        microgrid_id: string;
+        tiers: unknown;
+        service_charge: number;
+        service_charge_description: string | null;
+        tax_rate: number;
+      }>();
+    if (schedule) {
+      const tiers = Array.isArray(schedule.tiers)
+        ? (schedule.tiers as PreviewRateSchedule["tiers"])
+        : [];
+      ratesSchedule = {
+        id: schedule.id,
+        microgrid_id: schedule.microgrid_id,
+        tiers,
+        service_charge: schedule.service_charge,
+        service_charge_description: schedule.service_charge_description,
+        tax_rate: schedule.tax_rate,
+      };
+    }
+  }
+
+  // (8) Synthesize the renderer input bag (excluding logoBytes + paymentRedirectUrl).
+  const baseInput = assembleSyntheticPreviewInput({
+    community: {
+      id: community.id,
+      name: community.name,
+      invoice_config: invoiceConfig,
+      invoice_prefix: invoicePrefix,
+    },
+    organization: { id: organization.id, name: organization.name },
+    ratesSchedule,
+  });
+
+  // (9) Fetch logo bytes via service-role signed URL when the posted config
+  // has a logo_storage_path.
+  let logoBytes: Buffer | null = null;
+  const logoPath = invoiceConfig.branding?.logo_storage_path ?? null;
+  if (logoPath) {
+    const service = createServiceClient();
+    const { data: signed } = await service.storage
+      .from("invoice-logos")
+      .createSignedUrl(logoPath, SIGNED_LOGO_TTL_SECONDS);
+    if (signed?.signedUrl) {
+      try {
+        const resp = await fetch(signed.signedUrl);
+        if (resp.ok) {
+          const ab = await resp.arrayBuffer();
+          logoBytes = Buffer.from(ab);
+        }
+      } catch {
+        // Logo fetch failed — preview proceeds with logoBytes=null. The
+        // renderer falls back to text-only header rendering.
+        logoBytes = null;
+      }
+    }
+  }
+
+  // (10) Render. Returns 503 until PDF1b lands and the stub is removed.
+  let pdfBuffer: Buffer;
+  try {
+    pdfBuffer = await renderInvoicePdfStub({
+      ...baseInput,
+      logoBytes,
+      paymentRedirectUrl: PREVIEW_PAYMENT_REDIRECT_URL,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error:
+          "Preview unavailable until PDF1b (#203) lands. " +
+          (err instanceof Error ? err.message : ""),
+      },
+      { status: 503 },
+    );
+  }
+
+  return new NextResponse(new Uint8Array(pdfBuffer), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": 'inline; filename="preview.pdf"',
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/lib/invoices/__tests__/preview-input.test.ts
+++ b/src/lib/invoices/__tests__/preview-input.test.ts
@@ -47,18 +47,17 @@ describe("preview-input", () => {
       ratesSchedule: null,
       now: FIXED_NOW,
     });
-    expect(out.ratesSchedule.tiers).toHaveLength(1);
-    expect(out.ratesSchedule.tiers[0]).toMatchObject({
+    const tiers = (out.ratesSchedule as { tiers: Array<Record<string, unknown>> }).tiers;
+    expect(tiers).toHaveLength(1);
+    expect(tiers[0]).toMatchObject({
       label: "Tier 1",
       min_kwh: 0,
       max_kwh: null,
       rate_per_kwh: 1,
     });
-    expect(out.ratesSchedule.service_charge).toBe(0);
-    expect(out.ratesSchedule.tax_rate).toBe(0);
   });
 
-  it("(4) real rate schedule is passed through unchanged", () => {
+  it("(4) real rate schedule's tiers + service_charge are passed through", () => {
     const real = {
       id: "real-id",
       microgrid_id: "real-mg-id",
@@ -76,89 +75,30 @@ describe("preview-input", () => {
       ratesSchedule: real,
       now: FIXED_NOW,
     });
-    expect(out.ratesSchedule).toEqual(real);
-    expect(out.lineItem.service_charge).toBe(5000);
+    const passed = out.ratesSchedule as unknown as typeof real;
+    expect(passed.tiers).toEqual(real.tiers);
+    expect(passed.service_charge).toBe(5000);
+    expect(passed.service_charge_description).toBe("Fixed monthly service fee");
   });
 
-  it("(5) shape is stable — snapshot", () => {
+  it("(5) top-level shape matches RenderInvoiceInput", () => {
     const out = assembleSyntheticPreviewInput({
       community: COMMUNITY,
       organization: ORGANIZATION,
       ratesSchedule: null,
       now: FIXED_NOW,
     });
-    expect(out).toMatchInlineSnapshot(`
-      {
-        "community": {
-          "id": "00000000-0000-0000-0000-000000000010",
-          "invoice_config": {},
-          "invoice_prefix": "NFE",
-          "name": "Sample Community",
-        },
-        "enteredByUserName": "Sample Operator",
-        "household": {
-          "account_number": "ACC-0001",
-          "contact_email": null,
-          "customer_type": "residential",
-          "display_name": "Sample Household",
-          "id": "00000000-0000-0000-0000-000000000001",
-          "meter_serial": "SM-PREVIEW-0001",
-          "meter_type": "Smart Submeter",
-        },
-        "lineItem": {
-          "created_at": "2026-04-27T12:00:00.000Z",
-          "due_date": "2026-05-05T12:00:00.000Z",
-          "end_kwh": 14624.75,
-          "id": "00000000-0000-0000-0000-000000000004",
-          "invoice_number": "NFE-2026-PREVIEW",
-          "issue_date": "2026-04-27T12:00:00.000Z",
-          "pre_tax_total": 124.5,
-          "service_charge": 0,
-          "start_kwh": 14500.25,
-          "subtotal": 124.5,
-          "tax_amount": 0,
-          "tier_breakdown": [
-            {
-              "label": "Tier 1",
-              "rate_per_kwh": 1,
-              "subtotal": 124.5,
-              "usage_kwh": 124.5,
-            },
-          ],
-          "total": 124.5,
-          "usage_kwh": 124.5,
-        },
-        "meterDevice": {
-          "device_type": "metering",
-          "display_name": "Smart Submeter (Preview)",
-          "id": "00000000-0000-0000-0000-000000000002",
-        },
-        "organization": {
-          "id": "00000000-0000-0000-0000-000000000020",
-          "name": "Sample Org",
-        },
-        "period": {
-          "end_at": "2026-04-27T12:00:00.000Z",
-          "id": "00000000-0000-0000-0000-000000000003",
-          "label": "Sample period",
-          "start_at": "2026-03-28T12:00:00.000Z",
-        },
-        "ratesSchedule": {
-          "id": "00000000-0000-0000-0000-000000000000",
-          "microgrid_id": "00000000-0000-0000-0000-000000000000",
-          "service_charge": 0,
-          "service_charge_description": null,
-          "tax_rate": 0,
-          "tiers": [
-            {
-              "label": "Tier 1",
-              "max_kwh": null,
-              "min_kwh": 0,
-              "rate_per_kwh": 1,
-            },
-          ],
-        },
-      }
-    `);
+    // Renderer-required fields are at the top level (not nested under lineItem).
+    expect(out.invoiceNumber).toBe("NFE-2026-PREVIEW");
+    expect(out.enteredByUserName).toBe("Sample Operator");
+    expect(out.billingPeriodStart).toBe("2026-03-28T12:00:00.000Z");
+    expect(out.billingPeriodEnd).toBe("2026-04-27T12:00:00.000Z");
+    // Each entity exists.
+    expect(out.lineItem).toBeDefined();
+    expect(out.household).toBeDefined();
+    expect(out.community).toBeDefined();
+    expect(out.organization).toBeDefined();
+    expect(out.ratesSchedule).toBeDefined();
+    expect(out.meterDevice).toBeDefined();
   });
 });

--- a/src/lib/invoices/__tests__/preview-input.test.ts
+++ b/src/lib/invoices/__tests__/preview-input.test.ts
@@ -1,0 +1,164 @@
+/**
+ * preview-input.ts — unit tests (#204 / PDF2 AC #5).
+ *
+ * Covers:
+ *   (1) Synthesised invoice number uses the operator's prefix
+ *   (2) Empty/null prefix falls back to PREVIEW-{year}-PREVIEW
+ *   (3) No-microgrid path produces a fake 1-tier rate schedule
+ *   (4) Real rate schedule is passed through unchanged
+ *   (5) Stable shape — snapshot for regression
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  assembleSyntheticPreviewInput,
+  makePreviewInvoiceNumber,
+} from "../preview-input";
+
+const COMMUNITY = {
+  id: "00000000-0000-0000-0000-000000000010",
+  name: "Sample Community",
+  invoice_config: {},
+  invoice_prefix: "NFE",
+};
+
+const ORGANIZATION = {
+  id: "00000000-0000-0000-0000-000000000020",
+  name: "Sample Org",
+};
+
+const FIXED_NOW = new Date("2026-04-27T12:00:00.000Z");
+
+describe("preview-input", () => {
+  it("(1) synthesised invoice number uses the operator's prefix", () => {
+    const out = makePreviewInvoiceNumber("NFE", FIXED_NOW);
+    expect(out).toBe("NFE-2026-PREVIEW");
+  });
+
+  it("(2) empty/null prefix falls back to PREVIEW-{year}-PREVIEW", () => {
+    expect(makePreviewInvoiceNumber(null, FIXED_NOW)).toBe("PREVIEW-2026-PREVIEW");
+    expect(makePreviewInvoiceNumber("", FIXED_NOW)).toBe("PREVIEW-2026-PREVIEW");
+  });
+
+  it("(3) no-microgrid path uses the synthetic 1-tier rate schedule", () => {
+    const out = assembleSyntheticPreviewInput({
+      community: COMMUNITY,
+      organization: ORGANIZATION,
+      ratesSchedule: null,
+      now: FIXED_NOW,
+    });
+    expect(out.ratesSchedule.tiers).toHaveLength(1);
+    expect(out.ratesSchedule.tiers[0]).toMatchObject({
+      label: "Tier 1",
+      min_kwh: 0,
+      max_kwh: null,
+      rate_per_kwh: 1,
+    });
+    expect(out.ratesSchedule.service_charge).toBe(0);
+    expect(out.ratesSchedule.tax_rate).toBe(0);
+  });
+
+  it("(4) real rate schedule is passed through unchanged", () => {
+    const real = {
+      id: "real-id",
+      microgrid_id: "real-mg-id",
+      tiers: [
+        { label: "Tier 1", min_kwh: 0, max_kwh: 50, rate_per_kwh: 750 },
+        { label: "Tier 2", min_kwh: 50, max_kwh: null, rate_per_kwh: 1100 },
+      ],
+      service_charge: 5000,
+      service_charge_description: "Fixed monthly service fee",
+      tax_rate: 18,
+    };
+    const out = assembleSyntheticPreviewInput({
+      community: COMMUNITY,
+      organization: ORGANIZATION,
+      ratesSchedule: real,
+      now: FIXED_NOW,
+    });
+    expect(out.ratesSchedule).toEqual(real);
+    expect(out.lineItem.service_charge).toBe(5000);
+  });
+
+  it("(5) shape is stable — snapshot", () => {
+    const out = assembleSyntheticPreviewInput({
+      community: COMMUNITY,
+      organization: ORGANIZATION,
+      ratesSchedule: null,
+      now: FIXED_NOW,
+    });
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "community": {
+          "id": "00000000-0000-0000-0000-000000000010",
+          "invoice_config": {},
+          "invoice_prefix": "NFE",
+          "name": "Sample Community",
+        },
+        "enteredByUserName": "Sample Operator",
+        "household": {
+          "account_number": "ACC-0001",
+          "contact_email": null,
+          "customer_type": "residential",
+          "display_name": "Sample Household",
+          "id": "00000000-0000-0000-0000-000000000001",
+          "meter_serial": "SM-PREVIEW-0001",
+          "meter_type": "Smart Submeter",
+        },
+        "lineItem": {
+          "created_at": "2026-04-27T12:00:00.000Z",
+          "due_date": "2026-05-05T12:00:00.000Z",
+          "end_kwh": 14624.75,
+          "id": "00000000-0000-0000-0000-000000000004",
+          "invoice_number": "NFE-2026-PREVIEW",
+          "issue_date": "2026-04-27T12:00:00.000Z",
+          "pre_tax_total": 124.5,
+          "service_charge": 0,
+          "start_kwh": 14500.25,
+          "subtotal": 124.5,
+          "tax_amount": 0,
+          "tier_breakdown": [
+            {
+              "label": "Tier 1",
+              "rate_per_kwh": 1,
+              "subtotal": 124.5,
+              "usage_kwh": 124.5,
+            },
+          ],
+          "total": 124.5,
+          "usage_kwh": 124.5,
+        },
+        "meterDevice": {
+          "device_type": "metering",
+          "display_name": "Smart Submeter (Preview)",
+          "id": "00000000-0000-0000-0000-000000000002",
+        },
+        "organization": {
+          "id": "00000000-0000-0000-0000-000000000020",
+          "name": "Sample Org",
+        },
+        "period": {
+          "end_at": "2026-04-27T12:00:00.000Z",
+          "id": "00000000-0000-0000-0000-000000000003",
+          "label": "Sample period",
+          "start_at": "2026-03-28T12:00:00.000Z",
+        },
+        "ratesSchedule": {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "microgrid_id": "00000000-0000-0000-0000-000000000000",
+          "service_charge": 0,
+          "service_charge_description": null,
+          "tax_rate": 0,
+          "tiers": [
+            {
+              "label": "Tier 1",
+              "max_kwh": null,
+              "min_kwh": 0,
+              "rate_per_kwh": 1,
+            },
+          ],
+        },
+      }
+    `);
+  });
+});

--- a/src/lib/invoices/preview-input.ts
+++ b/src/lib/invoices/preview-input.ts
@@ -24,6 +24,15 @@
  */
 
 import type { InvoiceConfig } from "./config-schema";
+import type {
+  BillingLineItem,
+  Community,
+  Device,
+  Household,
+  Organization,
+  RateSchedule,
+} from "@/lib/types/domain";
+import type { RenderInvoiceInput } from "./render";
 
 /**
  * Minimal community-like input needed by the preview helper. Mirrors the
@@ -148,54 +157,85 @@ export function assembleSyntheticPreviewInput({
 
   const invoiceNumber = makePreviewInvoiceNumber(community.invoice_prefix, now);
 
+  // Synthetic entities. The renderer (PDF1b #203) reads only a subset of
+  // each row's columns, so the casts below are typed via `as unknown as ...`
+  // — defensive: if the renderer ever reads an unexpected field at runtime,
+  // it'll get `undefined` and render empty/placeholder, which is acceptable
+  // for a preview (no real billing arithmetic correctness required).
+  const lineItem = {
+    id: "00000000-0000-0000-0000-000000000004",
+    created_at: now.toISOString(),
+    start_kwh: startKwh,
+    end_kwh: endKwh,
+    usage_kwh: usageKwh,
+    tier_breakdown: tierBreakdown,
+    total_amount: grandTotal,
+    reading_source: "manual",
+    manual_reason: null,
+    entered_at: now.toISOString(),
+  } as unknown as BillingLineItem;
+
+  const household = {
+    id: "00000000-0000-0000-0000-000000000001",
+    display_name: "Sample Household",
+    account_number: "ACC-0001",
+    contact_email: null,
+    customer_type: "residential",
+    meter_serial: "SM-PREVIEW-0001",
+    meter_type: "Smart Submeter",
+    unit_label: null,
+    address_line1: "Sample street",
+    address_line2: null,
+    address_city: "Kampala",
+    address_country: "Uganda",
+  } as unknown as Household;
+
+  const meterDevice = {
+    id: "00000000-0000-0000-0000-000000000002",
+    name: "Smart Submeter (Preview)",
+    openems_component_id: "meter0",
+    device_type: "consumption_meter",
+  } as unknown as Device;
+
+  const ratesScheduleEntity = {
+    id: effectiveRates.id,
+    microgrid_id: effectiveRates.microgrid_id,
+    tiers: effectiveRates.tiers,
+    service_charge: effectiveRates.service_charge,
+    service_charge_description: effectiveRates.service_charge_description,
+  } as unknown as RateSchedule;
+
   return {
-    organization: {
-      id: organization.id,
-      name: organization.name,
-    },
+    lineItem,
+    household,
     community: {
       id: community.id,
       name: community.name,
       invoice_config: community.invoice_config,
       invoice_prefix: community.invoice_prefix,
-    },
-    household: {
-      id: "00000000-0000-0000-0000-000000000001",
-      display_name: "Sample Household",
-      account_number: "ACC-0001",
-      contact_email: null,
-      customer_type: "residential",
-      meter_serial: "SM-PREVIEW-0001",
-      meter_type: "Smart Submeter",
-    },
-    meterDevice: {
-      id: "00000000-0000-0000-0000-000000000002",
-      display_name: "Smart Submeter (Preview)",
-      device_type: "metering",
-    },
-    period: {
-      id: "00000000-0000-0000-0000-000000000003",
-      start_at: periodStart.toISOString(),
-      end_at: periodEnd.toISOString(),
-      label: "Sample period",
-    },
-    lineItem: {
-      id: "00000000-0000-0000-0000-000000000004",
-      invoice_number: invoiceNumber,
-      created_at: now.toISOString(),
-      issue_date: issueDate.toISOString(),
-      due_date: dueDate.toISOString(),
-      start_kwh: startKwh,
-      end_kwh: endKwh,
-      usage_kwh: usageKwh,
-      tier_breakdown: tierBreakdown,
-      subtotal,
-      service_charge: serviceCharge,
-      pre_tax_total: preTaxTotal,
-      tax_amount: taxAmount,
-      total: grandTotal,
-    },
-    ratesSchedule: effectiveRates,
+    } as unknown as Community,
+    organization: {
+      id: organization.id,
+      name: organization.name,
+    } as unknown as Organization,
+    ratesSchedule: ratesScheduleEntity,
+    invoiceNumber,
+    meterDevice,
     enteredByUserName: "Sample Operator",
+    billingPeriodStart: periodStart.toISOString(),
+    billingPeriodEnd: periodEnd.toISOString(),
+    // Audit/decoration fields preserved for future extension; not consumed
+    // by the renderer today but documented in the helper contract.
+    _previewMeta: {
+      issueDate: issueDate.toISOString(),
+      dueDate: dueDate.toISOString(),
+      subtotal,
+      serviceCharge,
+      preTaxTotal,
+      taxAmount,
+      grandTotal,
+    },
+  } satisfies Omit<RenderInvoiceInput, "logoBytes" | "paymentRedirectUrl"> & {
+    _previewMeta: Record<string, unknown>;
   };
 }

--- a/src/lib/invoices/preview-input.ts
+++ b/src/lib/invoices/preview-input.ts
@@ -1,0 +1,201 @@
+/**
+ * preview-input.ts — Synthesises a `RenderInvoiceInput` for the operator
+ * preview button (#204 / PDF2 AC #5).
+ *
+ * The preview must show the operator their branding/layout choices without
+ * consuming a real invoice counter. We assemble a plausible-looking sample:
+ *
+ *   - Synthetic invoice number `${invoice_prefix || 'PREVIEW'}-{year}-PREVIEW`.
+ *   - Synthetic line item with usage spread across tiers.
+ *   - Synthetic household + meter device with stable display names.
+ *   - Real `ratesSchedule` from the community's first microgrid; if no
+ *     microgrid exists yet, a fake 1-tier schedule.
+ *
+ * Contract:
+ *   - Pure helper (no I/O). The route fetches the microgrid's rate_schedule
+ *     beforehand and passes it in, OR passes `null` to opt into the synthetic
+ *     1-tier fallback.
+ *   - Returns `Omit<RenderInvoiceInput, 'logoBytes' | 'paymentRedirectUrl'>` —
+ *     the route adds those two after fetching/synthesising them.
+ *
+ * The shape produced here mirrors PDF1b's `RenderInvoiceInput` spec from
+ * `mbe-docs/docs/tickets/pdf-invoices/PDF1b-renderer-and-pdf-endpoint.md`.
+ * If the renderer's input bag changes, this helper must change in lockstep.
+ */
+
+import type { InvoiceConfig } from "./config-schema";
+
+/**
+ * Minimal community-like input needed by the preview helper. Mirrors the
+ * fields the renderer reads — keeps the helper decoupled from the row shape.
+ */
+export type PreviewCommunityInput = {
+  id: string;
+  name: string;
+  invoice_config: InvoiceConfig | Record<string, never>;
+  invoice_prefix: string | null;
+};
+
+export type PreviewOrganizationInput = {
+  id: string;
+  name: string;
+};
+
+/**
+ * Synthesised rate-schedule shape used when the community has no microgrid
+ * yet. Mirrors `rate_schedules` row plus the `description` column added in
+ * 00033 for tier-level service-charge captions.
+ */
+export type PreviewRateSchedule = {
+  id: string;
+  microgrid_id: string;
+  tiers: Array<{
+    label: string;
+    min_kwh: number;
+    max_kwh: number | null;
+    rate_per_kwh: number;
+  }>;
+  service_charge: number;
+  service_charge_description: string | null;
+  tax_rate: number;
+};
+
+const FAKE_RATE_SCHEDULE: PreviewRateSchedule = {
+  id: "00000000-0000-0000-0000-000000000000",
+  microgrid_id: "00000000-0000-0000-0000-000000000000",
+  tiers: [
+    {
+      label: "Tier 1",
+      min_kwh: 0,
+      max_kwh: null,
+      rate_per_kwh: 1,
+    },
+  ],
+  service_charge: 0,
+  service_charge_description: null,
+  tax_rate: 0,
+};
+
+/**
+ * Build the synthetic invoice number for the preview. Never increments the
+ * real `fn_next_invoice_number()` — operator preview MUST NOT consume the
+ * counter.
+ */
+export function makePreviewInvoiceNumber(
+  invoicePrefix: string | null,
+  now: Date = new Date(),
+): string {
+  const prefix =
+    invoicePrefix && invoicePrefix.length > 0 ? invoicePrefix : "PREVIEW";
+  const year = now.getUTCFullYear();
+  return `${prefix}-${year}-PREVIEW`;
+}
+
+/**
+ * Synthesise a preview-input payload (everything except `logoBytes` and
+ * `paymentRedirectUrl`, which the route layers on after fetching/synthesising
+ * them).
+ *
+ * @param community — the community row (id, name, invoice_config, invoice_prefix).
+ * @param organization — the parent org (id, name).
+ * @param ratesSchedule — the microgrid's actual rate schedule, OR null to
+ *   trigger the synthetic 1-tier fallback (operator is configuring before any
+ *   microgrid exists yet).
+ * @param now — clock injection point for tests.
+ */
+export function assembleSyntheticPreviewInput({
+  community,
+  organization,
+  ratesSchedule,
+  now = new Date(),
+}: {
+  community: PreviewCommunityInput;
+  organization: PreviewOrganizationInput;
+  ratesSchedule: PreviewRateSchedule | null;
+  now?: Date;
+}) {
+  const periodEnd = new Date(now);
+  const periodStart = new Date(now);
+  periodStart.setUTCDate(periodStart.getUTCDate() - 30);
+
+  const issueDate = now;
+  const dueDays =
+    (community.invoice_config as InvoiceConfig | undefined)?.payment
+      ?.due_days_after_issue ?? 8;
+  const dueDate = new Date(now);
+  dueDate.setUTCDate(dueDate.getUTCDate() + dueDays);
+
+  const usageKwh = 124.5;
+  const startKwh = 14_500.25;
+  const endKwh = startKwh + usageKwh;
+
+  const effectiveRates = ratesSchedule ?? FAKE_RATE_SCHEDULE;
+
+  // Tier breakdown: at N=124.5 kWh the breakdown is naive — full usage in the
+  // first tier (preview is for branding, not billing arithmetic correctness).
+  const tierBreakdown = effectiveRates.tiers.map((t, i) => ({
+    label: t.label,
+    rate_per_kwh: t.rate_per_kwh,
+    usage_kwh: i === 0 ? usageKwh : 0,
+    subtotal: i === 0 ? usageKwh * t.rate_per_kwh : 0,
+  }));
+
+  const subtotal = tierBreakdown.reduce((sum, t) => sum + t.subtotal, 0);
+  const serviceCharge = effectiveRates.service_charge;
+  const preTaxTotal = subtotal + serviceCharge;
+  const taxAmount = preTaxTotal * (effectiveRates.tax_rate / 100);
+  const grandTotal = preTaxTotal + taxAmount;
+
+  const invoiceNumber = makePreviewInvoiceNumber(community.invoice_prefix, now);
+
+  return {
+    organization: {
+      id: organization.id,
+      name: organization.name,
+    },
+    community: {
+      id: community.id,
+      name: community.name,
+      invoice_config: community.invoice_config,
+      invoice_prefix: community.invoice_prefix,
+    },
+    household: {
+      id: "00000000-0000-0000-0000-000000000001",
+      display_name: "Sample Household",
+      account_number: "ACC-0001",
+      contact_email: null,
+      customer_type: "residential",
+      meter_serial: "SM-PREVIEW-0001",
+      meter_type: "Smart Submeter",
+    },
+    meterDevice: {
+      id: "00000000-0000-0000-0000-000000000002",
+      display_name: "Smart Submeter (Preview)",
+      device_type: "metering",
+    },
+    period: {
+      id: "00000000-0000-0000-0000-000000000003",
+      start_at: periodStart.toISOString(),
+      end_at: periodEnd.toISOString(),
+      label: "Sample period",
+    },
+    lineItem: {
+      id: "00000000-0000-0000-0000-000000000004",
+      invoice_number: invoiceNumber,
+      created_at: now.toISOString(),
+      issue_date: issueDate.toISOString(),
+      due_date: dueDate.toISOString(),
+      start_kwh: startKwh,
+      end_kwh: endKwh,
+      usage_kwh: usageKwh,
+      tier_breakdown: tierBreakdown,
+      subtotal,
+      service_charge: serviceCharge,
+      pre_tax_total: preTaxTotal,
+      tax_amount: taxAmount,
+      total: grandTotal,
+    },
+    ratesSchedule: effectiveRates,
+    enteredByUserName: "Sample Operator",
+  };
+}


### PR DESCRIPTION
Closes #204

## Summary
- **New `Setup → Invoice` tab** on the community detail page (sibling to Overview + Payment). Co-located client components in `src/app/(dashboard)/communities/[id]/invoice/`. `showInvoiceTab` boolean prop wired through the layout via `currentUserCanAccessOrg`.
- **Form sections**: Identity (prefix, document title), Seller Details (legal name, trade name, tax IDs, address lines, contact email/phone), Branding (tagline, primary/accent colors, WhatsApp number, logo), Payment (due_days_after_issue), Tax (toggle + label + rate), Notice Copy (collapsible).
- **PATCH `/api/communities/[id]/invoice-config`** — Zod via `parseInvoiceConfig` from PDF1a; permission ordering UUID → row read → 404 → `currentUserCanAccessOrg` → 403 → Zod (mirrors UX5b #184). PATCH (not PUT) per `organizations/[id]` precedent.
- **POST `/api/communities/[id]/invoice-logo`** — permission-FIRST (before body read), service-role write to `invoice-logos/{community.id}/{Date.now()}-{crypto.randomUUID()}.{ext}`. MIME validation client-side ≤500KB / server-side ≤1MB. Returns the storage path + 5-min signed URL.
- **POST `/api/communities/[id]/invoice-preview`** — POST-not-GET so JSONB rides body. Permission-gated. Synthetic input via `assembleSyntheticPreviewInput`. Fake `paymentRedirectUrl`. **Wires the real `renderInvoicePdf` from PDF1b (#203 already merged on origin/main)**. `Content-Disposition: inline; filename="preview.pdf"` (distinct from PDF1b's `attachment`).
- **Synthetic-input helper** at `src/lib/invoices/preview-input.ts` produces a `RenderInvoiceInput`-shaped object (top-level `invoiceNumber`, `enteredByUserName`, `billingPeriodStart`/`End`; entities cast via `unknown as Domain` since synthetic fields only populate what the renderer reads).
- **Color picker primitive** with paired text input (a11y per refinement). **List editor primitive** with up/down reorder (drag-drop scoped out per refinement). **Logo uploader** with drag-drop + file picker + blob preview.

## Why
Operators need to configure seller details, branding, tax, payment due-days, and notice copy that drive the PDF bills — without code changes. PDF2 wires the read/write surface PDF1a shipped (Zod schema + JSONB column + storage bucket) and the renderer PDF1b shipped (preview reuses the renderer).

## Test plan
- [x] `npm test` — 54 new tests pass (subnav 9, invoice-shell 3, color-input 5, list-editor 8, invoice-config route 9, invoice-logo route 8, invoice-preview route 7, preview-input helper 5). Renderer-mock pattern verifies the preview route's content-disposition contract without invoking the real renderer (PDF1b has its own end-to-end fixture suite).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean (8 pre-existing warnings; 2 narrowly-scoped `eslint-disable-next-line @next/next/no-img-element` for signed/blob URL logo previews where `next/image` can't optimize).
- [x] `npm run build` — clean.
- [ ] Operator follow-up: open `/communities/<id>/invoice` as an org_manager-of-parent-org, configure prefix + branding, upload a logo, preview the PDF in a new tab, save.

## Notes
- **Renderer dependency handled via rebase**: branch was implemented in parallel with #203. After #203 merged, this branch was rebased on origin/main and the renderer stub (which previously returned 503) was replaced with the real `renderInvoicePdf` import. The synthetic-input helper was reshaped from its original "convenient bag" form to the `RenderInvoiceInput` spec.
- **`parseInvoiceUpdate` not used directly**: PDF1a's `parseInvoiceUpdate` Zod requires non-null prefix; the column allows null and AC #3 says null must be accepted. Used `parseInvoiceConfig` for JSONB validation + hand-rolled prefix check (`null OR INVOICE_PREFIX_RE`) per AC #3 step 5b.
- **Layout double round-trip**: layout fetches `currentUserCanAccessCommunity` (read gate) AND `currentUserCanAccessOrg` (edit gate) separately. Refinement notes accepted either approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)