### PR TITLE
PDF3 — Household form fields + RPC widening + Download bill action (#205)

### DIFF
--- a/src/app/api/households/[id]/route.ts
+++ b/src/app/api/households/[id]/route.ts
@@ -67,7 +67,25 @@ const ALLOWED_FIELDS = new Set([
   "address_postal_code",
   "geography_notes",
   "device_id",
+  // PDF3 (#205) — household identity / billing-device descriptors used by
+  // the consumer-facing PDF invoice.
+  "account_number",
+  "meter_serial",
+  "meter_type",
+  "customer_type",
+  "contact_email",
 ]);
+
+// PDF3 (#205) — length caps and format mirror the PDF1a (#202) column
+// CHECK constraints in 00033_pdf_invoices_schema.sql.
+const ACCOUNT_NUMBER_MAX_LENGTH = 30;
+const METER_SERIAL_MAX_LENGTH = 50;
+const METER_TYPE_MAX_LENGTH = 50;
+const CUSTOMER_TYPES = new Set(["residential", "commercial"]);
+// Format-only check — mirrors households_contact_email_format CHECK in
+// 00033 (PDF1a). Deliverability is verified out-of-band, never at the
+// route boundary.
+const CONTACT_EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 
 type HouseholdUpdate = {
   display_name?: string;
@@ -81,6 +99,12 @@ type HouseholdUpdate = {
   address_country?: string | null;
   address_postal_code?: string | null;
   geography_notes?: string | null;
+  // PDF3 (#205)
+  account_number?: string | null;
+  meter_serial?: string | null;
+  meter_type?: string;        // NOT NULL on the column — never set to null
+  customer_type?: string;     // NOT NULL on the column — never set to null
+  contact_email?: string | null;
 };
 
 function nullableString(v: unknown): string | null | undefined {
@@ -327,6 +351,127 @@ export async function PATCH(
       );
     }
     update.geography_notes = v;
+  }
+
+  // ── PDF3 (#205) — household PDF-invoice identity fields ────────────────
+  if ("account_number" in bodyRec) {
+    const v = nullableString(bodyRec.account_number);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "account_number must be a string or null",
+          reason: "invalid_account_number",
+        },
+        { status: 400 }
+      );
+    }
+    if (v !== null && v.length > ACCOUNT_NUMBER_MAX_LENGTH) {
+      return NextResponse.json(
+        {
+          error: `account_number must be ${ACCOUNT_NUMBER_MAX_LENGTH} characters or fewer`,
+          reason: "account_number_too_long",
+        },
+        { status: 400 }
+      );
+    }
+    update.account_number = v;
+  }
+  if ("meter_serial" in bodyRec) {
+    const v = nullableString(bodyRec.meter_serial);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "meter_serial must be a string or null",
+          reason: "invalid_meter_serial",
+        },
+        { status: 400 }
+      );
+    }
+    if (v !== null && v.length > METER_SERIAL_MAX_LENGTH) {
+      return NextResponse.json(
+        {
+          error: `meter_serial must be ${METER_SERIAL_MAX_LENGTH} characters or fewer`,
+          reason: "meter_serial_too_long",
+        },
+        { status: 400 }
+      );
+    }
+    update.meter_serial = v;
+  }
+  if ("meter_type" in bodyRec) {
+    // NOT NULL on the column — must be a non-empty string. Do NOT use
+    // nullableString here (it coerces empty-string → null which would
+    // violate the NOT NULL CHECK).
+    const raw = bodyRec.meter_type;
+    if (raw === null || typeof raw !== "string") {
+      return NextResponse.json(
+        {
+          error: "meter_type must be a non-empty string",
+          reason: "invalid_meter_type",
+        },
+        { status: 400 }
+      );
+    }
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json(
+        {
+          error: "meter_type must be a non-empty string",
+          reason: "invalid_meter_type",
+        },
+        { status: 400 }
+      );
+    }
+    if (trimmed.length > METER_TYPE_MAX_LENGTH) {
+      return NextResponse.json(
+        {
+          error: `meter_type must be ${METER_TYPE_MAX_LENGTH} characters or fewer`,
+          reason: "meter_type_too_long",
+        },
+        { status: 400 }
+      );
+    }
+    update.meter_type = trimmed;
+  }
+  if ("customer_type" in bodyRec) {
+    // NOT NULL + enum on the column — must be 'residential' or 'commercial'.
+    const raw = bodyRec.customer_type;
+    if (
+      raw === null ||
+      typeof raw !== "string" ||
+      !CUSTOMER_TYPES.has(raw)
+    ) {
+      return NextResponse.json(
+        {
+          error: "customer_type must be 'residential' or 'commercial'",
+          reason: "invalid_customer_type",
+        },
+        { status: 400 }
+      );
+    }
+    update.customer_type = raw;
+  }
+  if ("contact_email" in bodyRec) {
+    const v = nullableString(bodyRec.contact_email);
+    if (v === undefined) {
+      return NextResponse.json(
+        {
+          error: "contact_email must be a string or null",
+          reason: "invalid_contact_email",
+        },
+        { status: 400 }
+      );
+    }
+    if (v !== null && !CONTACT_EMAIL_RE.test(v)) {
+      return NextResponse.json(
+        {
+          error: "contact_email must be a valid email address",
+          reason: "invalid_contact_email",
+        },
+        { status: 400 }
+      );
+    }
+    update.contact_email = v;
   }
 
   const hasFieldUpdate = Object.keys(update).length > 0;

--- a/src/app/api/households/with-meter/route.ts
+++ b/src/app/api/households/with-meter/route.ts
@@ -36,6 +36,12 @@ import { createClient } from "@/lib/supabase/server";
  *   address_country?:     string | null;
  *   address_postal_code?: string | null;
  *   geography_notes?:     string | null;
+ *   // PDF3 (#205) — household PDF-invoice identity fields:
+ *   account_number?:      string | null;     // ≤ 30 chars
+ *   meter_serial?:        string | null;     // ≤ 50 chars
+ *   meter_type?:          string;            // NOT NULL; ≤ 50 chars
+ *   customer_type?:       string;            // 'residential' | 'commercial'
+ *   contact_email?:       string | null;     // format-validated
  * }
  *
  * Response:
@@ -108,6 +114,162 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return t ? t : null;
   };
 
+  // ── PDF3 (#205) — validation for the 5 new household identity fields ──
+  // Length caps + enum mirror the column CHECKs in PDF1a (#202) migration
+  // 00033 and the PATCH route's per-field validators in
+  // src/app/api/households/[id]/route.ts.
+  const ACCOUNT_NUMBER_MAX_LENGTH = 30;
+  const METER_SERIAL_MAX_LENGTH = 50;
+  const METER_TYPE_MAX_LENGTH = 50;
+  const CUSTOMER_TYPES = new Set(["residential", "commercial"]);
+  const CONTACT_EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+  // account_number — string OR null. Length cap.
+  let account_number: string | null = null;
+  if (body.account_number !== undefined && body.account_number !== null) {
+    if (typeof body.account_number !== "string") {
+      return NextResponse.json(
+        {
+          error: "account_number must be a string or null",
+          reason: "invalid_account_number",
+          field: "account_number",
+        },
+        { status: 400 }
+      );
+    }
+    const trimmed = body.account_number.trim();
+    if (trimmed.length === 0) {
+      account_number = null;
+    } else {
+      if (trimmed.length > ACCOUNT_NUMBER_MAX_LENGTH) {
+        return NextResponse.json(
+          {
+            error: `account_number must be ${ACCOUNT_NUMBER_MAX_LENGTH} characters or fewer`,
+            reason: "account_number_too_long",
+            field: "account_number",
+          },
+          { status: 400 }
+        );
+      }
+      account_number = trimmed;
+    }
+  }
+
+  // meter_serial — string OR null. Length cap.
+  let meter_serial: string | null = null;
+  if (body.meter_serial !== undefined && body.meter_serial !== null) {
+    if (typeof body.meter_serial !== "string") {
+      return NextResponse.json(
+        {
+          error: "meter_serial must be a string or null",
+          reason: "invalid_meter_serial",
+          field: "meter_serial",
+        },
+        { status: 400 }
+      );
+    }
+    const trimmed = body.meter_serial.trim();
+    if (trimmed.length === 0) {
+      meter_serial = null;
+    } else {
+      if (trimmed.length > METER_SERIAL_MAX_LENGTH) {
+        return NextResponse.json(
+          {
+            error: `meter_serial must be ${METER_SERIAL_MAX_LENGTH} characters or fewer`,
+            reason: "meter_serial_too_long",
+            field: "meter_serial",
+          },
+          { status: 400 }
+        );
+      }
+      meter_serial = trimmed;
+    }
+  }
+
+  // meter_type — NOT NULL on the column. When omitted/null/empty, we send
+  // `undefined` to the RPC so its COALESCE applies the 'Smart Submeter'
+  // default. When the operator typed a value, validate length.
+  let meter_type: string | undefined;
+  if (body.meter_type !== undefined && body.meter_type !== null) {
+    if (typeof body.meter_type !== "string") {
+      return NextResponse.json(
+        {
+          error: "meter_type must be a non-empty string",
+          reason: "invalid_meter_type",
+          field: "meter_type",
+        },
+        { status: 400 }
+      );
+    }
+    const trimmed = body.meter_type.trim();
+    if (trimmed.length > 0) {
+      if (trimmed.length > METER_TYPE_MAX_LENGTH) {
+        return NextResponse.json(
+          {
+            error: `meter_type must be ${METER_TYPE_MAX_LENGTH} characters or fewer`,
+            reason: "meter_type_too_long",
+            field: "meter_type",
+          },
+          { status: 400 }
+        );
+      }
+      meter_type = trimmed;
+    }
+    // empty-string → leave meter_type undefined → RPC COALESCEs to default
+  }
+
+  // customer_type — NOT NULL on the column; enum 'residential'|'commercial'.
+  // When omitted/null, send undefined so the RPC's COALESCE applies the
+  // 'residential' default. When supplied, must match the enum strictly.
+  let customer_type: string | undefined;
+  if (body.customer_type !== undefined && body.customer_type !== null) {
+    if (
+      typeof body.customer_type !== "string" ||
+      !CUSTOMER_TYPES.has(body.customer_type)
+    ) {
+      return NextResponse.json(
+        {
+          error: "customer_type must be 'residential' or 'commercial'",
+          reason: "invalid_customer_type",
+          field: "customer_type",
+        },
+        { status: 400 }
+      );
+    }
+    customer_type = body.customer_type;
+  }
+
+  // contact_email — string OR null with format validation.
+  let contact_email: string | null = null;
+  if (body.contact_email !== undefined && body.contact_email !== null) {
+    if (typeof body.contact_email !== "string") {
+      return NextResponse.json(
+        {
+          error: "contact_email must be a string or null",
+          reason: "invalid_contact_email",
+          field: "contact_email",
+        },
+        { status: 400 }
+      );
+    }
+    const trimmed = body.contact_email.trim();
+    if (trimmed.length === 0) {
+      contact_email = null;
+    } else {
+      if (!CONTACT_EMAIL_RE.test(trimmed)) {
+        return NextResponse.json(
+          {
+            error: "contact_email must be a valid email address",
+            reason: "invalid_contact_email",
+            field: "contact_email",
+          },
+          { status: 400 }
+        );
+      }
+      contact_email = trimmed;
+    }
+  }
+
   const supabase = await createClient();
 
   // #158: dispatch to the meter-required wrapper (back-compat) or the
@@ -127,6 +289,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     p_address_country: optional(body.address_country) ?? undefined,
     p_address_postal_code: optional(body.address_postal_code) ?? undefined,
     p_geography_notes: optional(body.geography_notes) ?? undefined,
+    // PDF3 (#205) — household PDF-invoice identity fields. NULL → omit so
+    // the RPC's COALESCE applies the column DEFAULT (for meter_type /
+    // customer_type) or persists NULL (for the 3 nullable columns).
+    p_account_number: account_number ?? undefined,
+    p_meter_serial: meter_serial ?? undefined,
+    p_meter_type: meter_type ?? undefined,
+    p_customer_type: customer_type ?? undefined,
+    p_contact_email: contact_email ?? undefined,
   };
 
   const { data, error } = device_id

--- a/src/components/HouseholdTable.tsx
+++ b/src/components/HouseholdTable.tsx
@@ -279,6 +279,9 @@ export function HouseholdTable({
             <thead>
               <tr className="border-b border-border text-muted-foreground">
                 <th className="pb-2 pr-4 font-medium">Household</th>
+                {/* PDF3 (#205) — Account Number column between Household
+                    and Address. Empty rows show "—" muted. */}
+                <th className="pb-2 pr-4 font-medium">Account number</th>
                 <th className="pb-2 pr-4 font-medium">Address</th>
                 <th className="pb-2 pr-4 font-medium">Billing device</th>
                 <th className="pb-2 text-right font-medium">Actions</th>
@@ -293,14 +296,32 @@ export function HouseholdTable({
                     className="border-b border-border align-top"
                   >
                     <td className="py-3 pr-4">
-                      <div className="font-medium text-foreground">
-                        {household.display_name}
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-foreground">
+                          {household.display_name}
+                        </span>
+                        {/* PDF3 (#205) — Customer Type chip next to display
+                            name. Visually compact (no extra column). */}
+                        <StatusChip
+                          kind="householdCustomerType"
+                          status={household.customer_type}
+                        />
                       </div>
                       <div className="text-xs text-muted-foreground">
                         {[household.primary_email, household.primary_phone]
                           .filter(Boolean)
                           .join(" · ") || "—"}
                       </div>
+                    </td>
+                    {/* PDF3 (#205) — Account Number column. */}
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      {household.account_number ? (
+                        <span className="text-foreground">
+                          {household.account_number}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </td>
                     <td className="py-3 pr-4 text-muted-foreground">
                       <span className="block max-w-[260px] truncate">

--- a/src/components/billing/__tests__/row-actions-menu.test.tsx
+++ b/src/components/billing/__tests__/row-actions-menu.test.tsx
@@ -107,6 +107,8 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
       onMarkAsUnpaid: vi.fn(),
       onCancelLink: vi.fn(),
       onMarkAsFailed: vi.fn(),
+      // PDF3 (#205) — bill-PDF download handler.
+      onDownloadPdf: vi.fn(),
     },
   };
 
@@ -130,6 +132,8 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     expect(labels).toContain("Generate payment link");
     expect(labels).toContain("Mark as paid…");
     expect(labels).toContain("View household");
+    // PDF3 (#205) — Download bill (PDF) is always present.
+    expect(labels).toContain("Download bill (PDF)");
   });
 
   it("State 2: Manual · Link sent · draft · edgeAvailable — 3 link_generated transitions", () => {
@@ -154,6 +158,8 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     // Manual + edgeAvailable → both source toggles
     expect(labels).toContain("Switch back to edge data");
     expect(labels).toContain("Re-enter manual readings…");
+    // PDF3 (#205) — Download bill (PDF) is always present.
+    expect(labels).toContain("Download bill (PDF)");
   });
 
   it("State 3: Manual · Unpaid · draft · NO edge — Switch back hidden, not disabled", () => {
@@ -175,6 +181,8 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     expect(labels).not.toContain("Switch back to edge data");
     expect(labels).toContain("Re-enter manual readings…");
     expect(labels).toContain("Generate payment link");
+    // PDF3 (#205) — Download bill (PDF) is always present.
+    expect(labels).toContain("Download bill (PDF)");
   });
 
   it("State 4: Edge · Paid · draft — paid->{unpaid,refunded} only; regen has warning", () => {
@@ -199,6 +207,8 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     );
     expect(regenEdge).toBeTruthy();
     expect(regenEdge?.kind === "action" && regenEdge.warning).toBe(true);
+    // PDF3 (#205) — Download bill (PDF) is always present.
+    expect(labels).toContain("Download bill (PDF)");
   });
 
   it("State 5: Edge · Refunded · draft (terminal) — single disabled item", () => {
@@ -225,6 +235,9 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     );
     expect(noActions).toBeTruthy();
     expect(noActions?.kind === "action" && noActions.disabled).toBe(true);
+    // PDF3 (#205) — Download bill (PDF) is visible even on terminal rows
+    // (refunded bills still want a paper trail).
+    expect(labels).toContain("Download bill (PDF)");
   });
 
   it("State 6: Edge · Paid · CLOSED period (Q4=B) — regen has warning + audit subtext", () => {
@@ -248,6 +261,11 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     expect(regen?.kind === "action" && regen.subtext).toBe(
       "Logged as audit revision.",
     );
+    // PDF3 (#205) — Download bill (PDF) is always present.
+    const labels = items
+      .filter((i) => i.kind === "action" || i.kind === "link")
+      .map((i) => (i.kind === "action" ? i.label : i.label));
+    expect(labels).toContain("Download bill (PDF)");
   });
 });
 
@@ -539,5 +557,67 @@ describe("RowActionsMenu — payment-link generation error", () => {
     expect(last.message).toMatch(/failed to generate payment link/i);
     expect(last.action?.label).toBe("Retry");
     expect(typeof last.action?.onClick).toBe("function");
+  });
+});
+
+// ── PDF3 (#205) — bill-download error path ──────────────────────────────────
+
+describe("RowActionsMenu — bill download error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("422 response pushes destructive banner with the upstream reason", async () => {
+    const onRowBanner = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: () =>
+          Promise.resolve({
+            error:
+              "Cannot generate bill — payment link could not be created.",
+            reason: "pesapal_unreachable",
+          }),
+      }),
+    );
+
+    renderMenu(
+      makeProps({
+        onRowBanner,
+        lineItem: {
+          id: "li-1",
+          payment_status: "unpaid",
+          reading_source: "edge",
+          total_amount: 100,
+        },
+      }),
+    );
+
+    await act(async () => {
+      openMenu(screen.getByRole("button", { name: /row actions for/i }));
+    });
+    await waitFor(() => screen.getByText(/download bill \(pdf\)/i));
+    await act(async () => {
+      fireEvent.click(screen.getByText(/download bill \(pdf\)/i));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const errCalls = onRowBanner.mock.calls.filter(
+      (c) => (c[0] as RowBannerEntry).tone === "destructive",
+    );
+    expect(errCalls.length).toBeGreaterThanOrEqual(1);
+    const last = errCalls[errCalls.length - 1][0] as RowBannerEntry;
+    expect(last.message).toMatch(/cannot generate bill/i);
+    expect(last.message).toMatch(/pesapal_unreachable/);
+    // Download retry surface IS the menu item itself; no inline action btn.
+    expect(last.action).toBeUndefined();
   });
 });

--- a/src/components/billing/row-actions-menu.tsx
+++ b/src/components/billing/row-actions-menu.tsx
@@ -119,8 +119,9 @@ export type MenuItem =
 
 /**
  * Compute the dropdown items for a row given the rendering inputs. Pure
- * function — no side effects. Snapshot-tested directly for the 6 named
- * states from the designer matrix.
+ * function — no side effects. Assertion-tested via inclusion checks (NOT
+ * snapshots) for the 6 named states from the designer matrix; see
+ * `__tests__/row-actions-menu.test.tsx`.
  */
 export function computeMenuItems(input: {
   microgridId: string;
@@ -141,6 +142,8 @@ export function computeMenuItems(input: {
     onMarkAsUnpaid: () => void;
     onCancelLink: () => void;
     onMarkAsFailed: () => void;
+    /** PDF3 (#205) — fires the bill-PDF download flow (probe-then-anchor). */
+    onDownloadPdf: () => void;
   };
 }): MenuItem[] {
   const {
@@ -324,6 +327,21 @@ export function computeMenuItems(input: {
     }
     items.push(...paymentGroup);
   }
+
+  // ── PDF3 (#205) — Download bill (PDF) ──────────────────────────────────────
+  // Always visible (including terminal/refunded rows — refunded bills still
+  // want a paper trail). MenuItem kind: "action" so the host can run the
+  // probe-then-anchor flow; "link" would render via Next.js <Link> and
+  // intercept the PDF response client-side.
+  if (items.length > 0) {
+    items.push({ kind: "separator", key: "sep-download" });
+  }
+  items.push({
+    kind: "action",
+    key: "download-pdf",
+    label: "Download bill (PDF)",
+    onSelect: handlers.onDownloadPdf,
+  });
 
   // ── View links ─────────────────────────────────────────────────────────────
   if (items.length > 0) {
@@ -550,6 +568,63 @@ export function RowActionsMenu(props: RowActionsMenuProps) {
     });
   }, [lineItem.id, onRequestSwitchToManual, onRowBanner]);
 
+  // ── PDF3 (#205) — Download bill (PDF) ─────────────────────────────────────
+  //
+  // Probe-then-anchor pattern. Why probe first:
+  //   - A 422 response body is `{ error, reason }` JSON. If we let an anchor
+  //     fire directly, the browser would surface its native error page
+  //     instead of letting us push a row banner with the upstream reason.
+  //   - The route's `Content-Disposition: attachment` header is the
+  //     cross-browser source of truth for the filename — so the second hit
+  //     uses a fresh GET via a hidden <a>, NOT a blob URL.
+  //   - The double-hit is fine: PDF1a's ensurePaymentLinkForLineItem() is
+  //     idempotent, and the invoice_number first-render persistence already
+  //     happened on the probe.
+  const handleDownloadPdf = React.useCallback(async () => {
+    const pdfUrl = `/api/billing-line-items/${lineItem.id}/pdf`;
+    try {
+      const res = await fetch(pdfUrl, { method: "GET" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          reason?: string;
+        };
+        const msg =
+          res.status === 403
+            ? "Not authorized to download this bill."
+            : res.status >= 500
+              ? "Server error. Please retry."
+              : `Cannot generate bill: ${body.reason ?? body.error ?? "unknown error"}`;
+        onRowBanner({
+          id: `${lineItem.id}-pdf-err-${Date.now()}`,
+          lineItemId: lineItem.id,
+          tone: "destructive",
+          message: msg,
+          durationMs: ERROR_BANNER_DURATION_MS,
+        });
+        return;
+      }
+      // Trigger a fresh GET via a hidden anchor — no `download` attribute,
+      // so the route's `Content-Disposition: attachment; filename="…"`
+      // drives the filename across all browsers.
+      const a = document.createElement("a");
+      a.href = pdfUrl;
+      a.target = "_self";
+      a.style.display = "none";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch {
+      onRowBanner({
+        id: `${lineItem.id}-pdf-net-${Date.now()}`,
+        lineItemId: lineItem.id,
+        tone: "destructive",
+        message: "Network error. Please retry.",
+        durationMs: ERROR_BANNER_DURATION_MS,
+      });
+    }
+  }, [lineItem.id, onRowBanner]);
+
   // ── Compute menu items (memoised) ─────────────────────────────────────────
   const items = React.useMemo(
     () =>
@@ -571,6 +646,8 @@ export function RowActionsMenu(props: RowActionsMenuProps) {
           onMarkAsUnpaid: () => void patchStatus("unpaid", null),
           onCancelLink: () => setCancelLinkOpen(true),
           onMarkAsFailed: () => setMarkFailedOpen(true),
+          // PDF3 (#205) — fire the probe-then-anchor download flow.
+          onDownloadPdf: () => void handleDownloadPdf(),
         },
       }),
     [
@@ -587,6 +664,7 @@ export function RowActionsMenu(props: RowActionsMenuProps) {
       generatePaymentLink,
       copyPaymentLink,
       patchStatus,
+      handleDownloadPdf,
     ],
   );
 

--- a/src/components/forms/HouseholdEditDialog.tsx
+++ b/src/components/forms/HouseholdEditDialog.tsx
@@ -70,6 +70,14 @@ type FormState = {
   address_postal_code: string;
   geography_notes: string;
   device_id: string | null;
+  // PDF3 (#205) — household PDF-invoice identity fields. customer_type +
+  // meter_type are NOT NULL on the column; the form always carries a
+  // value (??-fallback in initialState() for any partial-shape payload).
+  account_number: string;
+  meter_serial: string;
+  meter_type: string;
+  customer_type: "residential" | "commercial";
+  contact_email: string;
 };
 
 function initialState(h: Household, deviceId: string | null): FormState {
@@ -86,6 +94,16 @@ function initialState(h: Household, deviceId: string | null): FormState {
     address_postal_code: h.address_postal_code ?? "",
     geography_notes: h.geography_notes ?? "",
     device_id: deviceId,
+    // PDF3 (#205) — fall back to canonical defaults when a partial-shape
+    // Household payload arrives without the columns. Existing rows
+    // backfilled by 00033's column DEFAULTs already carry the canonical
+    // values; the ?? is defense-in-depth.
+    account_number: h.account_number ?? "",
+    meter_serial: h.meter_serial ?? "",
+    meter_type: h.meter_type ?? "Smart Submeter",
+    customer_type:
+      h.customer_type === "commercial" ? "commercial" : "residential",
+    contact_email: h.contact_email ?? "",
   };
 }
 
@@ -102,7 +120,13 @@ function isDirty(cur: FormState, init: FormState): boolean {
     cur.address_country !== init.address_country ||
     cur.address_postal_code !== init.address_postal_code ||
     cur.geography_notes !== init.geography_notes ||
-    cur.device_id !== init.device_id
+    cur.device_id !== init.device_id ||
+    // PDF3 (#205)
+    cur.account_number !== init.account_number ||
+    cur.meter_serial !== init.meter_serial ||
+    cur.meter_type !== init.meter_type ||
+    cur.customer_type !== init.customer_type ||
+    cur.contact_email !== init.contact_email
   );
 }
 
@@ -159,6 +183,27 @@ function buildDiff(
   }
   if (cur.device_id !== init.device_id) {
     out.device_id = cur.device_id;
+  }
+  // ── PDF3 (#205) ────────────────────────────────────────────────────────
+  if (cur.account_number !== init.account_number) {
+    const v = cur.account_number.trim();
+    out.account_number = v.length > 0 ? v : null;
+  }
+  if (cur.meter_serial !== init.meter_serial) {
+    const v = cur.meter_serial.trim();
+    out.meter_serial = v.length > 0 ? v : null;
+  }
+  if (cur.meter_type !== init.meter_type) {
+    // NOT NULL on the column — send the trimmed string. canSave guards
+    // against empty (route also rejects empty as 400 invalid_meter_type).
+    out.meter_type = cur.meter_type.trim();
+  }
+  if (cur.customer_type !== init.customer_type) {
+    out.customer_type = cur.customer_type;
+  }
+  if (cur.contact_email !== init.contact_email) {
+    const v = cur.contact_email.trim();
+    out.contact_email = v.length > 0 ? v : null;
   }
   return out;
 }
@@ -316,6 +361,56 @@ export function HouseholdEditDialog({
                   inputRef={firstFieldRef}
                   ariaInvalid={!displayNameValid}
                 />
+                {/* PDF3 (#205) — account_number + customer_type. */}
+                <Field
+                  id="hh-edit-account-number"
+                  label="Account number"
+                  value={state.account_number}
+                  onChange={(v) => update("account_number", v)}
+                  placeholder="Optional — appears on the PDF invoice"
+                />
+                <div>
+                  <span
+                    id="hh-edit-customer-type-label"
+                    className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                  >
+                    Customer type
+                  </span>
+                  <div
+                    role="radiogroup"
+                    aria-labelledby="hh-edit-customer-type-label"
+                    className="flex flex-row gap-4"
+                  >
+                    <label
+                      htmlFor="hh-edit-customer-type-residential"
+                      className="flex cursor-pointer items-center gap-2 text-sm text-foreground"
+                    >
+                      <input
+                        id="hh-edit-customer-type-residential"
+                        type="radio"
+                        name="hh-edit-customer-type"
+                        value="residential"
+                        checked={state.customer_type === "residential"}
+                        onChange={() => update("customer_type", "residential")}
+                      />
+                      <span>Residential</span>
+                    </label>
+                    <label
+                      htmlFor="hh-edit-customer-type-commercial"
+                      className="flex cursor-pointer items-center gap-2 text-sm text-foreground"
+                    >
+                      <input
+                        id="hh-edit-customer-type-commercial"
+                        type="radio"
+                        name="hh-edit-customer-type"
+                        value="commercial"
+                        checked={state.customer_type === "commercial"}
+                        onChange={() => update("customer_type", "commercial")}
+                      />
+                      <span>Commercial</span>
+                    </label>
+                  </div>
+                </div>
               </Section>
 
               {/* CONTACT */}
@@ -344,6 +439,15 @@ export function HouseholdEditDialog({
                     ariaInvalid={phoneInvalid}
                   />
                 </Pair>
+                {/* PDF3 (#205) — contact_email. */}
+                <Field
+                  id="hh-edit-contact-email"
+                  label="Contact email"
+                  type="email"
+                  value={state.contact_email}
+                  onChange={(v) => update("contact_email", v)}
+                  placeholder="For billing questions (optional)"
+                />
               </Section>
 
               {/* BILLING DEVICE */}
@@ -352,6 +456,25 @@ export function HouseholdEditDialog({
                 helper="The consumption meter that produces this household's bill each period. Unassigned households are skipped at billing time."
                 helperId={DEVICE_HELPER_ID}
               >
+                {/* PDF3 (#205) — meter_serial + meter_type pair, ABOVE the
+                    DeviceSelect (these are physical-device descriptors that
+                    pair logically with the meter assignment). */}
+                <Pair>
+                  <Field
+                    id="hh-edit-meter-serial"
+                    label="Meter serial"
+                    value={state.meter_serial}
+                    onChange={(v) => update("meter_serial", v)}
+                    placeholder="Optional — physical serial"
+                  />
+                  <Field
+                    id="hh-edit-meter-type"
+                    label="Meter type"
+                    value={state.meter_type}
+                    onChange={(v) => update("meter_type", v)}
+                    placeholder="Smart Submeter"
+                  />
+                </Pair>
                 <DeviceSelect
                   devices={devicesForPicker}
                   value={state.device_id}

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -29,7 +29,7 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Banner } from "@/components/ui/banner";
-import { RadioGroup } from "@/components/ui/radio-group";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { RadioCard } from "@/components/ui/radio-card";
 import { StatusChip } from "@/components/ui/status-chip";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -104,6 +104,16 @@ type FormState = {
    * valid regardless of meter count when this is set.
    */
   no_meter: boolean;
+  // PDF3 (#205) — household PDF-invoice identity fields. account_number,
+  // meter_serial, contact_email are optional (empty-string → null on
+  // submit). meter_type / customer_type are NOT NULL on the column;
+  // EMPTY_STATE seeds them with the DB defaults so a save without edits
+  // produces canonical values.
+  account_number: string;
+  meter_serial: string;
+  meter_type: string;
+  customer_type: "residential" | "commercial";
+  contact_email: string;
 };
 
 const EMPTY_STATE: FormState = {
@@ -120,6 +130,14 @@ const EMPTY_STATE: FormState = {
   geography_notes: "",
   device_id: "",
   no_meter: false,
+  // PDF3 (#205) defaults — mirror the PDF1a column DEFAULTs so a "Save with
+  // no edits" produces the canonical values without relying on the
+  // RPC-side COALESCE alone.
+  account_number: "",
+  meter_serial: "",
+  meter_type: "Smart Submeter",
+  customer_type: "residential",
+  contact_email: "",
 };
 
 const STEP_LABELS: Record<Step, string> = {
@@ -164,6 +182,10 @@ function isStepValid(step: Step, state: FormState, meterCount: number): boolean 
 }
 
 function hasAnyData(state: FormState): boolean {
+  // PDF3 (#205): meter_type / customer_type are seeded to canonical defaults
+  // in EMPTY_STATE, so we compare against those literals to detect "user
+  // changed something". account_number / meter_serial / contact_email all
+  // start as "" so a non-empty trim signals user edits.
   return (
     state.display_name.trim().length > 0 ||
     state.primary_phone.trim().length > 0 ||
@@ -177,7 +199,12 @@ function hasAnyData(state: FormState): boolean {
     state.address_postal_code.trim().length > 0 ||
     state.geography_notes.trim().length > 0 ||
     state.device_id.length > 0 ||
-    state.no_meter
+    state.no_meter ||
+    state.account_number.trim().length > 0 ||
+    state.meter_serial.trim().length > 0 ||
+    state.meter_type.trim() !== "Smart Submeter" ||
+    state.customer_type !== "residential" ||
+    state.contact_email.trim().length > 0
   );
 }
 
@@ -374,6 +401,15 @@ export function HouseholdWizard({
           // The route distinguishes the two paths and dispatches to
           // fn_create_household vs fn_create_household_with_meter.
           device_id: state.no_meter ? null : state.device_id,
+          // PDF3 (#205) — household PDF-invoice identity fields.
+          // Optional ones: empty-string → null. Required-on-column ones
+          // (meter_type / customer_type) always send the form's value
+          // (EMPTY_STATE seeds canonical defaults).
+          account_number: state.account_number.trim() || null,
+          meter_serial: state.meter_serial.trim() || null,
+          meter_type: state.meter_type.trim() || "Smart Submeter",
+          customer_type: state.customer_type,
+          contact_email: state.contact_email.trim() || null,
         }),
       });
       if (!res.ok) {
@@ -702,6 +738,23 @@ function StepBasics({
           aria-required="true"
         />
       </div>
+      {/* PDF3 (#205) — Account Number (optional, ≤ 30 chars). */}
+      <div>
+        <label
+          htmlFor="hh-account-number"
+          className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Account number
+        </label>
+        <Input
+          id="hh-account-number"
+          type="text"
+          maxLength={30}
+          value={state.account_number}
+          onChange={(e) => update("account_number", e.target.value)}
+          placeholder="Optional — appears on the PDF invoice"
+        />
+      </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label
@@ -750,6 +803,60 @@ function StepBasics({
             placeholder="optional"
           />
         </div>
+      </div>
+      {/* PDF3 (#205) — Customer type (radio group; default residential). */}
+      <div>
+        <span
+          id="hh-customer-type-label"
+          className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Customer type
+        </span>
+        <RadioGroup
+          value={state.customer_type}
+          onValueChange={(v) =>
+            update("customer_type", v as "residential" | "commercial")
+          }
+          aria-labelledby="hh-customer-type-label"
+          className="flex flex-row gap-4"
+        >
+          <label
+            htmlFor="hh-customer-type-residential"
+            className="flex cursor-pointer items-center gap-2 text-sm text-foreground"
+          >
+            <RadioGroupItem
+              id="hh-customer-type-residential"
+              value="residential"
+            />
+            <span>Residential</span>
+          </label>
+          <label
+            htmlFor="hh-customer-type-commercial"
+            className="flex cursor-pointer items-center gap-2 text-sm text-foreground"
+          >
+            <RadioGroupItem
+              id="hh-customer-type-commercial"
+              value="commercial"
+            />
+            <span>Commercial</span>
+          </label>
+        </RadioGroup>
+      </div>
+      {/* PDF3 (#205) — Contact email (optional; format-validated server-side). */}
+      <div>
+        <label
+          htmlFor="hh-contact-email"
+          className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          Contact email
+        </label>
+        <Input
+          id="hh-contact-email"
+          type="email"
+          value={state.contact_email}
+          onChange={(e) => update("contact_email", e.target.value)}
+          placeholder="For billing questions (optional)"
+        />
       </div>
     </fieldset>
   );
@@ -947,6 +1054,45 @@ function StepMeter({
     <fieldset className="space-y-4" disabled={disabled}>
       <legend className="sr-only">Step 3 of 4: Meter assignment</legend>
 
+      {/* PDF3 (#205) — physical-device descriptors that pair with the
+          meter assignment. Editable in both branches (no_meter included)
+          so the operator can record the physical serial even when the
+          OpenEMS link isn't established. */}
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label
+            htmlFor="hh-meter-serial"
+            className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Meter serial
+          </label>
+          <Input
+            id="hh-meter-serial"
+            type="text"
+            maxLength={50}
+            value={state.meter_serial}
+            onChange={(e) => update("meter_serial", e.target.value)}
+            placeholder="Optional — physical serial"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="hh-meter-type"
+            className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Meter type
+          </label>
+          <Input
+            id="hh-meter-type"
+            type="text"
+            maxLength={50}
+            value={state.meter_type}
+            onChange={(e) => update("meter_type", e.target.value)}
+            placeholder="Smart Submeter"
+          />
+        </div>
+      </div>
+
       {/* #158: no-meter (manual billing) checkbox. */}
       <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border bg-card p-3 hover:bg-muted">
         <input
@@ -1112,12 +1258,26 @@ function StepReview({
       >
         <ReviewRow label="Display name" value={state.display_name} />
         <ReviewRow
+          label="Account number"
+          value={state.account_number || "—"}
+        />
+        <ReviewRow
           label="Primary phone"
           value={state.primary_phone || "—"}
         />
         <ReviewRow
           label="Primary email"
           value={state.primary_email || "—"}
+        />
+        <ReviewRow
+          label="Customer type"
+          value={
+            state.customer_type === "commercial" ? "Commercial" : "Residential"
+          }
+        />
+        <ReviewRow
+          label="Contact email"
+          value={state.contact_email || "—"}
         />
       </ReviewSection>
 
@@ -1142,6 +1302,14 @@ function StepReview({
       </ReviewSection>
 
       <ReviewSection title="Primary meter" onEdit={() => onJumpTo(3)}>
+        {/* PDF3 (#205) — physical-device descriptors render regardless of
+            no_meter. They describe the physical device, not the
+            OpenEMS link. */}
+        <ReviewRow label="Meter serial" value={state.meter_serial || "—"} />
+        <ReviewRow
+          label="Meter type"
+          value={state.meter_type || "Smart Submeter"}
+        />
         {state.no_meter ? (
           // #158: explicit no-meter review row (manual billing path).
           <ReviewRow

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -21,6 +21,7 @@ type Kind =
   | "edgeSource"
   | "deviceType"
   | "household"
+  | "householdCustomerType"
   | "householdDeviceRole"
   | "meter"
   | "meterType"
@@ -83,6 +84,15 @@ const MAPS: Record<Kind, StatusMap> = {
     active:   { label: "Active",   tone: "success", dot: true },
     inactive: { label: "Inactive", tone: "neutral", dot: true },
     disputed: { label: "Disputed", tone: "alert",   dot: true },
+  },
+  // PDF3 (#205) — household customer-type chip surfaced inside the
+  // HouseholdTable's Household cell. Mirrors the `customer_type` column
+  // (residential | commercial; PDF1a / 00033). No `info` tone in the
+  // existing tone set — `neutral` (resting; the majority class) and
+  // `brand` (visually distinct; commercial) carry the contrast.
+  householdCustomerType: {
+    residential: { label: "Residential", tone: "neutral" },
+    commercial:  { label: "Commercial",  tone: "brand"   },
   },
   // Canonical device-type chip — mirrors `device_type` enum in AB #50.
   // Tone rationale (per mock mgm-ia-v1.html § IA note line 1794):

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -1018,15 +1018,20 @@ export type Database = {
       }
       fn_create_household: {
         Args: {
+          p_account_number?: string
           p_address_city?: string
           p_address_country?: string
           p_address_line1?: string
           p_address_line2?: string
           p_address_postal_code?: string
           p_address_region?: string
+          p_contact_email?: string
+          p_customer_type?: string
           p_device_id?: string
           p_display_name: string
           p_geography_notes?: string
+          p_meter_serial?: string
+          p_meter_type?: string
           p_microgrid_id: string
           p_primary_email?: string
           p_primary_phone?: string
@@ -1036,15 +1041,20 @@ export type Database = {
       }
       fn_create_household_with_meter: {
         Args: {
+          p_account_number?: string
           p_address_city?: string
           p_address_country?: string
           p_address_line1?: string
           p_address_line2?: string
           p_address_postal_code?: string
           p_address_region?: string
+          p_contact_email?: string
+          p_customer_type?: string
           p_device_id: string
           p_display_name: string
           p_geography_notes?: string
+          p_meter_serial?: string
+          p_meter_type?: string
           p_microgrid_id: string
           p_primary_email?: string
           p_primary_phone?: string

--- a/supabase/migrations/00034_household_rpc_widen_pdf_fields.sql
+++ b/supabase/migrations/00034_household_rpc_widen_pdf_fields.sql
@@ -1,0 +1,298 @@
+-- 00034_household_rpc_widen_pdf_fields.sql
+-- PDF Invoices (#205 / PDF3): widen fn_create_household + the
+-- fn_create_household_with_meter wrapper so the Add Household wizard and
+-- POST /api/households/with-meter route can persist the 5 PDF1a (#202)
+-- columns at create time:
+--
+--   p_account_number, p_meter_serial, p_meter_type,
+--   p_customer_type,  p_contact_email
+--
+-- All 5 are trailing optional parameters with DEFAULT NULL. Existing
+-- callers (legacy 13-arg invocations) continue to work unchanged.
+--
+-- ── Why DROP-then-CREATE on both signatures ──────────────────────────────
+--
+-- `CREATE OR REPLACE FUNCTION` only replaces a function with the EXACT
+-- arg-type list. Adding 5 new args produces a NEW 18-arg overload alongside
+-- the existing 13-arg one — which is precisely the PostgREST overload-
+-- ambiguity that #158 / migration 00023 already had to fix:
+--
+--   "Could not choose the best candidate function between:
+--      public.fn_create_household_with_meter(uuid,text,uuid,text,text,...)  -- 13-arg
+--      public.fn_create_household_with_meter(uuid,text,uuid,text,text,...)  -- 18-arg
+--    "
+--
+-- Fix mirrors 00023: DROP both 13-arg signatures FIRST, then CREATE OR
+-- REPLACE both 18-arg signatures. supabase-js passes explicit values for
+-- all named params (the route in src/app/api/households/with-meter/route.ts
+-- forwards every key on `rpcArgs`), so resolution is unambiguous post-drop.
+--
+-- ── Wrapper relationship (mirrors 00026) ─────────────────────────────────
+--
+-- Post-#158 (migration 00026), `fn_create_household_with_meter` is a thin
+-- wrapper that delegates to `fn_create_household` with a non-null
+-- p_device_id. The widening propagates: the wrapper accepts the 5 new
+-- params and forwards them verbatim to `fn_create_household`.
+--
+-- ── NULL-vs-DEFAULT for meter_type / customer_type ───────────────────────
+--
+-- PDF1a (#202 / migration 00033) added:
+--   meter_type    TEXT NOT NULL DEFAULT 'Smart Submeter'
+--   customer_type TEXT NOT NULL DEFAULT 'residential'
+--
+-- The column DEFAULT only applies when the INSERT OMITS the column.
+-- Supplying a NULL VALUE bypasses the DEFAULT and would violate NOT NULL.
+-- The wizard / edit dialog operator can leave these blank and the route
+-- will pass the form's "" → null path through to the RPC, so the RPC body
+-- uses COALESCE(p_meter_type, 'Smart Submeter') (and the analogous
+-- 'residential' for customer_type) inside the INSERT to honor the DEFAULT
+-- semantics explicitly.
+--
+-- ── Idempotency ──────────────────────────────────────────────────────────
+--
+-- DROP FUNCTION IF EXISTS — safe to re-run. The CREATE OR REPLACE that
+-- follows always executes; if the function exists at the new arity it's
+-- replaced. GRANT EXECUTE is unconditional and idempotent in Postgres.
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 1. Drop the existing 13-arg signatures (per 00023 precedent).
+-- ═════════════════════════════════════════════════════════════════════════
+
+DROP FUNCTION IF EXISTS fn_create_household_with_meter(
+  UUID,    -- p_microgrid_id
+  TEXT,    -- p_display_name
+  UUID,    -- p_device_id
+  TEXT,    -- p_primary_phone
+  TEXT,    -- p_primary_email
+  TEXT,    -- p_address_line1
+  TEXT,    -- p_address_line2
+  TEXT,    -- p_unit_label
+  TEXT,    -- p_address_city
+  TEXT,    -- p_address_region
+  TEXT,    -- p_address_country
+  TEXT,    -- p_address_postal_code
+  TEXT     -- p_geography_notes
+);
+
+DROP FUNCTION IF EXISTS fn_create_household(
+  UUID,    -- p_microgrid_id
+  TEXT,    -- p_display_name
+  UUID,    -- p_device_id
+  TEXT,    -- p_primary_phone
+  TEXT,    -- p_primary_email
+  TEXT,    -- p_address_line1
+  TEXT,    -- p_address_line2
+  TEXT,    -- p_unit_label
+  TEXT,    -- p_address_city
+  TEXT,    -- p_address_region
+  TEXT,    -- p_address_country
+  TEXT,    -- p_address_postal_code
+  TEXT     -- p_geography_notes
+);
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 2. Recreate fn_create_household with 18 args (13 existing + 5 new).
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Signature shape preserved from 00026; the 5 new trailing optional params
+-- (account_number, meter_serial, meter_type, customer_type, contact_email)
+-- correspond directly to the columns added by 00033 (PDF1a).
+--
+-- Body is otherwise identical to 00026: phone-required guard (#155),
+-- device-belongs-to-microgrid + consumption_meter guards (only when
+-- p_device_id is non-null), then INSERT into households, then optional
+-- household_devices link.
+
+CREATE OR REPLACE FUNCTION fn_create_household(
+  p_microgrid_id        UUID,
+  p_display_name        TEXT,
+  p_device_id           UUID    DEFAULT NULL,
+  p_primary_phone       TEXT    DEFAULT NULL,
+  p_primary_email       TEXT    DEFAULT NULL,
+  p_address_line1       TEXT    DEFAULT NULL,
+  p_address_line2       TEXT    DEFAULT NULL,
+  p_unit_label          TEXT    DEFAULT NULL,
+  p_address_city        TEXT    DEFAULT NULL,
+  p_address_region      TEXT    DEFAULT NULL,
+  p_address_country     TEXT    DEFAULT NULL,
+  p_address_postal_code TEXT    DEFAULT NULL,
+  p_geography_notes     TEXT    DEFAULT NULL,
+  p_account_number      TEXT    DEFAULT NULL,
+  p_meter_serial        TEXT    DEFAULT NULL,
+  p_meter_type          TEXT    DEFAULT NULL,
+  p_customer_type       TEXT    DEFAULT NULL,
+  p_contact_email       TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  _household_id UUID;
+BEGIN
+  -- Guard 0 (#155): phone is required for Pesapal billing-address contact.
+  IF p_primary_phone IS NULL OR trim(p_primary_phone) = '' THEN
+    RAISE EXCEPTION 'household_phone_required';
+  END IF;
+
+  -- Guards 1 + 2 only apply when a device is being linked.
+  IF p_device_id IS NOT NULL THEN
+    -- Guard 1: device's edge must belong to the target microgrid.
+    IF NOT EXISTS (
+      SELECT 1
+      FROM devices d
+      JOIN edges e ON e.id = d.edge_id
+      WHERE d.id = p_device_id
+        AND e.microgrid_id = p_microgrid_id
+    ) THEN
+      RAISE EXCEPTION
+        'device % does not belong to microgrid %',
+        p_device_id, p_microgrid_id;
+    END IF;
+
+    -- Guard 2: device must be of type consumption_meter.
+    IF (SELECT device_type FROM devices WHERE id = p_device_id) <> 'consumption_meter' THEN
+      RAISE EXCEPTION
+        'device % is not a consumption_meter',
+        p_device_id;
+    END IF;
+  END IF;
+
+  -- Atomic insert (+ optional device link). RLS on households /
+  -- household_devices applies via SECURITY INVOKER.
+  --
+  -- COALESCE on meter_type / customer_type so a NULL caller-arg honors the
+  -- column DEFAULT explicitly (Postgres can't fall through to DEFAULT when
+  -- a NULL VALUE is supplied).
+  INSERT INTO households (
+    microgrid_id,
+    display_name,
+    primary_phone,
+    primary_email,
+    address_line1,
+    address_line2,
+    unit_label,
+    address_city,
+    address_region,
+    address_country,
+    address_postal_code,
+    geography_notes,
+    account_number,
+    meter_serial,
+    meter_type,
+    customer_type,
+    contact_email
+  ) VALUES (
+    p_microgrid_id,
+    p_display_name,
+    p_primary_phone,
+    p_primary_email,
+    p_address_line1,
+    p_address_line2,
+    p_unit_label,
+    p_address_city,
+    p_address_region,
+    p_address_country,
+    p_address_postal_code,
+    p_geography_notes,
+    p_account_number,
+    p_meter_serial,
+    COALESCE(p_meter_type,    'Smart Submeter'),
+    COALESCE(p_customer_type, 'residential'),
+    p_contact_email
+  )
+  RETURNING id INTO _household_id;
+
+  IF p_device_id IS NOT NULL THEN
+    INSERT INTO household_devices (household_id, device_id, role)
+    VALUES (_household_id, p_device_id, 'primary_consumption_meter');
+  END IF;
+
+  RETURN _household_id;
+END;
+$$;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 3. Recreate fn_create_household_with_meter wrapper with 18 args.
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Mirrors 00026's wrapper shape — delegates to fn_create_household with
+-- a non-null p_device_id and forwards the 5 new params verbatim.
+
+CREATE OR REPLACE FUNCTION fn_create_household_with_meter(
+  p_microgrid_id        UUID,
+  p_display_name        TEXT,
+  p_device_id           UUID,
+  p_primary_phone       TEXT    DEFAULT NULL,
+  p_primary_email       TEXT    DEFAULT NULL,
+  p_address_line1       TEXT    DEFAULT NULL,
+  p_address_line2       TEXT    DEFAULT NULL,
+  p_unit_label          TEXT    DEFAULT NULL,
+  p_address_city        TEXT    DEFAULT NULL,
+  p_address_region      TEXT    DEFAULT NULL,
+  p_address_country     TEXT    DEFAULT NULL,
+  p_address_postal_code TEXT    DEFAULT NULL,
+  p_geography_notes     TEXT    DEFAULT NULL,
+  p_account_number      TEXT    DEFAULT NULL,
+  p_meter_serial        TEXT    DEFAULT NULL,
+  p_meter_type          TEXT    DEFAULT NULL,
+  p_customer_type       TEXT    DEFAULT NULL,
+  p_contact_email       TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN fn_create_household(
+    p_microgrid_id        => p_microgrid_id,
+    p_display_name        => p_display_name,
+    p_device_id           => p_device_id,
+    p_primary_phone       => p_primary_phone,
+    p_primary_email       => p_primary_email,
+    p_address_line1       => p_address_line1,
+    p_address_line2       => p_address_line2,
+    p_unit_label          => p_unit_label,
+    p_address_city        => p_address_city,
+    p_address_region      => p_address_region,
+    p_address_country     => p_address_country,
+    p_address_postal_code => p_address_postal_code,
+    p_geography_notes     => p_geography_notes,
+    p_account_number      => p_account_number,
+    p_meter_serial        => p_meter_serial,
+    p_meter_type          => p_meter_type,
+    p_customer_type       => p_customer_type,
+    p_contact_email       => p_contact_email
+  );
+END;
+$$;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 4. Re-grant EXECUTE on both new 18-arg signatures.
+-- ═════════════════════════════════════════════════════════════════════════
+
+GRANT EXECUTE ON FUNCTION fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO service_role;
+
+GRANT EXECUTE ON FUNCTION fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+) TO service_role;


### PR DESCRIPTION
Closes #205

## Summary
- **Migration `00034_household_rpc_widen_pdf_fields.sql`** — DROPs the existing 13-arg signatures of both `fn_create_household_with_meter` and `fn_create_household` (the wrapper relationship from 00026), then CREATEs both with 5 new optional params (`p_account_number`, `p_meter_serial`, `p_meter_type`, `p_customer_type`, `p_contact_email`). `COALESCE(p_meter_type, 'Smart Submeter')` / `COALESCE(p_customer_type, 'residential')` honor the column DEFAULTs from PDF1a when callers pass NULL. Idempotent + defensive `GRANT EXECUTE`.
- **Wizard fields**: Step 1 (Basics) gains Account Number, Customer Type radio, Contact Email. Step 3 (Meter) gains Meter Serial + Meter Type pair above the existing meter picker. Step 4 (Review) renders the 5 new ReviewRows.
- **Edit dialog fields**: same 5 fields slotted into Identity / Contact / Billing-device sections. `[open, init]` reset effect with `useMemo`-derived init preserved unchanged.
- **PATCH `/api/households/[id]`** route extended with hand-coded validators (matching the existing `nullableString` + `ALLOWED_FIELDS Set` pattern; NOT Zod). Per-field 400 reasons (`account_number_too_long`, `invalid_meter_type`, `invalid_customer_type`, `invalid_contact_email`, etc.).
- **POST `/api/households/with-meter`** forwards the 5 new fields to the widened RPC.
- **Table**: Account Number column between Household and Address. Customer Type chip via new `<StatusChip kind="householdCustomerType">` (`residential → neutral`, `commercial → brand`). Meter Serial NOT shown in table.
- **Row action "Download bill (PDF)"** in `<RowActionsMenu>` (always visible, including refunded rows). Probe-then-anchor-click pattern: `fetch(pdfUrl)` → `r.ok` triggers a hidden `<a>` click without the `download` attribute (route's `Content-Disposition: attachment` drives behavior); `!r.ok` parses `{ error, reason }` and pushes a destructive banner via `<RowBannerStack>`.
- **Tests**: 6 new inclusion-style `expect(labels).toContain('Download bill (PDF)')` assertions across the designer-matrix `it()` blocks; new describe block exercises the 422 error path.

## Why
Closes the PDF Invoices workstream. Aaron can now capture identity fields (account number, meter serial, meter type, customer type, contact email) at household creation/edit time, AND download a branded PDF bill in one click from the billing-period row.

## Test plan
- [x] `npm run db:types:check` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean (pre-existing warnings only).
- [x] `npm test` — 1511 passed, 35 skipped (2 pre-existing dek-bootstrap psql-binary failures).
- [x] `npm run build` — clean.
- [ ] Operator follow-up: apply migration `00034_household_rpc_widen_pdf_fields.sql` to cloud Supabase `tztbmsxxjjsryuvoyqji` via psql; verify `pg_get_functiondef('fn_create_household_with_meter(...)'::regprocedure)` shows the 18-arg signature.
- [ ] Operator follow-up: as Aaron, add a household with the new fields, edit one to add account_number/customer_type, click "Download bill (PDF)" on a billing-period row → verify the PDF downloads with `attachment` disposition and the bill renders with all the identity fields.

## Notes
- **Wizard step labels and edit dialog sections preserved**: refinement caught 5 PM-draft errors during ticket refinement (invented step/section names, wrong reset-effect deps, wrong RPC widening pattern). Implementation matches the actual codebase structure.
- **RPC overload-ambiguity guard**: BOTH `fn_create_household_with_meter` (the entry point) AND `fn_create_household` (the inner per 00026 refactor) needed DROP+CREATE; `CREATE OR REPLACE` doesn't replace differently-arity signatures and #158 already hit PostgREST overload-ambiguity from this trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)