### PR TITLE
Hotfix: drop nonexistent organizations.slug from /pdf route SELECT

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/pdf/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/pdf/__tests__/route.test.ts
@@ -226,7 +226,6 @@ function lineItemRow(overrides: Record<string, unknown> = {}) {
           organizations: {
             id: ORG_ID,
             name: "Org",
-            slug: "org",
             created_at: "2026-01-01",
           },
         },

--- a/src/app/api/billing-line-items/[lineItemId]/pdf/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/pdf/route.ts
@@ -140,7 +140,6 @@ export async function GET(
             organizations!inner (
               id,
               name,
-              slug,
               created_at
             )
           )


### PR DESCRIPTION
## Summary
- Drop `organizations.slug` from the nested PostgREST SELECT in `src/app/api/billing-line-items/[lineItemId]/pdf/route.ts`. The column doesn't exist on `organizations` (verified against cloud schema: only `id`, `name`, `created_at`, `address_*`).
- Drop the same field from the route test fixture.

## Why
Production hits `column organizations_4.slug does not exist` when the operator clicks "Download bill (PDF)" on a billing-period row. Recurrence of the hand-fabricated-SELECT pattern (architect Evolution Log entry from PR #181 / BC1): TypeScript can't catch nonexistent columns when the response type is hand-typed and the unit test mocks the response object directly.

Nothing downstream of the SELECT consumes `slug` — the renderer reads `organization.name` only.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` (PDF route slice) — 12/12 pass.
- [ ] Operator follow-up: retry "Download bill (PDF)" — expect 200 PDF stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)