### PR TITLE
PDF4 — Bump invoice logo size limit to 2 MB (#210)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/invoice/logo-upload-control.tsx
+++ b/src/app/(dashboard)/communities/[id]/invoice/logo-upload-control.tsx
@@ -9,8 +9,8 @@
  *
  * Client-side validation (defense-in-depth — the server also re-validates):
  *   - MIME: image/png, image/jpeg, image/svg+xml.
- *   - Size: ≤ 500 KB (the bucket caps at 1 MiB; 500 KB keeps deploy/preview
- *     bundles small).
+ *   - Size: ≤ 2 MB (the bucket caps at 2 MiB; client + server + bucket
+ *     limits are equal — defense-in-depth).
  *
  * Preview: `URL.createObjectURL()` blob URI rendered inline before the
  * upload click. We revoke the blob URL on unmount and on successful upload.
@@ -33,7 +33,7 @@ const ALLOWED_MIME_SET = new Set<string>([
   "image/svg+xml",
 ]);
 
-const CLIENT_MAX_BYTES = 500 * 1024; // 500 KB.
+const CLIENT_MAX_BYTES = 2 * 1024 * 1024; // 2 MB.
 
 export type LogoUploadResult = {
   logo_storage_path: string;
@@ -89,7 +89,7 @@ export function LogoUploadControl({
     }
     if (file.size > CLIENT_MAX_BYTES) {
       setError(
-        `File is too large (${Math.round(file.size / 1024)} KB). Maximum 500 KB.`,
+        `File is too large (${Math.round(file.size / 1024)} KB). Maximum 2 MB.`,
       );
       return;
     }
@@ -209,7 +209,7 @@ export function LogoUploadControl({
           />
         ) : (
           <p className="text-xs text-muted-foreground">
-            Drag a logo here or click to browse (PNG, JPG, SVG, up to 500 KB)
+            Drag a logo here or click to browse (PNG, JPG, SVG, up to 2 MB)
           </p>
         )}
         {(draftPreviewUrl || persistedThumbnailSrc) && (

--- a/src/app/api/communities/[id]/invoice-logo/__tests__/route.test.ts
+++ b/src/app/api/communities/[id]/invoice-logo/__tests__/route.test.ts
@@ -3,7 +3,7 @@
  *
  * Mocks Supabase + service-role storage + auth. Covers:
  *   (1) Happy path → 200, returns logo_storage_path + signed_thumbnail_url
- *   (2) Oversized file (>1 MB server cap) → 400
+ *   (2) Oversized file (>2 MB server cap) → 400
  *   (3) Wrong MIME → 400
  *   (4) Missing `file` field → 400
  *   (5) Cross-org → 403, NO upload attempted
@@ -121,9 +121,9 @@ describe("POST /api/communities/[id]/invoice-logo", () => {
     expect(uploadMock).toHaveBeenCalledTimes(1);
   });
 
-  it("(2) oversized file (>1 MB) → 400", async () => {
+  it("(2) oversized file (>2 MB) → 400", async () => {
     const fd = new FormData();
-    const oversized = new Blob([new Uint8Array(2 * 1024 * 1024)], {
+    const oversized = new Blob([new Uint8Array(2 * 1024 * 1024 + 1)], {
       type: "image/png",
     });
     fd.append("file", new File([oversized], "big.png", { type: "image/png" }));

--- a/src/app/api/communities/[id]/invoice-logo/route.ts
+++ b/src/app/api/communities/[id]/invoice-logo/route.ts
@@ -20,8 +20,9 @@ import { currentUserCanAccessOrg } from "@/lib/auth/access";
  * never wire a public, unauthenticated endpoint that returns the raw bytes
  * from `invoice-logos`** — that's the only place XSS would reactivate.
  *
- * Server-side defense-in-depth on size: 1 MB cap (UI enforces 500 KB tighter
- * client-side). The bucket also caps at 1 MiB in 00033.
+ * Server-side defense-in-depth on size: 2 MB cap (UI also enforces 2 MB;
+ * bucket caps at 2 MiB via the 00035 migration). Client + server + bucket
+ * are equal — defense-in-depth.
  *
  * Path schema: `{community.id}/{Date.now()}-{crypto.randomUUID()}.{ext}`.
  * `crypto.randomUUID()` is cryptographically random; collision is effectively
@@ -32,7 +33,7 @@ import { currentUserCanAccessOrg } from "@/lib/auth/access";
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1 MB server-side cap.
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB server-side cap.
 
 const ALLOWED_MIME = new Set<string>([
   "image/png",
@@ -128,7 +129,7 @@ export async function POST(
 
   if (file.size > MAX_FILE_SIZE_BYTES) {
     return NextResponse.json(
-      { error: "File too large. Maximum size is 1 MB." },
+      { error: "File too large. Maximum size is 2 MB." },
       { status: 400 },
     );
   }

--- a/supabase/migrations/00035_bump_invoice_logo_size_to_2mb.sql
+++ b/supabase/migrations/00035_bump_invoice_logo_size_to_2mb.sql
@@ -1,0 +1,16 @@
+-- 00035_bump_invoice_logo_size_to_2mb.sql
+-- PDF Invoices (#210 / PDF4): bump the `invoice-logos` Storage bucket's
+-- file_size_limit from 1 MiB to 2 MiB.
+--
+-- Supersedes the inline `file_size_limit = 1048576` set at
+-- 00033_pdf_invoices_schema.sql:302. Operator-asked: 2 MB is the new ceiling
+-- for community invoice logos. Defense-in-depth: this aligns the bucket cap
+-- with the route + UI limits (both also bumped to 2 MB in the same change).
+--
+-- Idempotent by construction: a bare UPDATE re-runs cleanly. If the bucket
+-- row is missing (fresh DB never ran 00033), this matches zero rows — fine;
+-- bucket creation remains 00033's responsibility.
+
+UPDATE storage.buckets
+SET file_size_limit = 2097152
+WHERE id = 'invoice-logos';


### PR DESCRIPTION
Closes #210

## Summary
- **Migration `00035_bump_invoice_logo_size_to_2mb.sql`** — idempotent `UPDATE storage.buckets SET file_size_limit = 2097152 WHERE id = 'invoice-logos';`. Supersedes the 1MB cap from `00033:302`.
- **Server-side**: `MAX_FILE_SIZE_BYTES` raised from 1MB → 2MB in `invoice-logo/route.ts`. Error copy now says "2 MB".
- **Client-side**: `CLIENT_MAX_BYTES` raised from 500KB → 2MB in `logo-upload-control.tsx`. Dropzone hint + error copy aligned.
- **Test fixture**: oversized case bumped to `2*1024*1024 + 1` to strictly exceed the new cap.

## Why
Operators uploading high-resolution org logos (Aaron's NFE branding asset is ~1.2 MB) hit the prior 500 KB / 1 MB limits. 2 MB matches the `<Image>` rendering practice for `@react-pdf/renderer` without inflating PDF output substantially.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm test` (invoice-logo route slice) — 8/8 pass.
- [x] `npm run build` — clean.
- [x] Local: `supabase db reset` + `SELECT file_size_limit FROM storage.buckets WHERE id='invoice-logos'` → 2097152.
- [ ] Operator follow-up: apply migration `00035` to cloud Supabase `tztbmsxxjjsryuvoyqji` AHEAD of merging this PR's code (so the bucket cap matches when Vercel rebuilds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)