### PR TITLE
PDF5 — Drop duplicate households.contact_email; reuse primary_email (#211)

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/pdf/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/pdf/__tests__/route.test.ts
@@ -240,7 +240,6 @@ function lineItemRow(overrides: Record<string, unknown> = {}) {
       address_line2: null,
       address_postal_code: null,
       address_region: null,
-      contact_email: null,
       created_at: "2026-01-01",
       customer_type: "residential",
       display_name: "Aaron",

--- a/src/app/api/billing-line-items/[lineItemId]/pdf/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/pdf/route.ts
@@ -154,7 +154,6 @@ export async function GET(
         address_line2,
         address_postal_code,
         address_region,
-        contact_email,
         created_at,
         customer_type,
         display_name,

--- a/src/app/api/households/[id]/route.ts
+++ b/src/app/api/households/[id]/route.ts
@@ -73,7 +73,6 @@ const ALLOWED_FIELDS = new Set([
   "meter_serial",
   "meter_type",
   "customer_type",
-  "contact_email",
 ]);
 
 // PDF3 (#205) — length caps and format mirror the PDF1a (#202) column
@@ -82,10 +81,6 @@ const ACCOUNT_NUMBER_MAX_LENGTH = 30;
 const METER_SERIAL_MAX_LENGTH = 50;
 const METER_TYPE_MAX_LENGTH = 50;
 const CUSTOMER_TYPES = new Set(["residential", "commercial"]);
-// Format-only check — mirrors households_contact_email_format CHECK in
-// 00033 (PDF1a). Deliverability is verified out-of-band, never at the
-// route boundary.
-const CONTACT_EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 
 type HouseholdUpdate = {
   display_name?: string;
@@ -104,7 +99,6 @@ type HouseholdUpdate = {
   meter_serial?: string | null;
   meter_type?: string;        // NOT NULL on the column — never set to null
   customer_type?: string;     // NOT NULL on the column — never set to null
-  contact_email?: string | null;
 };
 
 function nullableString(v: unknown): string | null | undefined {
@@ -450,28 +444,6 @@ export async function PATCH(
       );
     }
     update.customer_type = raw;
-  }
-  if ("contact_email" in bodyRec) {
-    const v = nullableString(bodyRec.contact_email);
-    if (v === undefined) {
-      return NextResponse.json(
-        {
-          error: "contact_email must be a string or null",
-          reason: "invalid_contact_email",
-        },
-        { status: 400 }
-      );
-    }
-    if (v !== null && !CONTACT_EMAIL_RE.test(v)) {
-      return NextResponse.json(
-        {
-          error: "contact_email must be a valid email address",
-          reason: "invalid_contact_email",
-        },
-        { status: 400 }
-      );
-    }
-    update.contact_email = v;
   }
 
   const hasFieldUpdate = Object.keys(update).length > 0;

--- a/src/app/api/households/with-meter/route.ts
+++ b/src/app/api/households/with-meter/route.ts
@@ -41,7 +41,6 @@ import { createClient } from "@/lib/supabase/server";
  *   meter_serial?:        string | null;     // ≤ 50 chars
  *   meter_type?:          string;            // NOT NULL; ≤ 50 chars
  *   customer_type?:       string;            // 'residential' | 'commercial'
- *   contact_email?:       string | null;     // format-validated
  * }
  *
  * Response:
@@ -122,7 +121,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const METER_SERIAL_MAX_LENGTH = 50;
   const METER_TYPE_MAX_LENGTH = 50;
   const CUSTOMER_TYPES = new Set(["residential", "commercial"]);
-  const CONTACT_EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 
   // account_number — string OR null. Length cap.
   let account_number: string | null = null;
@@ -239,37 +237,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     customer_type = body.customer_type;
   }
 
-  // contact_email — string OR null with format validation.
-  let contact_email: string | null = null;
-  if (body.contact_email !== undefined && body.contact_email !== null) {
-    if (typeof body.contact_email !== "string") {
-      return NextResponse.json(
-        {
-          error: "contact_email must be a string or null",
-          reason: "invalid_contact_email",
-          field: "contact_email",
-        },
-        { status: 400 }
-      );
-    }
-    const trimmed = body.contact_email.trim();
-    if (trimmed.length === 0) {
-      contact_email = null;
-    } else {
-      if (!CONTACT_EMAIL_RE.test(trimmed)) {
-        return NextResponse.json(
-          {
-            error: "contact_email must be a valid email address",
-            reason: "invalid_contact_email",
-            field: "contact_email",
-          },
-          { status: 400 }
-        );
-      }
-      contact_email = trimmed;
-    }
-  }
-
   const supabase = await createClient();
 
   // #158: dispatch to the meter-required wrapper (back-compat) or the
@@ -296,7 +263,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     p_meter_serial: meter_serial ?? undefined,
     p_meter_type: meter_type ?? undefined,
     p_customer_type: customer_type ?? undefined,
-    p_contact_email: contact_email ?? undefined,
   };
 
   const { data, error } = device_id

--- a/src/components/__tests__/billing-table.test.tsx
+++ b/src/components/__tests__/billing-table.test.tsx
@@ -94,7 +94,6 @@ const households: Household[] = [
     created_at: "2026-01-01T00:00:00Z",
     // PDF1a (#202) household identity fields.
     account_number: null,
-    contact_email: null,
     customer_type: "residential",
     meter_serial: null,
     meter_type: "Smart Submeter",
@@ -115,7 +114,6 @@ const households: Household[] = [
     geography_notes: null,
     created_at: "2026-01-01T00:00:00Z",
     account_number: null,
-    contact_email: null,
     customer_type: "residential",
     meter_serial: null,
     meter_type: "Smart Submeter",
@@ -136,7 +134,6 @@ const households: Household[] = [
     geography_notes: null,
     created_at: "2026-01-01T00:00:00Z",
     account_number: null,
-    contact_email: null,
     customer_type: "residential",
     meter_serial: null,
     meter_type: "Smart Submeter",

--- a/src/components/forms/HouseholdEditDialog.tsx
+++ b/src/components/forms/HouseholdEditDialog.tsx
@@ -77,7 +77,6 @@ type FormState = {
   meter_serial: string;
   meter_type: string;
   customer_type: "residential" | "commercial";
-  contact_email: string;
 };
 
 function initialState(h: Household, deviceId: string | null): FormState {
@@ -103,7 +102,6 @@ function initialState(h: Household, deviceId: string | null): FormState {
     meter_type: h.meter_type ?? "Smart Submeter",
     customer_type:
       h.customer_type === "commercial" ? "commercial" : "residential",
-    contact_email: h.contact_email ?? "",
   };
 }
 
@@ -125,8 +123,7 @@ function isDirty(cur: FormState, init: FormState): boolean {
     cur.account_number !== init.account_number ||
     cur.meter_serial !== init.meter_serial ||
     cur.meter_type !== init.meter_type ||
-    cur.customer_type !== init.customer_type ||
-    cur.contact_email !== init.contact_email
+    cur.customer_type !== init.customer_type
   );
 }
 
@@ -200,10 +197,6 @@ function buildDiff(
   }
   if (cur.customer_type !== init.customer_type) {
     out.customer_type = cur.customer_type;
-  }
-  if (cur.contact_email !== init.contact_email) {
-    const v = cur.contact_email.trim();
-    out.contact_email = v.length > 0 ? v : null;
   }
   return out;
 }
@@ -423,7 +416,7 @@ export function HouseholdEditDialog({
                 <Pair>
                   <Field
                     id="hh-edit-email"
-                    label="Primary email"
+                    label="Email"
                     type="email"
                     value={state.primary_email}
                     onChange={(v) => update("primary_email", v)}
@@ -439,15 +432,6 @@ export function HouseholdEditDialog({
                     ariaInvalid={phoneInvalid}
                   />
                 </Pair>
-                {/* PDF3 (#205) — contact_email. */}
-                <Field
-                  id="hh-edit-contact-email"
-                  label="Contact email"
-                  type="email"
-                  value={state.contact_email}
-                  onChange={(v) => update("contact_email", v)}
-                  placeholder="For billing questions (optional)"
-                />
               </Section>
 
               {/* BILLING DEVICE */}

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -105,15 +105,13 @@ type FormState = {
    */
   no_meter: boolean;
   // PDF3 (#205) — household PDF-invoice identity fields. account_number,
-  // meter_serial, contact_email are optional (empty-string → null on
-  // submit). meter_type / customer_type are NOT NULL on the column;
-  // EMPTY_STATE seeds them with the DB defaults so a save without edits
-  // produces canonical values.
+  // meter_serial are optional (empty-string → null on submit). meter_type /
+  // customer_type are NOT NULL on the column; EMPTY_STATE seeds them with
+  // the DB defaults so a save without edits produces canonical values.
   account_number: string;
   meter_serial: string;
   meter_type: string;
   customer_type: "residential" | "commercial";
-  contact_email: string;
 };
 
 const EMPTY_STATE: FormState = {
@@ -137,7 +135,6 @@ const EMPTY_STATE: FormState = {
   meter_serial: "",
   meter_type: "Smart Submeter",
   customer_type: "residential",
-  contact_email: "",
 };
 
 const STEP_LABELS: Record<Step, string> = {
@@ -184,8 +181,8 @@ function isStepValid(step: Step, state: FormState, meterCount: number): boolean 
 function hasAnyData(state: FormState): boolean {
   // PDF3 (#205): meter_type / customer_type are seeded to canonical defaults
   // in EMPTY_STATE, so we compare against those literals to detect "user
-  // changed something". account_number / meter_serial / contact_email all
-  // start as "" so a non-empty trim signals user edits.
+  // changed something". account_number / meter_serial both start as "" so a
+  // non-empty trim signals user edits.
   return (
     state.display_name.trim().length > 0 ||
     state.primary_phone.trim().length > 0 ||
@@ -203,8 +200,7 @@ function hasAnyData(state: FormState): boolean {
     state.account_number.trim().length > 0 ||
     state.meter_serial.trim().length > 0 ||
     state.meter_type.trim() !== "Smart Submeter" ||
-    state.customer_type !== "residential" ||
-    state.contact_email.trim().length > 0
+    state.customer_type !== "residential"
   );
 }
 
@@ -409,7 +405,6 @@ export function HouseholdWizard({
           meter_serial: state.meter_serial.trim() || null,
           meter_type: state.meter_type.trim() || "Smart Submeter",
           customer_type: state.customer_type,
-          contact_email: state.contact_email.trim() || null,
         }),
       });
       if (!res.ok) {
@@ -793,7 +788,7 @@ function StepBasics({
             htmlFor="hh-primary-email"
             className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
           >
-            Primary email
+            Email
           </label>
           <Input
             id="hh-primary-email"
@@ -841,22 +836,6 @@ function StepBasics({
             <span>Commercial</span>
           </label>
         </RadioGroup>
-      </div>
-      {/* PDF3 (#205) — Contact email (optional; format-validated server-side). */}
-      <div>
-        <label
-          htmlFor="hh-contact-email"
-          className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-        >
-          Contact email
-        </label>
-        <Input
-          id="hh-contact-email"
-          type="email"
-          value={state.contact_email}
-          onChange={(e) => update("contact_email", e.target.value)}
-          placeholder="For billing questions (optional)"
-        />
       </div>
     </fieldset>
   );
@@ -1266,7 +1245,7 @@ function StepReview({
           value={state.primary_phone || "—"}
         />
         <ReviewRow
-          label="Primary email"
+          label="Email"
           value={state.primary_email || "—"}
         />
         <ReviewRow
@@ -1274,10 +1253,6 @@ function StepReview({
           value={
             state.customer_type === "commercial" ? "Commercial" : "Residential"
           }
-        />
-        <ReviewRow
-          label="Contact email"
-          value={state.contact_email || "—"}
         />
       </ReviewSection>
 

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -310,7 +310,7 @@ describe("HouseholdWizard", () => {
       fillDisplayName("Block A, Unit 7");
       const phone = screen.getByLabelText(/Primary phone/i) as HTMLInputElement;
       fireEvent.change(phone, { target: { value: "+256 700 000 000" } });
-      const email = screen.getByLabelText(/Primary email/i) as HTMLInputElement;
+      const email = screen.getByLabelText(/^Email$/i) as HTMLInputElement;
       fireEvent.change(email, { target: { value: "ops@example.com" } });
       fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
 

--- a/src/lib/invoices/__tests__/render.test.ts
+++ b/src/lib/invoices/__tests__/render.test.ts
@@ -138,7 +138,6 @@ const HOUSEHOLD_AARON: Household = {
   meter_serial: "SM-882104",
   meter_type: "Smart Submeter",
   customer_type: "residential",
-  contact_email: "aaron@kisakye.ug",
   primary_email: "aaron@kisakye.ug",
   primary_phone: "+256 700 000 001",
   unit_label: "House 7",

--- a/src/lib/invoices/config-schema.ts
+++ b/src/lib/invoices/config-schema.ts
@@ -39,10 +39,10 @@ const HexColor = z.string().regex(HEX_COLOR_RE, {
 });
 
 /**
- * Format-only email validator. Matches the `households.contact_email` column
- * CHECK regex. Deliverability is verified out-of-band by tenant outreach,
- * never at the column boundary. Do NOT tighten to RFC 5322 — the format-only
- * intent is deliberate.
+ * Format-only email validator; rejects whitespace, requires `@` and `.`. Used
+ * by `seller.contact_email` (community invoice config). Deliverability is
+ * verified out-of-band, never at this boundary. Do NOT tighten to RFC 5322 —
+ * the format-only intent is deliberate.
  */
 const EmailFormat = z.string().regex(/^[^@\s]+@[^@\s]+\.[^@\s]+$/, {
   message: "must look like an email address (no whitespace, contains @ and .)",

--- a/src/lib/invoices/preview-input.ts
+++ b/src/lib/invoices/preview-input.ts
@@ -179,7 +179,6 @@ export function assembleSyntheticPreviewInput({
     id: "00000000-0000-0000-0000-000000000001",
     display_name: "Sample Household",
     account_number: "ACC-0001",
-    contact_email: null,
     customer_type: "residential",
     meter_serial: "SM-PREVIEW-0001",
     meter_type: "Smart Submeter",

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -483,7 +483,6 @@ export type Database = {
           address_line2: string | null
           address_postal_code: string | null
           address_region: string | null
-          contact_email: string | null
           created_at: string
           customer_type: string
           display_name: string
@@ -504,7 +503,6 @@ export type Database = {
           address_line2?: string | null
           address_postal_code?: string | null
           address_region?: string | null
-          contact_email?: string | null
           created_at?: string
           customer_type?: string
           display_name: string
@@ -525,7 +523,6 @@ export type Database = {
           address_line2?: string | null
           address_postal_code?: string | null
           address_region?: string | null
-          contact_email?: string | null
           created_at?: string
           customer_type?: string
           display_name?: string
@@ -1025,7 +1022,6 @@ export type Database = {
           p_address_line2?: string
           p_address_postal_code?: string
           p_address_region?: string
-          p_contact_email?: string
           p_customer_type?: string
           p_device_id?: string
           p_display_name: string
@@ -1048,7 +1044,6 @@ export type Database = {
           p_address_line2?: string
           p_address_postal_code?: string
           p_address_region?: string
-          p_contact_email?: string
           p_customer_type?: string
           p_device_id: string
           p_display_name: string

--- a/supabase/migrations/00036_households_drop_contact_email.sql
+++ b/supabase/migrations/00036_households_drop_contact_email.sql
@@ -1,0 +1,273 @@
+-- 00036_households_drop_contact_email.sql
+-- PDF Invoices (#211 / PDF5): drop the duplicate `households.contact_email`
+-- column added briefly by PDF1a (#202 / migration 00033) and reuse the
+-- pre-existing `households.primary_email` (TEXT NULL since 00001).
+--
+-- ── Rationale ─────────────────────────────────────────────────────────────
+--
+-- PDF1a's migration introduced a parallel email field next to the day-one
+-- `primary_email` column, mirroring the (already-fixed) `contact_phone` /
+-- `primary_phone` duplication. The household form now renders BOTH
+-- "Primary email" and "Contact email — for billing questions", which is
+-- confusing for operators. No downstream code reads `contact_email` (the PDF
+-- renderer's customer-support card sources the seller-side email from the
+-- community-level `invoice_config.seller.contact_email` JSONB, not from the
+-- household). Same-day cleanup: column shipped 2026-04-29 with PDF1a, dropped
+-- the same week.
+--
+-- ── Statement order MATTERS ───────────────────────────────────────────────
+--
+-- Run order:
+--   1. DROP both 18-arg function signatures (00034) — the function bodies
+--      INSERT INTO households (..., contact_email) VALUES (..., p_contact_email),
+--      so they must go FIRST or a transient state could 42703.
+--   2. Defensive backfill — preserves any operator data that landed in
+--      `contact_email` but not `primary_email`. No-op when zero such rows
+--      (expected; same-day cleanup with at most a few test entries).
+--   3. DROP CONSTRAINT then DROP COLUMN — explicit constraint drop is
+--      idempotent and matches 00033's add-constraint pattern; column-drop
+--      would cascade-drop the constraint anyway.
+--   4. RECREATE both functions at the post-PDF5 17-arg arity (the 18-arg
+--      shape from 00034 minus the trailing p_contact_email).
+--   5. GRANT EXECUTE on both new 17-arg signatures to authenticated and
+--      service_role — without GRANT, callers 403.
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 1. Drop both 18-arg signatures (per 00023 / 00034 precedent).
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Functions go FIRST so a transient state can't fire a stale function body
+-- against a dropped column. Mirrors the 00023 / 00034 overload-collision
+-- pattern: explicit arg-type list keeps PostgREST overload resolution
+-- unambiguous.
+
+DROP FUNCTION IF EXISTS fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+);
+
+DROP FUNCTION IF EXISTS fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT
+);
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 2. Defensive backfill — preserve any operator data only in contact_email.
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- AFTER function-drop (so stale bodies cannot fire) and BEFORE column-drop
+-- (so contact_email is still readable). Same-day cleanup; expected to be a
+-- no-op in production.
+
+UPDATE households
+SET primary_email = contact_email
+WHERE primary_email IS NULL AND contact_email IS NOT NULL;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 3. Drop the format CHECK then the column.
+-- ═════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE households DROP CONSTRAINT IF EXISTS households_contact_email_format;
+ALTER TABLE households DROP COLUMN IF EXISTS contact_email;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 4. Recreate fn_create_household at 17 args (drop trailing p_contact_email).
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Body matches 00034 verbatim except: the INSERT column list drops the
+-- trailing `contact_email`, and the VALUES list drops the trailing
+-- `p_contact_email`. All other behaviour preserved — phone-required guard
+-- (#155), device-belongs-to-microgrid + consumption_meter guards (only when
+-- p_device_id is non-null), COALESCE on meter_type/customer_type so a NULL
+-- caller-arg honors the column DEFAULT explicitly, optional
+-- household_devices link.
+
+CREATE OR REPLACE FUNCTION fn_create_household(
+  p_microgrid_id        UUID,
+  p_display_name        TEXT,
+  p_device_id           UUID    DEFAULT NULL,
+  p_primary_phone       TEXT    DEFAULT NULL,
+  p_primary_email       TEXT    DEFAULT NULL,
+  p_address_line1       TEXT    DEFAULT NULL,
+  p_address_line2       TEXT    DEFAULT NULL,
+  p_unit_label          TEXT    DEFAULT NULL,
+  p_address_city        TEXT    DEFAULT NULL,
+  p_address_region      TEXT    DEFAULT NULL,
+  p_address_country     TEXT    DEFAULT NULL,
+  p_address_postal_code TEXT    DEFAULT NULL,
+  p_geography_notes     TEXT    DEFAULT NULL,
+  p_account_number      TEXT    DEFAULT NULL,
+  p_meter_serial        TEXT    DEFAULT NULL,
+  p_meter_type          TEXT    DEFAULT NULL,
+  p_customer_type       TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  _household_id UUID;
+BEGIN
+  -- Guard 0 (#155): phone is required for Pesapal billing-address contact.
+  IF p_primary_phone IS NULL OR trim(p_primary_phone) = '' THEN
+    RAISE EXCEPTION 'household_phone_required';
+  END IF;
+
+  -- Guards 1 + 2 only apply when a device is being linked.
+  IF p_device_id IS NOT NULL THEN
+    -- Guard 1: device's edge must belong to the target microgrid.
+    IF NOT EXISTS (
+      SELECT 1
+      FROM devices d
+      JOIN edges e ON e.id = d.edge_id
+      WHERE d.id = p_device_id
+        AND e.microgrid_id = p_microgrid_id
+    ) THEN
+      RAISE EXCEPTION
+        'device % does not belong to microgrid %',
+        p_device_id, p_microgrid_id;
+    END IF;
+
+    -- Guard 2: device must be of type consumption_meter.
+    IF (SELECT device_type FROM devices WHERE id = p_device_id) <> 'consumption_meter' THEN
+      RAISE EXCEPTION
+        'device % is not a consumption_meter',
+        p_device_id;
+    END IF;
+  END IF;
+
+  -- Atomic insert (+ optional device link). RLS on households /
+  -- household_devices applies via SECURITY INVOKER.
+  --
+  -- COALESCE on meter_type / customer_type so a NULL caller-arg honors the
+  -- column DEFAULT explicitly (Postgres can't fall through to DEFAULT when
+  -- a NULL VALUE is supplied).
+  INSERT INTO households (
+    microgrid_id,
+    display_name,
+    primary_phone,
+    primary_email,
+    address_line1,
+    address_line2,
+    unit_label,
+    address_city,
+    address_region,
+    address_country,
+    address_postal_code,
+    geography_notes,
+    account_number,
+    meter_serial,
+    meter_type,
+    customer_type
+  ) VALUES (
+    p_microgrid_id,
+    p_display_name,
+    p_primary_phone,
+    p_primary_email,
+    p_address_line1,
+    p_address_line2,
+    p_unit_label,
+    p_address_city,
+    p_address_region,
+    p_address_country,
+    p_address_postal_code,
+    p_geography_notes,
+    p_account_number,
+    p_meter_serial,
+    COALESCE(p_meter_type,    'Smart Submeter'),
+    COALESCE(p_customer_type, 'residential')
+  )
+  RETURNING id INTO _household_id;
+
+  IF p_device_id IS NOT NULL THEN
+    INSERT INTO household_devices (household_id, device_id, role)
+    VALUES (_household_id, p_device_id, 'primary_consumption_meter');
+  END IF;
+
+  RETURN _household_id;
+END;
+$$;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 5. Recreate fn_create_household_with_meter wrapper at 17 args.
+-- ═════════════════════════════════════════════════════════════════════════
+--
+-- Mirrors 00034's wrapper shape, minus the p_contact_email forward.
+
+CREATE OR REPLACE FUNCTION fn_create_household_with_meter(
+  p_microgrid_id        UUID,
+  p_display_name        TEXT,
+  p_device_id           UUID,
+  p_primary_phone       TEXT    DEFAULT NULL,
+  p_primary_email       TEXT    DEFAULT NULL,
+  p_address_line1       TEXT    DEFAULT NULL,
+  p_address_line2       TEXT    DEFAULT NULL,
+  p_unit_label          TEXT    DEFAULT NULL,
+  p_address_city        TEXT    DEFAULT NULL,
+  p_address_region      TEXT    DEFAULT NULL,
+  p_address_country     TEXT    DEFAULT NULL,
+  p_address_postal_code TEXT    DEFAULT NULL,
+  p_geography_notes     TEXT    DEFAULT NULL,
+  p_account_number      TEXT    DEFAULT NULL,
+  p_meter_serial        TEXT    DEFAULT NULL,
+  p_meter_type          TEXT    DEFAULT NULL,
+  p_customer_type       TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN fn_create_household(
+    p_microgrid_id        => p_microgrid_id,
+    p_display_name        => p_display_name,
+    p_device_id           => p_device_id,
+    p_primary_phone       => p_primary_phone,
+    p_primary_email       => p_primary_email,
+    p_address_line1       => p_address_line1,
+    p_address_line2       => p_address_line2,
+    p_unit_label          => p_unit_label,
+    p_address_city        => p_address_city,
+    p_address_region      => p_address_region,
+    p_address_country     => p_address_country,
+    p_address_postal_code => p_address_postal_code,
+    p_geography_notes     => p_geography_notes,
+    p_account_number      => p_account_number,
+    p_meter_serial        => p_meter_serial,
+    p_meter_type          => p_meter_type,
+    p_customer_type       => p_customer_type
+  );
+END;
+$$;
+
+-- ═════════════════════════════════════════════════════════════════════════
+-- 6. Re-grant EXECUTE on both new 17-arg signatures.
+-- ═════════════════════════════════════════════════════════════════════════
+
+GRANT EXECUTE ON FUNCTION fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION fn_create_household(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT
+) TO service_role;
+
+GRANT EXECUTE ON FUNCTION fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION fn_create_household_with_meter(
+  UUID, TEXT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT, TEXT,
+  TEXT, TEXT, TEXT, TEXT
+) TO service_role;


### PR DESCRIPTION
Closes #211

## Summary
- **Migration `00036_households_drop_contact_email.sql`** in this exact order: (1) DROP both 18-arg `fn_create_household_with_meter` and `fn_create_household` signatures from 00034; (2) DROP CHECK constraint on `households.contact_email`; (3) BACKFILL `UPDATE households SET primary_email = contact_email WHERE primary_email IS NULL AND contact_email IS NOT NULL`; (4) DROP COLUMN `households.contact_email`; (5) CREATE both functions at 17 args (drops `_p_contact_email`); (6) GRANT EXECUTE on both 17-arg signatures to authenticated + service_role.
- **App-layer cascade**: dropped `contact_email` from `HouseholdWizard.tsx`, `HouseholdEditDialog.tsx`, PATCH route's `ALLOWED_FIELDS`, `with-meter` route's RPC args, the `/pdf` route's nested SELECT, and `preview-input.ts`. Renamed labels "Primary email" → "Email" at both wizard + edit dialog (form-state key remains `primary_email`).
- **`config-schema.ts`** EmailFormat doc-comment updated to point at `seller.contact_email` (community invoice_config — different field, NOT touched).
- **Test fixtures** swept clean. `render.test.ts:56`'s `seller.contact_email` correctly preserved (it's the community invoice_config seller block, NOT a household field).
- Codegen regenerated.

## Why
PDF1a (#202) added `households.contact_email` for the PDF flow without checking that `households.primary_email` (since 00001) already served the same purpose. PDF5 consolidates back to `primary_email` to eliminate the duplicate.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` — 124/124 in PDF5-affected slices (HouseholdWizard, household routes, billing-line-items routes).
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] `db:types:check` — codegen in sync.
- [ ] **CRITICAL ordering for operator**: merge this PR + wait for Vercel to deploy BEFORE applying migration `00036` to cloud (so production code never references the now-dropped column). After cloud apply, verify with `\d+ households` (no `contact_email` column) and `SELECT proname, pronargs FROM pg_proc WHERE proname IN ('fn_create_household','fn_create_household_with_meter')` returns 17 args for both.

## Notes
- Migration was renamed from `00035` to `00036` after rebase on origin/main (PR #213 / PDF4 took `00035`). Per the parallel-branch migration-numbering pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)