### PR TITLE
Drop 24h "stale" health state from OpenEMS + Payment chips (#215)

### DIFF
--- a/src/app/(dashboard)/communities/[id]/community-subnav.tsx
+++ b/src/app/(dashboard)/communities/[id]/community-subnav.tsx
@@ -46,10 +46,6 @@ function tooltipFor(data: PaymentChipData): string | null {
       return data.relativeTime
         ? `Last successful save: ${data.relativeTime}`
         : "Connection healthy";
-    case "stale":
-      return data.relativeTime
-        ? `Last save: ${data.relativeTime}. Run Save & test again to verify.`
-        : "Run Save & test again to verify.";
     case "failing":
       // Phase B (#157): emitted when the most recent IPN webhook for any
       // microgrid in this community reported `to_status='failed'` within

--- a/src/app/(dashboard)/communities/[id]/payment/__tests__/health.test.ts
+++ b/src/app/(dashboard)/communities/[id]/payment/__tests__/health.test.ts
@@ -48,7 +48,7 @@ describe("derivePaymentHealth()", () => {
     ).toBe("healthy");
   });
 
-  it("returns stale for save >= 24h ago", () => {
+  it("returns healthy for save >= 24h ago (24h cliff removed)", () => {
     expect(
       derivePaymentHealth(
         {
@@ -59,10 +59,10 @@ describe("derivePaymentHealth()", () => {
         },
         NOW,
       ),
-    ).toBe("stale");
+    ).toBe("healthy");
   });
 
-  it("returns stale when payment_provider set but payment_last_configured_at is null (defensive)", () => {
+  it("returns healthy when payment_provider set but payment_last_configured_at is null (fail-open defensive case)", () => {
     expect(
       derivePaymentHealth(
         {
@@ -71,7 +71,7 @@ describe("derivePaymentHealth()", () => {
         },
         NOW,
       ),
-    ).toBe("stale");
+    ).toBe("healthy");
   });
 
   it("returns failing when a recent IPN failure happened in the last 24h (Phase B / #157)", () => {
@@ -123,7 +123,7 @@ describe("derivePaymentHealth()", () => {
     ).toBe("healthy");
   });
 
-  it("falls back to existing healthy/stale logic when most_recent_failed_ipn_at is null", () => {
+  it("falls back to existing healthy logic when most_recent_failed_ipn_at is null", () => {
     expect(
       derivePaymentHealth(
         {

--- a/src/app/(dashboard)/communities/[id]/payment/health.ts
+++ b/src/app/(dashboard)/communities/[id]/payment/health.ts
@@ -1,24 +1,25 @@
-// Health-derivation helper for the community Payment tab (#119, #157).
+// Health-derivation helper for the community Payment tab (#119, #157, #215).
 //
 // Derives a PaymentHealth state from the community's payment_* fields PLUS
 // the most-recent payment_events failure timestamp (Phase B / #157). This
 // helper is PURE — no DB access. The layout + page each fetch the row(s)
 // and hand the result to this function.
 //
-// State table:
+// State table (post-#215 — 24h "stale" cliff dropped):
 //
 //   payment_provider IS NULL                                 → not_configured
 //   recent failed IPN event within 24h                       → failing  (Phase B)
-//   payment_last_configured_at < 24h ago                     → healthy
-//   payment_last_configured_at >= 24h ago (or null)          → stale
+//   else                                                     → healthy  (fail-open;
+//                                                              covers null timestamp,
+//                                                              recent saves, and
+//                                                              old saves alike)
 //
-// `failing` takes precedence over `healthy` / `stale` once a recent IPN
-// failure is observed — the operator should investigate before treating the
+// `failing` takes precedence over `healthy` once a recent IPN failure is
+// observed — the operator should investigate before treating the
 // integration as healthy. Phase A's MAPS entry for `failing` is wired here.
 
 export type PaymentHealth =
   | "healthy"
-  | "stale"
   | "failing"
   | "not_configured";
 
@@ -56,10 +57,8 @@ export function derivePaymentHealth(
     }
   }
 
-  if (!row.payment_last_configured_at) return "stale";
-
-  const at = new Date(row.payment_last_configured_at).getTime();
-  if (Number.isNaN(at)) return "stale";
-  const diff = now.getTime() - at;
-  return diff < TWENTY_FOUR_HOURS_MS ? "healthy" : "stale";
+  // Fail-open (#215): a configured provider with no negative signal reads
+  // healthy — including the null-timestamp defensive case and the formerly
+  // ≥24h "stale" case. "Not connected" copy is reserved for `payment_provider IS NULL`.
+  return "healthy";
 }

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/health.test.ts
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/health.test.ts
@@ -36,7 +36,7 @@ describe("deriveOpenemsBackendHealth()", () => {
     ).toBe("healthy");
   });
 
-  it("returns stale for success >= 24h ago", () => {
+  it("returns healthy for success >= 24h ago (24h cliff removed)", () => {
     expect(
       deriveOpenemsBackendHealth(
         {
@@ -48,7 +48,7 @@ describe("deriveOpenemsBackendHealth()", () => {
         },
         NOW
       )
-    ).toBe("stale");
+    ).toBe("healthy");
   });
 
   it("returns failing for auth_failed/unreachable/zero_edges/unknown_error", () => {
@@ -71,7 +71,7 @@ describe("deriveOpenemsBackendHealth()", () => {
     }
   });
 
-  it("returns stale as a catch-all for configured-but-unknown status", () => {
+  it("returns healthy as a fail-open catch-all for configured-but-unknown status", () => {
     expect(
       deriveOpenemsBackendHealth(
         {
@@ -81,6 +81,6 @@ describe("deriveOpenemsBackendHealth()", () => {
         },
         NOW
       )
-    ).toBe("stale");
+    ).toBe("healthy");
   });
 });

--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/health.ts
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/health.ts
@@ -1,20 +1,23 @@
-// Health-derivation helper for the OpenEMS Backend tab (#102).
+// Health-derivation helper for the OpenEMS Backend tab (#102, #215).
 //
-// Derives one of four health states from the microgrid's ems_* fields per
-// AC-HEALTH-DERIVATION:
+// Derives one of three health states from the microgrid's ems_* fields
+// (post-#215 — 24h "stale" cliff dropped):
 //
 //   ems_type IS NULL                                                 → not_configured
-//   ems_last_discover_status = 'success' AND < 24h ago               → healthy
-//   ems_last_discover_status = 'success' AND ≥ 24h ago               → stale
 //   ems_last_discover_status IN ('auth_failed','unreachable',
 //                                'zero_edges','unknown_error')       → failing
-//   all other cases                                                  → stale
+//   else                                                             → healthy  (fail-open;
+//                                                                      absorbs `success`
+//                                                                      regardless of age,
+//                                                                      AND the catch-all
+//                                                                      "configured but no
+//                                                                      recognized status")
 //
+// "Not connected" copy is strictly reserved for `ems_type IS NULL`.
 // Pure — no DB access. Callers (layout, page) each fetch the fields.
 
 export type OpenemsBackendHealth =
   | "healthy"
-  | "stale"
   | "failing"
   | "not_configured";
 
@@ -24,11 +27,9 @@ export type HealthInput = {
   ems_last_discover_status: string | null;
 } | null;
 
-const TWENTY_FOUR_HOURS_MS = 24 * 3600 * 1000;
-
 export function deriveOpenemsBackendHealth(
   row: HealthInput,
-  now: Date = new Date()
+  _now: Date = new Date()
 ): OpenemsBackendHealth {
   if (!row) return "not_configured";
   if (!row.ems_type) return "not_configured";
@@ -44,13 +45,8 @@ export function deriveOpenemsBackendHealth(
     return "failing";
   }
 
-  if (status === "success") {
-    if (!row.ems_last_discover_at) return "stale";
-    const at = new Date(row.ems_last_discover_at).getTime();
-    const diff = now.getTime() - at;
-    return diff < TWENTY_FOUR_HOURS_MS ? "healthy" : "stale";
-  }
-
-  // Catch-all: configured but no recognized discover status (including null).
-  return "stale";
+  // Fail-open (#215): `success` (any age) and the catch-all "configured but
+  // no recognized discover status" (including NULL) both read healthy.
+  // "Not connected" is strictly reserved for `ems_type IS NULL`.
+  return "healthy";
 }

--- a/src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/setup-subnav.tsx
@@ -44,10 +44,6 @@ function tooltipFor(data: OpenemsBackendChipData): string | null {
       return data.relativeTime
         ? `Last successful discovery: ${data.relativeTime}`
         : "Connection healthy";
-    case "stale":
-      return data.relativeTime
-        ? `Last successful discovery: ${data.relativeTime}. Run 'Test again' to verify.`
-        : "Run 'Test again' to verify the connection.";
     case "failing":
       return data.lastDiscoverError
         ? `Discovery failed: ${data.lastDiscoverError}. Reconfigure or test again.`

--- a/src/components/ui/__tests__/status-chip.test.tsx
+++ b/src/components/ui/__tests__/status-chip.test.tsx
@@ -90,16 +90,6 @@ describe("StatusChip — openemsBackendHealth kind", () => {
     expect(container.textContent).toContain("Healthy");
   });
 
-  it("renders 'stale' with warn background + dot", () => {
-    const { container } = render(
-      <StatusChip kind="openemsBackendHealth" status="stale" />,
-    );
-    const chip = container.querySelector("span");
-    expect(chip?.className).toContain("bg-warning-muted");
-    expect(chip?.querySelector("span")?.className).toContain("bg-warning");
-    expect(container.textContent).toContain("Stale");
-  });
-
   it("renders 'failing' with alert background + dot", () => {
     const { container } = render(
       <StatusChip kind="openemsBackendHealth" status="failing" />,
@@ -241,16 +231,6 @@ describe("StatusChip — paymentHealth kind", () => {
     expect(chip?.className).toContain("bg-success-muted");
     expect(chip?.querySelector("span")?.className).toContain("bg-success");
     expect(container.textContent).toContain("Healthy");
-  });
-
-  it("renders 'stale' with warn background + dot", () => {
-    const { container } = render(
-      <StatusChip kind="paymentHealth" status="stale" />,
-    );
-    const chip = container.querySelector("span");
-    expect(chip?.className).toContain("bg-warning-muted");
-    expect(chip?.querySelector("span")?.className).toContain("bg-warning");
-    expect(container.textContent).toContain("Stale");
   });
 
   it("renders 'failing' with alert background + dot (Phase B — emitted on recent IPN failure)", () => {

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -152,31 +152,28 @@ const MAPS: Record<Kind, StatusMap> = {
     PRODUCTION:  { label: "Production",  tone: "success" },
     UNKNOWN:     { label: "Unknown",     tone: "neutral" },
   },
-  // OpenEMS Backend per-microgrid health (#102).
-  //   healthy       — recent (< 24h) successful Discover.
-  //   stale         — last Discover ≥ 24h ago; user should run "Test again".
+  // OpenEMS Backend per-microgrid health (#102, #215).
+  //   healthy       — fail-open: ems_type set with no negative discover signal
+  //                   (covers `success` at any age and any unrecognized/null status).
   //   failing       — last Discover ended in auth_failed / unreachable /
   //                   zero_edges / unknown_error.
   //   not_configured — ems_type IS NULL; no Discover has run. NO dot (chip
   //                   shouldn't imply any state, just absence).
   openemsBackendHealth: {
     healthy:        { label: "Healthy",       tone: "success", dot: true  },
-    stale:          { label: "Stale",         tone: "warn",    dot: true  },
     failing:        { label: "Failing",       tone: "alert",   dot: true  },
     not_configured: { label: "Not connected", tone: "neutral" /* no dot */ },
   },
-  // Community Payment-provider health (#119).
-  //   healthy        — payment_last_configured_at is recent (< 24h).
-  //   stale          — configured but last Save & test was ≥ 24h ago; user
-  //                    should "Test again".
-  //   failing        — RESERVED for #121 (IPN webhook failure tracking).
-  //                    `derivePaymentHealth` never emits this today, but the
-  //                    MAPS entry stays pinned so Designer §3's tone table
-  //                    remains stable across the deferred-IPN rollout.
+  // Community Payment-provider health (#119, #157, #215).
+  //   healthy        — fail-open: payment_provider set with no recent IPN
+  //                    failure (covers null timestamp, recent saves, and old
+  //                    saves alike).
+  //   failing        — Phase B (#157): a payment_events row with
+  //                    `to_status='failed'` AND `source='ipn'` was recorded
+  //                    within the last 24h.
   //   not_configured — payment_provider IS NULL (no dot — just absence).
   paymentHealth: {
     healthy:        { label: "Healthy",       tone: "success", dot: true  },
-    stale:          { label: "Stale",         tone: "warn",    dot: true  },
     failing:        { label: "Failing",       tone: "alert",   dot: true  },
     not_configured: { label: "Not connected", tone: "neutral" /* no dot */ },
   },


### PR DESCRIPTION
Closes #215

## Summary
- **`derivePaymentHealth`** simplifies to fail-open `healthy`; `TWENTY_FOUR_HOURS_MS` retained for the IPN-failure 24h window (still in use). `"stale"` removed from `PaymentHealth` union.
- **`deriveOpenemsBackendHealth`** simplifies to fail-open `healthy`; `TWENTY_FOUR_HOURS_MS` removed. `"stale"` removed from `OpenemsBackendHealth` union.
- **`status-chip.tsx`** drops `stale:` rows from both `paymentHealth` and `openemsBackendHealth` MAPS. Doc-comment headers rewritten. `edge` kind's `stale` row untouched (out of scope).
- **`community-subnav.tsx` + `setup-subnav.tsx`** drop their `case "stale":` switch arms (would otherwise have failed `tsc --noEmit` after the union narrow).
- Test files swept: stale assertions flipped to healthy, `<StatusChip status="stale">` blocks removed.

## Why
A one-time configuration shouldn't display a yellow "warn" chip every 24h just because nobody re-clicked Save & test. The 24h cliff was a defensive nudge from #102/#119 when neither integration had a real-time failure signal — Payment now has IPN failure tracking (#157 / Phase B) which catches real failures within 24h, and for OpenEMS the trade-off is honestly captured: the chip stays `healthy` until the next Discover/Save & test or layered failure surface flips it.

## Test plan
- [x] `npx tsc --noEmit` — clean (forced surfacing of two missed switch arms).
- [x] `npm test` — 1511 passed, 35 skipped (env-gated), 0 failed.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] `grep '"stale"' src/` — only `edge` kind + dev-showcase + 3 historical doc-comments remain.
- [ ] Operator follow-up: load `/communities/<id>/payment` and `/microgrids/<id>/setup/openems-backend` after deploy — chip stays "Healthy" if there's no recent failure, regardless of when Save & test last ran. "Last test" / "Last successful discovery" timestamp captions still visible in the Setup shell.

## Notes
- Fail-open semantic: defensive cases (configured + NULL timestamp; configured + unrecognized status) all map to `healthy`. `not_configured` is now reserved strictly for `payment_provider IS NULL` / `ems_type IS NULL`.
- Three `"stale"` doc-comment references survive in the two helpers as explanatory historical context (each tagged with #215 / "formerly ≥24h" lineage). Aid for future readers; no behavioral conflict.
- Follow-up filed in OOS section of #215: wire `ems_last_discover_status` updates from `/pdf` + billing-generate + `ensurePaymentLinkForLineItem` failure paths so OpenEMS gets an automatic failure signal too (closes the small false-confidence window this PR accepts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)