### PR TITLE
Bug fix: invalidate Pesapal link on amount change + force-regenerate (#217)

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/__tests__/route.test.ts
@@ -61,10 +61,20 @@ vi.mock("@/lib/supabase/server", () => ({
   }),
 }));
 
-function makeReq(): NextRequest {
+function makeReq(body?: unknown): NextRequest {
+  if (body === undefined) {
+    return new NextRequest(
+      `http://localhost/api/billing-line-items/${LINE_ITEM_ID}/url`,
+      { method: "POST" },
+    );
+  }
   return new NextRequest(
     `http://localhost/api/billing-line-items/${LINE_ITEM_ID}/url`,
-    { method: "POST" },
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
   );
 }
 
@@ -305,5 +315,51 @@ describe("POST /api/billing-line-items/[lineItemId]/url", () => {
     expect(body.reason).toBe("ipn_not_registered");
     expect(String(body.error)).toMatch(/IPN/i);
     expect(String(body.error)).toMatch(/Save & test/i);
+  });
+
+  // ─── (10) #217 — { force: true } body threads to helper ──────────────────
+  it("(10) { force: true } body threads through to ensurePaymentLinkForLineItem", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeReq({ force: true }), {
+      params: Promise.resolve({ lineItemId: LINE_ITEM_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(ensurePaymentLinkMock).toHaveBeenCalledTimes(1);
+    const [_client, lineId, opts] = ensurePaymentLinkMock.mock.calls[0];
+    expect(lineId).toBe(LINE_ITEM_ID);
+    expect(opts.force).toBe(true);
+    expect(opts.actorUserId).toBe("actor-user-1");
+  });
+
+  // ─── (11) #217 — backward-compat: no body / {} / { force: false } ────────
+  it("(11) no body defaults force=false (backwards-compat with pre-#217 callers)", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ lineItemId: LINE_ITEM_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(ensurePaymentLinkMock).toHaveBeenCalledTimes(1);
+    const [, , opts] = ensurePaymentLinkMock.mock.calls[0];
+    expect(opts.force).toBe(false);
+  });
+
+  it("(11b) empty JSON body {} defaults force=false", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeReq({}), {
+      params: Promise.resolve({ lineItemId: LINE_ITEM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const [, , opts] = ensurePaymentLinkMock.mock.calls[0];
+    expect(opts.force).toBe(false);
+  });
+
+  it("(11c) explicit { force: false } sets force=false", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makeReq({ force: false }), {
+      params: Promise.resolve({ lineItemId: LINE_ITEM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const [, , opts] = ensurePaymentLinkMock.mock.calls[0];
+    expect(opts.force).toBe(false);
   });
 });

--- a/src/app/api/billing-line-items/[lineItemId]/url/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/url/route.ts
@@ -3,7 +3,14 @@
  *
  * Generates the hosted-checkout URL for exactly one billing_line_items row.
  * Enforces "one bill, one payment link". All order fields are derived from
- * Supabase records the caller can see via RLS — the request body is ignored.
+ * Supabase records the caller can see via RLS.
+ *
+ * Request body (optional, JSON):
+ *   { force?: boolean }   — when true, bypass the redirect-URL cache and mint
+ *                            a fresh Pesapal session. Used by the operator's
+ *                            "Regenerate payment link" UI (#217). Default
+ *                            false; missing/empty/`{}` body is backward-
+ *                            compatible with the pre-#217 surface.
  *
  * Path chain:
  *   lineItem → billing_period → microgrid → community (provider config)
@@ -61,7 +68,7 @@ type LineItemScopeRow = {
 };
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ lineItemId: string }> },
 ): Promise<NextResponse> {
   const startedAt = Date.now();
@@ -73,6 +80,13 @@ export async function POST(
       { status: 400 },
     );
   }
+
+  // Parse optional `{ force?: boolean }` body. Backwards-compatible: empty
+  // body / no body / `{}` / `{ force: false }` all default to `force: false`.
+  const body = (await request.json().catch(() => ({}))) as {
+    force?: unknown;
+  };
+  const force = body?.force === true;
 
   const supabase = await createClient();
 
@@ -162,6 +176,7 @@ export async function POST(
   try {
     result = await ensurePaymentLinkForLineItem(supabase, lineItemId, {
       actorUserId,
+      force,
     });
   } catch (err) {
     const mapped = mapPaymentError(err);

--- a/src/components/billing/row-actions-menu.tsx
+++ b/src/components/billing/row-actions-menu.tsx
@@ -135,7 +135,13 @@ export function computeMenuItems(input: {
   handlers: {
     onRequestRegenerate: (mode: "edge" | "manual") => void;
     onRequestSwitchToManual: () => void;
-    onGenerateLink: () => void;
+    /**
+     * Generate / regenerate payment link. Pass `{ force: true }` to bypass
+     * the redirect-URL cache (operator's explicit "Regenerate payment link"
+     * — #217). Default / no-arg keeps the cache-hit fast path for "Generate"
+     * on an unpaid row.
+     */
+    onGenerateLink: (opts?: { force?: boolean }) => void;
     onCopyLink: () => void;
     onMarkAsPaid: () => void;
     onMarkAsRefunded: () => void;
@@ -231,14 +237,18 @@ export function computeMenuItems(input: {
         kind: "action",
         key: "generate-link",
         label: "Generate payment link",
-        onSelect: handlers.onGenerateLink,
+        // First-mint path — cache is empty by definition; no force needed.
+        onSelect: () => handlers.onGenerateLink(),
       });
     } else if (lineItem.payment_status === "link_generated") {
       paymentLinkItems.push({
         kind: "action",
         key: "regenerate-link",
         label: "Regenerate payment link",
-        onSelect: handlers.onGenerateLink,
+        // Operator-explicit Regenerate (#217) — bypass the cache so the
+        // returned URL reflects the current total_amount, not the previous
+        // session's amount.
+        onSelect: () => handlers.onGenerateLink({ force: true }),
       });
     }
     // "Copy payment link" only when a URL is currently in component state
@@ -497,39 +507,50 @@ export function RowActionsMenu(props: RowActionsMenuProps) {
   );
 
   // ── Payment-link generation ───────────────────────────────────────────────
-  const generatePaymentLink = React.useCallback(async () => {
-    try {
-      const res = await fetch(
-        `/api/billing-line-items/${lineItem.id}/url`,
-        { method: "POST" },
-      );
-      if (!res.ok) {
+  // `opts.force=true` flips the route into "bypass cache + mint fresh"
+  // (operator's explicit Regenerate — #217). Default / no-arg keeps the
+  // cache-hit fast path for first-mint on unpaid rows.
+  const generatePaymentLink = React.useCallback(
+    async (opts?: { force?: boolean }) => {
+      const force = opts?.force === true;
+      try {
+        const res = await fetch(
+          `/api/billing-line-items/${lineItem.id}/url`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ force }),
+          },
+        );
+        if (!res.ok) {
+          pushPaymentLinkError();
+          return;
+        }
+        const data = (await res.json()) as {
+          redirectUrl: string;
+          orderTrackingId: string;
+          merchantReference: string;
+        };
+        setPendingUrl(data.redirectUrl);
+      } catch {
         pushPaymentLinkError();
-        return;
       }
-      const data = (await res.json()) as {
-        redirectUrl: string;
-        orderTrackingId: string;
-        merchantReference: string;
-      };
-      setPendingUrl(data.redirectUrl);
-    } catch {
-      pushPaymentLinkError();
-    }
-    function pushPaymentLinkError() {
-      onRowBanner({
-        id: `${lineItem.id}-link-err-${Date.now()}`,
-        lineItemId: lineItem.id,
-        tone: "destructive",
-        message: "Failed to generate payment link.",
-        action: {
-          label: "Retry",
-          onClick: () => void generatePaymentLink(),
-        },
-        durationMs: ERROR_RETRY_BANNER_DURATION_MS,
-      });
-    }
-  }, [lineItem.id, onRowBanner]);
+      function pushPaymentLinkError() {
+        onRowBanner({
+          id: `${lineItem.id}-link-err-${Date.now()}`,
+          lineItemId: lineItem.id,
+          tone: "destructive",
+          message: "Failed to generate payment link.",
+          action: {
+            label: "Retry",
+            onClick: () => void generatePaymentLink(opts),
+          },
+          durationMs: ERROR_RETRY_BANNER_DURATION_MS,
+        });
+      }
+    },
+    [lineItem.id, onRowBanner],
+  );
 
   const copyPaymentLink = React.useCallback(() => {
     if (!pendingUrl) return;
@@ -639,7 +660,7 @@ export function RowActionsMenu(props: RowActionsMenuProps) {
         handlers: {
           onRequestRegenerate: handleRegenerate,
           onRequestSwitchToManual: handleSwitchToManual,
-          onGenerateLink: () => void generatePaymentLink(),
+          onGenerateLink: (opts) => void generatePaymentLink(opts),
           onCopyLink: copyPaymentLink,
           onMarkAsPaid: () => setMarkPaidOpen(true),
           onMarkAsRefunded: () => setMarkRefundedOpen(true),

--- a/src/lib/payments/__tests__/ensure-payment-link.test.ts
+++ b/src/lib/payments/__tests__/ensure-payment-link.test.ts
@@ -155,8 +155,12 @@ function makeMockClient(opts: {
           },
         }),
       }),
-      update: (patch: { pesapal_redirect_url: string }) => ({
+      update: (patch: {
+        pesapal_redirect_url: string;
+        pesapal_order_id?: string;
+      }) => ({
         eq: (_col: string, _val: string) => ({
+          // force=false path: UPDATE-NULL guard via .is(...).
           is: (_col2: string, _val2: null) => ({
             select: (_cols: string) => {
               return Promise.resolve(
@@ -178,6 +182,19 @@ function makeMockClient(opts: {
               );
             },
           }),
+          // force=true path: unconditional UPDATE — no .is() guard.
+          select: (_cols: string) => {
+            state.persistedUrl = patch.pesapal_redirect_url;
+            return Promise.resolve({
+              data: [
+                {
+                  id: LINE_ITEM_ID,
+                  pesapal_redirect_url: patch.pesapal_redirect_url,
+                },
+              ],
+              error: null,
+            });
+          },
         }),
       }),
     };
@@ -392,6 +409,112 @@ describe("ensurePaymentLinkForLineItem", () => {
     expect(r.redirectUrl).toBe(GOOD_RESULT.redirectUrl);
     expect(state.persistedUrl).toBe(GOOD_RESULT.redirectUrl);
     // Audit call attempted exactly once and warned.
+    expect(state.auditCalls.length).toBe(1);
+    const matched = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes("audit_write_failed"));
+    expect(matched).toBeTruthy();
+    warnSpy.mockRestore();
+  });
+
+  // ── #217 — force=true bypasses cache and mints fresh ─────────────────────
+  it("force=true bypasses cache and mints fresh even when pesapal_redirect_url is non-null", async () => {
+    const cached = "https://pay.pesapal.com/checkout?token=CACHED_A";
+    const { client, state } = makeMockClient({
+      initialRow: { pesapal_redirect_url: cached, payment_status: "link_generated" },
+    });
+    const { ensurePaymentLinkForLineItem } = await import(
+      "../ensure-payment-link"
+    );
+
+    const r = await ensurePaymentLinkForLineItem(
+      client as never,
+      LINE_ITEM_ID,
+      { force: true, actorUserId: "actor-1" },
+    );
+
+    // Fresh mint, cache overwritten.
+    expect(r.wasMinted).toBe(true);
+    expect(r.redirectUrl).toBe(GOOD_RESULT.redirectUrl);
+    expect(r.redirectUrl).not.toBe(cached);
+    expect(state.persistedUrl).toBe(GOOD_RESULT.redirectUrl);
+    // submitOrder fired.
+    expect(generatePaymentLinkMock).toHaveBeenCalledTimes(1);
+    // Exactly one audit write with link_generated + generate_link.
+    expect(state.auditCalls.length).toBe(1);
+    const [fn, args] = state.auditCalls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(fn).toBe("fn_apply_payment_event");
+    expect(args._to_status).toBe("link_generated");
+    expect(args._source).toBe("generate_link");
+  });
+
+  // ── #217 regression — default (force=false) still cache-hits ─────────────
+  it("force=false (default) returns cache-hit when redirect_url is non-null", async () => {
+    const cached = "https://pay.pesapal.com/checkout?token=DEFAULT_CACHED";
+    const { client, state } = makeMockClient({
+      initialRow: { pesapal_redirect_url: cached, payment_status: "link_generated" },
+    });
+    const { ensurePaymentLinkForLineItem } = await import(
+      "../ensure-payment-link"
+    );
+
+    // Explicit force=false.
+    const rExplicit = await ensurePaymentLinkForLineItem(
+      client as never,
+      LINE_ITEM_ID,
+      { force: false },
+    );
+    expect(rExplicit.wasMinted).toBe(false);
+    expect(rExplicit.redirectUrl).toBe(cached);
+
+    // Reset coalescer between calls inside the same test so the second call
+    // doesn't piggyback onto the first promise.
+    const mod = await import("../ensure-payment-link");
+    mod._resetEnsurePaymentLinkCoalescerForTests();
+
+    // Default — no opts at all.
+    const rDefault = await ensurePaymentLinkForLineItem(
+      client as never,
+      LINE_ITEM_ID,
+    );
+    expect(rDefault.wasMinted).toBe(false);
+    expect(rDefault.redirectUrl).toBe(cached);
+
+    // Neither call hit submitOrder; zero audit writes for both.
+    expect(generatePaymentLinkMock).not.toHaveBeenCalled();
+    expect(state.auditCalls).toEqual([]);
+  });
+
+  // ── #217 — force=true on a paid row still warns + returns ────────────────
+  it("force=true on a paid row whose redirect_url was just NULL'd warns on audit-write but returns wasMinted: true", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { client, state } = makeMockClient({
+      // Aaron's exact post-migration state: paid row whose pesapal_redirect_url
+      // was just NULL'd by 00037's auto-invalidation on amount change. Operator
+      // would not see "Regenerate payment link" in the menu (it surfaces only
+      // on link_generated rows), but the helper contract still tolerates it.
+      initialRow: { pesapal_redirect_url: null, payment_status: "paid" },
+      rpcError: {
+        code: "P0001",
+        message: "invalid_transition: paid → link_generated",
+      },
+    });
+    const { ensurePaymentLinkForLineItem } = await import(
+      "../ensure-payment-link"
+    );
+
+    const r = await ensurePaymentLinkForLineItem(
+      client as never,
+      LINE_ITEM_ID,
+      { force: true, actorUserId: "actor-1" },
+    );
+
+    expect(r.wasMinted).toBe(true);
+    expect(r.redirectUrl).toBe(GOOD_RESULT.redirectUrl);
+    expect(state.persistedUrl).toBe(GOOD_RESULT.redirectUrl);
     expect(state.auditCalls.length).toBe(1);
     const matched = warnSpy.mock.calls
       .map((c) => String(c[0]))

--- a/src/lib/payments/ensure-payment-link.ts
+++ b/src/lib/payments/ensure-payment-link.ts
@@ -95,6 +95,25 @@ export interface EnsurePaymentLinkOptions {
   actorUserId?: string | null;
   /** Override the callback URL; defaults to NEXT_PUBLIC_PAYMENT_CALLBACK_URL. */
   callbackUrl?: string;
+  /**
+   * Operator-explicit "Regenerate" (#217). When true:
+   *   - Skip the cache-check (any existing pesapal_redirect_url is overwritten).
+   *   - Skip the in-memory coalescer in BOTH directions (the operator does
+   *     not piggyback onto a tenant /pay's mint, and concurrent tenant /pay
+   *     callers do not coalesce onto the operator's force result).
+   *   - Mint a fresh Pesapal session.
+   *   - UPDATE both `pesapal_redirect_url` AND `pesapal_order_id` in a single
+   *     statement UNCONDITIONALLY (no WHERE pesapal_redirect_url IS NULL
+   *     guard) so the row is internally consistent at every observable instant.
+   *   - Fire the `link_generated` audit-write side effect with the existing
+   *     warn-loudly-but-still-return semantic on rejection (paid →
+   *     link_generated raises P0001; the helper warns and returns the URL).
+   *
+   * Default `false` — current behaviour preserved for tenant /pay callers
+   * (they share the cache; the cache exists to dedupe their parallel
+   * redirect clicks).
+   */
+  force?: boolean;
 }
 
 // ── In-memory coalescer ──────────────────────────────────────────────────────
@@ -220,6 +239,8 @@ async function mintAndPersist(
   },
   opts: EnsurePaymentLinkOptions,
 ): Promise<EnsurePaymentLinkResult> {
+  const force = opts.force === true;
+
   // 1. Resolve community payment config (config + decrypted secret).
   const paymentConfig = await getCommunityPaymentConfig(
     supabase,
@@ -269,14 +290,35 @@ async function mintAndPersist(
     currency,
   });
 
-  // 6. Optimistic-concurrency persist: only the first caller's UPDATE wins.
-  //    The WHERE ... IS NULL guard is the serialisation point.
-  const { data: updated, error: updateErr } = await supabase
-    .from("billing_line_items")
-    .update({ pesapal_redirect_url: result.redirectUrl })
-    .eq("id", lineItemId)
-    .is("pesapal_redirect_url", null)
-    .select("id, pesapal_redirect_url");
+  // 6. Persist. Two paths:
+  //
+  //    force=false (default):
+  //      Optimistic-concurrency UPDATE-NULL guard. Only the first caller's
+  //      UPDATE wins; the loser re-SELECTs the winner's URL.
+  //
+  //    force=true (operator-explicit "Regenerate" — #217):
+  //      Drop the WHERE-IS-NULL guard. Operator intent is to overwrite any
+  //      stale cache. Write both `pesapal_redirect_url` AND `pesapal_order_id`
+  //      in the same UPDATE so the row is internally consistent at every
+  //      observable instant (no momentary stale-pair window). Always treat
+  //      this caller as the winner — fire the audit write directly.
+  const updateBuilder = force
+    ? supabase
+        .from("billing_line_items")
+        .update({
+          pesapal_redirect_url: result.redirectUrl,
+          pesapal_order_id: result.providerReference,
+        })
+        .eq("id", lineItemId)
+        .select("id, pesapal_redirect_url")
+    : supabase
+        .from("billing_line_items")
+        .update({ pesapal_redirect_url: result.redirectUrl })
+        .eq("id", lineItemId)
+        .is("pesapal_redirect_url", null)
+        .select("id, pesapal_redirect_url");
+
+  const { data: updated, error: updateErr } = await updateBuilder;
 
   if (updateErr) {
     throw new PaymentError(
@@ -287,7 +329,7 @@ async function mintAndPersist(
     );
   }
 
-  if (updated && updated.length > 0) {
+  if (force || (updated && updated.length > 0)) {
     // Winner. Fire the audit write (warn-loudly-but-still-return on failure).
     try {
       const { error: rpcErr } = await supabase.rpc("fn_apply_payment_event", {
@@ -375,13 +417,26 @@ export async function ensurePaymentLinkForLineItem(
   lineItemId: string,
   options: EnsurePaymentLinkOptions = {},
 ): Promise<EnsurePaymentLinkResult> {
-  const existing = inflight.get(lineItemId);
-  if (existing) return existing;
+  const force = options.force === true;
+
+  // Operator-explicit "Regenerate" (#217) bypasses the in-memory coalescer in
+  // BOTH directions: do NOT piggyback onto an in-flight tenant /pay mint, and
+  // do NOT register the force-promise into the coalescer for tenant callers
+  // to share. Tenant /pay callers continue to run their own UPDATE-NULL
+  // guarded path; their submitOrder result becomes an orphan if the
+  // operator's force UPDATE lands later, but that is the documented trade-off
+  // (one tenant gets a working session for one redirect; the persisted URL
+  // is the operator's fresh one).
+  if (!force) {
+    const existing = inflight.get(lineItemId);
+    if (existing) return existing;
+  }
 
   const promise = (async () => {
-    // 1. Cache check — plain SELECT (no FOR UPDATE).
+    // 1. Cache check — plain SELECT (no FOR UPDATE). Skipped under force=true:
+    //    the operator's intent is "mint fresh regardless of any cached URL."
     const scope = await loadLineItemScope(supabase, lineItemId);
-    if (scope.pesapalRedirectUrl) {
+    if (!force && scope.pesapalRedirectUrl) {
       return {
         redirectUrl: scope.pesapalRedirectUrl,
         orderTrackingId: null,
@@ -390,7 +445,8 @@ export async function ensurePaymentLinkForLineItem(
       } satisfies EnsurePaymentLinkResult;
     }
 
-    // 2. Cache miss — mint via Pesapal + UPDATE-NULL-guarded persist.
+    // 2. Mint via Pesapal + persist. force=false uses the UPDATE-NULL guard;
+    //    force=true unconditionally overwrites both URL and order id.
     return mintAndPersist(
       supabase,
       lineItemId,
@@ -399,11 +455,15 @@ export async function ensurePaymentLinkForLineItem(
     );
   })();
 
-  inflight.set(lineItemId, promise);
+  if (!force) {
+    inflight.set(lineItemId, promise);
+  }
   try {
     return await promise;
   } finally {
-    inflight.delete(lineItemId);
+    if (!force) {
+      inflight.delete(lineItemId);
+    }
   }
 }
 

--- a/src/lib/supabase/__tests__/billing_audit_log.test.ts
+++ b/src/lib/supabase/__tests__/billing_audit_log.test.ts
@@ -49,6 +49,13 @@ const FIXTURE = {
   hhA: "dddddddd-dddd-4000-8005-00000000000a",
   periodA: "dddddddd-dddd-4000-8006-00000000000a",
 
+  // Extra households on mgA, isolated from hhA so the link-invalidation
+  // tests (#217 / 00037) can run against fresh rows without contaminating
+  // the existing hhA-based assertions.
+  hhA_inv1: "dddddddd-dddd-4000-8005-00000000001a",
+  hhA_inv2: "dddddddd-dddd-4000-8005-00000000002a",
+  hhA_inv3: "dddddddd-dddd-4000-8005-00000000003a",
+
   // Org/community/microgrid for tenant B (cross-org isolation tests).
   orgB: "dddddddd-dddd-4000-8000-00000000000b",
   commB: "dddddddd-dddd-4000-8001-00000000000b",
@@ -105,6 +112,27 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
       display_name: "BC1 Household A",
       primary_phone: "+256700000001",
     });
+    // Three extra households for the #217 link-invalidation cases (A/B/C).
+    await svc.from("households").insert([
+      {
+        id: FIXTURE.hhA_inv1,
+        microgrid_id: FIXTURE.mgA,
+        display_name: "BC1 Household A-inv1",
+        primary_phone: "+256700001001",
+      },
+      {
+        id: FIXTURE.hhA_inv2,
+        microgrid_id: FIXTURE.mgA,
+        display_name: "BC1 Household A-inv2",
+        primary_phone: "+256700001002",
+      },
+      {
+        id: FIXTURE.hhA_inv3,
+        microgrid_id: FIXTURE.mgA,
+        display_name: "BC1 Household A-inv3",
+        primary_phone: "+256700001003",
+      },
+    ]);
     await svc.from("billing_periods").insert({
       id: FIXTURE.periodA,
       microgrid_id: FIXTURE.mgA,
@@ -386,6 +414,256 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
       .from("billing_periods")
       .update({ status: "draft", closed_at: null })
       .eq("id", FIXTURE.periodA);
+  });
+
+  // ── #217 / 00037 — payment-link auto-invalidation on amount change ────────
+  //
+  // Each case uses a distinct household so the post-state on one case does
+  // not contaminate the next. The seed for each case is INSERT-via-RPC for
+  // the `total_amount` baseline, then a direct UPDATE on the row to plant
+  // the cached payment fields (payment_status / paid_at / paid_by_user_id /
+  // pesapal_redirect_url / pesapal_order_id / payment_failed_at). The
+  // direct UPDATE bypasses the state machine deliberately — the fixture is
+  // simulating a row that has accumulated payment cache via past flows; the
+  // test focuses on what happens when `fn_record_line_item_with_audit` runs
+  // a re-key.
+
+  it("00037 / #217 (Case A): UPSERT-UPDATE NULLs pesapal_redirect_url + pesapal_order_id + payment_failed_at when amount changes (unpaid row)", async () => {
+    const svc = await serviceClient();
+
+    // Seed: insert via RPC at total_amount=1000 then plant the payment cache.
+    await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv1,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 10,
+      _start_kwh: 0,
+      _end_kwh: 10,
+      _tier_breakdown: [{ label: "T1", kwh: 10, amount: 1000 }],
+      _total_amount: 1000,
+      _reading_source: "edge",
+      _entered_by_user_id: null,
+      _manual_reason: null,
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv1" },
+    });
+    const failedAt = new Date().toISOString();
+    await svc
+      .from("billing_line_items")
+      .update({
+        pesapal_redirect_url: "https://pesapal.test/A",
+        pesapal_order_id: "ord-A",
+        payment_failed_at: failedAt,
+        // payment_status remains 'unpaid' (default)
+      })
+      .eq("billing_period_id", FIXTURE.periodA)
+      .eq("household_id", FIXTURE.hhA_inv1);
+
+    // Re-key with a different total_amount.
+    const { error } = await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv1,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 15,
+      _start_kwh: 0,
+      _end_kwh: 15,
+      _tier_breakdown: [{ label: "T1", kwh: 15, amount: 1500 }],
+      _total_amount: 1500,
+      _reading_source: "manual",
+      _entered_by_user_id: alejandroSuperAdmin.userId,
+      _manual_reason: "operator correction",
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv1" },
+    });
+    expect(error).toBeNull();
+
+    const { data: after } = await svc
+      .from("billing_line_items")
+      .select(
+        "total_amount, pesapal_redirect_url, pesapal_order_id, payment_failed_at, payment_status",
+      )
+      .eq("billing_period_id", FIXTURE.periodA)
+      .eq("household_id", FIXTURE.hhA_inv1)
+      .single<{
+        total_amount: number;
+        pesapal_redirect_url: string | null;
+        pesapal_order_id: string | null;
+        payment_failed_at: string | null;
+        payment_status: string;
+      }>();
+
+    expect(Number(after?.total_amount)).toBe(1500);
+    expect(after?.pesapal_redirect_url).toBeNull();
+    expect(after?.pesapal_order_id).toBeNull();
+    expect(after?.payment_failed_at).toBeNull();
+    expect(after?.payment_status).toBe("unpaid");
+  });
+
+  it("00037 / #217 (Case B): UPSERT-UPDATE preserves pesapal_redirect_url + pesapal_order_id + payment_failed_at when amount is unchanged", async () => {
+    const svc = await serviceClient();
+
+    await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv2,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 20,
+      _start_kwh: 0,
+      _end_kwh: 20,
+      _tier_breakdown: [{ label: "T1", kwh: 20, amount: 2000 }],
+      _total_amount: 2000,
+      _reading_source: "edge",
+      _entered_by_user_id: null,
+      _manual_reason: null,
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv2" },
+    });
+    const failedAt = new Date().toISOString();
+    await svc
+      .from("billing_line_items")
+      .update({
+        pesapal_redirect_url: "https://pesapal.test/B",
+        pesapal_order_id: "ord-B",
+        payment_failed_at: failedAt,
+      })
+      .eq("billing_period_id", FIXTURE.periodA)
+      .eq("household_id", FIXTURE.hhA_inv2);
+
+    // Re-run with the SAME total_amount — auto-invalidation must NOT fire.
+    const { error } = await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv2,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 20,
+      _start_kwh: 0,
+      _end_kwh: 20,
+      _tier_breakdown: [{ label: "T1", kwh: 20, amount: 2000 }],
+      _total_amount: 2000,
+      _reading_source: "edge",
+      _entered_by_user_id: null,
+      _manual_reason: null,
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv2" },
+    });
+    expect(error).toBeNull();
+
+    const { data: after } = await svc
+      .from("billing_line_items")
+      .select(
+        "total_amount, pesapal_redirect_url, pesapal_order_id, payment_failed_at",
+      )
+      .eq("billing_period_id", FIXTURE.periodA)
+      .eq("household_id", FIXTURE.hhA_inv2)
+      .single<{
+        total_amount: number;
+        pesapal_redirect_url: string | null;
+        pesapal_order_id: string | null;
+        payment_failed_at: string | null;
+      }>();
+    expect(Number(after?.total_amount)).toBe(2000);
+    expect(after?.pesapal_redirect_url).toBe("https://pesapal.test/B");
+    expect(after?.pesapal_order_id).toBe("ord-B");
+    expect(after?.payment_failed_at).toBeTruthy();
+  });
+
+  it("00037 / #217 (Case C): UPSERT-UPDATE NULLs pesapal_redirect_url + pesapal_order_id on amount change but PRESERVES payment_status='paid' + paid_at + paid_by_user_id", async () => {
+    const svc = await serviceClient();
+
+    // Seed: insert via RPC at total_amount=3000 then mark paid via the
+    // canonical state-machine RPC (so the audit-fields CHECK constraint is
+    // satisfied), then plant pesapal_redirect_url separately.
+    await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv3,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 30,
+      _start_kwh: 0,
+      _end_kwh: 30,
+      _tier_breakdown: [{ label: "T1", kwh: 30, amount: 3000 }],
+      _total_amount: 3000,
+      _reading_source: "edge",
+      _entered_by_user_id: null,
+      _manual_reason: null,
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv3" },
+    });
+    const { data: row } = await svc
+      .from("billing_line_items")
+      .select("id")
+      .eq("billing_period_id", FIXTURE.periodA)
+      .eq("household_id", FIXTURE.hhA_inv3)
+      .single<{ id: string }>();
+    const liId = row!.id;
+
+    await svc.rpc("fn_apply_payment_event", {
+      _line_item_id: liId,
+      _to_status: "paid",
+      _source: "manual",
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _raw_payload: { payment_notes: "cash collected pre-rekey" },
+    });
+    await svc
+      .from("billing_line_items")
+      .update({
+        pesapal_redirect_url: "https://pesapal.test/C",
+        pesapal_order_id: "ord-C",
+      })
+      .eq("id", liId);
+
+    const { data: paidBefore } = await svc
+      .from("billing_line_items")
+      .select("payment_status, paid_at, paid_by_user_id, payment_notes")
+      .eq("id", liId)
+      .single<{
+        payment_status: string;
+        paid_at: string | null;
+        paid_by_user_id: string | null;
+        payment_notes: string | null;
+      }>();
+    expect(paidBefore?.payment_status).toBe("paid");
+    expect(paidBefore?.paid_at).toBeTruthy();
+
+    // Re-key with a different total_amount.
+    const { error } = await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv3,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 35,
+      _start_kwh: 0,
+      _end_kwh: 35,
+      _tier_breakdown: [{ label: "T1", kwh: 35, amount: 3500 }],
+      _total_amount: 3500,
+      _reading_source: "manual",
+      _entered_by_user_id: alejandroSuperAdmin.userId,
+      _manual_reason: "dispute reread",
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv3" },
+    });
+    expect(error).toBeNull();
+
+    const { data: after } = await svc
+      .from("billing_line_items")
+      .select(
+        "total_amount, pesapal_redirect_url, pesapal_order_id, payment_status, paid_at, paid_by_user_id, payment_notes",
+      )
+      .eq("id", liId)
+      .single<{
+        total_amount: number;
+        pesapal_redirect_url: string | null;
+        pesapal_order_id: string | null;
+        payment_status: string;
+        paid_at: string | null;
+        paid_by_user_id: string | null;
+        payment_notes: string | null;
+      }>();
+    expect(Number(after?.total_amount)).toBe(3500);
+    // Pesapal cache invalidated (operator must reconcile manually).
+    expect(after?.pesapal_redirect_url).toBeNull();
+    expect(after?.pesapal_order_id).toBeNull();
+    // Past payment record permanent — survives the re-key.
+    expect(after?.payment_status).toBe("paid");
+    expect(after?.paid_at).toBe(paidBefore?.paid_at);
+    expect(after?.paid_by_user_id).toBe(paidBefore?.paid_by_user_id);
+    expect(after?.payment_notes).toBe(paidBefore?.payment_notes);
   });
 
   // ── Atomicity ─────────────────────────────────────────────────────────────

--- a/supabase/migrations/00037_invalidate_payment_link_on_reread.sql
+++ b/supabase/migrations/00037_invalidate_payment_link_on_reread.sql
@@ -1,0 +1,209 @@
+-- 00037_invalidate_payment_link_on_reread.sql
+-- PDF5 follow-up (#217): re-entering manual reading kept the stale Pesapal
+-- redirect link with the previous total_amount.
+--
+-- ── Why ───────────────────────────────────────────────────────────────────────
+--
+-- `fn_record_line_item_with_audit` (00029) is the canonical writer for the
+-- billing_line_items UPSERT. Its DO UPDATE SET clause explicitly enumerates
+-- the columns to overwrite; everything else is silently preserved. That
+-- "preserve everything else" policy is correct for the payment-state machine
+-- columns owned by `fn_apply_payment_event` (payment_status, paid_at,
+-- paid_by_user_id, payment_notes, payment_refunded_at) — the past payment
+-- record must survive a re-keying of the reading.
+--
+-- But three columns hold the cached Pesapal session (`pesapal_redirect_url`,
+-- `pesapal_order_id`, `payment_failed_at`) and these are AMOUNT-BOUND. When
+-- the operator re-enters a different reading and `total_amount` changes, the
+-- cached Pesapal session is for the OLD amount — the customer would land on
+-- a checkout page that still says the old total. The cache must be
+-- invalidated.
+--
+-- We invalidate only when `EXCLUDED.total_amount IS DISTINCT FROM
+-- billing_line_items.total_amount` (true amount change) so that re-running
+-- the regenerate flow with the same readings (a no-op) does not throw away
+-- a working Pesapal session.
+--
+-- `payment_failed_at` documents that a SPECIFIC Pesapal session failed; the
+-- new amount needs a fresh attempt and the old failure timestamp is no
+-- longer meaningful. `payment_refunded_at` is intentionally NOT invalidated
+-- — a refund is a permanent ledger entry; money moved back to the customer
+-- and that fact does not get erased by a re-keyed reading.
+--
+-- ── Defects this fixes ────────────────────────────────────────────────────────
+--
+-- See #217 for the full reproduction. Aaron re-keyed Samuel Wataba's reading
+-- on Sezibwa microgrid; the regenerated invoice carried the new total_amount
+-- but the customer-facing PDF and the operator UI displayed the old
+-- pesapal_redirect_url pointing at the old amount.
+--
+-- This migration ALSO unblocks the Part-B operator-recovery flow: after the
+-- auto-invalidation, "Regenerate payment link" can mint a fresh URL via the
+-- updated `ensurePaymentLinkForLineItem({ force: true })` path. (The route
+-- and helper changes ship in the same PR but in TypeScript code, not SQL.)
+--
+-- ── Idempotency ───────────────────────────────────────────────────────────────
+--
+-- `CREATE OR REPLACE FUNCTION` with the SAME signature as 00029 — pure body
+-- refactor, no codegen impact. Re-running this migration is safe.
+
+CREATE OR REPLACE FUNCTION fn_record_line_item_with_audit(
+  _billing_period_id   UUID,
+  _household_id        UUID,
+  _device_id           UUID,
+  _usage_kwh           NUMERIC,
+  _start_kwh           NUMERIC,
+  _end_kwh             NUMERIC,
+  _tier_breakdown      JSONB,
+  _total_amount        NUMERIC,
+  _reading_source      billing_line_item_reading_source,
+  _entered_by_user_id  UUID,
+  _manual_reason       TEXT,
+  _actor_user_id       UUID,
+  _audit_details       JSONB
+) RETURNS billing_line_items
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_row             billing_line_items%ROWTYPE;
+  v_was_inserted    BOOLEAN;
+  v_period_status   billing_period_status;
+  v_event_type      billing_audit_event_type;
+  v_entered_at      TIMESTAMPTZ;
+  v_audit_details   JSONB := COALESCE(_audit_details, '{}'::jsonb);
+  v_line_item_id    UUID;
+BEGIN
+  -- Resolve entered_at only when the new reading is manual (otherwise NULL,
+  -- per AC1 of #173).
+  IF _reading_source = 'manual' THEN
+    v_entered_at := now();
+  ELSE
+    v_entered_at := NULL;
+  END IF;
+
+  -- UPSERT on (billing_period_id, household_id). On conflict, UPDATE the
+  -- reading + calc + provenance columns AND invalidate the amount-bound
+  -- payment-cache columns when the amount truly changes (#217).
+  INSERT INTO billing_line_items (
+    billing_period_id,
+    household_id,
+    device_id,
+    usage_kwh,
+    start_kwh,
+    end_kwh,
+    tier_breakdown,
+    total_amount,
+    reading_source,
+    entered_by_user_id,
+    entered_at,
+    manual_reason
+  )
+  VALUES (
+    _billing_period_id,
+    _household_id,
+    _device_id,
+    _usage_kwh,
+    _start_kwh,
+    _end_kwh,
+    COALESCE(_tier_breakdown, '[]'::jsonb),
+    _total_amount,
+    _reading_source,
+    CASE WHEN _reading_source = 'manual' THEN _entered_by_user_id ELSE NULL END,
+    v_entered_at,
+    CASE WHEN _reading_source = 'manual' THEN _manual_reason ELSE NULL END
+  )
+  ON CONFLICT (billing_period_id, household_id) DO UPDATE SET
+    device_id            = EXCLUDED.device_id,
+    usage_kwh            = EXCLUDED.usage_kwh,
+    start_kwh            = EXCLUDED.start_kwh,
+    end_kwh              = EXCLUDED.end_kwh,
+    tier_breakdown       = EXCLUDED.tier_breakdown,
+    total_amount         = EXCLUDED.total_amount,
+    reading_source       = EXCLUDED.reading_source,
+    entered_by_user_id   = EXCLUDED.entered_by_user_id,
+    entered_at           = EXCLUDED.entered_at,
+    manual_reason        = EXCLUDED.manual_reason,
+    -- Amount-change invalidation (#217). IS DISTINCT FROM correctly handles
+    -- NULL on either side and gives us "only invalidate when the amount
+    -- truly changed." total_amount is NOT NULL so this practically collapses
+    -- to `<>`, but IS DISTINCT FROM is defensive against future schema
+    -- relaxation.
+    pesapal_redirect_url = CASE
+      WHEN EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount
+      THEN NULL
+      ELSE billing_line_items.pesapal_redirect_url
+    END,
+    pesapal_order_id     = CASE
+      WHEN EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount
+      THEN NULL
+      ELSE billing_line_items.pesapal_order_id
+    END,
+    payment_failed_at    = CASE
+      WHEN EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount
+      THEN NULL
+      ELSE billing_line_items.payment_failed_at
+    END
+    -- DELIBERATELY OMITTED — owned by fn_apply_payment_event and survive the
+    -- UPSERT regardless of amount change:
+    --   payment_status, paid_at, paid_by_user_id, payment_notes,
+    --   payment_refunded_at
+    --
+    -- Why preserve payment_status / paid_at on amount change? If a line item
+    -- was paid and then re-keyed, the past payment STILL HAPPENED. Erasing
+    -- it would falsify the audit trail. The operator must reconcile manually
+    -- (refund the difference, or accept the new amount as outstanding).
+    --
+    -- Why preserve payment_refunded_at on amount change? A refund is a
+    -- permanent ledger entry — money moved back to the customer; that does
+    -- not get erased by a re-keyed reading.
+  RETURNING (xmax = 0), id
+  INTO v_was_inserted, v_line_item_id;
+
+  -- Re-read the row as a composite (RETURNING * + scalar isn't supported in
+  -- one INTO clause). Cheap — we already hold the row lock from the UPSERT.
+  SELECT * INTO v_row
+  FROM billing_line_items
+  WHERE id = v_line_item_id;
+
+  -- Look up period status to derive period_was_closed (Q4=B audit hint).
+  SELECT status INTO v_period_status
+  FROM billing_periods
+  WHERE id = _billing_period_id;
+
+  IF v_period_status = 'closed' THEN
+    v_audit_details := v_audit_details || jsonb_build_object('period_was_closed', true);
+  END IF;
+
+  v_event_type := CASE
+    WHEN v_was_inserted THEN 'line_item_generated'::billing_audit_event_type
+    ELSE 'line_item_regenerated'::billing_audit_event_type
+  END;
+
+  INSERT INTO billing_audit_log (
+    billing_period_id,
+    billing_line_item_id,
+    event_type,
+    actor_user_id,
+    details
+  )
+  VALUES (
+    _billing_period_id,
+    v_row.id,
+    v_event_type,
+    _actor_user_id,
+    v_audit_details
+  );
+
+  RETURN v_row;
+END;
+$$;
+
+-- Defensive re-grant. CREATE OR REPLACE preserves privileges, but mirroring
+-- the pattern from 00030:88-89 keeps the grant explicit at the migration
+-- boundary in case the function was dropped + recreated by a future change.
+GRANT EXECUTE ON FUNCTION fn_record_line_item_with_audit(
+  UUID, UUID, UUID, NUMERIC, NUMERIC, NUMERIC, JSONB, NUMERIC,
+  billing_line_item_reading_source, UUID, TEXT, UUID, JSONB
+) TO authenticated;


### PR DESCRIPTION
Closes #217

## Summary
- **Migration `00037_invalidate_payment_link_on_reread.sql`** — `CREATE OR REPLACE` `fn_record_line_item_with_audit` (same 13-arg signature). The `DO UPDATE SET` clause adds three CASE expressions: when `EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount`, NULL out `pesapal_redirect_url`, `pesapal_order_id`, and `payment_failed_at`. Otherwise preserve. `payment_status / paid_at / paid_by_user_id / payment_notes / payment_refunded_at` remain preserved unconditionally.
- **`ensurePaymentLinkForLineItem`** gains a `force?: boolean` option. On `force=true`: skip cache-check + coalescer (both directions), always mint fresh, UNCONDITIONALLY UPDATE both `pesapal_redirect_url` AND `pesapal_order_id` in a single SET (no stale-pair window), fire the `link_generated` audit-write side effect (warn-and-return on `paid → link_generated` rejection), return `wasMinted: true`.
- **`POST /api/billing-line-items/[id]/url`** parses optional `{ force?: boolean }` body. Backwards-compatible: empty body / `{}` / `{ force: false }` all behave as before.
- **`<RowActionsMenu>`** "Regenerate payment link" passes `{ force: true }`; "Generate payment link" passes nothing. `onGenerateLink` callback widened to `(opts?: { force?: boolean }) => void`.
- Tests cover schema cases A/B/C, helper force/cache/paid-row paths, route force + backward-compat regression.

## Why
Aaron's report (Samuel Wataba on Sezibwa Microgrid): re-enter manual reading → new total computed → cached `pesapal_redirect_url` survives the UPSERT (silently preserved because the column was added in 00033 after the RPC body was written) → "Regenerate payment link" cache-hits the stale URL → customer gets old amount in WhatsApp.

Two compounding fixes: (Part A) the RPC auto-invalidates payment-link cache when the amount actually changes, so subsequent /pdf and /pay calls mint fresh automatically. (Part B) the operator's explicit "Regenerate" click bypasses the cache entirely — force-mint regardless of cached state.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — pre-existing warnings only.
- [x] `npm test` (`SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1`) — 1518/1518 pass; helper +3, route +5, schema (RLS-gated) +3.
- [x] `npm run build` — clean.
- [x] `npm run db:types` — zero diff (signature unchanged).
- [ ] Operator follow-up: apply migration `00037` to cloud Supabase `tztbmsxxjjsryuvoyqji`. Verify with `pg_get_functiondef('fn_record_line_item_with_audit(...)'::regprocedure)` that the new SET clause is in place.
- [ ] Operator follow-up: reproduce Aaron's flow on Samuel Wataba's row — re-enter reading with a different value, verify post-UPSERT `pesapal_redirect_url IS NULL` and `pesapal_order_id IS NULL`. Click "Regenerate payment link" — fresh URL minted with new amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)