### PR TITLE
Audit snapshot: capture previous reading state on line_item_regenerated (#218)

### DIFF
--- a/src/components/billing/__tests__/audit-log-list.test.tsx
+++ b/src/components/billing/__tests__/audit-log-list.test.tsx
@@ -71,6 +71,24 @@ const ENTRIES: BillingAuditLogEntry[] = [
       new_reading_source: "manual",
       manual_reason: "Operator estimate",
       period_was_closed: true,
+      // #218: previous_snapshot is additive JSONB on regenerate events. The
+      // humanizer reads only specific top-level keys via
+      // `entry.details?.["…"]` and never iterates `Object.keys(details)`,
+      // so this field is silently ignored by the existing renderers (as
+      // intended — display is OOS for #218; this fixture guards against
+      // future "improve the humanizer" regressions accidentally surfacing
+      // the snapshot or swapping its `manual_reason` with the top-level
+      // NEW reason).
+      previous_snapshot: {
+        start_kwh: 100,
+        end_kwh: 350,
+        usage_kwh: 250,
+        tier_breakdown: [{ label: "T1", kwh: 250, amount: 12500 }],
+        device_id: null,
+        entered_by_user_id: "11111111-1111-4111-8111-111111111111",
+        entered_at: "2026-04-20T10:00:00Z",
+        manual_reason: "initial estimate",
+      },
     },
   },
   {
@@ -177,6 +195,12 @@ describe("<AuditLogList> — list rendering", () => {
       container.querySelectorAll(".italic.text-muted-foreground")
     ).find((el) => el.textContent?.includes("Operator estimate"));
     expect(reasonEl).toBeDefined();
+    // #218 naming-clash guard: `previous_snapshot.manual_reason` is the
+    // PREVIOUS reason, distinct from the top-level (NEW) `manual_reason`.
+    // The humanizer reads only top-level keys; it must not surface the
+    // snapshot's `manual_reason` as raw display, and a future PR must not
+    // silently swap the two semantically-distinct keys.
+    expect(screen.queryByText("initial estimate")).toBeNull();
   });
 
   it("renders 3-state actor names (System / Restricted / verbatim)", () => {

--- a/src/lib/billing/generate.ts
+++ b/src/lib/billing/generate.ts
@@ -174,6 +174,21 @@ type PriorItem = {
   reading_source: ReadingSource;
   end_kwh: number | null;
   device_id: string | null;
+  // ── New for #218 (previous-snapshot capture) ─────────────────────────────
+  // Required to build `auditDetails.previous_snapshot` for the
+  // `line_item_regenerated` event. The SELECT at :362 must read these too —
+  // the explicit `as unknown as PriorItem[]` cast at :366 suppresses
+  // PostgREST's inferred shape, so widening this type without widening the
+  // SELECT would compile but resolve `undefined` at runtime.
+  start_kwh: number | null;
+  usage_kwh: number | null;
+  /** JSONB — shape is `TierBreakdown[]` in the live row but we keep it
+   *  `unknown` here to match the audit-snapshot contract (round-trip,
+   *  no validation). */
+  tier_breakdown: unknown;
+  entered_by_user_id: string | null;
+  entered_at: string | null;
+  manual_reason: string | null;
 };
 
 // ── Implementation ──────────────────────────────────────────────────────────
@@ -359,7 +374,11 @@ export async function runGenerationFor(
   const { data: existingItemsRaw } = await supabase
     .from("billing_line_items")
     .select(
-      "household_id, total_amount, payment_status, reading_source, end_kwh, device_id"
+      // The trailing fields (start_kwh, usage_kwh, tier_breakdown,
+      // entered_by_user_id, entered_at, manual_reason) are read for #218's
+      // `previous_snapshot` audit-details capture — the RPC overwrites them
+      // on UPSERT-UPDATE, so we must read them BEFORE calling the RPC.
+      "household_id, total_amount, payment_status, reading_source, end_kwh, device_id, start_kwh, usage_kwh, tier_breakdown, entered_by_user_id, entered_at, manual_reason"
     )
     .eq("billing_period_id", periodId);
   const existingByHousehold = new Map<string, PriorItem>();
@@ -640,6 +659,28 @@ export async function runGenerationFor(
       new_reading_source: readingSource,
       ...(readingSource === "manual" && manualReason
         ? { manual_reason: manualReason }
+        : {}),
+      // #218: capture the reading-side snapshot of the row immediately BEFORE
+      // this regeneration overwrites it. Present only on UPDATE (when prior
+      // exists); absent on fresh INSERT. Numerics use `Number(x)`-or-null
+      // coercion to match the existing previous_total_amount precision
+      // pattern above. Note: `previous_snapshot.manual_reason` is the
+      // PREVIOUS reason, distinct from the top-level `manual_reason` (NEW).
+      ...(prior
+        ? {
+            previous_snapshot: {
+              start_kwh:
+                prior.start_kwh != null ? Number(prior.start_kwh) : null,
+              end_kwh: prior.end_kwh != null ? Number(prior.end_kwh) : null,
+              usage_kwh:
+                prior.usage_kwh != null ? Number(prior.usage_kwh) : null,
+              tier_breakdown: prior.tier_breakdown,
+              device_id: prior.device_id,
+              entered_by_user_id: prior.entered_by_user_id,
+              entered_at: prior.entered_at,
+              manual_reason: prior.manual_reason,
+            },
+          }
         : {}),
     };
 

--- a/src/lib/supabase/__tests__/billing_audit_log.test.ts
+++ b/src/lib/supabase/__tests__/billing_audit_log.test.ts
@@ -62,6 +62,21 @@ const FIXTURE = {
   mgB: "dddddddd-dddd-4000-8002-00000000000b",
   hhB: "dddddddd-dddd-4000-8005-00000000000b",
   periodB: "dddddddd-dddd-4000-8006-00000000000b",
+
+  // #218: isolated fixture for previous_snapshot tests. Distinct from A
+  // because the AC #242 UPDATE-via-CONFLICT test mutates periodA/hhA row
+  // state and downstream assertions would couple to ordering. C is
+  // un-metered (no household_devices row, no edge/device) so
+  // runGenerationFor routes through the manual-override path without
+  // contacting OpenEMS.
+  orgC: "dddddddd-dddd-4000-8000-00000000000c",
+  commC: "dddddddd-dddd-4000-8001-00000000000c",
+  mgC: "dddddddd-dddd-4000-8002-00000000000c",
+  hhC: "dddddddd-dddd-4000-8005-00000000000c",
+  periodC: "dddddddd-dddd-4000-8006-00000000000c",
+  // periodC2 is a SEPARATE period with no prior line item — for the fresh
+  // INSERT (no previous_snapshot) test path.
+  periodC2: "dddddddd-dddd-4000-8006-00000000001c",
 };
 
 // Test users created in beforeAll.
@@ -80,7 +95,7 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
     const svc = await serviceClient();
 
     await cleanupTestData({
-      orgIds: [FIXTURE.orgA, FIXTURE.orgB],
+      orgIds: [FIXTURE.orgA, FIXTURE.orgB, FIXTURE.orgC],
       userEmails: [EMAIL_SUPER, EMAIL_ORGA, EMAIL_ORGB],
     });
 
@@ -164,6 +179,48 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
       status: "draft",
     });
 
+    // ── Fixture C — #218 previous_snapshot isolated fixture ──────────────
+    // Un-metered household: NO household_devices row, NO edge/device.
+    // runGenerationFor routes through the manual-override path so OpenEMS
+    // is never contacted. A rate_schedules row is required (un-metered or
+    // not) — runGenerationFor returns fatal 400 without one.
+    await svc.from("organizations").insert({ id: FIXTURE.orgC, name: "BC1 Org C" });
+    await svc.from("communities").insert({ id: FIXTURE.commC, org_id: FIXTURE.orgC, name: "BC1 Comm C" });
+    await svc.from("microgrids").insert({
+      id: FIXTURE.mgC,
+      community_id: FIXTURE.commC,
+      name: "BC1 MG C",
+      currency: "UGX",
+    });
+    await svc.from("rate_schedules").insert({
+      microgrid_id: FIXTURE.mgC,
+      tiers: [
+        { label: "T1", min_kwh: 0, max_kwh: null, rate_per_kwh: 50 },
+      ],
+      service_charge: 0,
+      tax_rate: 0,
+    });
+    await svc.from("households").insert({
+      id: FIXTURE.hhC,
+      microgrid_id: FIXTURE.mgC,
+      display_name: "BC1 Household C",
+      primary_phone: "+256700000003",
+    });
+    await svc.from("billing_periods").insert({
+      id: FIXTURE.periodC,
+      microgrid_id: FIXTURE.mgC,
+      start_date: "2026-04-01",
+      end_date: "2026-04-30",
+      status: "draft",
+    });
+    await svc.from("billing_periods").insert({
+      id: FIXTURE.periodC2,
+      microgrid_id: FIXTURE.mgC,
+      start_date: "2026-05-01",
+      end_date: "2026-05-31",
+      status: "draft",
+    });
+
     // Test users
     alejandroSuperAdmin = await createTestUser({
       email: EMAIL_SUPER,
@@ -184,7 +241,7 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
   afterAll(async () => {
     if (skip) return;
     await cleanupTestData({
-      orgIds: [FIXTURE.orgA, FIXTURE.orgB],
+      orgIds: [FIXTURE.orgA, FIXTURE.orgB, FIXTURE.orgC],
       userEmails: [EMAIL_SUPER, EMAIL_ORGA, EMAIL_ORGB],
     });
   }, 60_000);
@@ -664,6 +721,242 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
     expect(after?.paid_at).toBe(paidBefore?.paid_at);
     expect(after?.paid_by_user_id).toBe(paidBefore?.paid_by_user_id);
     expect(after?.payment_notes).toBe(paidBefore?.payment_notes);
+  });
+
+  // ── #218: previous_snapshot capture (RPC pass-through, builder, absence) ───
+  //
+  // Three orthogonal axes:
+  //   (a) RPC pass-through — caller-built JSONB lands byte-for-byte in
+  //       billing_audit_log.details (the RPC treats the blob as opaque).
+  //   (b) Builder end-to-end — runGenerationFor (real, no mock) populates
+  //       previous_snapshot from the prior row on UPDATE; naming-clash
+  //       contract (top-level manual_reason = NEW; previous_snapshot.
+  //       manual_reason = PREVIOUS) is preserved.
+  //   (c) Absence — fresh INSERT (no prior) does NOT include
+  //       previous_snapshot.
+
+  it("fn_record_line_item_with_audit: round-trips _audit_details.previous_snapshot byte-for-byte (RPC pass-through, #218)", async () => {
+    const svc = await serviceClient();
+
+    // Build a hand-crafted previous_snapshot JSONB. We use the existing A
+    // fixture's deviceA UUID inside the snapshot just so the value is a
+    // realistic UUID; the snapshot is just data — the RPC doesn't FK-check
+    // device_id inside the JSONB.
+    const seededEnteredAt = "2026-04-15T08:30:00.000Z";
+    const seededSnapshot = {
+      start_kwh: 100,
+      end_kwh: 350,
+      usage_kwh: 250,
+      tier_breakdown: [{ label: "T1", kwh: 250, amount: 12500 }],
+      device_id: FIXTURE.deviceA,
+      entered_by_user_id: alejandroSuperAdmin.userId,
+      entered_at: seededEnteredAt,
+      manual_reason: "initial estimate",
+    };
+
+    const { error } = await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 300,
+      _start_kwh: 100,
+      _end_kwh: 400,
+      _tier_breakdown: [{ label: "T1", kwh: 300, amount: 15000 }],
+      _total_amount: 15000,
+      _reading_source: "manual",
+      _entered_by_user_id: alejandroSuperAdmin.userId,
+      _manual_reason: "corrected",
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: {
+        household_name: "BC1 Household A",
+        previous_total_amount: 12500,
+        new_total_amount: 15000,
+        previous_reading_source: "manual",
+        new_reading_source: "manual",
+        manual_reason: "corrected",
+        previous_snapshot: seededSnapshot,
+      },
+    });
+    expect(error).toBeNull();
+
+    const { data: lastAudit } = await svc
+      .from("billing_audit_log")
+      .select("details")
+      .eq("billing_period_id", FIXTURE.periodA)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    const details = lastAudit?.[0]?.details as Record<string, unknown>;
+    const snap = details?.previous_snapshot as Record<string, unknown>;
+
+    expect(snap).toBeTruthy();
+    expect(snap.start_kwh).toBe(100);
+    expect(snap.end_kwh).toBe(350);
+    expect(snap.usage_kwh).toBe(250);
+    expect(snap.device_id).toBe(FIXTURE.deviceA);
+    expect(snap.entered_by_user_id).toBe(alejandroSuperAdmin.userId);
+    expect(snap.manual_reason).toBe("initial estimate");
+    expect(snap.tier_breakdown).toEqual([
+      { label: "T1", kwh: 250, amount: 12500 },
+    ]);
+    // TIMESTAMPTZ → JSON; Postgres may add microsecond precision absent in
+    // JS Date.toISOString(). Compare via Date round-trip equality.
+    expect(new Date(snap.entered_at as string).toISOString()).toBe(
+      new Date(seededEnteredAt).toISOString()
+    );
+
+    // Top-level keys (humanizer reads these, not the snapshot's keys) are
+    // preserved alongside the additive previous_snapshot field.
+    expect(details.new_total_amount).toBe(15000);
+    expect(details.previous_total_amount).toBe(12500);
+    expect(details.manual_reason).toBe("corrected");
+
+    // Naming-clash contract: top-level manual_reason is the NEW reason;
+    // previous_snapshot.manual_reason is the PREVIOUS reason. Distinct keys.
+    expect(details.manual_reason).not.toBe(snap.manual_reason);
+
+    // Payment keys are NOT present in the snapshot — the test caller didn't
+    // put them in, and the RPC doesn't add them.
+    expect(snap).not.toHaveProperty("payment_status");
+    expect(snap).not.toHaveProperty("paid_at");
+    expect(snap).not.toHaveProperty("paid_by_user_id");
+    expect(snap).not.toHaveProperty("pesapal_order_id");
+  });
+
+  it("runGenerationFor: builds previous_snapshot from the prior row on UPDATE (#218 builder e2e)", async () => {
+    const svc = await serviceClient();
+
+    // Pre-pin a prior line item for (periodC, hhC) via service-role UPSERT.
+    // Setting reading_source='manual' with non-null entered_at /
+    // manual_reason avoids a degenerate test (an 'edge' row would have
+    // those fields NULL per the RPC, masking the snapshot capture).
+    const priorEnteredAt = new Date("2026-04-10T08:00:00.000Z").toISOString();
+    const { data: priorRow, error: priorErr } = await svc
+      .from("billing_line_items")
+      .insert({
+        billing_period_id: FIXTURE.periodC,
+        household_id: FIXTURE.hhC,
+        device_id: null,
+        usage_kwh: 250,
+        start_kwh: 100,
+        end_kwh: 350,
+        tier_breakdown: [{ label: "T1", kwh: 250, amount: 12500 }],
+        total_amount: 12500,
+        reading_source: "manual",
+        entered_by_user_id: alejandroSuperAdmin.userId,
+        entered_at: priorEnteredAt,
+        manual_reason: "initial estimate",
+      })
+      .select("id")
+      .single<{ id: string }>();
+    expect(priorErr).toBeNull();
+    const priorLineItemId = priorRow!.id;
+
+    // Now call runGenerationFor (the real function) as the super_admin so
+    // the RPC's SECURITY INVOKER + RLS-INSERT-WITH-CHECK fires under a
+    // proper auth.uid() — service-role would bypass RLS and mask any
+    // regression.
+    const { runGenerationFor } = await import("@/lib/billing/generate");
+    const out = await runGenerationFor({
+      supabase: alejandroSuperAdmin.client,
+      periodId: FIXTURE.periodC,
+      householdIds: [FIXTURE.hhC],
+      manualReadings: [
+        {
+          householdId: FIXTURE.hhC,
+          startKwh: 100,
+          endKwh: 400,
+          reason: "corrected",
+        },
+      ],
+      mode: "write",
+      actorUserId: alejandroSuperAdmin.userId,
+    });
+    if ("kind" in out && out.kind === "fatal") {
+      throw new Error(
+        `runGenerationFor returned fatal ${out.status}: ${out.body.error}`
+      );
+    }
+    const results = (out as { results: { kind: string; householdId: string }[] }).results;
+    const written = results.find((r) => r.householdId === FIXTURE.hhC);
+    expect(written?.kind).toBe("written");
+
+    // Read back the latest audit row for this line item.
+    const { data: lastAudit } = await svc
+      .from("billing_audit_log")
+      .select("event_type, details")
+      .eq("billing_line_item_id", priorLineItemId)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    expect(lastAudit?.length).toBe(1);
+    expect(lastAudit?.[0]?.event_type).toBe("line_item_regenerated");
+    const details = lastAudit?.[0]?.details as Record<string, unknown>;
+    const snap = details?.previous_snapshot as Record<string, unknown>;
+
+    // Snapshot reflects the seeded prior row (pre-overwrite state).
+    expect(snap).toBeTruthy();
+    // Numeric coercion: builder uses Number(x)-or-null.
+    expect(snap.start_kwh).toBe(100);
+    expect(snap.end_kwh).toBe(350);
+    expect(snap.usage_kwh).toBe(250);
+    expect(snap.tier_breakdown).toEqual([
+      { label: "T1", kwh: 250, amount: 12500 },
+    ]);
+    expect(snap.device_id).toBeNull();
+    expect(snap.entered_by_user_id).toBe(alejandroSuperAdmin.userId);
+    expect(new Date(snap.entered_at as string).toISOString()).toBe(
+      new Date(priorEnteredAt).toISOString()
+    );
+
+    // Top-level previous_total_amount also reflects the prior row.
+    expect(details.previous_total_amount).toBe(12500);
+    // new_total_amount reflects the recomputed total: usage_kwh = 300 at
+    // 50 UGX/kWh = 15000.
+    expect(details.new_total_amount).toBe(15000);
+
+    // Naming-clash contract: top-level manual_reason is the NEW reason
+    // ('corrected'), snapshot's manual_reason is the PREVIOUS reason
+    // ('initial estimate'). Both must coexist; the test fails if a future
+    // implementer accidentally swaps or merges them.
+    expect(details.manual_reason).toBe("corrected");
+    expect(snap.manual_reason).toBe("initial estimate");
+  });
+
+  it("runGenerationFor: fresh INSERT (no prior) emits NO previous_snapshot key (#218 absence)", async () => {
+    const svc = await serviceClient();
+
+    const { runGenerationFor } = await import("@/lib/billing/generate");
+    const out = await runGenerationFor({
+      supabase: alejandroSuperAdmin.client,
+      periodId: FIXTURE.periodC2,
+      householdIds: [FIXTURE.hhC],
+      manualReadings: [
+        {
+          householdId: FIXTURE.hhC,
+          startKwh: 0,
+          endKwh: 100,
+          reason: "first reading",
+        },
+      ],
+      mode: "write",
+      actorUserId: alejandroSuperAdmin.userId,
+    });
+    if ("kind" in out && out.kind === "fatal") {
+      throw new Error(
+        `runGenerationFor returned fatal ${out.status}: ${out.body.error}`
+      );
+    }
+
+    const { data: lastAudit } = await svc
+      .from("billing_audit_log")
+      .select("event_type, details")
+      .eq("billing_period_id", FIXTURE.periodC2)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    expect(lastAudit?.length).toBe(1);
+    expect(lastAudit?.[0]?.event_type).toBe("line_item_generated");
+    const details = lastAudit?.[0]?.details as Record<string, unknown>;
+    // Strict absence: the key is not present (vs present-but-null/empty).
+    expect(details).not.toHaveProperty("previous_snapshot");
   });
 
   // ── Atomicity ─────────────────────────────────────────────────────────────

--- a/src/lib/types/billing-audit.ts
+++ b/src/lib/types/billing-audit.ts
@@ -60,11 +60,53 @@ export type LineItemRegeneratedDetails = {
   previous_reading_source: "edge" | "manual" | null;
   /** reading_source on the post-write line item. */
   new_reading_source: "edge" | "manual";
-  /** present only when new_reading_source === 'manual' AND a non-empty reason was supplied. */
+  /** present only when new_reading_source === 'manual' AND a non-empty reason was supplied.
+   *  This is the NEW manual reason; the PREVIOUS reason lives in
+   *  previous_snapshot.manual_reason (see below). */
   manual_reason?: string;
   /** added by fn_record_line_item_with_audit (NOT by the route handler) when
    *  the period.status was 'closed' at write time. Absent otherwise. */
   period_was_closed?: true;
+  /** Snapshot of the reading-side fields on the row immediately BEFORE this
+   *  regeneration overwrote them. Present only on UPDATE (when prior exists);
+   *  absent on fresh INSERT. Optional for backward-compat with audit rows
+   *  written before this field was introduced (#218).
+   *
+   *  Provenance: added by the CALLER (runGenerationFor) before the RPC
+   *  call, NOT by the RPC. Contrast `period_was_closed` above, which is
+   *  added by the RPC (00029:291 jsonb merge). Both keys land in the
+   *  same JSONB blob. */
+  previous_snapshot?: PreviousReadingSnapshot;
+};
+
+/** Pre-overwrite snapshot of the reading-side columns on a billing_line_items
+ *  row. Captured by runGenerationFor and persisted into
+ *  billing_audit_log.details.previous_snapshot for line_item_regenerated
+ *  events. Numerics are coerced to JS Number to match the existing
+ *  previous_total_amount pattern (see #218 Dev Notes for precision tradeoff). */
+export type PreviousReadingSnapshot = {
+  /** previous billing_line_items.start_kwh (NUMERIC → JS Number) */
+  start_kwh: number | null;
+  /** previous billing_line_items.end_kwh (NUMERIC → JS Number) */
+  end_kwh: number | null;
+  /** previous billing_line_items.usage_kwh (NUMERIC → JS Number) */
+  usage_kwh: number | null;
+  /** previous billing_line_items.tier_breakdown (JSONB; opaque, persisted as-is).
+   *  Type intentionally `unknown` — the audit contract is "round-trip the
+   *  JSONB blob unchanged", we don't validate the per-tier shape here.
+   *  If a future consumer needs typed access, cast at the consumer
+   *  (`as TierBreakdown[]`); do NOT widen this type. */
+  tier_breakdown: unknown;
+  /** previous billing_line_items.device_id (UUID or NULL when un-metered) */
+  device_id: string | null;
+  /** previous billing_line_items.entered_by_user_id — who entered the previous
+   *  reading. UUID; not PII per the entity model. */
+  entered_by_user_id: string | null;
+  /** previous billing_line_items.entered_at (ISO TIMESTAMPTZ string or NULL). */
+  entered_at: string | null;
+  /** previous billing_line_items.manual_reason — the PREVIOUS reason string.
+   *  Distinct from the top-level manual_reason which is the NEW reason. */
+  manual_reason: string | null;
 };
 
 // ── Read-endpoint entry shape ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #218

## Summary
- **Type extension** in `src/lib/types/billing-audit.ts`: optional `previous_snapshot?: PreviousReadingSnapshot` on `LineItemRegeneratedDetails`. New `PreviousReadingSnapshot` type with TSDoc on every field. Naming-clash documented (top-level `manual_reason` is the NEW reason; `previous_snapshot.manual_reason` is the PREVIOUS).
- **`runGenerationFor`** in `src/lib/billing/generate.ts`: extends `existingByHousehold` SELECT with `start_kwh, usage_kwh, tier_breakdown, entered_by_user_id, entered_at, manual_reason`; widens `PriorItem`; the `auditDetails` builder writes `previous_snapshot` when `prior` exists (using `Number()`-or-null coercion for numerics, mirroring the existing `previous_total_amount` pattern).
- **No schema migration**. JSONB is unstructured; the field lands additively.
- **Tests** (3 new integration cases in `billing_audit_log.test.ts` + audit-log-list rendering safety):
  - **Case 1 (RPC pass-through)**: hand-built JSONB with `previous_snapshot` round-trips byte-for-byte through `fn_record_line_item_with_audit`.
  - **Case 2 (builder end-to-end)**: isolated mgC/periodC/hhC fixture with `rate_schedules` seed; pre-pinned manual prior row; `runGenerationFor` invoked via super-admin client (RLS exercised); naming-clash assertion `details.manual_reason !== details.previous_snapshot.manual_reason`.
  - **Case 3 (fresh-INSERT absence)**: separate `periodC2` with no prior; asserts `details` has no `previous_snapshot` key (strict `not.toHaveProperty`).

## Why
On re-entry of manual readings, the RPC overwrites `start_kwh / end_kwh / usage_kwh / tier_breakdown / device_id / entered_by_user_id / entered_at / manual_reason`. The audit log previously captured only the `previous_total_amount` and `previous_reading_source` — losing the underlying reading evidence needed for billing-dispute defense. PDF5 captures the full snapshot of the BEFORE state in `billing_audit_log.details` so the trail is reconstructable.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — pre-existing warnings only.
- [x] `npm test` (`SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1`) — 1518/1518 pass; `audit-log-list.test.tsx` 12/12 pass; new RLS-gated cases skip cleanly when local Supabase is offline.
- [x] `npm run build` — clean.
- [x] `database.gen.ts` zero-diff.
- [ ] Operator follow-up: as a super_admin, re-enter a reading on any closed-period line item, then `SELECT details FROM billing_audit_log WHERE billing_line_item_id='<id>' ORDER BY created_at DESC LIMIT 1` — verify `details.previous_snapshot` matches the pre-edit row state.

## Notes
- Audit-log UI rendering is intentionally unchanged. The data lands in JSONB and is queryable via SQL/Studio. Surfacing the snapshot in the activity-log UI is a designer-driven follow-up.
- Each regeneration writes its own audit row; multi-regeneration trail is reconstructable by ordering rows by `created_at` for the same `billing_line_item_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)