### PR TITLE
Menu signal: drive Generate/Regenerate label by pesapal_redirect_url presence (#221)

### DIFF
--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -606,6 +606,8 @@ export function BillingTable({
                 payment_status: item.payment_status,
                 reading_source: item.reading_source,
                 total_amount: item.total_amount,
+                // #221 — drives the Generate vs Regenerate menu signal.
+                pesapal_redirect_url: item.pesapal_redirect_url,
               }}
               household={{ id: h.id, display_name: h.display_name }}
               period={{

--- a/src/components/__tests__/billing-table.test.tsx
+++ b/src/components/__tests__/billing-table.test.tsx
@@ -14,7 +14,7 @@
 //     (f) Gate banner absent when isPaymentConfigured=true
 
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BillingTable } from "../BillingTable";
 import { LocaleProvider } from "../format/locale-context";
 import type {
@@ -57,6 +57,16 @@ if (typeof globalThis.ResizeObserver === "undefined") {
     unobserve() {}
     disconnect() {}
   };
+}
+
+// Radix DropdownMenu also uses PointerEvents in jsdom — stub it for the
+// #221 regression-guard test that opens the kebab menu.
+if (typeof globalThis.PointerEvent === "undefined") {
+  globalThis.PointerEvent = class PointerEvent extends MouseEvent {
+    constructor(type: string, init?: PointerEventInit) {
+      super(type, init);
+    }
+  } as typeof PointerEvent;
 }
 
 // ─── Fixture data ───────────────────────────────────────────────────────────
@@ -545,5 +555,52 @@ describe("BillingTable", () => {
       (b) => /row actions for/i.test(b.getAttribute("aria-label") ?? ""),
     );
     expect(kebabs.length).toBe(3);
+  });
+
+  // ── #221 regression-guard ────────────────────────────────────────────────
+  //
+  // BillingTable.tsx:604-609 hand-builds the lineItem prop forwarded to
+  // <RowActionsMenu>. If `pesapal_redirect_url` is dropped from that
+  // literal, the menu loses its Generate-vs-Regenerate signal silently —
+  // the type widening alone wouldn't catch it (Architect evolution-log
+  // entry on hand-fabricated `.returns<>` traps). This test renders the
+  // full prop chain with a drift-state row and verifies "Regenerate
+  // payment link" reaches the dropdown.
+  it("(#221) forwards pesapal_redirect_url through the prop chain — drift row shows Regenerate", async () => {
+    const driftLineItems: BillingLineItem[] = [
+      {
+        ...lineItems[0],
+        // The drift state from #221: payment_status='unpaid' but a URL
+        // is cached on the row.
+        payment_status: "unpaid",
+        pesapal_redirect_url: "https://pay.example/drift",
+      },
+      lineItems[1],
+      lineItems[2],
+    ];
+
+    render(
+      <Wrapper>
+        <BillingTable
+          {...baseProps}
+          lineItems={driftLineItems}
+          isPaymentConfigured={true}
+        />
+      </Wrapper>,
+    );
+
+    // Open the kebab menu for the drift row (h-1 / Alice).
+    const trigger = screen.getByRole("button", {
+      name: /row actions for alice/i,
+    });
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { bubbles: true, cancelable: true });
+      fireEvent.click(trigger);
+    });
+
+    await waitFor(() => screen.getByText(/regenerate payment link/i));
+    expect(screen.getByText(/regenerate payment link/i)).toBeTruthy();
+    // And explicitly NOT "Generate payment link".
+    expect(screen.queryByText(/^generate payment link$/i)).toBeNull();
   });
 });

--- a/src/components/billing/__tests__/row-actions-menu.test.tsx
+++ b/src/components/billing/__tests__/row-actions-menu.test.tsx
@@ -52,6 +52,7 @@ function makeProps(
       payment_status: "unpaid",
       reading_source: "edge",
       total_amount: 12500,
+      pesapal_redirect_url: null,
     },
     household: { id: "h-1", display_name: "Alice Mukasa" },
     period: {
@@ -120,6 +121,7 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
         payment_status: "unpaid",
         reading_source: "edge",
         total_amount: 100,
+        pesapal_redirect_url: null,
       },
       edgeAvailable: true,
       isPaymentConfigured: true,
@@ -144,6 +146,9 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
         payment_status: "link_generated",
         reading_source: "manual",
         total_amount: 100,
+        // #221 — link_generated implies a URL exists; new signal surfaces
+        // "Regenerate payment link" as well as the 3 status transitions.
+        pesapal_redirect_url: "https://pay.example/state2",
       },
       edgeAvailable: true,
       isPaymentConfigured: true,
@@ -158,6 +163,8 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     // Manual + edgeAvailable → both source toggles
     expect(labels).toContain("Switch back to edge data");
     expect(labels).toContain("Re-enter manual readings…");
+    // #221 — URL-presence signal surfaces "Regenerate payment link".
+    expect(labels).toContain("Regenerate payment link");
     // PDF3 (#205) — Download bill (PDF) is always present.
     expect(labels).toContain("Download bill (PDF)");
   });
@@ -170,6 +177,7 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
         payment_status: "unpaid",
         reading_source: "manual",
         total_amount: 100,
+        pesapal_redirect_url: null,
       },
       edgeAvailable: false,
       isPaymentConfigured: true,
@@ -193,6 +201,10 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
         payment_status: "paid",
         reading_source: "edge",
         total_amount: 100,
+        // #221 — URL populated to exercise the paid-exclusion: even with
+        // a cached URL on a paid row, payment-link items must NOT appear
+        // (operator must Mark as unpaid first).
+        pesapal_redirect_url: "https://pay.example/state4",
       },
       edgeAvailable: true,
       isPaymentConfigured: true,
@@ -207,6 +219,10 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
     );
     expect(regenEdge).toBeTruthy();
     expect(regenEdge?.kind === "action" && regenEdge.warning).toBe(true);
+    // #221 — paid rows are excluded from the payment-link group entirely
+    // (regardless of cached URL). Operator workflow: Mark as unpaid first.
+    expect(labels).not.toContain("Regenerate payment link");
+    expect(labels).not.toContain("Generate payment link");
     // PDF3 (#205) — Download bill (PDF) is always present.
     expect(labels).toContain("Download bill (PDF)");
   });
@@ -219,6 +235,7 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
         payment_status: "refunded",
         reading_source: "edge",
         total_amount: 100,
+        pesapal_redirect_url: null,
       },
       edgeAvailable: true,
       isPaymentConfigured: true,
@@ -249,6 +266,10 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
         payment_status: "paid",
         reading_source: "edge",
         total_amount: 100,
+        // #221 — URL populated to assert paid-exclusion still applies on
+        // a closed period (regardless of period status, paid blocks the
+        // payment-link group).
+        pesapal_redirect_url: "https://pay.example/state6",
       },
       edgeAvailable: true,
       isPaymentConfigured: true,
@@ -266,6 +287,144 @@ describe("computeMenuItems — designer matrix (6 states)", () => {
       .filter((i) => i.kind === "action" || i.kind === "link")
       .map((i) => (i.kind === "action" ? i.label : i.label));
     expect(labels).toContain("Download bill (PDF)");
+  });
+});
+
+// ── #221: Generate vs Regenerate signal (URL-presence, not payment_status) ───
+//
+// `pesapal_redirect_url` is the truth-of-cache; `payment_status` is the
+// truth-of-intent. They can drift. The menu's question is "is there a link
+// to regenerate?" — a cache question. Cases A/B/C/D below cover the four
+// (status × URL-presence) corners that matter for the gate.
+
+describe("computeMenuItems — #221 Generate vs Regenerate signal", () => {
+  const baseInput = {
+    microgridId: "mg-1",
+    household: { id: "h-1", display_name: "Test" },
+    period: {
+      id: "p-1",
+      status: "draft" as const,
+      start_date: "2026-04-01",
+      end_date: "2026-04-30",
+    },
+    pendingUrl: null as string | null,
+    edgeAvailable: true,
+    isPaymentConfigured: true,
+    handlers: {
+      onRequestRegenerate: vi.fn(),
+      onRequestSwitchToManual: vi.fn(),
+      onGenerateLink: vi.fn(),
+      onCopyLink: vi.fn(),
+      onMarkAsPaid: vi.fn(),
+      onMarkAsRefunded: vi.fn(),
+      onMarkAsUnpaid: vi.fn(),
+      onCancelLink: vi.fn(),
+      onMarkAsFailed: vi.fn(),
+      onDownloadPdf: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Case A: unpaid + URL=null → 'Generate payment link' present, 'Regenerate' absent", () => {
+    const items = computeMenuItems({
+      ...baseInput,
+      lineItem: {
+        id: "li-A",
+        payment_status: "unpaid",
+        reading_source: "edge",
+        total_amount: 100,
+        pesapal_redirect_url: null,
+      },
+    });
+    const labels = items
+      .filter((i) => i.kind === "action")
+      .map((i) => (i.kind === "action" ? i.label : ""));
+    expect(labels).toContain("Generate payment link");
+    expect(labels).not.toContain("Regenerate payment link");
+  });
+
+  it("Case B: unpaid + URL populated (drift) → 'Regenerate' present, 'Generate' absent; click passes { force: true }", () => {
+    const onGenerateLink = vi.fn();
+    const items = computeMenuItems({
+      ...baseInput,
+      handlers: { ...baseInput.handlers, onGenerateLink },
+      lineItem: {
+        id: "li-B",
+        payment_status: "unpaid",
+        reading_source: "edge",
+        total_amount: 100,
+        // The Aaron-reported drift scenario: payment_status='unpaid' but
+        // a stale URL is cached on the row (e.g. operator clicked "Mark
+        // as unpaid" on a previously-link_generated row).
+        pesapal_redirect_url: "https://pay.example/case-b",
+      },
+    });
+    const labels = items
+      .filter((i) => i.kind === "action")
+      .map((i) => (i.kind === "action" ? i.label : ""));
+    expect(labels).toContain("Regenerate payment link");
+    expect(labels).not.toContain("Generate payment link");
+
+    // Click the regenerate item; confirm `force: true` flows through.
+    const regen = items.find(
+      (i) => i.kind === "action" && i.label === "Regenerate payment link",
+    );
+    expect(regen?.kind).toBe("action");
+    if (regen?.kind === "action") {
+      regen.onSelect();
+    }
+    expect(onGenerateLink).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("Case C: link_generated + URL populated → 'Regenerate' present; click passes { force: true }", () => {
+    const onGenerateLink = vi.fn();
+    const items = computeMenuItems({
+      ...baseInput,
+      handlers: { ...baseInput.handlers, onGenerateLink },
+      lineItem: {
+        id: "li-C",
+        payment_status: "link_generated",
+        reading_source: "edge",
+        total_amount: 100,
+        pesapal_redirect_url: "https://pay.example/case-c",
+      },
+    });
+    const labels = items
+      .filter((i) => i.kind === "action")
+      .map((i) => (i.kind === "action" ? i.label : ""));
+    expect(labels).toContain("Regenerate payment link");
+    expect(labels).not.toContain("Generate payment link");
+
+    const regen = items.find(
+      (i) => i.kind === "action" && i.label === "Regenerate payment link",
+    );
+    expect(regen?.kind).toBe("action");
+    if (regen?.kind === "action") {
+      regen.onSelect();
+    }
+    expect(onGenerateLink).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("Case D: paid + URL populated → no payment-link entries (gated by !isPaid)", () => {
+    const items = computeMenuItems({
+      ...baseInput,
+      lineItem: {
+        id: "li-D",
+        payment_status: "paid",
+        reading_source: "edge",
+        total_amount: 100,
+        pesapal_redirect_url: "https://pay.example/case-d",
+      },
+    });
+    const labels = items
+      .filter((i) => i.kind === "action")
+      .map((i) => (i.kind === "action" ? i.label : ""));
+    // Both link items absent — operator workflow is "Mark as unpaid" first.
+    expect(labels).not.toContain("Generate payment link");
+    expect(labels).not.toContain("Regenerate payment link");
   });
 });
 
@@ -302,6 +461,7 @@ describe("RowActionsMenu — payment-status PATCH per ALLOWED_MANUAL_TRANSITIONS
           payment_status: "paid",
           reading_source: "edge",
           total_amount: 100,
+          pesapal_redirect_url: null,
         },
       }),
     );
@@ -331,6 +491,11 @@ describe("RowActionsMenu — payment-status PATCH per ALLOWED_MANUAL_TRANSITIONS
           payment_status: "link_generated",
           reading_source: "edge",
           total_amount: 100,
+          // #221 — link_generated implies a URL is cached; the existing
+          // 3-status-transition assertions below are unchanged (Regenerate
+          // payment link is also visible but not asserted here — see the
+          // designer-matrix State 2 test for that coverage).
+          pesapal_redirect_url: "https://pay.example/link-gen",
         },
       }),
     );
@@ -376,6 +541,7 @@ describe("RowActionsMenu — fallback regenerate handler", () => {
           payment_status: "unpaid",
           reading_source: "edge",
           total_amount: 100,
+          pesapal_redirect_url: null,
         },
       }),
     );
@@ -423,6 +589,7 @@ describe("RowActionsMenu — fallback regenerate handler", () => {
           payment_status: "unpaid",
           reading_source: "edge",
           total_amount: 100,
+          pesapal_redirect_url: null,
         },
       }),
     );
@@ -466,6 +633,8 @@ describe("RowActionsMenu — IPN auto-close on payment_status change", () => {
         payment_status: "link_generated",
         reading_source: "edge",
         total_amount: 100,
+        // #221 — link_generated implies a cached URL exists.
+        pesapal_redirect_url: "https://pay.example/ipn-test",
       },
     });
 
@@ -534,6 +703,7 @@ describe("RowActionsMenu — payment-link generation error", () => {
           payment_status: "unpaid",
           reading_source: "edge",
           total_amount: 100,
+          pesapal_redirect_url: null,
         },
       }),
     );
@@ -596,6 +766,7 @@ describe("RowActionsMenu — bill download error", () => {
           payment_status: "unpaid",
           reading_source: "edge",
           total_amount: 100,
+          pesapal_redirect_url: null,
         },
       }),
     );

--- a/src/components/billing/row-actions-menu.tsx
+++ b/src/components/billing/row-actions-menu.tsx
@@ -54,6 +54,14 @@ export interface RowActionsMenuLineItem {
   payment_status: BillingLineItemPaymentStatus;
   reading_source: ReadingSource;
   total_amount: number;
+  /**
+   * Cached Pesapal redirect URL on the row (set by the helper's mint path
+   * and cleared by the 00037 auto-invalidation trigger when total_amount
+   * changes). Distinct from `pendingUrl` (component state) and from
+   * `payment_status` (state-machine intent). Drives the Generate vs
+   * Regenerate menu signal — see #221.
+   */
+  pesapal_redirect_url: string | null;
 }
 
 export interface RowActionsMenuHousehold {
@@ -122,6 +130,26 @@ export type MenuItem =
  * function — no side effects. Assertion-tested via inclusion checks (NOT
  * snapshots) for the 6 named states from the designer matrix; see
  * `__tests__/row-actions-menu.test.tsx`.
+ *
+ * Generate vs Regenerate signal (#221): driven by
+ * `lineItem.pesapal_redirect_url` (the truth-of-cache — what the helper's
+ * mint path will cache-hit on), NOT `payment_status` (the truth-of-intent
+ * — what the system thinks the customer is doing). The two can drift in
+ * legitimate scenarios:
+ *   - Operator clicked "Mark as unpaid" on a `link_generated` row —
+ *     `fn_apply_payment_event` resets payment_status but does NOT clear
+ *     pesapal_redirect_url (00028:331-373).
+ *   - Pre-#157 history.
+ *   - Helper warn-and-return paths that wrote a fresh URL before the
+ *     audit RPC rejected the status transition (ensure-payment-link.ts
+ *     :305-374).
+ * In all those cases the menu's question is "is there a link to
+ * regenerate?" — that's a cache question, not an intent question.
+ *
+ * Paid rows are excluded from the payment-link group entirely (see the
+ * explicit `!isPaid` gate). Operator workflow on paid is "Mark as
+ * unpaid" first (URL preserved by design), then "Regenerate" appears
+ * naturally with the new signal.
  */
 export function computeMenuItems(input: {
   microgridId: string;
@@ -229,18 +257,36 @@ export function computeMenuItems(input: {
 
   // ── Payment-link group ─────────────────────────────────────────────────────
   // Hidden entirely when payment is not configured (gate banner above the
-  // table already explains why).
+  // table already explains why) OR on terminal/paid rows.
+  //
+  // Paid rows are excluded via the explicit `!isPaid` check: under the
+  // OLD if/else-if logic on payment_status, `paid` rows fell through (no
+  // branch matched). Under the URL-presence signal (#221), a paid row
+  // with a non-null URL would otherwise surface "Regenerate" — that's
+  // not the operator's flow. They Mark as unpaid first (which preserves
+  // the URL per fn_apply_payment_event 00028:331-373), and then
+  // Regenerate appears naturally. Note: `paid` is NOT folded into
+  // `isTerminal` because `isTerminal` also gates the source/regenerate
+  // group at :182, where paid rows MUST still see "Regenerate from edge
+  // data" / "Switch to manual entry…" per State 4 of the designer matrix.
   const paymentLinkItems: MenuItem[] = [];
-  if (isPaymentConfigured && !isTerminal) {
-    if (lineItem.payment_status === "unpaid") {
+  if (isPaymentConfigured && !isTerminal && !isPaid) {
+    // Signal: URL-presence (truth-of-cache), NOT payment_status
+    // (truth-of-intent). Loose `== null` to harden against any typing
+    // slip (the field is `string | null` per the schema).
+    if (lineItem.pesapal_redirect_url == null) {
       paymentLinkItems.push({
         kind: "action",
         key: "generate-link",
         label: "Generate payment link",
         // First-mint path — cache is empty by definition; no force needed.
+        // Wrapper preserved (NOT a bare `handlers.onGenerateLink` reference)
+        // — Radix `onSelect` passes an `Event` argument; the wrapper drops
+        // it so TypeScript matches the `(opts?: { force?: boolean }) => void`
+        // call shape.
         onSelect: () => handlers.onGenerateLink(),
       });
-    } else if (lineItem.payment_status === "link_generated") {
+    } else {
       paymentLinkItems.push({
         kind: "action",
         key: "regenerate-link",


### PR DESCRIPTION
Closes #221

## Summary
- **`<RowActionsMenu>`** now decides "Generate" vs "Regenerate" by `lineItem.pesapal_redirect_url == null`, NOT by `payment_status === 'link_generated'`. URL-presence is the truth-of-cache; payment_status is the truth-of-intent — they can drift, and the menu's question is a cache question.
- The "Regenerate" branch passes `{ force: true }` (the existing #217 plumbing); "Generate" passes nothing.
- **`paid` rows continue to skip payment-link entries** entirely — added `!isPaid` to the gate as a separate clause (NOT folded into `isTerminal`), preserving designer-matrix State 4 source/regenerate group visibility.
- **`RowActionsMenuLineItem`** widened with `pesapal_redirect_url: string | null`. **`<BillingTable>`** prop chain extended to forward the field (was previously omitted).
- **Tests**: 4 new pure-function `computeMenuItems` cases (A/B/C/D) covering the URL-presence × payment_status grid; designer-matrix State 2/4/6 fixture URLs updated; new BillingTable integration test asserts the drift-state row (`payment_status='unpaid'` + URL populated — Aaron's exact Samuel Wataba scenario) shows "Regenerate". 14 existing fixture literals updated for the type widening (surfaced by tsc).

## Why
Aaron's testing on Samuel Wataba's row (Sezibwa) hit the drift case: row had `payment_status='unpaid'` AND a populated `pesapal_redirect_url` (legitimately — happens after "Mark as unpaid", or via pre-#157 code paths, or after a force-mint warn-and-return on a paid row). The old menu logic showed "Generate payment link" because it keyed off `payment_status`, and the Generate handler doesn't pass `force: true`, so the helper cache-hit the stale URL. Operator had no UI path to mint fresh.

## Test plan
- [x] `npx tsc --noEmit` — clean (the type widening surfaced 14 fixtures requiring `pesapal_redirect_url`; all updated).
- [x] `npm run lint` — clean.
- [x] `npm test` — 1521/1521 pass; targeted slice 33/33 pass.
- [x] `npm run build` — clean.
- [ ] Operator follow-up: no manual action required. Aaron's row was already URL-cleared during incident response. Future drift states will surface the right action automatically.

## Notes
- No DB migration. Pure UI signal change.
- No edits to `fn_apply_payment_event`, the SQL transition matrix, or the `link_generated` enum value. The status state machine is correct as-is; only the menu's cache-question signal moved.
- `PointerEvent` shim added to `billing-table.test.tsx` (guarded under `typeof undefined`) for Radix DropdownMenu open in jsdom; mirrors the existing `ResizeObserver` shim pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)