### PR TITLE
Fix energy-charge math reconciliation: render rate/usage at correct precision (#224)

### DIFF
--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -453,7 +453,7 @@ export function BillingTable({
   // CopyTable columns built from tiers
   // Format helpers (plain string, for CopyTable column defs)
   const kwhFormat = (v: number | string | null) =>
-    formatKwh(v == null ? null : Number(v), locale, { bareNumber: true });
+    formatKwh(v == null ? null : Number(v), locale, { bareNumber: true, digits: 3 });
   const amountFormat = (v: number | string | null) =>
     formatCurrency(v == null ? null : Number(v), locale, localeCurrency, { bareNumber: true });
 

--- a/src/components/format/__tests__/format.test.tsx
+++ b/src/components/format/__tests__/format.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { LocaleProvider } from "../locale-context";
 import { Currency } from "../currency";
-import { formatCurrency } from "../currency";
+import { formatCurrency, formatRate } from "../currency";
 import { Kwh } from "../kwh";
 import { formatKwh } from "../kwh";
 import { LocalDate } from "../local-date";
@@ -107,5 +107,47 @@ describe("formatCurrency", () => {
     const result = formatCurrency(4216800, "en", "UGX", { bareNumber: false, maxFractionDigits: 2, minFractionDigits: 2 });
     expect(result.includes("UGX")).toBe(true);
     expect(result.includes("4,216,800.00")).toBe(true);
+  });
+});
+
+describe("formatRate", () => {
+  it("returns em-dash for null", () => {
+    expect(formatRate(null, "en")).toBe("—");
+  });
+
+  it("integer rate pads to minDigits=2", () => {
+    expect(formatRate(250, "en")).toBe("250.00");
+  });
+
+  it("one-decimal rate pads to minDigits=2", () => {
+    expect(formatRate(756.2, "en")).toBe("756.20");
+  });
+
+  it("three-decimal rate is preserved up to maxDigits=4", () => {
+    expect(formatRate(100.555, "en")).toBe("100.555");
+  });
+
+  it("five-decimal rate rounds half-away to maxDigits=4", () => {
+    expect(formatRate(100.55555, "en")).toBe("100.5556");
+  });
+
+  it("zero renders as 0.00", () => {
+    expect(formatRate(0, "en")).toBe("0.00");
+  });
+
+  it("negative rate renders with leading minus and padding", () => {
+    expect(formatRate(-250, "en")).toBe("-250.00");
+  });
+
+  it("custom minDigits/maxDigits override defaults (digits:3)", () => {
+    expect(formatRate(123.456, "en", { minDigits: 3, maxDigits: 3 })).toBe("123.456");
+  });
+
+  it("custom digits=3 pads whole number to three zeros", () => {
+    expect(formatRate(15, "en", { minDigits: 3, maxDigits: 3 })).toBe("15.000");
+  });
+
+  it("minDigits/maxDigits=0 rounds to integer", () => {
+    expect(formatRate(7.5, "en", { minDigits: 0, maxDigits: 0 })).toBe("8");
   });
 });

--- a/src/components/format/currency.tsx
+++ b/src/components/format/currency.tsx
@@ -13,9 +13,14 @@
 //     paste workflows where the cell value is digits only.
 //   - className is composable via cn() so callers can override sizing/tone.
 //
-// String helper:
+// String helpers:
 //   - `formatCurrency(value, locale, currency, opts?)` — pure function,
 //     no React context. Reuses the same getNF() cache. Returns "—" for null.
+//   - `formatRate(value, locale, opts?)` — pure function for unit-rate display
+//     (tariff rates in UGX/kWh, etc.). DIFFERENT semantics from formatCurrency:
+//     rates are unit-rate calculation factors decoupled from the currency's
+//     minor-unit convention. Defaults: minDigits=2, maxDigits=4. No currency
+//     parameter — the column header carries the unit. Returns "—" for null.
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
@@ -53,6 +58,30 @@ export function formatCurrency(
     if (opts.minFractionDigits !== undefined) nfOpts.minimumFractionDigits = opts.minFractionDigits;
   }
   return getNF(locale, nfOpts).format(value);
+}
+
+/**
+ * Pure string formatter for unit rates (e.g. UGX/kWh tariff rate).
+ *
+ * Unlike `formatCurrency`, rates are NOT subject to a currency's minor-unit
+ * convention — a tariff rate of 756.20 needs to display as "756.20" even
+ * when the currency (UGX) renders amounts as integers. Defaults
+ * (minDigits=2, maxDigits=4) preserve typical tariff precision while
+ * trimming runaway decimals in stored values.
+ */
+export function formatRate(
+  value: number | null,
+  locale: string,
+  opts: { minDigits?: number; maxDigits?: number } = {},
+): string {
+  if (value == null) return "—";
+  const minDigits = opts.minDigits ?? 2;
+  const maxDigits = opts.maxDigits ?? 4;
+  return getNF(locale, {
+    style: "decimal",
+    minimumFractionDigits: minDigits,
+    maximumFractionDigits: maxDigits,
+  }).format(value);
 }
 
 export interface CurrencyProps extends React.HTMLAttributes<HTMLSpanElement> {

--- a/src/lib/invoices/__tests__/render.test.ts
+++ b/src/lib/invoices/__tests__/render.test.ts
@@ -92,6 +92,22 @@ const RATE_SCHEDULE: RateSchedule = {
   created_at: "2026-04-01T00:00:00.000Z",
 } as RateSchedule;
 
+// F6 regression fixture (#224): NFE-2026-00003 reproduces Aaron's Tier 2 math
+// "0.117 × 756.20 = 88.4754 → 88" reconciliation. Sub-15 max_kwh forces the
+// 15.117 usage to spill into Tier 2 by 0.117 kWh.
+const RATE_SCHEDULE_REGRESSION: RateSchedule = {
+  id: "rs-regression",
+  microgrid_id: "mg-1",
+  service_charge: 10000,
+  service_charge_description: "Fixed monthly service fee",
+  tax_rate: 0,
+  tiers: [
+    { label: "Tier 1", min_kwh: 1, max_kwh: 15, rate_per_kwh: 250 },
+    { label: "Tier 2", min_kwh: 16, max_kwh: 80, rate_per_kwh: 756.2 },
+  ],
+  created_at: "2026-04-01T00:00:00.000Z",
+} as RateSchedule;
+
 const ORG: Organization = {
   id: "org-1",
   name: "WattWorks Foundation Limited",
@@ -374,6 +390,38 @@ function buildF5Input(): RenderInvoiceInput {
   };
 }
 
+// F6 (#224 regression): reproduces Arthur Bamwite's NFE-2026-00003 — the
+// stored Tier 2 usage of 0.117 kWh at rate 756.2 UGX/kWh must display so
+// that 0.117 × 756.20 ≈ 88 UGX reconciles for the customer.
+function buildF6Input(): RenderInvoiceInput {
+  return {
+    lineItem: makeLineItem({
+      start_kwh: 1000,
+      end_kwh: 1015.117,
+      usage_kwh: 15.117,
+      tier_breakdown: [
+        { label: "Tier 1", kwh: 15, amount: 3750 },
+        { label: "Tier 2", kwh: 0.117, amount: 88.4754 },
+      ],
+      // 3750 + 88.4754 + 10000 service_charge ≈ 13838 (no tax)
+      total_amount: 13838,
+      invoice_number: "NFE-2026-00003",
+    }),
+    household: HOUSEHOLD_AARON,
+    community: COMMUNITY_MINIMAL, // tax hidden — keep focus on rate/usage math
+    organization: ORG,
+    ratesSchedule: RATE_SCHEDULE_REGRESSION,
+    paymentRedirectUrl: null,
+    invoiceNumber: "NFE-2026-00003",
+    logoBytes: null,
+    meterDevice: METER_DEVICE,
+    enteredByUserName: null,
+    currency: "UGX",
+    billingPeriodStart: "2026-04-01",
+    billingPeriodEnd: "2026-04-30",
+  };
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("renderInvoicePdf — fixtures (#203 PDF1b)", () => {
@@ -454,6 +502,47 @@ describe("renderInvoicePdf — fixtures (#203 PDF1b)", () => {
     );
 
     maybeAssertByteStability("no-line-item-payment-link", buf);
+  });
+
+  it("F6 regression #224 — NFE-2026-00003 Tier 2 reconciles 0.117 × 756.20 to 88", async () => {
+    const input = buildF6Input();
+    const buf = await renderInvoicePdf(input);
+
+    await expectStructuralPdfShape(
+      buf,
+      [
+        "NFE-2026-00003",
+        // Tier 2 usage cell — preserved at digits:3, not rounded to "0.12".
+        "0.117",
+        // Current Reading / Total Consumption preserved at digits:3.
+        "15.117",
+        // Tier 2 rate cell — formatRate pads 756.2 → "756.20".
+        "756.20",
+        // Tier 1 rate cell — formatRate pads integer 250 → "250.00".
+        "250.00",
+      ],
+      [
+        // Old formatKwh(digits:2) would have rounded 0.117 → "0.12". The
+        // fixture's stored numbers (3750, 88.4754, 13838, 15.117, 0.117,
+        // 250, 756.2, 10000) deliberately don't include a "0.12" substring,
+        // so this assertion is targeted.
+        "0.12",
+        // Old formatCurrency(bareNumber:true) would have rendered 756.2 as
+        // "756". The trailing space avoids colliding with "756.20".
+        "756 ",
+      ],
+    );
+
+    // Per-row reconciliation: displayed_usage × displayed_rate must round
+    // to within ±1 UGX of displayed_amount. The integer-UGX rounding
+    // allowance is what makes the math feel right to the customer; exact
+    // equality is not the bar.
+    const reconcile = (usage: number, rate: number, amount: number) =>
+      Math.abs(Math.round(usage * rate) - amount) <= 1;
+    expect(reconcile(0.117, 756.20, 88)).toBe(true);
+    expect(reconcile(15.000, 250.00, 3750)).toBe(true);
+
+    maybeAssertByteStability("regression-nfe-2026-00003", buf);
   });
 
   it("rejects invalid invoice_config via parseInvoiceConfig (ZodError)", async () => {

--- a/src/lib/invoices/render.tsx
+++ b/src/lib/invoices/render.tsx
@@ -40,7 +40,7 @@ import {
   renderToBuffer,
 } from "@react-pdf/renderer";
 
-import { formatCurrency } from "@/components/format/currency";
+import { formatCurrency, formatRate } from "@/components/format/currency";
 import { formatKwh } from "@/components/format/kwh";
 import { formatLocalDate } from "@/components/format/local-date";
 import type {
@@ -810,13 +810,13 @@ function InvoiceDocument(props: RenderProps): React.ReactElement {
                     <View style={styles.detailHalf}>
                       <Text style={styles.label}>Previous Reading</Text>
                       <Text style={styles.value}>
-                        {formatKwh(startKwh, props.locale, { digits: 2 })} kWh
+                        {formatKwh(startKwh, props.locale, { digits: 3 })} kWh
                       </Text>
                     </View>
                     <View style={styles.detailHalf}>
                       <Text style={styles.label}>Current Reading</Text>
                       <Text style={styles.value}>
-                        {formatKwh(endKwh, props.locale, { digits: 2 })} kWh
+                        {formatKwh(endKwh, props.locale, { digits: 3 })} kWh
                       </Text>
                     </View>
                   </View>
@@ -824,7 +824,7 @@ function InvoiceDocument(props: RenderProps): React.ReactElement {
                     <View style={styles.detailHalf}>
                       <Text style={styles.label}>Total Consumption</Text>
                       <Text style={styles.value}>
-                        {formatKwh(usageKwh, props.locale, { digits: 2 })} kWh
+                        {formatKwh(usageKwh, props.locale, { digits: 3 })} kWh
                       </Text>
                     </View>
                     <View style={styles.detailHalf}>
@@ -894,14 +894,10 @@ function InvoiceDocument(props: RenderProps): React.ReactElement {
                         : row.label}
                     </Text>
                     <Text style={[styles.tdNum, { flex: 1 }]}>
-                      {formatKwh(row.kwh, props.locale, { digits: 2 })}
+                      {formatKwh(row.kwh, props.locale, { digits: 3 })}
                     </Text>
                     <Text style={[styles.tdNum, { flex: 1 }]}>
-                      {rate != null
-                        ? formatCurrency(rate, props.locale, props.currency, {
-                            bareNumber: true,
-                          })
-                        : "—"}
+                      {formatRate(rate, props.locale)}
                     </Text>
                     <Text style={[styles.tdNum, { flex: 1 }]}>
                       {formatCurrency(row.amount, props.locale, props.currency, {


### PR DESCRIPTION
Closes #224

## Summary
- **New `formatRate(value, locale, { minDigits=2, maxDigits=4 })` helper** in `src/components/format/currency.tsx`. Uses `Intl.NumberFormat` with `style: "decimal"` so the currency's minor-unit convention doesn't strip the rate's decimal precision. Reuses the `getNF()` cache with a distinct key.
- **Renderer call-site updates** in `src/lib/invoices/render.tsx`:
  - Meter & Usage Summary kWh readings (lines 813/819/827): `digits: 2` → `digits: 3`.
  - Tier USAGE column (line 897): `digits: 2` → `digits: 3`.
  - Tier RATE column (lines 899-901): `formatCurrency(rate, .., { bareNumber: true })` → `formatRate(rate, .., defaults)`.
  - Tier AMOUNT column: unchanged — still integer UGX.
- **BillingTable in-app**: single-line `digits: 3` change on shared `kwhFormat` (`:455-456`); `amountFormat` untouched.
- **F6 regression fixture** in `render.test.ts` pins Aaron's exact NFE-2026-00003 values (usage 15.117, tier 2 kwh 0.117, rate 756.2, amount 88.4754, total 13838) and asserts `expectedStrings` contains "0.117"/"15.117"/"756.20"/"250.00"; `forbiddenStrings` excludes "0.12"/"756 "; per-row `reconcile()` invariant verifies `displayed_usage × displayed_rate` rounds to `displayed_amount ± 1`.

## Why
Aaron's reported "math error" on NFE-2026-00003 Tier 2 (`0.12 × 756 = 88`?) is actually a display-rounding inconsistency. The stored math is correct: `0.117 × 756.2 = 88.4754 ≈ 88`. The renderer rounded each column to a different precision (`digits: 2` on kWh, currency-convention-stripped on rate) so the displayed components didn't reconcile to the displayed total. Same fix solves Aaron's adjacent complaint that he entered "756.20" but saw "756" — tariff RATES aren't currency *amounts*, they're per-unit factors that need decimal precision regardless of UGX's minor-unit convention.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — pre-existing warnings only.
- [x] `npm test` — 91/91 in format + render slices; full suite 1399 pass (10 RLS files skip — JWT secret unset in this worktree; pre-existing).
- [x] `npm run build` — clean.
- [ ] Operator follow-up: re-render Arthur Bamwite's bill (`NFE-2026-00003`). Tier 2 row should show `0.117 ... 756.20 ... 88` (reconcilable) instead of `0.12 ... 756 ... 88`.

## Notes
- No DB migration. Pure display layer.
- Stored values (`rate_per_kwh`, `usage_kwh`, `total_amount`) are correct; only column formatters change.
- Already-shipped bills retain their original (confusing) PDF rendering — not auto re-issued. Operator can re-render any specific bill a customer questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)