### PR TITLE
Round line-item kWh + amount precision to defeat IEEE-754 dust (#227)

### DIFF
--- a/src/components/billing/__tests__/manual-usage-cell.test.tsx
+++ b/src/components/billing/__tests__/manual-usage-cell.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * manual-usage-cell.test.tsx (#227)
+ *
+ * Verifies that the editable input cell formats persisted values via
+ * `toFixed(3)` instead of `String(value)`, so IEEE-754 dust never
+ * surfaces in the input field. Covers (a) initial mount, (b) prop
+ * re-sync, (c) revert paths (empty, escape), (d) commit (onChange ->
+ * PATCH), and (e) the read-only branch is unaffected.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import { ManualUsageCell } from "@/components/billing/manual-usage-cell";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const LI_ID = "li-227-test";
+
+function passthroughFormat(v: number | null): string {
+  if (v == null) return "—";
+  return String(v);
+}
+
+describe("ManualUsageCell (#227 — formatForInput)", () => {
+  beforeEach(() => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("{}", { status: 200 })) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders dust-bearing 178.3500000000002 as '178.350' in the input", () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.3500000000002}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("178.350");
+  });
+
+  it("renders a clean 15.117 unchanged (toFixed(3) is idempotent on 3-decimal input)", () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={15.117}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("15.117");
+  });
+
+  it("renders null as empty string", () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={null}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("renders trailing-zero padding for whole numbers (178 -> '178.000')", () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("178.000");
+  });
+
+  it("user typing passes through unchanged (onChange does not re-format)", () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.4}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("178.400");
+
+    // Simulate user clearing + typing — the raw typing must persist
+    // through onChange without re-formatting.
+    fireEvent.change(input, { target: { value: "178.4" } });
+    expect(input.value).toBe("178.4");
+    fireEvent.change(input, { target: { value: "200" } });
+    expect(input.value).toBe("200");
+  });
+
+  it("blur commits the typed value (parsed Number, not the toFixed(3) string)", async () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.4}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "200.5" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(`/api/billing-line-items/${LI_ID}/usage`);
+    expect(init.method).toBe("PATCH");
+    expect(init.body).toBe(JSON.stringify({ usage_kwh: 200.5 }));
+  });
+
+  it("empty blur reverts to formatted persisted value and does NOT fire PATCH", async () => {
+    const onError = vi.fn();
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.4}
+        format={passthroughFormat}
+        editable={true}
+        onError={onError}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    // Empty input: revert silently, no PATCH, onError clears.
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(input.value).toBe("178.400");
+    expect(onError).toHaveBeenCalledWith(LI_ID, null);
+  });
+
+  it("Escape after edit reverts via formatForInput and does NOT fire PATCH", () => {
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.3500000000002}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "999" } });
+    expect(input.value).toBe("999");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input.value).toBe("178.350");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("read-only branch (editable=false) renders the format() output, NOT the toFixed string", () => {
+    const fmt = vi.fn(passthroughFormat);
+    render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.3500000000002}
+        format={fmt}
+        editable={false}
+      />
+    );
+    // No spinbutton when read-only.
+    expect(screen.queryByRole("spinbutton")).toBeNull();
+    // The span renders the format() output of the persisted value.
+    expect(fmt).toHaveBeenCalledWith(178.3500000000002);
+  });
+
+  it("prop re-sync: value changing from dust-bearing to clean updates the input to the new toFixed(3)", () => {
+    const { rerender } = render(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.3500000000002}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    let input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("178.350");
+
+    // Simulate a post-refresh prop change.
+    rerender(
+      <ManualUsageCell
+        lineItemId={LI_ID}
+        field="usage_kwh"
+        value={178.4}
+        format={passthroughFormat}
+        editable={true}
+      />
+    );
+    input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("178.400");
+  });
+});

--- a/src/components/billing/manual-usage-cell.tsx
+++ b/src/components/billing/manual-usage-cell.tsx
@@ -73,6 +73,27 @@ function parseInput(raw: string):
   return { ok: true, value: n };
 }
 
+/**
+ * Format a persisted numeric value for an editable `<input type="number">`.
+ *
+ * #227 fix: replaces `String(value)`, which would surface IEEE-754 dust
+ * (e.g. `String(178.3500000000002)` → `"178.3500000000002"`) raw in the
+ * input field. `toFixed(3)` pins to 3-decimal kWh precision (mWh
+ * resolution — matches `roundKwh`), preserves the underlying number, and
+ * intentionally emits NO thousands separators so the value parses cleanly
+ * back through `<input type="number">`'s validator. Trailing zeros are
+ * padded (`178.4` → `"178.400"`) — that is the stable end-state once a
+ * fresh write lands.
+ *
+ * Used only when the cell (re)initialises and on revert paths. The
+ * keystroke `onChange` path leaves the user's raw typing untouched.
+ */
+function formatForInput(value: number | null): string {
+  if (value == null) return "";
+  if (!Number.isFinite(value)) return "";
+  return value.toFixed(3);
+}
+
 export function ManualUsageCell({
   lineItemId,
   field,
@@ -83,15 +104,13 @@ export function ManualUsageCell({
   className,
 }: ManualUsageCellProps) {
   const router = useRouter();
-  const [draft, setDraft] = React.useState<string>(
-    value == null ? "" : String(value)
-  );
+  const [draft, setDraft] = React.useState<string>(formatForInput(value));
   const [saving, setSaving] = React.useState(false);
 
   // Re-sync the draft whenever the persisted value changes (e.g. after
   // router.refresh() pulls a new server-confirmed number).
   React.useEffect(() => {
-    setDraft(value == null ? "" : String(value));
+    setDraft(formatForInput(value));
   }, [value]);
 
   // Read-only path — match the surrounding CopyTable visual (right-aligned
@@ -114,7 +133,7 @@ export function ManualUsageCell({
     if (!parsed.ok) {
       if (parsed.reason === "empty") {
         // Empty input: revert silently to the persisted value, no save fire.
-        setDraft(value == null ? "" : String(value));
+        setDraft(formatForInput(value));
         onError?.(lineItemId, null);
         return;
       }
@@ -147,7 +166,7 @@ export function ManualUsageCell({
           reason?: string;
         };
         // Revert local draft to the persisted value.
-        setDraft(value == null ? "" : String(value));
+        setDraft(formatForInput(value));
         onError?.(
           lineItemId,
           body.error ?? `Could not save (HTTP ${res.status}).`
@@ -159,7 +178,7 @@ export function ManualUsageCell({
       setSaving(false);
       router.refresh();
     } catch (err) {
-      setDraft(value == null ? "" : String(value));
+      setDraft(formatForInput(value));
       onError?.(
         lineItemId,
         err instanceof Error ? err.message : "Network error. Please retry."
@@ -188,7 +207,7 @@ export function ManualUsageCell({
           } else if (e.key === "Escape") {
             e.preventDefault();
             // Revert to the persisted value and unfocus.
-            setDraft(value == null ? "" : String(value));
+            setDraft(formatForInput(value));
             onError?.(lineItemId, null);
             (e.currentTarget as HTMLInputElement).blur();
           }

--- a/src/lib/billing/__tests__/calculations.test.ts
+++ b/src/lib/billing/__tests__/calculations.test.ts
@@ -20,19 +20,30 @@ describe("calculateTieredCost", () => {
     // Tier 1: 15 kWh (capacity: 15-1+1=15), Tier 2: 65 kWh (80-16+1=65),
     // Tier 3: 70 kWh (150-81+1=70), Tier 4: 50 kWh (remaining)
     expect(result.tierBreakdown).toHaveLength(4);
+    // #227: tier-level amounts are now rounded to integer at write time.
     expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 15, amount: 15 * 250 });
-    expect(result.tierBreakdown[1]).toEqual({ label: "Tier 2", kwh: 65, amount: 65 * 756.2 });
+    expect(result.tierBreakdown[1]).toEqual({ label: "Tier 2", kwh: 65, amount: Math.round(65 * 756.2) });
     expect(result.tierBreakdown[2]).toEqual({ label: "Tier 3", kwh: 70, amount: 70 * 412 });
-    expect(result.tierBreakdown[3]).toEqual({ label: "Tier 4", kwh: 50, amount: 50 * 756.2 });
+    expect(result.tierBreakdown[3]).toEqual({ label: "Tier 4", kwh: 50, amount: Math.round(50 * 756.2) });
 
-    const expectedSubtotal = 15 * 250 + 65 * 756.2 + 70 * 412 + 50 * 756.2;
-    expect(result.subtotal).toBeCloseTo(expectedSubtotal);
+    // #227: subtotal/netAmount/taxAmount/totalAmount are integer.
+    const expectedSubtotal =
+      15 * 250 + Math.round(65 * 756.2) + 70 * 412 + Math.round(50 * 756.2);
+    expect(result.subtotal).toBe(expectedSubtotal);
     expect(result.serviceCharge).toBe(SERVICE_CHARGE);
-    expect(result.netAmount).toBeCloseTo(expectedSubtotal + SERVICE_CHARGE);
-    expect(result.taxAmount).toBeCloseTo((expectedSubtotal + SERVICE_CHARGE) * TAX_RATE);
-    expect(result.totalAmount).toBeCloseTo(
-      (expectedSubtotal + SERVICE_CHARGE) * (1 + TAX_RATE)
+    expect(result.netAmount).toBe(expectedSubtotal + SERVICE_CHARGE);
+    expect(result.taxAmount).toBe(
+      Math.round((expectedSubtotal + SERVICE_CHARGE) * TAX_RATE)
     );
+    expect(result.totalAmount).toBe(
+      result.netAmount + result.taxAmount
+    );
+
+    // Integer-shape invariant.
+    expect(Number.isInteger(result.subtotal)).toBe(true);
+    expect(Number.isInteger(result.netAmount)).toBe(true);
+    expect(Number.isInteger(result.taxAmount)).toBe(true);
+    expect(Number.isInteger(result.totalAmount)).toBe(true);
   });
 
   it("should handle usage fitting in first tier only (10 kWh)", () => {
@@ -42,8 +53,8 @@ describe("calculateTieredCost", () => {
     expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 10, amount: 10 * 250 });
 
     const expectedSubtotal = 10 * 250;
-    expect(result.subtotal).toBeCloseTo(expectedSubtotal);
-    expect(result.netAmount).toBeCloseTo(expectedSubtotal + SERVICE_CHARGE);
+    expect(result.subtotal).toBe(expectedSubtotal);
+    expect(result.netAmount).toBe(expectedSubtotal + SERVICE_CHARGE);
   });
 
   it("should handle usage exactly on tier boundary (15 kWh)", () => {
@@ -60,8 +71,10 @@ describe("calculateTieredCost", () => {
     expect(result.subtotal).toBe(0);
     expect(result.serviceCharge).toBe(SERVICE_CHARGE);
     expect(result.netAmount).toBe(SERVICE_CHARGE);
-    expect(result.taxAmount).toBeCloseTo(SERVICE_CHARGE * TAX_RATE);
-    expect(result.totalAmount).toBeCloseTo(SERVICE_CHARGE * (1 + TAX_RATE));
+    expect(result.taxAmount).toBe(Math.round(SERVICE_CHARGE * TAX_RATE));
+    expect(result.totalAmount).toBe(
+      result.netAmount + result.taxAmount
+    );
   });
 
   it("should handle fractional kWh (15.5 kWh)", () => {
@@ -70,7 +83,12 @@ describe("calculateTieredCost", () => {
     // Tier 1 capacity = 15, so 15 kWh in tier 1, 0.5 kWh in tier 2
     expect(result.tierBreakdown).toHaveLength(2);
     expect(result.tierBreakdown[0]).toEqual({ label: "Tier 1", kwh: 15, amount: 15 * 250 });
-    expect(result.tierBreakdown[1]).toEqual({ label: "Tier 2", kwh: 0.5, amount: 0.5 * 756.2 });
+    // #227: tier amount rounds to integer (0.5 * 756.2 = 378.1 → 378).
+    expect(result.tierBreakdown[1]).toEqual({
+      label: "Tier 2",
+      kwh: 0.5,
+      amount: Math.round(0.5 * 756.2),
+    });
   });
 
   it("should handle a single unbounded tier", () => {
@@ -83,8 +101,8 @@ describe("calculateTieredCost", () => {
     expect(result.tierBreakdown[0]).toEqual({ label: "Flat Rate", kwh: 100, amount: 50000 });
     expect(result.subtotal).toBe(50000);
     expect(result.netAmount).toBe(51000);
-    expect(result.taxAmount).toBeCloseTo(5100);
-    expect(result.totalAmount).toBeCloseTo(56100);
+    expect(result.taxAmount).toBe(5100);
+    expect(result.totalAmount).toBe(56100);
   });
 
   it("should handle empty tiers array", () => {
@@ -93,7 +111,9 @@ describe("calculateTieredCost", () => {
     expect(result.tierBreakdown).toHaveLength(0);
     expect(result.subtotal).toBe(0);
     expect(result.netAmount).toBe(SERVICE_CHARGE);
-    expect(result.totalAmount).toBeCloseTo(SERVICE_CHARGE * (1 + TAX_RATE));
+    expect(result.totalAmount).toBe(
+      SERVICE_CHARGE + Math.round(SERVICE_CHARGE * TAX_RATE)
+    );
   });
 
   it("should handle 6 tiers (N-tier support)", () => {
@@ -130,11 +150,34 @@ describe("calculateTieredCost", () => {
     expect(result.tierBreakdown[2].kwh).toBe(70);
     expect(result.tierBreakdown[3].kwh).toBe(9850);
 
-    const expectedSubtotal =
-      15 * 250 + 65 * 756.2 + 70 * 412 + 9850 * 756.2;
-    expect(result.subtotal).toBeCloseTo(expectedSubtotal);
-    expect(result.totalAmount).toBeCloseTo(
-      (expectedSubtotal + SERVICE_CHARGE) * (1 + TAX_RATE)
+    // Integer-shape invariant for large-input case.
+    expect(Number.isInteger(result.subtotal)).toBe(true);
+    expect(Number.isInteger(result.totalAmount)).toBe(true);
+  });
+
+  // ── #227 dust regression ────────────────────────────────────────────────────
+  // The Peter Ntale fixture: usage of 178.3500000000002 (IEEE-754 dust from
+  // `261.92 - 83.570`) must produce rounded tier values and integer totals.
+  it("rounds IEEE-754 dust on usageKwh input (178.3500000000002 fixture, #227)", () => {
+    const result = calculateTieredCost(
+      178.3500000000002,
+      seedTiers,
+      SERVICE_CHARGE,
+      TAX_RATE
     );
+
+    // Tier 1: 15 (cap), Tier 2: 65 (cap), Tier 3: 70 (cap),
+    // Tier 4: 178.35 - 150 = 28.35.
+    expect(result.tierBreakdown).toHaveLength(4);
+    expect(result.tierBreakdown[3].kwh).toBe(28.35);
+    // × 1000 == 28350 defeats numeric vacuity (28.35 === 28.350 in JS).
+    expect(result.tierBreakdown[3].kwh * 1000).toBe(28350);
+
+    // Every tier amount is integer.
+    for (const t of result.tierBreakdown) {
+      expect(Number.isInteger(t.amount)).toBe(true);
+    }
+    expect(Number.isInteger(result.subtotal)).toBe(true);
+    expect(Number.isInteger(result.totalAmount)).toBe(true);
   });
 });

--- a/src/lib/billing/__tests__/generate.test.ts
+++ b/src/lib/billing/__tests__/generate.test.ts
@@ -1,0 +1,241 @@
+/**
+ * generate.test.ts (#227)
+ *
+ * Validates that `runGenerationFor` rounds reading-side numerics before
+ * passing them to the RPC (write mode) and before pushing to the preview
+ * payload (preview mode). The Peter Ntale fixture (start_kwh = 83.570,
+ * end_kwh = 261.92 → usage_kwh = 178.35000000000002 in IEEE-754) is the
+ * primary regression seed.
+ *
+ * Harness: same local-Supabase-CLI pattern as
+ * `src/lib/supabase/__tests__/billing_audit_log.test.ts`. Skips
+ * automatically when `SKIP_RLS_TESTS=1` or `SUPABASE_JWT_SECRET` is
+ * missing. Rationale: mocking the full Supabase chain that
+ * runGenerationFor traverses (periods, schedules, households,
+ * line_items, devices, RPC) is ~150 LoC of stubs — leveraging the live
+ * local DB is simpler AND exercises the SQL+TS rounding together.
+ *
+ * Fixture isolation: uses its own org/community/microgrid/household/
+ * period to avoid contamination from billing_audit_log.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  assertEnvironmentReady,
+  shouldSkip,
+  serviceClient,
+  cleanupTestData,
+  createTestUser,
+} from "@/lib/supabase/__tests__/rls.helpers";
+
+const skip = shouldSkip();
+const desc = skip ? describe.skip : describe;
+
+if (skip) {
+  console.log("[generate.test] SKIP_RLS_TESTS=1 — skipping suite.");
+}
+
+const FIXTURE = {
+  // Org/community/microgrid for the precision suite — un-metered
+  // household so runGenerationFor routes through the manual-override
+  // path without contacting OpenEMS.
+  orgP: "dddddddd-dddd-4000-8000-00000000000d",
+  commP: "dddddddd-dddd-4000-8001-00000000000d",
+  mgP: "dddddddd-dddd-4000-8002-00000000000d",
+  hhP: "dddddddd-dddd-4000-8005-00000000000d",
+  periodP: "dddddddd-dddd-4000-8006-00000000000d",
+  periodP2: "dddddddd-dddd-4000-8006-00000000001d",
+};
+
+let alejandroSuperAdmin: {
+  userId: string;
+  jwt: string;
+  client: import("@supabase/supabase-js").SupabaseClient;
+};
+
+const EMAIL_SUPER = `gen227-super-${Date.now()}@test.local`;
+
+desc("runGenerationFor: precision rounding (#227)", () => {
+  beforeAll(async () => {
+    if (skip) return;
+    await assertEnvironmentReady();
+    const svc = await serviceClient();
+
+    await cleanupTestData({
+      orgIds: [FIXTURE.orgP],
+      userEmails: [EMAIL_SUPER],
+    });
+
+    // Un-metered household setup — runGenerationFor's manual-override
+    // path is exercised so we don't need OpenEMS config.
+    await svc.from("organizations").insert({ id: FIXTURE.orgP, name: "227 Org P" });
+    await svc.from("communities").insert({
+      id: FIXTURE.commP,
+      org_id: FIXTURE.orgP,
+      name: "227 Comm P",
+    });
+    await svc.from("microgrids").insert({
+      id: FIXTURE.mgP,
+      community_id: FIXTURE.commP,
+      name: "227 MG P",
+      currency: "UGX",
+    });
+    // Single tier at 100 UGX/kWh — Peter Ntale usage 178.35 × 100 = 17835.
+    await svc.from("rate_schedules").insert({
+      microgrid_id: FIXTURE.mgP,
+      tiers: [{ label: "T1", min_kwh: 0, max_kwh: null, rate_per_kwh: 100 }],
+      service_charge: 0,
+      tax_rate: 0,
+    });
+    await svc.from("households").insert({
+      id: FIXTURE.hhP,
+      microgrid_id: FIXTURE.mgP,
+      display_name: "227 Peter Ntale",
+      primary_phone: "+256700000099",
+    });
+    await svc.from("billing_periods").insert({
+      id: FIXTURE.periodP,
+      microgrid_id: FIXTURE.mgP,
+      start_date: "2026-04-01",
+      end_date: "2026-04-30",
+      status: "draft",
+    });
+    await svc.from("billing_periods").insert({
+      id: FIXTURE.periodP2,
+      microgrid_id: FIXTURE.mgP,
+      start_date: "2026-05-01",
+      end_date: "2026-05-31",
+      status: "draft",
+    });
+
+    alejandroSuperAdmin = await createTestUser({
+      email: EMAIL_SUPER,
+      role: "super_admin",
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (skip) return;
+    await cleanupTestData({
+      orgIds: [FIXTURE.orgP],
+      userEmails: [EMAIL_SUPER],
+    });
+  }, 60_000);
+
+  it("write mode: rounds usage_kwh + tier values + total_amount on the Peter Ntale fixture", async () => {
+    // 261.92 - 83.570 === 178.35000000000002 in IEEE-754. The route
+    // accepts the dust-bearing values from the caller; the rounding
+    // happens internally inside runGenerationFor before the RPC.
+    const { runGenerationFor } = await import("@/lib/billing/generate");
+    const out = await runGenerationFor({
+      supabase: alejandroSuperAdmin.client,
+      periodId: FIXTURE.periodP,
+      householdIds: [FIXTURE.hhP],
+      manualReadings: [
+        {
+          householdId: FIXTURE.hhP,
+          startKwh: 83.570,
+          endKwh: 261.92,
+          reason: "Peter Ntale fixture",
+        },
+      ],
+      mode: "write",
+      actorUserId: alejandroSuperAdmin.userId,
+    });
+    if ("kind" in out && out.kind === "fatal") {
+      throw new Error(
+        `runGenerationFor returned fatal ${out.status}: ${out.body.error}`
+      );
+    }
+
+    // Re-read the persisted row.
+    const svc = await serviceClient();
+    const { data: row } = await svc
+      .from("billing_line_items")
+      .select("usage_kwh, start_kwh, end_kwh, total_amount, tier_breakdown")
+      .eq("billing_period_id", FIXTURE.periodP)
+      .eq("household_id", FIXTURE.hhP)
+      .single<{
+        usage_kwh: number | string;
+        start_kwh: number | string;
+        end_kwh: number | string;
+        total_amount: number | string;
+        tier_breakdown: { label: string; kwh: number; amount: number }[];
+      }>();
+
+    const usage = Number(row!.usage_kwh);
+    const start = Number(row!.start_kwh);
+    const end = Number(row!.end_kwh);
+    const total = Number(row!.total_amount);
+
+    // Primary regression: usage exactly 178.35, NOT 178.35000000000002.
+    expect(usage).toBe(178.35);
+    // × 1000 defeats numeric vacuity (178.35 === 178.350 in JS).
+    expect(usage * 1000).toBe(178350);
+    expect(start).toBe(83.57);
+    expect(end).toBe(261.92);
+
+    // total_amount = 178.35 × 100 = 17835 — integer.
+    expect(total).toBe(17835);
+    expect(Number.isInteger(total)).toBe(true);
+
+    // Tier breakdown: single tier carries all 178.35 kWh.
+    expect(row!.tier_breakdown.length).toBe(1);
+    const t0 = row!.tier_breakdown[0];
+    expect(t0.kwh).toBe(178.35);
+    expect(t0.kwh * 1000).toBe(178350);
+    expect(Number.isInteger(t0.amount)).toBe(true);
+    expect(t0.amount).toBe(17835);
+  });
+
+  it("preview mode: pushes rounded values to the preview payload", async () => {
+    // Fresh period (periodP2) so we don't read the row written by the
+    // previous test.
+    const { runGenerationFor } = await import("@/lib/billing/generate");
+    const out = await runGenerationFor({
+      supabase: alejandroSuperAdmin.client,
+      periodId: FIXTURE.periodP2,
+      householdIds: [FIXTURE.hhP],
+      manualReadings: [
+        {
+          householdId: FIXTURE.hhP,
+          startKwh: 83.570,
+          endKwh: 261.92,
+          reason: "Peter Ntale preview",
+        },
+      ],
+      mode: "preview",
+      actorUserId: alejandroSuperAdmin.userId,
+    });
+    if ("kind" in out && out.kind === "fatal") {
+      throw new Error(
+        `runGenerationFor returned fatal ${out.status}: ${out.body.error}`
+      );
+    }
+    const results = (out as { results: Array<Record<string, unknown>> }).results;
+    const preview = results.find(
+      (r) => r.householdId === FIXTURE.hhP && r.kind === "preview"
+    ) as
+      | {
+          startKwh: number;
+          endKwh: number;
+          usageKwh: number;
+          totalAmount: number;
+          tierBreakdown: { label: string; kwh: number; amount: number }[];
+        }
+      | undefined;
+    expect(preview).toBeTruthy();
+
+    expect(preview!.usageKwh).toBe(178.35);
+    expect(preview!.usageKwh * 1000).toBe(178350);
+    expect(preview!.startKwh).toBe(83.57);
+    expect(preview!.endKwh).toBe(261.92);
+    expect(Number.isInteger(preview!.totalAmount)).toBe(true);
+    expect(preview!.totalAmount).toBe(17835);
+
+    expect(preview!.tierBreakdown.length).toBe(1);
+    expect(preview!.tierBreakdown[0].kwh).toBe(178.35);
+    expect(preview!.tierBreakdown[0].kwh * 1000).toBe(178350);
+    expect(Number.isInteger(preview!.tierBreakdown[0].amount)).toBe(true);
+  });
+});

--- a/src/lib/billing/__tests__/precision.test.ts
+++ b/src/lib/billing/__tests__/precision.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { roundKwh, roundAmount } from "../precision";
+
+describe("roundKwh", () => {
+  it("rounds 178.3500000000002 (the Peter Ntale fixture) to 178.35", () => {
+    expect(roundKwh(178.3500000000002)).toBe(178.35);
+  });
+
+  // Numeric vacuity guard: 178.35 === 178.350 in JS, so the bare toBe
+  // assertion above is not by itself sufficient to prove the dust is
+  // gone. Multiplying by 1000 exposes the integer underneath.
+  it("rounds 178.3500000000002 cleanly (× 1000 == 178350)", () => {
+    expect(roundKwh(178.3500000000002) * 1000).toBe(178350);
+  });
+
+  it("passes through already-clean 3-decimal values unchanged", () => {
+    expect(roundKwh(15.117)).toBe(15.117);
+    expect(roundKwh(79.686)).toBe(79.686);
+    expect(roundKwh(5.001)).toBe(5.001);
+  });
+
+  it("rounds zero to zero", () => {
+    expect(roundKwh(0)).toBe(0);
+  });
+
+  // Round-half-away-from-zero for positive values. JS Math.round is
+  // asymmetric at the exact negative half (Math.round(-0.5) === -0),
+  // but route validators reject negative inputs upstream — these tests
+  // pin the positive-only contract.
+  it("rounds positive half-cases away from zero", () => {
+    expect(roundKwh(1.2345)).toBe(1.235);
+    expect(roundKwh(1.2344)).toBe(1.234);
+  });
+
+  // Theoretical negative passthrough — included for completeness even
+  // though route validators reject < 0 upstream. No -x.xxx5 test —
+  // negative half-cases are explicitly out of contract.
+  it("rounds non-half-case negative values", () => {
+    expect(roundKwh(-1.2346)).toBe(-1.235);
+    expect(roundKwh(-1.2344)).toBe(-1.234);
+  });
+
+  // Non-finite passthrough (pin behavior to prevent regression to 0).
+  it("returns NaN for NaN input", () => {
+    expect(roundKwh(NaN)).toBeNaN();
+  });
+
+  it("returns Infinity for Infinity input", () => {
+    expect(roundKwh(Infinity)).toBe(Infinity);
+  });
+});
+
+describe("roundAmount", () => {
+  it("rounds 88.4754 down to 88", () => {
+    expect(roundAmount(88.4754)).toBe(88);
+  });
+
+  // JS Math.round is round-half-away-from-zero for positive values.
+  it("rounds 88.5 up to 89 (positive half-away)", () => {
+    expect(roundAmount(88.5)).toBe(89);
+  });
+
+  it("passes through integer values unchanged", () => {
+    expect(roundAmount(13838)).toBe(13838);
+    expect(roundAmount(0)).toBe(0);
+  });
+
+  it("returns NaN for NaN input", () => {
+    expect(roundAmount(NaN)).toBeNaN();
+  });
+
+  it("returns Infinity for Infinity input", () => {
+    expect(roundAmount(Infinity)).toBe(Infinity);
+  });
+});

--- a/src/lib/billing/calculations.ts
+++ b/src/lib/billing/calculations.ts
@@ -1,4 +1,5 @@
 import type { TierConfig, TierBreakdown } from "@/lib/types/domain";
+import { roundKwh, roundAmount } from "./precision";
 
 export type BillingCalculation = {
   tierBreakdown: TierBreakdown[];
@@ -9,6 +10,17 @@ export type BillingCalculation = {
   totalAmount: number; // netAmount + taxAmount
 };
 
+// #227: every numeric output that lands in storage or display is
+// rounded here so any caller (runGenerationFor, TierEditor preview,
+// usage/route test fixture, etc.) gets clean values. Defense-in-depth
+// with the rounding in `runGenerationFor` and `fn_record_line_item_with_audit`.
+//
+// kWh values use `roundKwh` (3 decimals = mWh precision). UGX amounts
+// use `roundAmount` (integer — UGX has no minor units, and the bill
+// display rounds to integer anyway). Tax is computed against the
+// already-integer netAmount so `taxAmount` and `totalAmount` are integer
+// by construction.
+
 export function calculateTieredCost(
   usageKwh: number,
   tiers: TierConfig[],
@@ -16,15 +28,15 @@ export function calculateTieredCost(
   taxRate: number
 ): BillingCalculation {
   if (usageKwh <= 0 || tiers.length === 0) {
-    const netAmount = serviceCharge;
-    const taxAmount = netAmount * taxRate;
+    const netAmount = roundAmount(serviceCharge);
+    const taxAmount = roundAmount(netAmount * taxRate);
     return {
       tierBreakdown: [],
       subtotal: 0,
-      serviceCharge,
+      serviceCharge: roundAmount(serviceCharge),
       netAmount,
       taxAmount,
-      totalAmount: netAmount + taxAmount,
+      totalAmount: roundAmount(netAmount + taxAmount),
     };
   }
 
@@ -41,22 +53,24 @@ export function calculateTieredCost(
 
     tierBreakdown.push({
       label: tier.label,
-      kwh: kwhInTier,
-      amount,
+      kwh: roundKwh(kwhInTier),
+      amount: roundAmount(amount),
     });
 
     remaining -= kwhInTier;
   }
 
-  const subtotal = tierBreakdown.reduce((sum, t) => sum + t.amount, 0);
-  const netAmount = subtotal + serviceCharge;
-  const taxAmount = netAmount * taxRate;
-  const totalAmount = netAmount + taxAmount;
+  const subtotal = roundAmount(
+    tierBreakdown.reduce((sum, t) => sum + t.amount, 0)
+  );
+  const netAmount = roundAmount(subtotal + serviceCharge);
+  const taxAmount = roundAmount(netAmount * taxRate);
+  const totalAmount = roundAmount(netAmount + taxAmount);
 
   return {
     tierBreakdown,
     subtotal,
-    serviceCharge,
+    serviceCharge: roundAmount(serviceCharge),
     netAmount,
     taxAmount,
     totalAmount,

--- a/src/lib/billing/generate.ts
+++ b/src/lib/billing/generate.ts
@@ -52,6 +52,7 @@ import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { calculateTieredCost } from "@/lib/billing/calculations";
+import { roundKwh, roundAmount } from "@/lib/billing/precision";
 import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import { getMicrogridEmsConfig } from "@/lib/openems/config";
 import type { DeviceConfig } from "@/lib/adapters/types";
@@ -634,17 +635,28 @@ export async function runGenerationFor(
       rateSchedule.tax_rate
     );
 
+    // #227: round the reading-side numerics. `calc.tierBreakdown` and
+    // `calc.totalAmount` are already rounded by calculateTieredCost.
+    // Rounding here closes IEEE-754 dust from arithmetic like
+    // `261.92 - 83.570 === 178.35000000000002` before the values land
+    // in storage or in the preview payload.
+    const startKwhRounded = roundKwh(startKwh);
+    const endKwhRounded = roundKwh(endKwh);
+    const usageKwhRounded = roundKwh(usageKwh);
+    const previousTotalAmount =
+      prior ? roundAmount(Number(prior.total_amount)) : null;
+
     if (mode === "preview") {
       results.push({
         kind: "preview",
         householdId: hid,
         householdName,
-        startKwh,
-        endKwh,
-        usageKwh,
+        startKwh: startKwhRounded,
+        endKwh: endKwhRounded,
+        usageKwh: usageKwhRounded,
         tierBreakdown: calc.tierBreakdown,
         totalAmount: calc.totalAmount,
-        previousTotalAmount: prior ? Number(prior.total_amount) : null,
+        previousTotalAmount,
         previousPaymentStatus: prior?.payment_status ?? null,
       });
       continue;
@@ -653,7 +665,7 @@ export async function runGenerationFor(
     // mode === 'write' — call the audit-aware RPC.
     const auditDetails: LineItemRegeneratedDetails = {
       household_name: householdName,
-      previous_total_amount: prior ? Number(prior.total_amount) : null,
+      previous_total_amount: previousTotalAmount,
       new_total_amount: calc.totalAmount,
       previous_reading_source: prior?.reading_source ?? null,
       new_reading_source: readingSource,
@@ -690,9 +702,9 @@ export async function runGenerationFor(
         _billing_period_id: periodId,
         _household_id: hid,
         _device_id: deviceId,
-        _usage_kwh: usageKwh,
-        _start_kwh: startKwh,
-        _end_kwh: endKwh,
+        _usage_kwh: usageKwhRounded,
+        _start_kwh: startKwhRounded,
+        _end_kwh: endKwhRounded,
         _tier_breakdown: calc.tierBreakdown,
         _total_amount: calc.totalAmount,
         _reading_source: readingSource,
@@ -725,7 +737,7 @@ export async function runGenerationFor(
       householdId: hid,
       householdName,
       lineItem: writtenRow,
-      previousTotalAmount: prior ? Number(prior.total_amount) : null,
+      previousTotalAmount,
       previousPaymentStatus: prior?.payment_status ?? null,
       previousReadingSource: prior?.reading_source ?? null,
     });

--- a/src/lib/billing/precision.ts
+++ b/src/lib/billing/precision.ts
@@ -1,0 +1,37 @@
+/**
+ * precision.ts — kWh / amount rounding helpers (#227).
+ *
+ * These helpers exist to cure IEEE-754 float-dust on computed values
+ * (e.g. `261.92 - 83.570 === 178.35000000000002`) before those values
+ * are written to storage OR surfaced in the UI. The bug they close is
+ * documented in #227 — Peter Ntale's row displayed `178.3500000000000`
+ * in the in-app billing table.
+ *
+ * Contract:
+ *   - `roundKwh(x)`   → 3 decimals (mWh precision). Meter readings are
+ *                       typically reported at this resolution.
+ *   - `roundAmount(x)` → integer. UGX has no minor units; the displayed
+ *                       grand total is integer; subtotals likewise.
+ *
+ * Semantics:
+ *   - Round-half-away-from-zero for positive values (JS `Math.round`
+ *     default). Negative half-cases are NOT in contract — route
+ *     validators reject negative inputs upstream.
+ *   - Non-finite passthrough (NaN, ±Infinity) is preserved — callers
+ *     are responsible for validating finiteness before calling.
+ *   - Idempotent: rounding an already-rounded value is a no-op.
+ *
+ * No side effects. No I/O. Pure functions.
+ */
+
+/** Round to 3 decimal places (mWh precision). */
+export function roundKwh(x: number): number {
+  if (!Number.isFinite(x)) return x;
+  return Math.round(x * 1000) / 1000;
+}
+
+/** Round to nearest integer (UGX has no minor units). */
+export function roundAmount(x: number): number {
+  if (!Number.isFinite(x)) return x;
+  return Math.round(x);
+}

--- a/src/lib/supabase/__tests__/billing_audit_log.test.ts
+++ b/src/lib/supabase/__tests__/billing_audit_log.test.ts
@@ -959,6 +959,87 @@ desc("00029_billing_line_item_source_and_audit.sql (#173)", () => {
     expect(details).not.toHaveProperty("previous_snapshot");
   });
 
+  // ── #227 / 00039 — write-time rounding inside the RPC ─────────────────────
+  //
+  // The function ROUNDs _usage_kwh / _start_kwh / _end_kwh to 3 decimals and
+  // _total_amount to 0 decimals at write time; tier_breakdown JSONB is
+  // unpacked + repacked with each element's kwh rounded to 3 and amount to 0.
+  // Caller-side TS rounding is layered defense; this test pins the SQL
+  // contract independently.
+  //
+  // PostgREST returns NUMERIC scalars as JS strings in some shapes; the row
+  // read uses `Number(x)` to normalise. JSONB-embedded numerics are returned
+  // as JS numbers natively. Don't flip these assertions.
+
+  it("00039 / #227: fn_record_line_item_with_audit ROUNDs usage_kwh + start/end + total_amount + tier_breakdown on the Peter Ntale fixture", async () => {
+    const svc = await serviceClient();
+
+    // Use the existing hhA_inv1 row (already created by Case A). The
+    // re-key with dust-bearing inputs MUST land rounded values.
+    const { error, data } = await svc.rpc("fn_record_line_item_with_audit", {
+      _billing_period_id: FIXTURE.periodA,
+      _household_id: FIXTURE.hhA_inv1,
+      _device_id: FIXTURE.deviceA,
+      _usage_kwh: 178.3500000000002,
+      _start_kwh: 83.57,
+      _end_kwh: 261.92,
+      _tier_breakdown: [
+        { label: "Tier 1", kwh: 178.3500000000002, amount: 88.4754 },
+      ],
+      _total_amount: 88.4754,
+      _reading_source: "manual",
+      _entered_by_user_id: alejandroSuperAdmin.userId,
+      _manual_reason: "#227 dust regression",
+      _actor_user_id: alejandroSuperAdmin.userId,
+      _audit_details: { household_name: "BC1 Household A-inv1" },
+    });
+    expect(error).toBeNull();
+    // RPC returns the persisted row as a composite. PostgREST may wrap
+    // it in an array shape — normalise.
+    const returnedRowRaw = Array.isArray(data) ? data[0] : data;
+    const returnedRow = returnedRowRaw as {
+      usage_kwh: number | string;
+      start_kwh: number | string;
+      end_kwh: number | string;
+      total_amount: number | string;
+      tier_breakdown: { label: string; kwh: number; amount: number }[];
+    };
+
+    // Primary regression: usage exactly 178.35, NOT 178.35000000000002.
+    expect(Number(returnedRow.usage_kwh)).toBe(178.35);
+    expect(Number(returnedRow.usage_kwh) * 1000).toBe(178350);
+    expect(Number(returnedRow.start_kwh)).toBe(83.57);
+    expect(Number(returnedRow.end_kwh)).toBe(261.92);
+    // total_amount rounds to integer 88.
+    expect(Number(returnedRow.total_amount)).toBe(88);
+
+    // Tier breakdown — JSONB scalars come back as JS numbers natively.
+    expect(returnedRow.tier_breakdown.length).toBe(1);
+    expect(returnedRow.tier_breakdown[0].label).toBe("Tier 1");
+    expect(returnedRow.tier_breakdown[0].kwh).toBe(178.35);
+    expect(returnedRow.tier_breakdown[0].amount).toBe(88);
+
+    // Re-read the persisted row to verify storage matches (not just the
+    // RETURNING shape).
+    const { data: stored } = await svc
+      .from("billing_line_items")
+      .select("usage_kwh, start_kwh, end_kwh, total_amount, tier_breakdown")
+      .eq("billing_period_id", FIXTURE.periodA)
+      .eq("household_id", FIXTURE.hhA_inv1)
+      .single<{
+        usage_kwh: number | string;
+        start_kwh: number | string;
+        end_kwh: number | string;
+        total_amount: number | string;
+        tier_breakdown: { label: string; kwh: number; amount: number }[];
+      }>();
+    expect(Number(stored!.usage_kwh)).toBe(178.35);
+    expect(Number(stored!.usage_kwh) * 1000).toBe(178350);
+    expect(Number(stored!.total_amount)).toBe(88);
+    expect(stored!.tier_breakdown[0].kwh).toBe(178.35);
+    expect(stored!.tier_breakdown[0].amount).toBe(88);
+  });
+
   // ── Atomicity ─────────────────────────────────────────────────────────────
 
   it("fn_record_line_item_with_audit: failed audit insert rolls back the line item upsert", async () => {

--- a/supabase/migrations/00039_round_line_item_precision.sql
+++ b/supabase/migrations/00039_round_line_item_precision.sql
@@ -1,0 +1,237 @@
+-- 00039_round_line_item_precision.sql
+-- #227: round line-item numeric inputs at write time inside
+-- `fn_record_line_item_with_audit` so any caller — the rate engine
+-- (`runGenerationFor`), a direct manual INSERT, a fixture seeder, a
+-- future migration — gets clean precision in storage.
+--
+-- ── Why ───────────────────────────────────────────────────────────────────────
+--
+-- Peter Ntale's row on the Sezibwa microgrid persisted `usage_kwh =
+-- 178.3500000000000` from JS arithmetic `261.92 - 83.570`. In real
+-- arithmetic that's exactly 178.35, but IEEE-754 binary representation
+-- adds 14-decimal dust. The in-app billing table's editable cell
+-- (`ManualUsageCell`) surfaces the dust raw via `String(value)`.
+--
+-- The TypeScript helpers in `src/lib/billing/precision.ts` round at
+-- the rate-engine boundary; this migration is defense-in-depth so any
+-- future writer that bypasses the engine still lands clean numbers.
+--
+-- ── Rounding rules ────────────────────────────────────────────────────────────
+--
+--   _usage_kwh, _start_kwh, _end_kwh        →  3 decimals (mWh precision).
+--   _total_amount                            →  integer  (UGX has no minor).
+--   _tier_breakdown[].kwh                    →  3 decimals.
+--   _tier_breakdown[].amount                 →  integer.
+--
+-- The tier-breakdown JSONB is unpacked with `WITH ORDINALITY` so the
+-- tier order (T1 → T2 → T3 → T4) is preserved across the round-trip.
+-- `jsonb_agg` without `ORDER BY` does NOT guarantee element order.
+--
+-- ── Tier-breakdown shape invariant ────────────────────────────────────────────
+--
+-- The unpack-repack emits exactly `{label, kwh, amount}` — the shape
+-- defined by `TierBreakdown` in `src/lib/types/domain.ts` and what
+-- `calculations.ts` writes. If a future ticket adds a field to
+-- `TierBreakdown`, THIS FUNCTION MUST BE REVISITED or the new field is
+-- silently dropped on UPSERT.
+--
+-- ── Preserve verbatim from 00037 (#217 link-invalidation) ─────────────────────
+--
+-- The CASE clauses on `pesapal_redirect_url`, `pesapal_order_id`, and
+-- `payment_failed_at` compare `EXCLUDED.total_amount IS DISTINCT FROM
+-- billing_line_items.total_amount`. Wrapping the parameter with ROUND()
+-- in the INSERT VALUES means EXCLUDED already reflects the rounded
+-- amount; the IS DISTINCT FROM semantics on integer-vs-integer remain
+-- correct, and a re-run with the same readings is a no-op.
+--
+-- The DELIBERATELY OMITTED comment block (payment_status, paid_at,
+-- paid_by_user_id, payment_notes, payment_refunded_at) is preserved
+-- byte-for-byte so the next maintainer reads the same warning.
+--
+-- ── Idempotency ───────────────────────────────────────────────────────────────
+--
+-- `CREATE OR REPLACE FUNCTION` with the SAME 13-argument signature as
+-- 00037 — pure body refactor, no codegen impact. Re-running is safe.
+-- No backfill: existing rows keep their stored dust until the next
+-- UPSERT lands a rounded value (display masked by the Part B
+-- `formatForInput` cell helper).
+
+CREATE OR REPLACE FUNCTION fn_record_line_item_with_audit(
+  _billing_period_id   UUID,
+  _household_id        UUID,
+  _device_id           UUID,
+  _usage_kwh           NUMERIC,
+  _start_kwh           NUMERIC,
+  _end_kwh             NUMERIC,
+  _tier_breakdown      JSONB,
+  _total_amount        NUMERIC,
+  _reading_source      billing_line_item_reading_source,
+  _entered_by_user_id  UUID,
+  _manual_reason       TEXT,
+  _actor_user_id       UUID,
+  _audit_details       JSONB
+) RETURNS billing_line_items
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_row                     billing_line_items%ROWTYPE;
+  v_was_inserted            BOOLEAN;
+  v_period_status           billing_period_status;
+  v_event_type              billing_audit_event_type;
+  v_entered_at              TIMESTAMPTZ;
+  v_audit_details           JSONB := COALESCE(_audit_details, '{}'::jsonb);
+  v_line_item_id            UUID;
+  v_tier_breakdown_rounded  JSONB;
+BEGIN
+  -- Resolve entered_at only when the new reading is manual (otherwise NULL,
+  -- per AC1 of #173).
+  IF _reading_source = 'manual' THEN
+    v_entered_at := now();
+  ELSE
+    v_entered_at := NULL;
+  END IF;
+
+  -- Round each tier-breakdown element. WITH ORDINALITY preserves the
+  -- tier sequence (T1 → T2 → …) — jsonb_agg without ORDER BY does not
+  -- guarantee element order. Shape MUST remain {label, kwh, amount};
+  -- adding a field to TierBreakdown requires updating this function.
+  v_tier_breakdown_rounded := COALESCE(
+    (SELECT jsonb_agg(
+       jsonb_build_object(
+         'label',  elem->>'label',
+         'kwh',    ROUND((elem->>'kwh')::numeric, 3),
+         'amount', ROUND((elem->>'amount')::numeric, 0)
+       )
+       ORDER BY ord
+     )
+     FROM jsonb_array_elements(COALESCE(_tier_breakdown, '[]'::jsonb))
+       WITH ORDINALITY AS t(elem, ord)),
+    '[]'::jsonb);
+
+  -- UPSERT on (billing_period_id, household_id). The INSERT VALUES
+  -- clause applies ROUND() to each numeric column; EXCLUDED.* in the
+  -- DO UPDATE SET clause inherits those rounded values, so the #217
+  -- IS DISTINCT FROM CASE expressions compare rounded-vs-rounded.
+  INSERT INTO billing_line_items (
+    billing_period_id,
+    household_id,
+    device_id,
+    usage_kwh,
+    start_kwh,
+    end_kwh,
+    tier_breakdown,
+    total_amount,
+    reading_source,
+    entered_by_user_id,
+    entered_at,
+    manual_reason
+  )
+  VALUES (
+    _billing_period_id,
+    _household_id,
+    _device_id,
+    ROUND(_usage_kwh, 3),
+    ROUND(_start_kwh, 3),
+    ROUND(_end_kwh,   3),
+    COALESCE(v_tier_breakdown_rounded, '[]'::jsonb),
+    ROUND(_total_amount, 0),
+    _reading_source,
+    CASE WHEN _reading_source = 'manual' THEN _entered_by_user_id ELSE NULL END,
+    v_entered_at,
+    CASE WHEN _reading_source = 'manual' THEN _manual_reason ELSE NULL END
+  )
+  ON CONFLICT (billing_period_id, household_id) DO UPDATE SET
+    device_id            = EXCLUDED.device_id,
+    usage_kwh            = EXCLUDED.usage_kwh,
+    start_kwh            = EXCLUDED.start_kwh,
+    end_kwh              = EXCLUDED.end_kwh,
+    tier_breakdown       = EXCLUDED.tier_breakdown,
+    total_amount         = EXCLUDED.total_amount,
+    reading_source       = EXCLUDED.reading_source,
+    entered_by_user_id   = EXCLUDED.entered_by_user_id,
+    entered_at           = EXCLUDED.entered_at,
+    manual_reason        = EXCLUDED.manual_reason,
+    -- Amount-change invalidation (#217). IS DISTINCT FROM correctly handles
+    -- NULL on either side and gives us "only invalidate when the amount
+    -- truly changed." total_amount is NOT NULL so this practically collapses
+    -- to `<>`, but IS DISTINCT FROM is defensive against future schema
+    -- relaxation.
+    pesapal_redirect_url = CASE
+      WHEN EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount
+      THEN NULL
+      ELSE billing_line_items.pesapal_redirect_url
+    END,
+    pesapal_order_id     = CASE
+      WHEN EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount
+      THEN NULL
+      ELSE billing_line_items.pesapal_order_id
+    END,
+    payment_failed_at    = CASE
+      WHEN EXCLUDED.total_amount IS DISTINCT FROM billing_line_items.total_amount
+      THEN NULL
+      ELSE billing_line_items.payment_failed_at
+    END
+    -- DELIBERATELY OMITTED — owned by fn_apply_payment_event and survive the
+    -- UPSERT regardless of amount change:
+    --   payment_status, paid_at, paid_by_user_id, payment_notes,
+    --   payment_refunded_at
+    --
+    -- Why preserve payment_status / paid_at on amount change? If a line item
+    -- was paid and then re-keyed, the past payment STILL HAPPENED. Erasing
+    -- it would falsify the audit trail. The operator must reconcile manually
+    -- (refund the difference, or accept the new amount as outstanding).
+    --
+    -- Why preserve payment_refunded_at on amount change? A refund is a
+    -- permanent ledger entry — money moved back to the customer; that does
+    -- not get erased by a re-keyed reading.
+  RETURNING (xmax = 0), id
+  INTO v_was_inserted, v_line_item_id;
+
+  -- Re-read the row as a composite (RETURNING * + scalar isn't supported in
+  -- one INTO clause). Cheap — we already hold the row lock from the UPSERT.
+  SELECT * INTO v_row
+  FROM billing_line_items
+  WHERE id = v_line_item_id;
+
+  -- Look up period status to derive period_was_closed (Q4=B audit hint).
+  SELECT status INTO v_period_status
+  FROM billing_periods
+  WHERE id = _billing_period_id;
+
+  IF v_period_status = 'closed' THEN
+    v_audit_details := v_audit_details || jsonb_build_object('period_was_closed', true);
+  END IF;
+
+  v_event_type := CASE
+    WHEN v_was_inserted THEN 'line_item_generated'::billing_audit_event_type
+    ELSE 'line_item_regenerated'::billing_audit_event_type
+  END;
+
+  INSERT INTO billing_audit_log (
+    billing_period_id,
+    billing_line_item_id,
+    event_type,
+    actor_user_id,
+    details
+  )
+  VALUES (
+    _billing_period_id,
+    v_row.id,
+    v_event_type,
+    _actor_user_id,
+    v_audit_details
+  );
+
+  RETURN v_row;
+END;
+$$;
+
+-- Defensive re-grant. CREATE OR REPLACE preserves privileges, but mirroring
+-- the pattern from 00037 keeps the grant explicit at the migration
+-- boundary in case the function was dropped + recreated by a future change.
+GRANT EXECUTE ON FUNCTION fn_record_line_item_with_audit(
+  UUID, UUID, UUID, NUMERIC, NUMERIC, NUMERIC, JSONB, NUMERIC,
+  billing_line_item_reading_source, UUID, TEXT, UUID, JSONB
+) TO authenticated;


### PR DESCRIPTION
Closes #227

## Summary
- **Migration `00039_round_line_item_precision.sql`** — `CREATE OR REPLACE fn_record_line_item_with_audit` (same 13-arg signature). INSERT VALUES wraps kWh fields with `ROUND(.., 3)` and `total_amount` with `ROUND(.., 0)`. Tier breakdown JSONB unpacked via `jsonb_array_elements WITH ORDINALITY`, each element's `kwh` rounded to 3 + `amount` rounded to 0, repacked via `jsonb_agg ORDER BY ord` for stable tier order. **#217 auto-invalidation CASE clauses preserved byte-for-byte** — the `IS DISTINCT FROM total_amount` semantics work because both sides are now integer after rounding.
- **`src/lib/billing/precision.ts`** — new `roundKwh(x)` (`Math.round(x * 1000) / 1000`) + `roundAmount(x)` (`Math.round(x)`) helpers.
- **`calculateTieredCost`** rounds tier breakdown values + subtotal + netAmount + taxAmount + totalAmount.
- **`runGenerationFor`** rounds all numeric RPC inputs in both write + preview branches; `previousTotalAmount` rounded once and surfaced consistently in preview / audit / WrittenHouseholdResult.
- **`ManualUsageCell`** — new `formatForInput(value)` helper (`value.toFixed(3)` for kWh; `""` for null/non-finite). 6 call sites updated; `onChange` untouched so live typing still works.
- Tests: 13 precision cases, 10 cell cases including the Peter Ntale dust regression, generator integration test, audit_log RPC-level rounding case, calculations.test.ts flipped `toBeCloseTo → toBe`.

## Why
Peter Ntale's row showed `178.3500000000000` in the in-app billing table USAGE column. Float-arithmetic dust (`end_kwh - start_kwh = 261.92 - 83.570` in IEEE-754) was persisted verbatim and leaked through `ManualUsageCell`'s editable path which bypassed the formatter (`String(value)` instead of `format(value)`). #224's PDF-renderer fix didn't cover the in-app surface.

Layered defense:
- JS write-time rounding (calculations + generator) catches the rate engine.
- SQL write-time rounding (RPC migration) catches any future writer that bypasses the engine.
- Display-time rounding (`formatForInput`) handles already-stored dust until next UPSERT.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — pre-existing warnings only.
- [x] `npm test` — 1584 pass, 33/33 in targeted suites (precision + calculations + cell). 2 pre-existing timeouts in audit-log-list/HouseholdWizard which pass in isolation (unrelated).
- [x] `npm run build` — clean.
- [x] Codegen zero-diff (signature unchanged).
- [ ] Operator follow-up: apply migration `00039` to cloud. Verify Peter Ntale's USAGE cell shows `178.350` (Part B fix surfaces clean display before re-save); re-key Peter's end_kwh and verify post-UPSERT `usage_kwh = 178.35` in DB (Part A storage fix landed).

## Notes
- No backfill UPDATE on existing dust rows. Display masks; storage cleans on next write.
- `#217` auto-invalidation invariant verified byte-for-byte against `00037`. Rounding is idempotent under `IS DISTINCT FROM` since both sides are now integer.
- `WITH ORDINALITY + ORDER BY ord` for tier-order stability (jsonb_agg without ORDER BY is undefined-order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)