### PR TITLE
CSV export for URA filing: route + dialog wire + persistent action (#229)

### DIFF
--- a/src/app/api/billing-periods/[periodId]/export-csv/__tests__/route.test.ts
+++ b/src/app/api/billing-periods/[periodId]/export-csv/__tests__/route.test.ts
@@ -1,0 +1,350 @@
+/**
+ * GET /api/billing-periods/[periodId]/export-csv — route tests (#229).
+ *
+ * Coverage:
+ *   - 400 bad UUID
+ *   - 401 unauthenticated
+ *   - 404 period missing / RLS-hidden
+ *   - 403 cross-org (defense-in-depth helper toggle)
+ *   - 200 happy path: text/csv content-type, sanitized filename, BOM prefix,
+ *     Cache-Control: no-store
+ *   - 200 on draft period
+ *   - 200 empty period (no line items) → header-only CSV
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const PERIOD_ID = "550e8400-e29b-41d4-a716-446655440001";
+const MICROGRID_ID = "550e8400-e29b-41d4-a716-446655440002";
+const COMMUNITY_ID = "550e8400-e29b-41d4-a716-446655440003";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+let canAccessMicrogridReturn = true;
+
+vi.mock("@/lib/auth/access", () => ({
+  currentUserCanAccessMicrogrid: async () => canAccessMicrogridReturn,
+}));
+
+type FromState = {
+  billing_periods: { data: unknown; error: unknown };
+  microgrids: { data: unknown; error: unknown };
+  rate_schedules: { data: unknown; error: unknown };
+  billing_line_items: { data: unknown; error: unknown };
+  household_devices: { data: unknown; error: unknown };
+};
+
+const sessionFromState: FromState = {
+  billing_periods: { data: null, error: null },
+  microgrids: { data: null, error: null },
+  rate_schedules: { data: null, error: null },
+  billing_line_items: { data: null, error: null },
+  household_devices: { data: null, error: null },
+};
+
+const serviceFromState: FromState = {
+  billing_periods: { data: null, error: null },
+  microgrids: { data: null, error: null },
+  rate_schedules: { data: null, error: null },
+  billing_line_items: { data: null, error: null },
+  household_devices: { data: null, error: null },
+};
+
+const mockGetUser = vi.fn().mockResolvedValue({
+  data: { user: { id: "actor-user-1" } },
+  error: null,
+});
+
+function makeSessionFromImpl(table: string) {
+  if (table === "billing_periods") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve(sessionFromState.billing_periods),
+        }),
+      }),
+    };
+  }
+  throw new Error(`Unexpected session-table: ${table}`);
+}
+
+function makeServiceFromImpl(table: string) {
+  if (table === "microgrids") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve(serviceFromState.microgrids),
+        }),
+      }),
+    };
+  }
+  if (table === "rate_schedules") {
+    return {
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            limit: () => ({
+              maybeSingle: () =>
+                Promise.resolve(serviceFromState.rate_schedules),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === "billing_line_items") {
+    return {
+      select: () => ({
+        eq: () => Promise.resolve(serviceFromState.billing_line_items),
+      }),
+    };
+  }
+  if (table === "household_devices") {
+    return {
+      select: () => ({
+        in: () => ({
+          eq: () => Promise.resolve(serviceFromState.household_devices),
+        }),
+      }),
+    };
+  }
+  throw new Error(`Unexpected service-table: ${table}`);
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: makeSessionFromImpl,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: makeServiceFromImpl,
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeReq(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/billing-periods/${PERIOD_ID}/export-csv`,
+    { method: "GET" },
+  );
+}
+
+function periodRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: PERIOD_ID,
+    microgrid_id: MICROGRID_ID,
+    start_date: "2026-04-01",
+    end_date: "2026-04-30",
+    status: "closed",
+    ...overrides,
+  };
+}
+
+function microgridRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MICROGRID_ID,
+    community_id: COMMUNITY_ID,
+    name: "Sezibwa",
+    currency: "UGX",
+    address_line1: null,
+    address_line2: null,
+    address_city: null,
+    address_region: null,
+    address_country: null,
+    address_postal_code: null,
+    lat: null,
+    lng: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ems_type: "openems_b2b",
+    ems_backend_url: null,
+    ems_aws_region: null,
+    ems_aws_access_key_id: null,
+    ems_known_edge_ids: [],
+    ems_last_discover_at: null,
+    ems_last_discover_count: null,
+    ems_last_discover_error: null,
+    ems_last_discover_status: null,
+    communities: {
+      id: COMMUNITY_ID,
+      invoice_config: { tax: { show_section: true, rate_pct: 18 } },
+    },
+    ...overrides,
+  };
+}
+
+const RATE_SCHEDULE_ROW = {
+  tiers: [{ label: "Tier 1", min_kwh: 1, max_kwh: null, rate_per_kwh: 500 }],
+  service_charge: 0,
+  tax_rate: 0.18,
+  created_at: "2026-04-01",
+};
+
+const LINE_ITEM_ROW = {
+  id: "00000000-0000-0000-0000-000000000001",
+  invoice_number: "NFE-2026-00001",
+  created_at: "2026-04-30T08:30:00Z",
+  start_kwh: 0,
+  end_kwh: 100,
+  usage_kwh: 100,
+  tier_breakdown: [{ label: "Tier 1", kwh: 100, amount: 50000 }],
+  total_amount: 50000,
+  payment_status: "unpaid",
+  paid_at: null,
+  household_id: "hh-1",
+  households: {
+    id: "hh-1",
+    display_name: "Aaron",
+    account_number: "A-1",
+    meter_serial: "MS-1",
+    meter_type: "Smart Submeter",
+    customer_type: "residential",
+    unit_label: null,
+    address_line1: null,
+    address_line2: null,
+    address_city: null,
+    address_country: null,
+    primary_phone: "+256700000001",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canAccessMicrogridReturn = true;
+  sessionFromState.billing_periods = { data: periodRow(), error: null };
+  serviceFromState.microgrids = { data: microgridRow(), error: null };
+  serviceFromState.rate_schedules = { data: RATE_SCHEDULE_ROW, error: null };
+  serviceFromState.billing_line_items = {
+    data: [LINE_ITEM_ROW],
+    error: null,
+  };
+  serviceFromState.household_devices = {
+    data: [
+      {
+        household_id: "hh-1",
+        devices: { openems_component_id: "meter0" },
+      },
+    ],
+    error: null,
+  };
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "actor-user-1" } },
+    error: null,
+  });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/billing-periods/[periodId]/export-csv", () => {
+  it("400: invalid UUID in path", async () => {
+    const { GET } = await import("../route");
+    const req = new NextRequest(
+      `http://localhost/api/billing-periods/not-a-uuid/export-csv`,
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ periodId: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("401: unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("404: period not found / RLS-hidden", async () => {
+    sessionFromState.billing_periods = { data: null, error: null };
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("403: caller cannot access microgrid (defense-in-depth after row load)", async () => {
+    canAccessMicrogridReturn = false;
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.reason).toBe("forbidden");
+  });
+
+  it("200: happy path returns CSV with correct headers + sanitized filename", async () => {
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Content-Disposition")).toBe(
+      `attachment; filename="sezibwa-billing-period-2026-04-01-to-2026-04-30.csv"`,
+    );
+  });
+
+  it("200: response body begins with the UTF-8 BOM (0xEF 0xBB 0xBF)", async () => {
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    const buf = new Uint8Array(await res.arrayBuffer());
+    expect(Array.from(buf.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+  });
+
+  it("200: works on draft periods (operators preview pre-close)", async () => {
+    sessionFromState.billing_periods = {
+      data: periodRow({ status: "draft" }),
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+  });
+
+  it("200 empty period → header-only CSV (no data rows) but tier columns present in header", async () => {
+    serviceFromState.billing_line_items = { data: [], error: null };
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // strip BOM, split on CRLF, drop trailing empty
+    const stripped = body.startsWith("﻿") ? body.slice(1) : body;
+    const lines = stripped.split("\r\n");
+    if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+    expect(lines.length).toBe(1);
+    // Header still has tier columns (Tier 1 kWh + Tier 1 UGX), so 18 + 2 = 20.
+    expect(lines[0].split(",").length).toBe(18 + 2);
+    expect(lines[0]).toContain("Tier 1 kWh");
+    expect(lines[0]).toContain("Tier 1 UGX");
+  });
+
+  it("filename sanitization: microgrid name with special chars → lowered + dashed", async () => {
+    serviceFromState.microgrids = {
+      data: microgridRow({ name: "NFE — Pilot #1" }),
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeReq(), {
+      params: Promise.resolve({ periodId: PERIOD_ID }),
+    });
+    expect(res.headers.get("Content-Disposition")).toBe(
+      `attachment; filename="nfe-pilot-1-billing-period-2026-04-01-to-2026-04-30.csv"`,
+    );
+  });
+});

--- a/src/app/api/billing-periods/[periodId]/export-csv/route.ts
+++ b/src/app/api/billing-periods/[periodId]/export-csv/route.ts
@@ -1,0 +1,388 @@
+/**
+ * GET /api/billing-periods/[periodId]/export-csv
+ *
+ * #229 — Operator-facing CSV download for URA filing. Bundles every
+ * line item in the period into a single CSV that Aaron pastes
+ * row-by-row into URA's online portal (via Excel as an intermediary).
+ *
+ * Pattern (mirrors PDF1b at `src/app/api/billing-line-items/[lineItemId]/pdf/route.ts`):
+ *   - UUID parse → 400.
+ *   - Session-bound Supabase client (`@/lib/supabase/server`) for the
+ *     auth fetch + row read. RLS is the access gate.
+ *   - Permission ordering: row read → 404 if RLS-hidden → defense-in-depth
+ *     `currentUserCanAccessMicrogrid` → 403.
+ *   - Service-role client used ONLY for the joins (households, devices,
+ *     rate schedule) so the export does not depend on RLS visibility for
+ *     joined rows; the access gate above already authorized the period.
+ *   - Most-recent rate_schedule per microgrid (`ORDER BY created_at DESC LIMIT 1`).
+ *   - Microgrid SELECT goes through `MICROGRID_PUBLIC_COLUMNS` (no
+ *     `.select("*")`).
+ *   - Works on both `draft` and `closed` periods.
+ *   - Headers: `text/csv; charset=utf-8`, sanitized
+ *     `Content-Disposition: attachment; filename="…"`, `Cache-Control: no-store`.
+ *
+ * The CSV body itself is built by the pure helper
+ * `src/lib/billing/csv-export.ts` — this route's job is purely the
+ * permission gate, the join assembly, and the response wiring.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { currentUserCanAccessMicrogrid } from "@/lib/auth/access";
+import {
+  buildBillingPeriodCsv,
+  buildCsvFilename,
+  type CsvExportInput,
+  type CsvExportRow,
+} from "@/lib/billing/csv-export";
+import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { MICROGRID_PUBLIC_COLUMNS } from "@/lib/types/microgrid-columns";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type DeviceJoinRow = {
+  household_id: string;
+  // PostgREST !inner returns the join as either `T` or `T[]` depending
+  // on cardinality + rest version; the unwrap helper below normalizes.
+  devices:
+    | { openems_component_id: string | null }
+    | Array<{ openems_component_id: string | null }>
+    | null;
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ periodId: string }> },
+): Promise<NextResponse> {
+  const startedAt = Date.now();
+  const { periodId } = await params;
+
+  if (!UUID_RE.test(periodId)) {
+    return NextResponse.json(
+      {
+        error: "Invalid billing period id — expected UUID.",
+        reason: "bad_request",
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+
+  // 1. Auth gate.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json(
+      { error: "Unauthorized.", reason: "unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  // 2. Resolve the billing period (RLS-scoped to caller). RLS-hidden or
+  //    missing → 404.
+  const { data: periodRow, error: periodErr } = await supabase
+    .from("billing_periods")
+    .select("id, microgrid_id, start_date, end_date, status")
+    .eq("id", periodId)
+    .maybeSingle();
+
+  if (periodErr) {
+    return NextResponse.json(
+      {
+        error: `Failed to look up billing period: ${periodErr.message}`,
+        reason: "unknown_error",
+      },
+      { status: 500 },
+    );
+  }
+  if (!periodRow) {
+    return NextResponse.json(
+      { error: "Billing period not found.", reason: "not_found" },
+      { status: 404 },
+    );
+  }
+
+  const microgridId = periodRow.microgrid_id as string;
+
+  // 3. Defense-in-depth permission check (production-wise RLS already
+  //    404'd cross-org rows; this branch is exercised by mocked tests).
+  if (!(await currentUserCanAccessMicrogrid(supabase, microgridId))) {
+    return NextResponse.json(
+      {
+        error: "You do not have permission to export this billing period.",
+        reason: "forbidden",
+      },
+      { status: 403 },
+    );
+  }
+
+  // 4. Service-role client for the joins. Authorization is already
+  //    decided above; service-role here avoids per-row RLS evaluation
+  //    on the join graph.
+  const svc = createServiceClient();
+
+  // 4a. Microgrid (enumerated columns via MICROGRID_PUBLIC_COLUMNS).
+  const { data: microgridRaw, error: microgridErr } = await svc
+    .from("microgrids")
+    .select(`${MICROGRID_PUBLIC_COLUMNS}, communities!inner(id, invoice_config)`)
+    .eq("id", microgridId)
+    .maybeSingle();
+
+  if (microgridErr || !microgridRaw) {
+    return NextResponse.json(
+      {
+        error: `Failed to load microgrid: ${microgridErr?.message ?? "not found"}`,
+        reason: "unknown_error",
+      },
+      { status: 500 },
+    );
+  }
+
+  const microgridRow = microgridRaw as unknown as Record<string, unknown>;
+  const communityRaw = unwrap(microgridRow.communities);
+  const microgridName = (microgridRow.name as string | null) ?? "microgrid";
+  const microgridCurrency = (microgridRow.currency as string | null) ?? "UGX";
+  const invoiceConfigRaw =
+    (communityRaw?.invoice_config as Record<string, unknown> | null) ?? null;
+  const taxRaw =
+    (invoiceConfigRaw?.tax as Record<string, unknown> | undefined) ?? null;
+  const showSection =
+    taxRaw && typeof taxRaw.show_section === "boolean"
+      ? (taxRaw.show_section as boolean)
+      : true;
+  const ratePct =
+    taxRaw && typeof taxRaw.rate_pct === "number"
+      ? (taxRaw.rate_pct as number)
+      : 0;
+
+  // 4b. Most-recent rate schedule for the microgrid.
+  const { data: rsRow, error: rsErr } = await svc
+    .from("rate_schedules")
+    .select("tiers, service_charge, tax_rate, created_at")
+    .eq("microgrid_id", microgridId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (rsErr || !rsRow) {
+    return NextResponse.json(
+      {
+        error:
+          "Cannot export — no rate schedule configured for this microgrid.",
+        reason: "missing_rate_schedule",
+      },
+      { status: 422 },
+    );
+  }
+
+  const rateScheduleTiers =
+    (rsRow.tiers as Array<{
+      label: string;
+      min_kwh: number;
+      max_kwh: number | null;
+      rate_per_kwh: number;
+    }> | null) ?? [];
+  const rateScheduleServiceCharge = (rsRow.service_charge as number) ?? 0;
+  const rateScheduleTaxRate = (rsRow.tax_rate as number) ?? 0;
+
+  // 4c. Line items + joined household. LEFT-join devices via
+  //     household_devices on role='primary_consumption_meter'.
+  const { data: lineItemRows, error: liErr } = await svc
+    .from("billing_line_items")
+    .select(
+      `
+      id,
+      invoice_number,
+      created_at,
+      start_kwh,
+      end_kwh,
+      usage_kwh,
+      tier_breakdown,
+      total_amount,
+      payment_status,
+      paid_at,
+      household_id,
+      households!inner (
+        id,
+        display_name,
+        account_number,
+        meter_serial,
+        meter_type,
+        customer_type,
+        unit_label,
+        address_line1,
+        address_line2,
+        address_city,
+        address_country,
+        primary_phone
+      )
+    `,
+    )
+    .eq("billing_period_id", periodId);
+
+  if (liErr) {
+    return NextResponse.json(
+      {
+        error: `Failed to load billing line items: ${liErr.message}`,
+        reason: "unknown_error",
+      },
+      { status: 500 },
+    );
+  }
+
+  const liRows = (lineItemRows ?? []) as Array<Record<string, unknown>>;
+
+  // 4d. Resolve a primary_consumption_meter device per household
+  //     (separate query — simpler than nesting through household_devices
+  //     in the line-items select).
+  const householdIds = Array.from(
+    new Set(
+      liRows
+        .map((r) => r.household_id as string | null)
+        .filter((id): id is string => typeof id === "string"),
+    ),
+  );
+
+  const deviceByHouseholdId = new Map<
+    string,
+    { openems_component_id: string | null }
+  >();
+  if (householdIds.length > 0) {
+    const { data: devRows } = await svc
+      .from("household_devices")
+      .select(
+        `
+        household_id,
+        devices!inner (
+          openems_component_id
+        )
+      `,
+      )
+      .in("household_id", householdIds)
+      .eq("role", "primary_consumption_meter");
+
+    for (const row of (devRows ?? []) as DeviceJoinRow[]) {
+      const dev = unwrap(row.devices as unknown);
+      if (dev && row.household_id && !deviceByHouseholdId.has(row.household_id)) {
+        deviceByHouseholdId.set(row.household_id, {
+          openems_component_id:
+            (dev.openems_component_id as string | null) ?? null,
+        });
+      }
+    }
+  }
+
+  // 5. Assemble helper input.
+  const rows: CsvExportRow[] = liRows.map((row) => {
+    const hh = unwrap(row.households) ?? {};
+    const householdId = (row.household_id as string | null) ?? null;
+    const device = householdId
+      ? deviceByHouseholdId.get(householdId) ?? null
+      : null;
+    return {
+      household: {
+        display_name: (hh.display_name as string | null) ?? "",
+        account_number: (hh.account_number as string | null) ?? null,
+        meter_serial: (hh.meter_serial as string | null) ?? null,
+        meter_type: (hh.meter_type as string | null) ?? "",
+        customer_type: (hh.customer_type as string | null) ?? "",
+        unit_label: (hh.unit_label as string | null) ?? null,
+        address_line1: (hh.address_line1 as string | null) ?? null,
+        address_line2: (hh.address_line2 as string | null) ?? null,
+        address_city: (hh.address_city as string | null) ?? null,
+        address_country: (hh.address_country as string | null) ?? null,
+        primary_phone: (hh.primary_phone as string | null) ?? null,
+      },
+      device: device ? { openems_component_id: device.openems_component_id } : null,
+      lineItem: {
+        id: row.id as string,
+        invoice_number: (row.invoice_number as string | null) ?? null,
+        created_at: (row.created_at as string | null) ?? "",
+        start_kwh: (row.start_kwh as number | null) ?? null,
+        end_kwh: (row.end_kwh as number | null) ?? null,
+        usage_kwh: (row.usage_kwh as number | null) ?? null,
+        tier_breakdown:
+          (row.tier_breakdown as Array<{
+            label: string;
+            kwh: number;
+            amount: number;
+          }> | null) ?? [],
+        total_amount: (row.total_amount as number) ?? 0,
+        payment_status: (row.payment_status as string) ?? "unpaid",
+        paid_at: (row.paid_at as string | null) ?? null,
+      },
+    };
+  });
+
+  const helperInput: CsvExportInput = {
+    microgrid: { name: microgridName, currency: microgridCurrency },
+    period: {
+      id: periodRow.id as string,
+      start_date: periodRow.start_date as string,
+      end_date: periodRow.end_date as string,
+      status: periodRow.status as string,
+    },
+    rateSchedule: {
+      tiers: rateScheduleTiers,
+      service_charge: rateScheduleServiceCharge,
+      tax_rate: rateScheduleTaxRate,
+    },
+    invoiceConfig: {
+      tax: { show_section: showSection, rate_pct: ratePct },
+    },
+    rows,
+  };
+
+  const csv = buildBillingPeriodCsv(helperInput);
+  const csvBytes = Buffer.from(csv, "utf-8");
+
+  const filename = buildCsvFilename({
+    microgridName,
+    startDate: periodRow.start_date as string,
+    endDate: periodRow.end_date as string,
+  });
+
+  // 6. Forensic log — NO PII (no household names, addresses, phones, or
+  //    line-item amounts).
+  console.info(
+    JSON.stringify(
+      scrubSecretValues(
+        {
+          event: "billing.csv.exported",
+          period_id: periodId,
+          microgrid_id: microgridId,
+          household_count: rows.length,
+          byte_size: csvBytes.byteLength,
+          duration_ms: Date.now() - startedAt,
+          actor_user_id: user.id,
+          at: new Date().toISOString(),
+        },
+        {},
+      ),
+    ),
+  );
+
+  return new NextResponse(new Uint8Array(csvBytes), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/** PostgREST !inner relations sometimes deserialize as `T[]` instead of
+ * `T`. Normalize to `T | null`. */
+function unwrap(candidate: unknown): Record<string, unknown> | null {
+  if (candidate == null) return null;
+  if (Array.isArray(candidate)) {
+    return (candidate[0] ?? null) as Record<string, unknown> | null;
+  }
+  return candidate as Record<string, unknown>;
+}

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -117,6 +117,25 @@ export function BillingTable({
 
   const isDraft = period.status === "draft";
 
+  // #229 — CSV export download trigger. Colocated (not extracted to a
+  // shared util) because both call sites — the close-dialog button and
+  // the persistent "Export CSV" header button — live in this file. A
+  // 6-line helper module with one consumer would be over-extraction.
+  //
+  // Mirrors the PDF1b / #205 / #222 pattern: programmatic anchor click
+  // WITHOUT a `download` attribute. The route's
+  // `Content-Disposition: attachment; filename="…"` drives the
+  // filename; leaving `download` off lets the browser honor that
+  // server-provided name verbatim.
+  function triggerCsvDownload(periodId: string) {
+    const a = document.createElement("a");
+    a.href = `/api/billing-periods/${periodId}/export-csv`;
+    a.rel = "noopener";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+
   // Build householdId -> lineItem map
   const lineItemMap = new Map<string, BillingLineItem>();
   for (const item of lineItems) {
@@ -681,6 +700,7 @@ export function BillingTable({
         summaryRows={closePeriodSummaryRows}
         grandTotal={grandTotal}
         onConfirm={handleClose}
+        onExportCsv={() => triggerCsvDownload(period.id)}
         unfilledHouseholdNames={unfilledHouseholdNames}
       />
 
@@ -761,6 +781,33 @@ export function BillingTable({
             >
               View history
             </Link>
+            {/* #229 — persistent CSV export. Always rendered (draft +
+                closed); the close-success dialog retains its "Export
+                CSV for URA" button as a URA-filing-focused surface,
+                while this header button serves all use cases (preview
+                drafts, re-download, share with team). Disabled with a
+                tooltip when there is no data to export. */}
+            {(() => {
+              const exportDisabled =
+                households.length === 0 || lineItems.length === 0;
+              const exportTooltip =
+                households.length === 0
+                  ? "No households to export"
+                  : lineItems.length === 0
+                    ? "Generate readings before exporting"
+                    : undefined;
+              return (
+                <button
+                  type="button"
+                  onClick={() => triggerCsvDownload(period.id)}
+                  disabled={exportDisabled}
+                  title={exportTooltip}
+                  className="rounded-md border border-border bg-card px-4 py-2 text-sm text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Export CSV
+                </button>
+              );
+            })()}
             {isDraft && (
               <>
                 <button

--- a/src/components/__tests__/billing-table.test.tsx
+++ b/src/components/__tests__/billing-table.test.tsx
@@ -563,6 +563,178 @@ describe("BillingTable", () => {
     expect(kebabs.length).toBe(3);
   });
 
+  // ── #229: Export CSV button + close-dialog wiring ────────────────────────
+  describe("Export CSV (#229)", () => {
+    function setupAnchorSpy() {
+      // Spy on document.createElement so we can intercept the
+      // programmatic <a> the helper builds + clicks.
+      const origCreateElement = document.createElement.bind(document);
+      const lastAnchor: { href?: string; clicked?: boolean } = {};
+      const spy = vi
+        .spyOn(document, "createElement")
+        .mockImplementation((tagName: string) => {
+          const el = origCreateElement(tagName as "a") as HTMLElement;
+          if (tagName === "a") {
+            const a = el as HTMLAnchorElement;
+            const origClick = a.click.bind(a);
+            a.click = () => {
+              lastAnchor.href = a.href;
+              lastAnchor.clicked = true;
+              // Don't actually navigate in jsdom.
+              try {
+                origClick();
+              } catch {
+                /* jsdom may throw on navigation */
+              }
+            };
+          }
+          return el;
+        });
+      return { lastAnchor, restore: () => spy.mockRestore() };
+    }
+
+    it("persistent header button renders on closed AND draft periods", () => {
+      const closedPeriod: BillingPeriod = {
+        ...period,
+        status: "closed",
+        closed_at: "2026-04-01T00:00:00Z",
+      };
+      const { rerender, container } = render(
+        <Wrapper>
+          <BillingTable {...baseProps} period={closedPeriod} />
+        </Wrapper>,
+      );
+      let btn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Export CSV",
+      );
+      expect(btn).toBeDefined();
+
+      rerender(
+        <Wrapper>
+          <BillingTable {...baseProps} />
+        </Wrapper>,
+      );
+      btn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Export CSV",
+      );
+      expect(btn).toBeDefined();
+    });
+
+    it("clicking the persistent button triggers /api/billing-periods/<id>/export-csv navigation", () => {
+      const { lastAnchor, restore } = setupAnchorSpy();
+      try {
+        const { container } = render(
+          <Wrapper>
+            <BillingTable {...baseProps} />
+          </Wrapper>,
+        );
+        const btn = Array.from(container.querySelectorAll("button")).find(
+          (b) => b.textContent?.trim() === "Export CSV",
+        )!;
+        expect(btn).toBeDefined();
+        fireEvent.click(btn);
+        expect(lastAnchor.clicked).toBe(true);
+        expect(lastAnchor.href).toContain(
+          `/api/billing-periods/${period.id}/export-csv`,
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it("disabled with 'Generate readings before exporting' tooltip when lineItems.length === 0 (but households exist)", () => {
+      const { container } = render(
+        <Wrapper>
+          <BillingTable {...baseProps} lineItems={[]} />
+        </Wrapper>,
+      );
+      const btn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Export CSV",
+      ) as HTMLButtonElement;
+      expect(btn).toBeDefined();
+      expect(btn.disabled).toBe(true);
+      expect(btn.title).toBe("Generate readings before exporting");
+    });
+
+    it("disabled with 'No households to export' tooltip when households.length === 0", () => {
+      const { container } = render(
+        <Wrapper>
+          <BillingTable {...baseProps} households={[]} lineItems={[]} />
+        </Wrapper>,
+      );
+      const btn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Export CSV",
+      ) as HTMLButtonElement;
+      expect(btn).toBeDefined();
+      expect(btn.disabled).toBe(true);
+      expect(btn.title).toBe("No households to export");
+    });
+
+    it("close-dialog's 'Export CSV for URA' button invokes onExportCsv which triggers /api/.../export-csv navigation", async () => {
+      const { lastAnchor, restore } = setupAnchorSpy();
+      try {
+        // Render the dialog directly with the prop wired the same way
+        // BillingTable wires it. Avoids exercising the full close flow.
+        const { ClosePeriodDialog } = await import(
+          "../ui/close-period-dialog"
+        );
+        const onExportCsv = vi.fn(() => {
+          // Mirror BillingTable's triggerCsvDownload call.
+          const a = document.createElement("a");
+          a.href = `/api/billing-periods/${period.id}/export-csv`;
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+        });
+        render(
+          <ClosePeriodDialog
+            open
+            onOpenChange={() => {}}
+            periodLabel="March 2026"
+            summaryRows={[]}
+            grandTotal={0}
+            onConfirm={async () => {}}
+            onExportCsv={onExportCsv}
+          />,
+        );
+        // Radix portals into document.body; query against document, not container.
+        const queryButtonByText = (text: RegExp) =>
+          Array.from(document.querySelectorAll("button")).find((b) =>
+            text.test(b.textContent ?? ""),
+          );
+        // The dialog opens at phase=2; tick the checkbox + click "Close
+        // period" to advance to phase=3 where the export CSV button is
+        // shown.
+        const checkbox = document.querySelector(
+          "input[type='checkbox']",
+        ) as HTMLInputElement;
+        expect(checkbox).toBeTruthy();
+        fireEvent.click(checkbox);
+        const closeBtn = queryButtonByText(/^Close period$/) as
+          | HTMLButtonElement
+          | undefined;
+        expect(closeBtn).toBeTruthy();
+        await act(async () => {
+          closeBtn!.click();
+        });
+        await waitFor(() => {
+          expect(queryButtonByText(/^Export CSV for URA$/)).toBeTruthy();
+        });
+        const exportBtn = queryButtonByText(
+          /^Export CSV for URA$/,
+        ) as HTMLButtonElement;
+        fireEvent.click(exportBtn);
+        expect(onExportCsv).toHaveBeenCalledTimes(1);
+        expect(lastAnchor.clicked).toBe(true);
+        expect(lastAnchor.href).toContain(
+          `/api/billing-periods/${period.id}/export-csv`,
+        );
+      } finally {
+        restore();
+      }
+    });
+  });
+
   // ── #221 regression-guard ────────────────────────────────────────────────
   //
   // BillingTable.tsx:604-609 hand-builds the lineItem prop forwarded to

--- a/src/lib/billing/__tests__/csv-export.test.ts
+++ b/src/lib/billing/__tests__/csv-export.test.ts
@@ -1,0 +1,519 @@
+/**
+ * csv-export.test.ts — pure-function tests for #229 CSV serializer.
+ *
+ * The helper is fully data-driven; these tests cover the AC-spec'd
+ * invariants:
+ *   - 19-column header (+ 2 per tier).
+ *   - Per-row VAT/service/subtotal derivation from
+ *     `community.invoice_config.tax.rate_pct` (NOT `rateSchedule.tax_rate`).
+ *   - Tier column lookup by `label`, not index (re-ordered breakdowns
+ *     still align).
+ *   - Address composition mirrors the PDF's 5-field filter+join.
+ *   - BOM byte sequence + CRLF line endings + RFC 4180 quoting.
+ *   - Sort stability (display_name asc, line-item id asc secondary).
+ *   - Special characters (commas, quotes, newlines) are properly escaped.
+ *   - Filename sanitization helper edge cases.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildBillingPeriodCsv,
+  buildCsvFilename,
+  sanitizeFilenameSegment,
+  type CsvExportInput,
+  type CsvExportRow,
+} from "../csv-export";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TIERS_4 = [
+  { label: "Tier 1", min_kwh: 1, max_kwh: 50, rate_per_kwh: 500 },
+  { label: "Tier 2", min_kwh: 51, max_kwh: 100, rate_per_kwh: 800 },
+  { label: "Tier 3", min_kwh: 101, max_kwh: 200, rate_per_kwh: 1100 },
+  { label: "Tier 4", min_kwh: 201, max_kwh: null, rate_per_kwh: 1400 },
+];
+
+const TIERS_2 = [
+  { label: "Tier 1", min_kwh: 1, max_kwh: 50, rate_per_kwh: 500 },
+  { label: "Tier 2", min_kwh: 51, max_kwh: null, rate_per_kwh: 800 },
+];
+
+function makeRow(overrides: Partial<CsvExportRow> = {}): CsvExportRow {
+  return {
+    household: {
+      display_name: "Alice",
+      account_number: "A-001",
+      meter_serial: "MS-001",
+      meter_type: "Smart Submeter",
+      customer_type: "residential",
+      // Default to comma-free fields so most tests can naively
+      // `.split(",")` to assert per-cell values. Tests that exercise
+      // address composition override these explicitly.
+      unit_label: null,
+      address_line1: null,
+      address_line2: null,
+      address_city: null,
+      address_country: null,
+      primary_phone: "+256700000001",
+    },
+    device: { openems_component_id: "meter0" },
+    lineItem: {
+      id: "00000000-0000-0000-0000-000000000001",
+      invoice_number: "NFE-2026-00001",
+      created_at: "2026-04-30T08:30:00Z",
+      start_kwh: 100,
+      end_kwh: 180,
+      usage_kwh: 80,
+      tier_breakdown: [
+        { label: "Tier 1", kwh: 50, amount: 25000 },
+        { label: "Tier 2", kwh: 30, amount: 24000 },
+      ],
+      total_amount: 49000,
+      payment_status: "unpaid",
+      paid_at: null,
+    },
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<CsvExportInput> = {}): CsvExportInput {
+  return {
+    microgrid: { name: "Sezibwa", currency: "UGX" },
+    period: {
+      id: "00000000-0000-0000-0000-0000000000aa",
+      start_date: "2026-04-01",
+      end_date: "2026-04-30",
+      status: "closed",
+    },
+    rateSchedule: {
+      tiers: TIERS_2,
+      service_charge: 0,
+      tax_rate: 0,
+    },
+    invoiceConfig: {
+      tax: { show_section: false, rate_pct: 0 },
+    },
+    rows: [makeRow()],
+    ...overrides,
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseLines(csv: string): string[] {
+  // Strip BOM if present, split on CRLF, drop trailing empty (from
+  // terminator).
+  const body = csv.startsWith("﻿") ? csv.slice(1) : csv;
+  const lines = body.split("\r\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("buildBillingPeriodCsv — header + structure", () => {
+  it("emits 18 fixed columns + 2 per tier (4-tier microgrid → 26 columns)", () => {
+    // AC bullet #13 is the per-tier block (counted as a single item in
+    // the spec's "19-column header" phrasing → 18 individual non-tier
+    // columns).
+    const csv = buildBillingPeriodCsv(
+      makeInput({ rateSchedule: { tiers: TIERS_4, service_charge: 0, tax_rate: 0 } }),
+    );
+    const lines = parseLines(csv);
+    const headerCols = lines[0].split(",");
+    expect(headerCols.length).toBe(18 + 8);
+    expect(headerCols[0]).toBe("Invoice Number");
+    expect(headerCols[1]).toBe("Issue Date");
+    expect(headerCols[2]).toBe("Household");
+    expect(headerCols[5]).toBe("Meter Type");
+    expect(headerCols[7]).toBe("Address");
+  });
+
+  it("2-tier microgrid → 18 + 4 = 22 columns", () => {
+    const csv = buildBillingPeriodCsv(makeInput());
+    const cols = parseLines(csv)[0].split(",");
+    expect(cols.length).toBe(18 + 4);
+  });
+
+  it("currency token threads into Service / VAT / Total / tier headers", () => {
+    const csv = buildBillingPeriodCsv(
+      makeInput({ microgrid: { name: "X", currency: "KES" } }),
+    );
+    const cols = parseLines(csv)[0].split(",");
+    expect(cols).toContain("Service Charge KES");
+    expect(cols).toContain("Taxable Subtotal KES");
+    expect(cols).toContain("VAT KES");
+    expect(cols).toContain("Total KES");
+    expect(cols).toContain("Tier 1 KES");
+    expect(cols).toContain("Tier 2 KES");
+  });
+
+  it("empty rows array → header-only CSV (single line)", () => {
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [] }));
+    const lines = parseLines(csv);
+    expect(lines.length).toBe(1);
+  });
+});
+
+describe("buildBillingPeriodCsv — bytes (BOM + CRLF)", () => {
+  it("starts with UTF-8 BOM (0xEF 0xBB 0xBF)", () => {
+    const csv = buildBillingPeriodCsv(makeInput());
+    const bytes = new Uint8Array(Buffer.from(csv, "utf-8"));
+    expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+  });
+
+  it("uses CRLF line endings between rows", () => {
+    const csv = buildBillingPeriodCsv(
+      makeInput({ rows: [makeRow(), makeRow({ household: { ...makeRow().household, display_name: "Bob" } })] }),
+    );
+    // Count CRLF occurrences = header + 2 data rows + trailing = 3
+    const crlfCount = (csv.match(/\r\n/g) ?? []).length;
+    expect(crlfCount).toBe(3);
+    expect(csv.endsWith("\r\n")).toBe(true);
+  });
+});
+
+describe("buildBillingPeriodCsv — tier lookup", () => {
+  it("4-tier microgrid: rows that reached only Tier 1 emit empty cells for Tiers 2-4 (NOT zero)", () => {
+    const rowOnlyT1 = makeRow({
+      household: { ...makeRow().household, display_name: "Solo" },
+      lineItem: {
+        ...makeRow().lineItem,
+        id: "00000000-0000-0000-0000-000000000010",
+        tier_breakdown: [{ label: "Tier 1", kwh: 25, amount: 12500 }],
+        total_amount: 12500,
+      },
+    });
+    const csv = buildBillingPeriodCsv(
+      makeInput({
+        rateSchedule: { tiers: TIERS_4, service_charge: 0, tax_rate: 0 },
+        rows: [rowOnlyT1],
+      }),
+    );
+    const lines = parseLines(csv);
+    const dataCols = lines[1].split(",");
+    // Tier columns start at index 12. T1 kWh = 25, T1 UGX = 12500,
+    // T2/T3/T4 kWh + UGX should be empty strings.
+    expect(dataCols[12]).toBe("25");
+    expect(dataCols[13]).toBe("12500");
+    expect(dataCols[14]).toBe("");
+    expect(dataCols[15]).toBe("");
+    expect(dataCols[16]).toBe("");
+    expect(dataCols[17]).toBe("");
+    expect(dataCols[18]).toBe("");
+    expect(dataCols[19]).toBe("");
+  });
+
+  it("empty tier_breakdown ([]) — all tier cells are empty", () => {
+    const rowEmpty = makeRow({
+      lineItem: {
+        ...makeRow().lineItem,
+        tier_breakdown: [],
+        total_amount: 0,
+      },
+    });
+    const csv = buildBillingPeriodCsv(
+      makeInput({
+        rateSchedule: { tiers: TIERS_4, service_charge: 0, tax_rate: 0 },
+        rows: [rowEmpty],
+      }),
+    );
+    const dataCols = parseLines(csv)[1].split(",");
+    for (let i = 12; i < 12 + 8; i++) {
+      expect(dataCols[i]).toBe("");
+    }
+  });
+
+  it("tier lookup is BY LABEL not index — re-ordered tier_breakdown still aligns", () => {
+    const reorderedRow = makeRow({
+      lineItem: {
+        ...makeRow().lineItem,
+        // T2 listed BEFORE T1 — must still align under the right column.
+        tier_breakdown: [
+          { label: "Tier 2", kwh: 30, amount: 24000 },
+          { label: "Tier 1", kwh: 50, amount: 25000 },
+        ],
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [reorderedRow] }));
+    const cols = parseLines(csv)[1].split(",");
+    // Column 12 = Tier 1 kWh, 13 = Tier 1 UGX, 14 = Tier 2 kWh, 15 = Tier 2 UGX
+    expect(cols[12]).toBe("50");
+    expect(cols[13]).toBe("25000");
+    expect(cols[14]).toBe("30");
+    expect(cols[15]).toBe("24000");
+  });
+});
+
+describe("buildBillingPeriodCsv — VAT/tax derivation", () => {
+  it("VAT enabled (show_section=true, rate_pct=18) → VAT-from-total math", () => {
+    // total = 49000 → net = round(49000/1.18) = round(41525.4237…) = 41525
+    // VAT = 49000 - 41525 = 7475
+    const csv = buildBillingPeriodCsv(
+      makeInput({
+        invoiceConfig: { tax: { show_section: true, rate_pct: 18 } },
+        rateSchedule: { tiers: TIERS_2, service_charge: 0, tax_rate: 0.18 },
+        rows: [makeRow()],
+      }),
+    );
+    const cols = parseLines(csv)[1].split(",");
+    // Header order, after 4 tier cols: Service / Taxable / VAT / Total
+    // base cols 0-11 + 4 tier cols = first non-tier index is 16
+    // 16=Service Charge, 17=Taxable Subtotal, 18=VAT, 19=Total
+    expect(cols[16]).toBe("0"); // service charge
+    expect(cols[17]).toBe("41525"); // taxable subtotal
+    expect(cols[18]).toBe("7475"); // VAT
+    expect(cols[19]).toBe("49000"); // total
+  });
+
+  it("VAT disabled (show_section=false) → VAT cell EMPTY, taxable = energy + service", () => {
+    const csv = buildBillingPeriodCsv(
+      makeInput({
+        invoiceConfig: { tax: { show_section: false, rate_pct: 0 } },
+        rateSchedule: { tiers: TIERS_2, service_charge: 5000, tax_rate: 0 },
+        rows: [makeRow()],
+      }),
+    );
+    const cols = parseLines(csv)[1].split(",");
+    // energy = 25000 + 24000 = 49000, +service 5000 = 54000 taxable, VAT empty
+    expect(cols[16]).toBe("5000"); // service charge
+    expect(cols[17]).toBe("54000"); // taxable subtotal = energy + service
+    expect(cols[18]).toBe(""); // VAT empty (not zero)
+  });
+
+  it("VAT rate_pct=0 → VAT cell EMPTY (treated as disabled)", () => {
+    const csv = buildBillingPeriodCsv(
+      makeInput({
+        invoiceConfig: { tax: { show_section: true, rate_pct: 0 } },
+        rows: [makeRow()],
+      }),
+    );
+    const cols = parseLines(csv)[1].split(",");
+    expect(cols[18]).toBe("");
+  });
+
+  it("ANTI-TEST: VAT does NOT come from rateSchedule.tax_rate — only from invoiceConfig.tax.rate_pct", () => {
+    // If the helper (buggily) used rateSchedule.tax_rate=0.20, the VAT
+    // for total=49000 would be 49000 - round(49000/1.20) = 8167.
+    // But we set invoiceConfig.tax.rate_pct=10 → VAT should be 4455
+    // (49000 - round(49000/1.10) = 49000 - 44545 = 4455).
+    const csv = buildBillingPeriodCsv(
+      makeInput({
+        invoiceConfig: { tax: { show_section: true, rate_pct: 10 } },
+        rateSchedule: { tiers: TIERS_2, service_charge: 0, tax_rate: 0.2 },
+        rows: [makeRow()],
+      }),
+    );
+    const cols = parseLines(csv)[1].split(",");
+    expect(cols[17]).toBe("44545"); // taxable @ 10% not 20%
+    expect(cols[18]).toBe("4455"); // VAT @ 10% not 20%
+    // Sanity: NOT the value that would result from tax_rate=0.20
+    expect(cols[18]).not.toBe("8167");
+  });
+});
+
+describe("buildBillingPeriodCsv — RFC 4180 quoting", () => {
+  it('special characters in name: O\'Brien, Inc. "Trading" → properly quoted with escaped double-quotes', () => {
+    const tricky = makeRow({
+      household: {
+        ...makeRow().household,
+        display_name: 'O\'Brien, Inc. "Trading"',
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [tricky] }));
+    // The Household column is index 2.
+    const lines = parseLines(csv);
+    // We cannot naively split on comma because the cell is quoted.
+    // Assert by raw substring.
+    expect(lines[1]).toContain('"O\'Brien, Inc. ""Trading"""');
+  });
+
+  it("newline inside an address is quoted", () => {
+    const withNewline = makeRow({
+      household: {
+        ...makeRow().household,
+        address_line1: "Line1\nWith newline",
+        unit_label: null,
+        address_line2: null,
+        address_city: null,
+        address_country: null,
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [withNewline] }));
+    expect(csv).toContain('"Line1\nWith newline"');
+  });
+});
+
+describe("buildBillingPeriodCsv — null fields", () => {
+  it("null account_number, meter_serial, paid_at → empty cells (NOT 'null')", () => {
+    const nullRow = makeRow({
+      household: {
+        ...makeRow().household,
+        account_number: null,
+        meter_serial: null,
+        primary_phone: null,
+      },
+      device: null,
+      lineItem: {
+        ...makeRow().lineItem,
+        invoice_number: null,
+        paid_at: null,
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [nullRow] }));
+    expect(csv).not.toMatch(/\bnull\b/);
+    expect(csv).not.toMatch(/\bundefined\b/);
+    const cols = parseLines(csv)[1].split(",");
+    expect(cols[0]).toBe(""); // invoice number
+    expect(cols[3]).toBe(""); // account number
+    expect(cols[4]).toBe(""); // meter ID
+    expect(cols[8]).toBe(""); // phone
+  });
+});
+
+describe("buildBillingPeriodCsv — Address composition", () => {
+  it("missing line2 → 4 fields joined with single comma, no double comma", () => {
+    const row = makeRow({
+      household: {
+        ...makeRow().household,
+        unit_label: "Unit 7",
+        address_line1: "12 Main Rd",
+        address_line2: null,
+        address_city: "Kampala",
+        address_country: "Uganda",
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [row] }));
+    // Address contains commas → it will be quoted in the cell. Check the
+    // raw quoted address substring.
+    expect(csv).toContain('"Unit 7, 12 Main Rd, Kampala, Uganda"');
+  });
+
+  it("all 5 address fields null → empty Address cell", () => {
+    const row = makeRow({
+      household: {
+        ...makeRow().household,
+        unit_label: null,
+        address_line1: null,
+        address_line2: null,
+        address_city: null,
+        address_country: null,
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [row] }));
+    const cols = parseLines(csv)[1].split(",");
+    expect(cols[7]).toBe(""); // Address index
+  });
+
+  it("blank-only address fields (whitespace) are filtered out", () => {
+    const row = makeRow({
+      household: {
+        ...makeRow().household,
+        unit_label: "   ",
+        address_line1: "12 Main",
+        address_line2: null,
+        address_city: "Kampala",
+        address_country: null,
+      },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [row] }));
+    // Two fields → comma-joined, will be quoted because contains comma.
+    expect(csv).toContain('"12 Main, Kampala"');
+  });
+});
+
+describe("buildBillingPeriodCsv — payment-status title case", () => {
+  it.each([
+    ["unpaid", "Unpaid"],
+    ["paid", "Paid"],
+    ["failed", "Failed"],
+    ["refunded", "Refunded"],
+    ["link_generated", "Link Generated"],
+  ])("%s → %s", (input, expected) => {
+    const row = makeRow({
+      lineItem: { ...makeRow().lineItem, payment_status: input },
+    });
+    const csv = buildBillingPeriodCsv(makeInput({ rows: [row] }));
+    // Payment Status is the 2nd-to-last column.
+    const cols = parseLines(csv)[1].split(",");
+    expect(cols[cols.length - 2]).toBe(expected);
+  });
+});
+
+describe("buildBillingPeriodCsv — sort stability", () => {
+  it("sorts by display_name ascending", () => {
+    const rows = [
+      makeRow({
+        household: { ...makeRow().household, display_name: "Charlie" },
+      }),
+      makeRow({
+        household: { ...makeRow().household, display_name: "Alice" },
+      }),
+      makeRow({
+        household: { ...makeRow().household, display_name: "Bob" },
+      }),
+    ];
+    const csv = buildBillingPeriodCsv(makeInput({ rows }));
+    const lines = parseLines(csv);
+    // Household column is index 2. We can grab it from each data row
+    // by splitting; none of these names have commas.
+    const names = lines.slice(1).map((l) => l.split(",")[2]);
+    expect(names).toEqual(["Alice", "Bob", "Charlie"]);
+  });
+
+  it("identical display_name → secondary sort by lineItem.id ASC; re-running produces byte-identical output", () => {
+    const rows = [
+      makeRow({
+        household: { ...makeRow().household, display_name: "Same" },
+        lineItem: {
+          ...makeRow().lineItem,
+          id: "00000000-0000-0000-0000-000000000002",
+          invoice_number: "INV-002",
+        },
+      }),
+      makeRow({
+        household: { ...makeRow().household, display_name: "Same" },
+        lineItem: {
+          ...makeRow().lineItem,
+          id: "00000000-0000-0000-0000-000000000001",
+          invoice_number: "INV-001",
+        },
+      }),
+    ];
+    const csv1 = buildBillingPeriodCsv(makeInput({ rows }));
+    // Shuffle the input array; output must be byte-identical.
+    const csv2 = buildBillingPeriodCsv(makeInput({ rows: [...rows].reverse() }));
+    expect(csv2).toBe(csv1);
+    // The row whose lineItem.id sorts first (…0001 → INV-001) appears
+    // before the …0002 row regardless of input order.
+    const lines = parseLines(csv1);
+    expect(lines[1].split(",")[0]).toBe("INV-001");
+    expect(lines[2].split(",")[0]).toBe("INV-002");
+  });
+});
+
+describe("sanitizeFilenameSegment", () => {
+  it.each([
+    ["Sezibwa", "sezibwa"],
+    [
+      "Kisakye (Test with OpenEMS Integrated)",
+      "kisakye-test-with-openems-integrated",
+    ],
+    ["NFE — Pilot #1", "nfe-pilot-1"],
+    ["   trim me   ", "trim-me"],
+  ])("%s → %s", (input, expected) => {
+    expect(sanitizeFilenameSegment(input)).toBe(expected);
+  });
+});
+
+describe("buildCsvFilename", () => {
+  it("emits <slug>-billing-period-<start>-to-<end>.csv", () => {
+    expect(
+      buildCsvFilename({
+        microgridName: "Sezibwa",
+        startDate: "2026-04-01",
+        endDate: "2026-04-30",
+      }),
+    ).toBe("sezibwa-billing-period-2026-04-01-to-2026-04-30.csv");
+  });
+});

--- a/src/lib/billing/csv-export.ts
+++ b/src/lib/billing/csv-export.ts
@@ -1,0 +1,316 @@
+/**
+ * csv-export.ts — pure CSV serializer for billing-period exports (#229).
+ *
+ * Aaron's URA-filing workflow: download the CSV → open in Excel as an
+ * intermediary → paste row-by-row into URA's online portal. The output
+ * is therefore optimized for:
+ *
+ *   - RFC 4180 compliance (CRLF, double-quote escaping).
+ *   - UTF-8 BOM (`0xEF 0xBB 0xBF`) so Excel for Mac / Windows detects
+ *     UTF-8 without falling back to the system locale and mangling
+ *     accents in household names.
+ *   - Locale-neutral raw decimal values — operators' spreadsheets do the
+ *     display formatting. We do NOT call `Intl.NumberFormat` or
+ *     `toLocaleString`.
+ *   - Per-tier column expansion (Tier 1 kWh, Tier 1 <CUR>, …) so URA's
+ *     per-tier fields paste directly.
+ *
+ * Header columns mirror PDF1a/PDF1b semantics (`Invoice Number`,
+ * `Issue Date`, `Meter Type`, composed `Address`) so a CSV row and a
+ * PDF for the same line item are byte-consistent at the cell level.
+ *
+ * VAT derivation mirrors `src/lib/invoices/render.tsx:1226-1243` — the
+ * VAT column is derived from `community.invoice_config.tax.rate_pct`
+ * via the "VAT-from-total" formula. The `rate_schedules.tax_rate`
+ * multiplier (informational on the input) is NOT used for column
+ * derivation; PDFs and CSVs must agree on the same tax convention.
+ *
+ * Pure function — no I/O, no `Date.now()`, no DB access. All inputs are
+ * explicit so the helper is fully unit-testable.
+ */
+
+import { roundAmount } from "./precision";
+
+/** Per-row input to {@link buildBillingPeriodCsv}. */
+export interface CsvExportRow {
+  household: {
+    display_name: string;
+    account_number: string | null;
+    meter_serial: string | null;
+    meter_type: string;
+    customer_type: string;
+    unit_label: string | null;
+    address_line1: string | null;
+    address_line2: string | null;
+    address_city: string | null;
+    address_country: string | null;
+    primary_phone: string | null;
+  };
+  device: { openems_component_id: string | null } | null;
+  lineItem: {
+    id: string;
+    invoice_number: string | null;
+    created_at: string;
+    start_kwh: number | null;
+    end_kwh: number | null;
+    usage_kwh: number | null;
+    tier_breakdown: Array<{ label: string; kwh: number; amount: number }>;
+    total_amount: number;
+    payment_status: string;
+    paid_at: string | null;
+  };
+}
+
+/** Aggregate input to {@link buildBillingPeriodCsv}. */
+export interface CsvExportInput {
+  microgrid: { name: string; currency: string };
+  period: {
+    id: string;
+    start_date: string;
+    end_date: string;
+    status: string;
+  };
+  /**
+   * Selected rate schedule (most-recent for the microgrid). `tiers`
+   * drives per-tier column expansion; `service_charge` populates the
+   * Service Charge column; `tax_rate` is INFORMATIONAL (the multiplier
+   * baked into `total_amount` at write-time) and is intentionally NOT
+   * used for CSV VAT derivation — see {@link CsvExportInput.invoiceConfig}.
+   */
+  rateSchedule: {
+    tiers: Array<{
+      label: string;
+      min_kwh: number;
+      max_kwh: number | null;
+      rate_per_kwh: number;
+    }>;
+    service_charge: number;
+    tax_rate: number;
+  };
+  /**
+   * VAT/tax config from the community. `rate_pct` is a PERCENTAGE
+   * (e.g. `18` for 18%, NOT the multiplier `0.18`). When
+   * `show_section === false` OR `rate_pct === 0`, the VAT cell is
+   * emitted as empty (distinguishing "tax exempt" from "tax = 0 on a
+   * tiny bill"), and Taxable Subtotal = energy + service charge.
+   */
+  invoiceConfig: {
+    tax: { show_section: boolean; rate_pct: number };
+  };
+  rows: CsvExportRow[];
+}
+
+/** Mapping from the lower-case enum value to the title-cased display label. */
+const PAYMENT_STATUS_LABELS: Record<string, string> = {
+  unpaid: "Unpaid",
+  paid: "Paid",
+  failed: "Failed",
+  refunded: "Refunded",
+  link_generated: "Link Generated",
+};
+
+/** RFC 4180 quoting: wrap in `"…"` if the cell contains any of `,`, `"`,
+ * `\r`, `\n`; escape embedded `"` as `""`. */
+function csvCell(value: unknown): string {
+  if (value == null) return "";
+  const s = typeof value === "string" ? value : String(value);
+  if (s.length === 0) return "";
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/** Compose the service Address from the same 5 fields as the PDF renderer
+ * (`render.tsx:665-674`): filter empty/blank, comma-join the rest. */
+function composeAddress(h: CsvExportRow["household"]): string {
+  return [
+    h.unit_label,
+    h.address_line1,
+    h.address_line2,
+    h.address_city,
+    h.address_country,
+  ]
+    .map((s) => (s ?? "").trim())
+    .filter((s) => s.length > 0)
+    .join(", ");
+}
+
+/** Title-case a customer_type enum value (e.g. `residential` → `Residential`). */
+function titleCaseCustomerType(s: string): string {
+  if (!s) return "";
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+/** Issue Date is `created_at` rendered as ISO date `YYYY-MM-DD`. */
+function isoDate(iso: string | null): string {
+  if (!iso) return "";
+  // ISO timestamps from Postgres: `YYYY-MM-DDTHH:MM:SS…` — take the date prefix.
+  return iso.slice(0, 10);
+}
+
+/** Filename sanitization per AC: lowercase, non-alphanumerics → single
+ * dash, strip leading/trailing dashes. */
+export function sanitizeFilenameSegment(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build the `Content-Disposition` filename for a CSV download.
+ *
+ *   `<sanitized-microgrid>-billing-period-<start>-to-<end>.csv`
+ */
+export function buildCsvFilename(input: {
+  microgridName: string;
+  startDate: string;
+  endDate: string;
+}): string {
+  const slug = sanitizeFilenameSegment(input.microgridName);
+  return `${slug}-billing-period-${input.startDate}-to-${input.endDate}.csv`;
+}
+
+/** UTF-8 BOM bytes (`0xEF 0xBB 0xBF`). */
+export const UTF8_BOM = "﻿";
+
+/**
+ * Build the full CSV body for a billing-period export.
+ *
+ * Output contract:
+ *   - Starts with the UTF-8 BOM character (`﻿`), which serializes
+ *     to bytes `0xEF 0xBB 0xBF`.
+ *   - One header row + N data rows separated by `\r\n` (RFC 4180).
+ *   - Per-tier columns are expanded in `rateSchedule.tiers` order.
+ *   - Rows are sorted by `household.display_name` (case-insensitive,
+ *     locale-stable via `localeCompare`); ties broken by `lineItem.id`.
+ *   - Empty rows array → header-only CSV.
+ */
+export function buildBillingPeriodCsv(input: CsvExportInput): string {
+  const cur = input.microgrid.currency;
+  const tiers = input.rateSchedule.tiers ?? [];
+  const tax = input.invoiceConfig?.tax;
+  const showTax =
+    !!tax && tax.show_section !== false && (tax.rate_pct ?? 0) > 0;
+  const taxRatePct = tax?.rate_pct ?? 0;
+  const serviceCharge = input.rateSchedule.service_charge ?? 0;
+
+  // ── Header ────────────────────────────────────────────────────────────────
+  const header: string[] = [
+    "Invoice Number",
+    "Issue Date",
+    "Household",
+    "Account Number",
+    "Meter ID",
+    "Meter Type",
+    "Customer Type",
+    "Address",
+    "Phone",
+    "Begin kWh",
+    "End kWh",
+    "Usage kWh",
+  ];
+  for (const t of tiers) {
+    header.push(`${t.label} kWh`);
+    header.push(`${t.label} ${cur}`);
+  }
+  header.push(`Service Charge ${cur}`);
+  header.push(`Taxable Subtotal ${cur}`);
+  header.push(`VAT ${cur}`);
+  header.push(`Total ${cur}`);
+  header.push("Payment Status");
+  header.push("Paid At");
+
+  // ── Sort rows (stable secondary by line-item id) ──────────────────────────
+  const sortedRows = [...input.rows].sort((a, b) => {
+    const nameCmp = a.household.display_name.localeCompare(
+      b.household.display_name,
+    );
+    if (nameCmp !== 0) return nameCmp;
+    return a.lineItem.id.localeCompare(b.lineItem.id);
+  });
+
+  // ── Data rows ─────────────────────────────────────────────────────────────
+  const dataRows: string[][] = sortedRows.map((row) => {
+    const { household: h, device, lineItem: li } = row;
+
+    // Tier lookup by label — handles tier_breakdown arrays that have
+    // shifted order or omit unreached tiers entirely.
+    const breakdownByLabel = new Map<
+      string,
+      { kwh: number; amount: number }
+    >();
+    for (const tb of li.tier_breakdown ?? []) {
+      breakdownByLabel.set(tb.label, { kwh: tb.kwh, amount: tb.amount });
+    }
+
+    const tierCells: string[] = [];
+    for (const t of tiers) {
+      const hit = breakdownByLabel.get(t.label);
+      if (hit === undefined) {
+        // URA distinguishes blank from zero — emit empty cells for
+        // unreached tiers, NOT "0".
+        tierCells.push("");
+        tierCells.push("");
+      } else {
+        tierCells.push(csvCell(hit.kwh));
+        tierCells.push(csvCell(hit.amount));
+      }
+    }
+
+    // Derive Taxable Subtotal + VAT to MATCH the PDF (see
+    // `render.tsx:1226-1243`).
+    const totalAmount = li.total_amount ?? 0;
+    const energySubtotal = (li.tier_breakdown ?? []).reduce(
+      (acc, tb) => acc + (tb.amount ?? 0),
+      0,
+    );
+    const preTaxSubtotal = energySubtotal + serviceCharge;
+    let taxableSubtotal: number;
+    let vatCell: string;
+    if (showTax) {
+      const net = roundAmount(totalAmount / (1 + taxRatePct / 100));
+      const vat = roundAmount(totalAmount - net);
+      taxableSubtotal = net;
+      vatCell = csvCell(vat);
+    } else {
+      taxableSubtotal = preTaxSubtotal;
+      // VAT disabled — emit EMPTY (not zero) to distinguish "tax exempt"
+      // from "tax = 0 on a tiny bill".
+      vatCell = "";
+    }
+
+    const paymentLabel =
+      PAYMENT_STATUS_LABELS[li.payment_status] ?? li.payment_status;
+
+    return [
+      csvCell(li.invoice_number),
+      csvCell(isoDate(li.created_at)),
+      csvCell(h.display_name),
+      csvCell(h.account_number),
+      csvCell(device?.openems_component_id ?? null),
+      csvCell(h.meter_type),
+      csvCell(titleCaseCustomerType(h.customer_type)),
+      csvCell(composeAddress(h)),
+      csvCell(h.primary_phone),
+      csvCell(li.start_kwh),
+      csvCell(li.end_kwh),
+      csvCell(li.usage_kwh),
+      ...tierCells,
+      csvCell(serviceCharge),
+      csvCell(taxableSubtotal),
+      vatCell,
+      csvCell(totalAmount),
+      csvCell(paymentLabel),
+      csvCell(isoDate(li.paid_at)),
+    ];
+  });
+
+  // ── Assemble ──────────────────────────────────────────────────────────────
+  const lines = [header.join(","), ...dataRows.map((r) => r.join(","))];
+  // CRLF line endings per RFC 4180 §2.1; trailing CRLF to terminate the
+  // last record (some Excel-on-Windows builds drop the last row without
+  // it).
+  return UTF8_BOM + lines.join("\r\n") + "\r\n";
+}


### PR DESCRIPTION
Closes #229

## Summary
- **New `src/lib/billing/csv-export.ts`** — pure `buildBillingPeriodCsv(input)` helper. RFC 4180 with CRLF + BOM (`0xEF 0xBB 0xBF`). 19 fixed columns + 2 per tier, ordered: Invoice Number, Issue Date, Household, Account Number, Meter ID, **Meter Type** (Aaron's explicit ask), Customer Type, Address, Phone, Begin/End/Usage kWh, [Tier N kWh / Tier N UGX] × N, Service Charge / Taxable Subtotal / VAT / Total UGX, Payment Status, Paid At.
- **New `GET /api/billing-periods/[periodId]/export-csv`** — session-auth'd, permission-ordered (row → 404 → permission → 403). Works on both `draft` and `closed` periods. Headers: `text/csv; charset=utf-8`, sanitized `Content-Disposition: attachment; filename="<microgrid>-billing-period-<start>-to-<end>.csv"`, `Cache-Control: no-store`. Logs `billing.csv.exported` with zero PII.
- **Wired the close-dialog button** at `BillingTable.tsx:703` — `onExportCsv={() => triggerCsvDownload(period.id)}` (programmatic anchor click, mirrors PDF/regenerate patterns).
- **Added a persistent "Export CSV" button** at `BillingTable.tsx:784-810` after View history. Always visible (draft + closed); disabled with tooltip on empty periods. Label is plain "Export CSV"; close-dialog retains "Export CSV for URA" for the URA-focused success state.

## Why
Aaron clicked "Export CSV for URA" after closing the Apr 2026 Sezibwa period and got no response. The button was scaffolded UI with three layered problems: (1) `BillingTable.tsx` didn't pass `onExportCsv`, so the click was silent; (2) no CSV endpoint existed anywhere; (3) the button only appeared in the transient post-close dialog with no persistent access. This PR addresses all three.

## Key implementation decisions

- **VAT/Service/Taxable Subtotal derived per-row from `community.invoice_config.tax.rate_pct`**, NOT `rate_schedules.tax_rate` — mirrors PDF1b's `render.tsx:1226-1243` math. An anti-test asserts the source: swapping to `rate_schedules.tax_rate` makes the test fail.
- **Tier columns matched by `label`**, not array index — `tier_breakdown` can be reordered (per #218 audit-snapshot history); the anti-test verifies shuffled input still aligns under the correct column.
- **Invoice Number empty when NULL** — the CSV route deliberately does NOT mint `invoice_number` (that side-effect lives on the PDF route).
- **`MICROGRID_PUBLIC_COLUMNS`** used for the microgrid SELECT (per the no-select-star design rule).
- **No PII in forensic logs**: `{period_id, microgrid_id, household_count, byte_size, duration_ms, actor_user_id, at}` only.
- **BOM + CRLF + RFC 4180 quoting**: Excel/URA-compatibility. Special chars (`"`, `,`, CR/LF) escape per spec.
- **Filename sanitization**: `name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')` → `Kisakye (Test with OpenEMS Integrated)` becomes `kisakye-test-with-openems-integrated`.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — pre-existing warnings only; none in new files.
- [x] `npm test` — 31 helper + 9 route + 5 new BillingTable cases; full suite 1631 pass / 52 skip / 0 fail.
- [x] `npm run build` — clean.
- [ ] Operator follow-up: as Aaron — open Sezibwa → Billing → Apr 2026 closed period → click new "Export CSV" persistent button. Verify CSV opens cleanly in Excel/Numbers (BOM preserved, columns aligned, special chars escaped, Meter Type column present, Invoice Number + Issue Date populated). Re-close test period → close-dialog button now also downloads.

## Notes
- No DB migration. Pure read-side feature.
- 6 files changed (3 new + 3 extended).
- Backward compat: dialog `onExportCsv` prop was already optional; existing callers (only `_dev/components` showcase) continue working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)