### PR TITLE
docs: document SKIP_DEK_BOOTSTRAP_TEST=1 alongside SKIP_RLS_TESTS=1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ RLS tests (`src/lib/supabase/__tests__/rls.test.ts`) require:
 3. **Seed loaded** — run `supabase db reset` once after `supabase start`
 
 Set `SKIP_RLS_TESTS=1` to bypass RLS tests when local Supabase is not available (e.g. CI without Docker).
+Set `SKIP_DEK_BOOTSTRAP_TEST=1` to additionally bypass the DEK bootstrap suite (`src/lib/supabase/__tests__/dek-bootstrap.test.ts`) — same "needs local Supabase" pattern but its own guard. Both flags are typically set together when running tests without a local Supabase.
 Missing env vars without `SKIP_RLS_TESTS=1` fail loudly — this is intentional.
 
 See `docs/setup.md § "RLS Tests"` for full instructions.


### PR DESCRIPTION
## Summary

- CLAUDE.md previously documented only `SKIP_RLS_TESTS=1` as the local-Supabase-not-running bypass flag, but the DEK bootstrap suite (`src/lib/supabase/__tests__/dek-bootstrap.test.ts`) has its own peer flag `SKIP_DEK_BOOTSTRAP_TEST=1`. Without it, `npm test` reports one failure on a fresh machine without `supabase start`.
- Single-line addition documenting the peer flag and noting both are typically set together.

## Context

- Discovered during first-time machine setup validation (Claude Code dry-run on a fresh WSL2 environment).
- Also serves as a dry-run validation of the merge-controls pipeline (DCO, required_signatures, CodeQL, Vercel preview).

## Test plan

- [x] `git log --show-signature` shows `Good "git" signature ... ED25519` locally
- [x] DCO trailer present (`Signed-off-by: Alejandro Malbet <amalbet@gmail.com>`)
- [ ] CodeQL workflow runs and passes
- [ ] Vercel preview deploys successfully
- [ ] GitHub "Verified" badge appears on commit
- [ ] `required_signatures` ruleset passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)