### PR TITLE
ci: add Test workflow + fix two HouseholdWizard flakes (closes #236 steps 0-1, 4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+# Test gate. Runs on every PR + push to main. Required by the
+# repository's "require-DCO" ruleset (status check name: "Test"). The
+# job's name below MUST stay as "Test" so the required-check context
+# resolves; do NOT add a matrix-suffix or rename.
+#
+# Skip flags (SKIP_RLS_TESTS, SKIP_DEK_BOOTSTRAP_TEST) bypass the
+# Supabase-dependent suites — running them here would require
+# `supabase start` (Docker) + seed + JWT secret. Tracked as a follow-up
+# to issue #236.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Tighten default token permissions; explicitly grant only what's required.
+permissions:
+  contents: read
+
+jobs:
+  Test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx tsc --noEmit
+
+      - run: npm run lint
+
+      - run: npm test
+        env:
+          SKIP_RLS_TESTS: '1'
+          SKIP_DEK_BOOTSTRAP_TEST: '1'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,9 @@ Five rules every contributor must follow:
    ```
    Then upload `~/.ssh/id_ed25519_signing.pub` at github.com → Settings → SSH and GPG keys → "New SSH key" with **Key type: Signing Key**. After setup, every `git commit` carries an "SSH" signature and GitHub shows the "Verified" badge.
 3. **`CodeQL` status check** — `.github/workflows/codeql.yml` runs `github/codeql-action` on every PR + push to main. The check name `CodeQL` MUST match the workflow job name; do NOT rename or add a matrix-suffix.
-4. **`Vercel` preview deploy** passes (build succeeds + preview URL provisioned).
-5. **`non_fast_forward` + `deletion` protection** — `main` cannot be force-pushed or deleted.
+4. **`Test` status check** — `.github/workflows/test.yml` runs `npm ci` → `npx tsc --noEmit` → `npm run lint` → `npm test` (with `SKIP_RLS_TESTS=1` and `SKIP_DEK_BOOTSTRAP_TEST=1`) on every PR + push to main. The check name `Test` MUST match the workflow job name; do NOT rename or add a matrix-suffix. RLS / DEK bootstrap suites stay skipped here — running them requires `supabase start` (Docker) + seed + `SUPABASE_JWT_SECRET`; tracked as a follow-up to #236.
+5. **`Vercel` preview deploy** passes (build succeeds + preview URL provisioned).
+6. **`non_fast_forward` + `deletion` protection** — `main` cannot be force-pushed or deleted.
 
 **Bypass path** (genuine emergencies only — Aaron-blocking production hotfixes when the rules themselves are mis-configured):
 - Temporarily PATCH the ruleset to `enforcement: disabled`, merge, re-enable to `active`:

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -853,9 +853,11 @@ describe("HouseholdWizard", () => {
       expect(
         screen.queryByRole("button", { name: /Create household/i })
       ).toBeNull();
-      // Next is enabled
-      const next = screen.getByRole("button", { name: /^Next$/ });
-      expect(next).toHaveProperty("disabled", false);
+      // Next is enabled (wrapped in waitFor — the enable transition is async after Save & select)
+      await waitFor(() => {
+        const next = screen.getByRole("button", { name: /^Next$/ });
+        expect(next).toHaveProperty("disabled", false);
+      });
     });
 
     it("empty discovery (no consumption meters after filter) renders the no-meters message", async () => {
@@ -1185,10 +1187,13 @@ describe("HouseholdWizard", () => {
 
       // Advance to step 4 — preserved values must show in the review.
       fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
-      await waitFor(() =>
-        expect(
-          screen.getByRole("button", { name: /Create household/i })
-        ).toBeDefined()
+      // Use findByRole with an extended timeout: the step-4 render follows
+      // 4 step transitions + the fetch-mock dance, and the default 1s
+      // waitFor occasionally races on contended CI/local runs.
+      await screen.findByRole(
+        "button",
+        { name: /Create household/i },
+        { timeout: 5000 }
       );
       // Display name and phone preserved on the review panel.
       expect(screen.getByText("My Household")).toBeDefined();


### PR DESCRIPTION
Closes #236 (steps 0, 1, 4). Steps 2 (ruleset patch) and 3 (negative gate test) are post-merge architect actions.

## Summary

Adds a `Test` workflow that runs on every PR + push to main, executing `npm ci` → `tsc --noEmit` → `npm run lint` → `npm test` (with `SKIP_RLS_TESTS=1` and `SKIP_DEK_BOOTSTRAP_TEST=1`). Currently informational; will be added to the ruleset's `required_status_checks` post-merge via `gh api PUT` (architect action, see issue #236 step 2).

Also fixes two async-state-update races in `HouseholdWizard.test.tsx` that surfaced at ~27% / ~10% flake rates locally and would have intermittently blocked PRs once the gate is enforced.

## Commits

1. **`ac69661` — flake fixes** (precursor): wraps two synchronous assertions in `waitFor` / `findByRole` to await async state transitions. Verified 30/30 consecutive runs all pass on commit `eb87b6f` + this patch.
2. **`d9548c1` — workflow + CLAUDE.md**: adds `.github/workflows/test.yml`, documents new required check in `CLAUDE.md § Required Merge Controls` (renumbered Vercel/non_fast_forward to 5/6).

## Test plan

- [x] `npx tsc --noEmit` clean locally on this branch
- [x] `npm run lint` clean (0 errors, pre-existing warnings only)
- [x] `SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test` → 1641/0/52 (passed/failed/skipped) — 30 consecutive runs, 0 failures
- [x] Both commits cryptographically signed (`Good "git" signature for amalbet@gmail.com with ED25519`)
- [x] Both commits DCO-trailed (`Signed-off-by: Alejandro Malbet <amalbet@gmail.com>`)
- [ ] **Test workflow runs successfully on this PR itself** (validates the YAML)
- [ ] CodeQL passes
- [ ] Vercel preview deploys

## Out of scope (deferred per #236)

- **RLS tests in CI** — requires `supabase/setup-cli@v1` + `supabase start`. Follow-up ticket.
- **Ruleset update** to make `Test` required — post-merge architect action. Bootstrap pattern same as PR #231 (CodeQL): merge workflow → wait for one push-to-main run → patch ruleset.
- **Negative gate test** (deliberately failing test → confirm merge blocked) — post-merge architect action, after the ruleset patch.

## Side findings (from issue #236 investigation)

- Dependabot now reports 21 high+moderate vulns on `main` (was 7 per the 2026-04-27 project-status). Separate triage; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)