### PR TITLE
[DO NOT MERGE] verify Test gate blocks failing tests (#236 step 3)

### DIFF
--- a/src/__gate_verify_do_not_merge__.test.ts
+++ b/src/__gate_verify_do_not_merge__.test.ts
@@ -1,0 +1,13 @@
+// PR #237 / issue #236 verification — DO NOT MERGE.
+// This file exists solely to prove that the `Test` required status
+// check blocks merge when vitest reports a failure. After confirming
+// the gate behaves correctly on the verification PR, the branch will
+// be deleted and this file removed.
+
+import { describe, it, expect } from "vitest";
+
+describe("CI gate verification (PR will be closed unmerged)", () => {
+  it("intentionally fails so we can verify the Test gate blocks merge", () => {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
**This PR will be closed without merging.** Part of #236 step 3 — verifying that the new `Test` required status check correctly blocks merge when vitest fails.

## What this PR does

Adds `src/__gate_verify_do_not_merge__.test.ts` containing one test that intentionally asserts `expect(true).toBe(false)`.

## Expected outcome

- ❌ `Test` check fails (vitest exits 1)
- ✅ `CodeQL` passes (the failing test is valid TypeScript)
- ✅ `Vercel` preview deploys (test files excluded from production build)
- 🚫 GitHub UI shows "Required statuses must pass before merging"
- 🚫 `gh pr merge` is rejected

## After verification

Architect closes this PR + deletes the branch + removes the local test file. No commits land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)