### PR TITLE
[DO NOT MERGE] v2: verify Test gate blocks failing tests (#236 step 3)

### DIFF
--- a/src/lib/__gate_verify_do_not_merge__.test.ts
+++ b/src/lib/__gate_verify_do_not_merge__.test.ts
@@ -1,0 +1,20 @@
+// #236 step 3 verification — DO NOT MERGE.
+//
+// Placed under `src/lib/` so the `lib` vitest project (include:
+// "src/lib/**/*.test.{ts,tsx}") actually picks it up. The first
+// verification attempt (PR #238) put this file directly at `src/` —
+// not matched by ANY project's include — so vitest silently skipped it
+// and the Test check reported SUCCESS, allowing the verification PR to
+// merge. Lesson: gate verification artifacts must live inside an
+// `include`-d project path.
+//
+// After confirming the gate behaves correctly here, the branch will be
+// deleted and this file removed.
+
+import { describe, it, expect } from "vitest";
+
+describe("CI gate verification v2 (PR will be closed unmerged)", () => {
+  it("intentionally fails so we can verify the Test gate blocks merge", () => {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
**This PR will be closed without merging.** Redo of #236 step 3 after the first attempt (#238) inadvertently merged because the failing test was at a path no vitest project included.

## Expected outcome

- ❌ `Test` check FAILS
- ✅ `CodeQL` passes
- ✅ `Vercel` preview deploys
- 🚫 Merge blocked by ruleset

## What changed vs #238

`__gate_verify_do_not_merge__.test.ts` moved from `src/` (invisible) to `src/lib/` (visible to the `lib` vitest project). Local sanity confirmed: `npm test -- __gate_verify` reports 1 failed.

## Architect lesson

`vitest.config.ts` uses `projects[]` with explicit `include` patterns (`src/components/**`, `src/lib/**`, `src/app/**`, plus the RLS file list). Test files outside these paths are silently skipped. Will be captured in Evolution Log after this verification completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)