### PR TITLE
fix(payments): relax audit-fields CHECK so IPN-sourced paid transitions succeed (#243)

### DIFF
--- a/src/app/api/billing-line-items/[lineItemId]/payment-status/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/payment-status/route.ts
@@ -218,9 +218,13 @@ export async function PATCH(
     throw err;
   }
 
-  // 5. Session guard: paid / refunded require a non-null actor for the audit
-  //    invariant (the SQL CHECK constraint requires paid_by_user_id when
-  //    status is 'paid' / 'refunded'). Surface a 401 actionable message.
+  // 5. Session guard: paid / refunded via the manual-mark route require a
+  //    non-null actor. This is the route-level defense-in-depth gate; the SQL
+  //    CHECK constraint was relaxed in #243 (Pesapal IPN has no human actor),
+  //    so the DB no longer enforces "paid rows have paid_by_user_id". The
+  //    audit source-of-truth is now payment_events (source + actor_user_id
+  //    per event). For the manual-mark path we still require an authenticated
+  //    user — IPN goes through src/app/api/payments/ipn/route.ts instead.
   if (
     (parsed.status === "paid" || parsed.status === "refunded") &&
     !actorUserId

--- a/src/lib/supabase/__tests__/payment_state_machine.test.ts
+++ b/src/lib/supabase/__tests__/payment_state_machine.test.ts
@@ -242,7 +242,7 @@ desc("00027_payment_state_machine_enum.sql + 00028_payment_state_machine.sql (#1
     expect(events?.[0]?.source).toBe("generate_link");
   });
 
-  it.skip("fn_apply_payment_event: ipn link_generated → paid succeeds and writes paid_at + audit row [SKIPPED — blocked on #243: fn_apply_payment_event violates audit-fields constraint on IPN paths with NULL actor]", async () => {
+  it("fn_apply_payment_event: ipn link_generated → paid succeeds and writes paid_at + audit row", async () => {
     const svc = await serviceClient();
 
     const { error } = await svc.rpc("fn_apply_payment_event", {
@@ -263,7 +263,7 @@ desc("00027_payment_state_machine_enum.sql + 00028_payment_state_machine.sql (#1
     expect(row?.paid_at).toBeTruthy();
   });
 
-  it.skip("fn_apply_payment_event: idempotent re-delivery within 60s does NOT append a duplicate audit row [SKIPPED — blocked on #243]", async () => {
+  it("fn_apply_payment_event: idempotent re-delivery within 60s does NOT append a duplicate audit row", async () => {
     const svc = await serviceClient();
 
     const { count: countBefore } = await svc
@@ -293,7 +293,7 @@ desc("00027_payment_state_machine_enum.sql + 00028_payment_state_machine.sql (#1
     expect(countAfter).toBe(countBefore);
   });
 
-  it.skip("fn_apply_payment_event: ipn rejects refunded → paid (invalid_transition) [SKIPPED — blocked on #243]", async () => {
+  it("fn_apply_payment_event: ipn rejects refunded → paid (invalid_transition)", async () => {
     const svc = await serviceClient();
 
     // First make lineItemB go through unpaid → link_generated → paid → refunded.

--- a/supabase/migrations/00040_relax_payment_audit_fields_check.sql
+++ b/supabase/migrations/00040_relax_payment_audit_fields_check.sql
@@ -1,0 +1,54 @@
+-- 00040_relax_payment_audit_fields_check.sql
+-- Closes #243 — relax billing_line_items_payment_audit_fields_required
+-- so paid rows are no longer required to carry paid_by_user_id.
+--
+-- Why: Pesapal IPN webhook (src/app/api/payments/ipn/route.ts) calls
+-- fn_apply_payment_event with _actor_user_id=NULL (no human actor), which
+-- makes the COALESCE in the function leave paid_by_user_id NULL, violating
+-- the existing constraint's "paid rows must have paid_by_user_id" arm.
+-- Launch blocker for #121 (IPN webhook).
+--
+-- Source-of-truth audit trail lives in payment_events (source +
+-- actor_user_id captured per event); the column on billing_line_items
+-- was redundant for the IPN path.
+--
+-- Architectural rationale ("Shape C") in #243 refinement comment:
+--   - Function-level enforcement (fn_apply_payment_event) remains the
+--     sole writer for status transitions.
+--   - RLS already restricts who can write billing_line_items.
+--   - The CHECK becomes the temporal-audit invariant: paid/refunded rows
+--     have paid_at NOT NULL. The "who" lives in payment_events.
+--
+-- Manual-mark route (PATCH /api/billing-line-items/[lineItemId]/payment-status)
+-- is unaffected — it still authenticates the caller via its own auth gate
+-- and passes the user_id through to fn_apply_payment_event. Defense-in-depth
+-- shifts from "DB enforces user-present on paid rows" to "route + function
+-- enforce flow, DB enforces temporal-audit invariant."
+
+ALTER TABLE billing_line_items
+  DROP CONSTRAINT IF EXISTS billing_line_items_payment_audit_fields_required;
+
+ALTER TABLE billing_line_items
+  ADD CONSTRAINT billing_line_items_payment_audit_fields_required
+  CHECK (
+    (
+      payment_status = ANY (ARRAY[
+        'unpaid'::billing_line_item_payment_status,
+        'failed'::billing_line_item_payment_status,
+        'link_generated'::billing_line_item_payment_status
+      ])
+      AND paid_at IS NULL
+      AND paid_by_user_id IS NULL
+    )
+    OR
+    (
+      payment_status = ANY (ARRAY[
+        'paid'::billing_line_item_payment_status,
+        'refunded'::billing_line_item_payment_status
+      ])
+      AND paid_at IS NOT NULL
+    )
+  );
+
+COMMENT ON CONSTRAINT billing_line_items_payment_audit_fields_required ON billing_line_items IS
+  'Temporal-audit invariant: paid/refunded rows must have paid_at. The previous "paid rows must have paid_by_user_id" arm was dropped in #243 because Pesapal IPN has no human actor; payment_events (source + actor_user_id) is the audit source-of-truth.';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
           name: "components",
           include: ["src/components/**/*.test.{ts,tsx}"],
           environment: "jsdom",
+          // Multi-step wizard tests walk through 3-4 steps via
+          // fireEvent + waitFor; the default 5s testTimeout occasionally
+          // races under CI/local contention. 15s headroom — a legitimately
+          // deadlocked test still fails fast.
+          testTimeout: 15_000,
         },
       },
       {


### PR DESCRIPTION
Closes #243. Companion to #242 (PR #244) — un-skips the 3 tests that were `.skip`-ped with `[blocked on #243]` markers.

## Summary

`fn_apply_payment_event` was violating `billing_line_items_payment_audit_fields_required` when called with `_actor_user_id IS NULL AND _to_status='paid'` (the Pesapal IPN path). Relaxing the CHECK to drop the `paid_by_user_id NOT NULL` arm preserves the temporal-audit invariant (`paid → paid_at NOT NULL`) and shifts the "manual marks need a user" guarantee to where it already lives — the manual-mark route's session check. Source-of-truth audit (who/when/from-where) was already captured per-event in `payment_events`.

## Commits

1. **`15e5e16` — fix(payments)**: migration `00040_relax_payment_audit_fields_check.sql` drops + recreates the CHECK without the `paid_by_user_id` arm. `fn_apply_payment_event` unchanged. 3 tests un-skipped. Stale comment in `payment-status/route.ts` refreshed.
2. **`c27e669` — test(config)**: bumps the `components` vitest project's `testTimeout` from 5s → 15s. HouseholdWizard suite walks through multi-step transitions and occasionally races at 5s under contention. Surfaced during the 30-run verification on this branch (1/30 flake). Folding into this PR as same "make CI stable" theme; cleaner than per-test patches as the file has now produced ≥4 distinct flakes in this family.

## Architectural note — Aaron's payment flow

`fn_apply_payment_event`'s **transition matrix, error vocabulary, idempotency window, and state-machine guarantees are unchanged.** This PR only relaxes the DB-level redundancy on `paid_by_user_id`; the route-level gate for manual marks still requires an authenticated user, and `payment_events` continues to capture `source` + `actor_user_id` per event.

**Production impact (calibrated):** this is a **launch blocker for #121 (Pesapal IPN webhook, Redwan's pending work).** No production damage has occurred — IPN is not yet live; Aaron has been manually marking payments. The bug was silent since PR #157 because the failing test was masked by a fixture bug (fixed in PR #244).

## Post-merge architect/ops steps (NOT in this PR)

- `supabase db push` to apply migration 00040 to cloud dev project (`tztbmsxxjjsryuvoyqji`)
- Smoke test: simulate a Pesapal IPN POST; confirm `payment_status='paid'`, `paid_at` set, `paid_by_user_id IS NULL`, `payment_events` row created with `source='ipn'`
- Coordinate with Redwan on the IPN go-live window
- Apply to production Supabase project in coordination with Aaron's no-IPN window

## Verification

- [x] `npx supabase db reset --yes` applies all 40 migrations cleanly
- [x] New constraint definition confirmed via `pg_get_constraintdef`
- [x] `payment_state_machine.test.ts` in isolation: 8/8 pass
- [x] `npm run db:types:check` clean
- [x] Implementer's 30-run stability check: 29/30 (1 unrelated wizard flake → fixed in commit `c27e669`)
- [x] Architect's post-fix 10-run sanity check: 10/10 pass
- [x] Both commits cryptographically signed (DCO + SSH ED25519)
- [ ] `Test` CI workflow passes on this PR (still RLS-blind — #241 will fix that)
- [ ] CodeQL passes
- [ ] Vercel preview deploys

## Downstream consumer audit (Step F from implementer brief)

Grep for `paid_by_user_id` across `src/` (36 hits in 17 files). Production consumers that READ the value:
- `pdf/route.ts` passes it through as `string | null`; renderer doesn't display. No NULL-fallback needed.
- Billing period detail page: SELECT-lists the column but the displayed actor name comes from `entered_by_user_id` join, not `paid_by_user_id`. No display path.

CSV export (#229/#232) does NOT include a "Paid by" column. No format risk.

No display path needs a NULL fallback today. Filed no follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)