### PR TITLE
feat: add internal API routes for customerapp billing automation

### DIFF
--- a/src/app/api/internal/billing-periods/route.ts
+++ b/src/app/api/internal/billing-periods/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkInternalApiKey } from "@/lib/internal-auth";
+import { createServiceClient } from "@/lib/supabase/service";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function POST(request: NextRequest) {
+  if (!checkInternalApiKey(request)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const rec = raw as Record<string, unknown>;
+
+  if (typeof rec.microgrid_id !== "string" || !UUID_RE.test(rec.microgrid_id)) {
+    return NextResponse.json({ error: "microgrid_id must be a UUID" }, { status: 400 });
+  }
+  if (typeof rec.start_date !== "string" || !DATE_RE.test(rec.start_date)) {
+    return NextResponse.json({ error: "start_date must be YYYY-MM-DD" }, { status: 400 });
+  }
+  if (typeof rec.end_date !== "string" || !DATE_RE.test(rec.end_date)) {
+    return NextResponse.json({ error: "end_date must be YYYY-MM-DD" }, { status: 400 });
+  }
+  if (rec.start_date >= rec.end_date) {
+    return NextResponse.json({ error: "end_date must be after start_date" }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("billing_periods")
+    .insert({
+      microgrid_id: rec.microgrid_id,
+      start_date: rec.start_date,
+      end_date: rec.end_date,
+      status: "draft",
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: data.id }, { status: 201 });
+}

--- a/src/app/api/internal/billing/generate/route.ts
+++ b/src/app/api/internal/billing/generate/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkInternalApiKey, CUSTOMERAPP_ACTOR_ID } from "@/lib/internal-auth";
+import { createServiceClient } from "@/lib/supabase/service";
+import { runGenerationFor, isRunGenerationFatal } from "@/lib/billing/generate";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(request: NextRequest) {
+  if (!checkInternalApiKey(request)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const rec = raw as Record<string, unknown>;
+
+  if (typeof rec.billingPeriodId !== "string" || !UUID_RE.test(rec.billingPeriodId)) {
+    return NextResponse.json({ error: "billingPeriodId must be a UUID" }, { status: 400 });
+  }
+
+  if (!Array.isArray(rec.manualReadings) || rec.manualReadings.length === 0) {
+    return NextResponse.json(
+      { error: "manualReadings must be a non-empty array" },
+      { status: 400 }
+    );
+  }
+
+  const manualReadings: Array<{
+    householdId: string;
+    startKwh: number;
+    endKwh: number;
+    reason?: string;
+  }> = [];
+
+  for (let i = 0; i < rec.manualReadings.length; i++) {
+    const m = rec.manualReadings[i] as Record<string, unknown>;
+    if (typeof m.householdId !== "string" || !UUID_RE.test(m.householdId)) {
+      return NextResponse.json(
+        { error: `manualReadings[${i}].householdId must be a UUID` },
+        { status: 400 }
+      );
+    }
+    if (typeof m.startKwh !== "number" || !Number.isFinite(m.startKwh) || m.startKwh < 0) {
+      return NextResponse.json(
+        { error: `manualReadings[${i}].startKwh must be a non-negative finite number` },
+        { status: 400 }
+      );
+    }
+    if (typeof m.endKwh !== "number" || !Number.isFinite(m.endKwh) || m.endKwh < m.startKwh) {
+      return NextResponse.json(
+        { error: `manualReadings[${i}].endKwh must be a finite number >= startKwh` },
+        { status: 400 }
+      );
+    }
+    manualReadings.push({
+      householdId: m.householdId,
+      startKwh: m.startKwh,
+      endKwh: m.endKwh,
+      ...(typeof m.reason === "string" ? { reason: m.reason } : {}),
+    });
+  }
+
+  const supabase = createServiceClient();
+
+  const out = await runGenerationFor({
+    supabase,
+    periodId: rec.billingPeriodId,
+    manualReadings,
+    mode: "write",
+    actorUserId: CUSTOMERAPP_ACTOR_ID,
+  });
+
+  if (isRunGenerationFatal(out)) {
+    return NextResponse.json(out.body, { status: out.status });
+  }
+
+  const lineItems = out.results.filter((r) => r.kind === "written").length;
+  const errors = out.results
+    .filter((r) => r.kind === "error")
+    .map((e) => ({
+      householdId: e.householdId,
+      householdName: e.householdName,
+      error: e.error,
+      code: e.code,
+    }));
+
+  return NextResponse.json({ lineItems, errors });
+}

--- a/src/lib/internal-auth.ts
+++ b/src/lib/internal-auth.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import type { NextRequest } from "next/server";
+
+/**
+ * UUID recorded in billing_audit_log when an action is triggered by the
+ * customerapp automation system rather than a human operator.
+ */
+export const CUSTOMERAPP_ACTOR_ID = "00000000-0000-4000-8000-000000000001";
+
+/**
+ * Returns true if the request carries a valid x-api-key header matching
+ * INTERNAL_API_KEY. Callers must return 401 immediately when this returns false.
+ *
+ * Guards against misconfiguration: if INTERNAL_API_KEY is not set in the
+ * environment, every request is rejected so the route is never silently open.
+ */
+export function checkInternalApiKey(request: NextRequest): boolean {
+  const envKey = process.env.INTERNAL_API_KEY;
+  if (!envKey || envKey.length < 32) {
+    return false;
+  }
+  const provided = request.headers.get("x-api-key");
+  return !!provided && provided === envKey;
+}


### PR DESCRIPTION
POST /api/internal/billing-periods — creates a draft billing_period using the service-role client, authenticated via x-api-key header.

POST /api/internal/billing/generate — calls runGenerationFor() with manualReadings, authenticated via x-api-key. Records CUSTOMERAPP_ACTOR_ID in the audit log instead of a human operator user_id.

Both routes share checkInternalApiKey() from src/lib/internal-auth.ts which rejects requests if INTERNAL_API_KEY env var is unset or shorter than 32 chars. Add INTERNAL_API_KEY to Vercel env vars (same value in MBE and customerapp).