### PR TITLE
feat(api): replace INTERNAL_API_KEY with per-org API tokens + rename /internal → /v1 (#255)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@react-pdf/renderer": "^4.5.1",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.0",
+        "argon2": "^0.44.0",
         "aws4": "^1.13.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -543,6 +544,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -2189,6 +2196,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -4847,6 +4863,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5477,11 +5509,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7589,7 +7637,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -8390,6 +8437,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -8447,6 +8503,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -8728,7 +8795,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9464,7 +9530,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9477,7 +9542,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10690,7 +10754,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@react-pdf/renderer": "^4.5.1",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.0",
+    "argon2": "^0.44.0",
     "aws4": "^1.13.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/api/v1/billing-periods/__tests__/route.test.ts
+++ b/src/app/api/v1/billing-periods/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/internal/billing-periods — route tests (#253).
+ * POST /api/v1/billing-periods — route tests (#253 + #255).
  *
  * Coverage (failure-mode AC from the ticket body):
  *   - Same-day period (start_date === end_date): accepted, creates draft row (201).
@@ -11,8 +11,11 @@
  *   - Missing required fields: rejected with 400.
  *   - Duplicate (microgrid_id, start_date, end_date): accepted (per Alejandro
  *     2026-05-26 — no 409-on-duplicate; matches UI behavior).
+ *   - #255: auth now via `resolveOrgFromToken`; on success the resolved
+ *     `token_name` flows into the audit row as `actor_ref` (replacing the
+ *     `'pre-token-system'` placeholder from #250).
  *
- * The route mocks the supabase service client + `checkInternalApiKey` at the
+ * The route mocks the supabase service client + `resolveOrgFromToken` at the
  * module boundary. Live-DB constraint behavior (unique indexes, RLS) is not
  * exercised here — covered by the integration suites tracked in #251 / #254.
  */
@@ -35,7 +38,19 @@ import { NextRequest } from "next/server";
 // the test passes. The audit-row capture in `insertsByTable['billing_audit_log']`
 // is for tests that want to assert against the attribution shape.
 
-let mockAuthOk = true;
+let mockAuthResult: {
+  ok: boolean;
+  org_id?: string;
+  token_id?: string;
+  token_name?: string;
+  status?: number;
+  reason?: string;
+} = {
+  ok: true,
+  org_id: "org-uuid-1",
+  token_id: "token-uuid-1",
+  token_name: "customerapp-prod-2026",
+};
 let insertsByTable: Record<string, Array<Record<string, unknown>>> = {};
 let mockInsertResult: { data: { id: string } | null; error: { message: string } | null } = {
   data: { id: "bp-id-1" },
@@ -43,7 +58,7 @@ let mockInsertResult: { data: { id: string } | null; error: { message: string } 
 };
 
 vi.mock("@/lib/internal-auth", () => ({
-  checkInternalApiKey: () => mockAuthOk,
+  resolveOrgFromToken: () => Promise.resolve(mockAuthResult),
 }));
 
 vi.mock("@/lib/supabase/service", () => ({
@@ -65,23 +80,28 @@ vi.mock("@/lib/supabase/service", () => ({
 const MICROGRID_ID = "550e8400-e29b-41d4-a716-446655440000";
 
 function makePostRequest(body: unknown): NextRequest {
-  return new NextRequest("http://localhost/api/internal/billing-periods", {
+  return new NextRequest("http://localhost/api/v1/billing-periods", {
     method: "POST",
     headers: { "Content-Type": "application/json", "x-api-key": "stub" },
     body: typeof body === "string" ? body : JSON.stringify(body),
   });
 }
 
-describe("POST /api/internal/billing-periods (#253)", () => {
+describe("POST /api/v1/billing-periods (#253 + #255)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAuthOk = true;
+    mockAuthResult = {
+      ok: true,
+      org_id: "org-uuid-1",
+      token_id: "token-uuid-1",
+      token_name: "customerapp-prod-2026",
+    };
     insertsByTable = {};
     mockInsertResult = { data: { id: "bp-id-1" }, error: null };
   });
 
   it("401 when auth fails", async () => {
-    mockAuthOk = false;
+    mockAuthResult = { ok: false, status: 401, reason: "missing_header" };
     const { POST } = await import("../route");
     const res = await POST(
       makePostRequest({
@@ -91,6 +111,8 @@ describe("POST /api/internal/billing-periods (#253)", () => {
       })
     );
     expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("missing_header");
   });
 
   it("accepts same-day period (start_date === end_date) — #253 regression fix", async () => {
@@ -147,13 +169,12 @@ describe("POST /api/internal/billing-periods (#253)", () => {
       end_date: "2026-01-31",
       status: "draft",
     });
-    // #250 audit-write was added in this PR; verify it stamps the expected
-    // attribution shape (customerapp + pre-token-system placeholder per
-    // implementer notes — will become real token name when #255 lands).
+    // #255 — audit-write attribution now carries the real per-org token
+    // name (replacing the `'pre-token-system'` placeholder from #250).
     expect(insertsByTable["billing_audit_log"]?.[0]).toMatchObject({
       event_type: "billing_period_created",
       actor_kind: "customerapp",
-      actor_ref: "pre-token-system",
+      actor_ref: "customerapp-prod-2026",
       actor_user_id: null,
       billing_period_id: "bp-id-1",
     });

--- a/src/app/api/v1/billing-periods/route.ts
+++ b/src/app/api/v1/billing-periods/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkInternalApiKey } from "@/lib/internal-auth";
+import { resolveOrgFromToken } from "@/lib/internal-auth";
 import { createServiceClient } from "@/lib/supabase/service";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export async function POST(request: NextRequest) {
-  if (!checkInternalApiKey(request)) {
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  // #255 — per-org token auth replaces the dead-code INTERNAL_API_KEY
+  // model from PR #246. On failure, return the structured reason as the
+  // error body so failure-mode tests can pin which leg of the auth flow
+  // rejected the call.
+  const auth = await resolveOrgFromToken(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status });
   }
 
   let raw: unknown;
@@ -50,13 +55,9 @@ export async function POST(request: NextRequest) {
   }
 
   // Audit: record that a billing period was created via the customerapp
-  // internal route. Pre-existing gap (PR #246 inherited it); #250 closes
-  // it with the new `billing_period_created` event type added in migration
-  // 00041.
-  //
-  // PLACEHOLDER: actor_ref will become the per-org token name when #255
-  // lands (Wave B). Stamping `'pre-token-system'` keeps the audit trail
-  // attributable to "customerapp internal route, pre-token auth".
+  // internal route. #250 added the audit-write; #255 replaces the
+  // `'pre-token-system'` placeholder actor_ref with the real per-org
+  // token name resolved by `resolveOrgFromToken`.
   //
   // Warn-but-still-return on audit failure: a missed audit row must not
   // mask a successfully created billing period from the caller.
@@ -65,7 +66,7 @@ export async function POST(request: NextRequest) {
     event_type: "billing_period_created",
     actor_user_id: null,
     actor_kind: "customerapp",
-    actor_ref: "pre-token-system",
+    actor_ref: auth.token_name,
     details: {
       billing_period_id: data.id,
       microgrid_id: rec.microgrid_id,

--- a/src/app/api/v1/billing/generate/route.ts
+++ b/src/app/api/v1/billing/generate/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkInternalApiKey } from "@/lib/internal-auth";
+import { resolveOrgFromToken } from "@/lib/internal-auth";
 import { createServiceClient } from "@/lib/supabase/service";
 import { runGenerationFor, isRunGenerationFatal } from "@/lib/billing/generate";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export async function POST(request: NextRequest) {
-  if (!checkInternalApiKey(request)) {
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  // #255 — per-org token auth replaces the dead-code INTERNAL_API_KEY
+  // model from PR #246. On failure, return the structured reason as the
+  // error body.
+  const auth = await resolveOrgFromToken(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status });
   }
 
   let raw: unknown;
@@ -71,10 +75,9 @@ export async function POST(request: NextRequest) {
   // (actor_kind, actor_ref) — see `src/lib/billing/generate.ts` for the
   // full rationale + PostgREST overload-resolution caveat.
   //
-  // PLACEHOLDER: actor_ref will become the per-org token name when #255
-  // lands (Wave B). Until then, we stamp `'pre-token-system'` so audit
-  // rows are still traceable to "this came from the customerapp internal
-  // route, before token-based auth was wired in".
+  // #255 — actor_ref is now the real per-org token name resolved by
+  // `resolveOrgFromToken`, replacing the `'pre-token-system'` placeholder
+  // from #250.
   const out = await runGenerationFor({
     supabase,
     periodId: rec.billingPeriodId,
@@ -82,14 +85,28 @@ export async function POST(request: NextRequest) {
     mode: "write",
     actorUserId: null,
     actorKind: "customerapp",
-    actorRef: "pre-token-system",
+    actorRef: auth.token_name,
   });
 
   if (isRunGenerationFatal(out)) {
     return NextResponse.json(out.body, { status: out.status });
   }
 
-  const lineItems = out.results.filter((r) => r.kind === "written").length;
+  // #255 — response shape returns per-line-item entity IDs so the
+  // customerapp can reference generated line items downstream (e.g. for
+  // payment-link generation). PR #246 returned `{ lineItems: <count> }`;
+  // the new shape per the AC ("POST /api/v1/billing/generate response
+  // includes per-line-item IDs (full entity-IDs commitment per #249)").
+  const lineItems = out.results
+    .filter((r): r is Extract<typeof r, { kind: "written" }> => r.kind === "written")
+    .map((r) => ({
+      id: r.lineItem.id,
+      householdId: r.householdId,
+      householdName: r.householdName,
+      totalAmount: r.lineItem.total_amount,
+      usageKwh: r.lineItem.usage_kwh,
+    }));
+
   const errors = out.results
     .filter((r) => r.kind === "error")
     .map((e) => ({

--- a/src/lib/billing/audit-humanize.tsx
+++ b/src/lib/billing/audit-humanize.tsx
@@ -223,7 +223,7 @@ export function humanizeAuditEvent(
     // ── #250: new event types added in migration 00041 ─────────────────────
 
     case "billing_period_created":
-      // Written by `/api/internal/billing-periods` POST. Distinguished from
+      // Written by `/api/v1/billing-periods` POST. Distinguished from
       // the legacy `period_created` event (which has no defined writer yet)
       // so the UI can render the internal-route origin once the audit feed
       // surfaces actor_kind.

--- a/src/lib/billing/generate.ts
+++ b/src/lib/billing/generate.ts
@@ -51,7 +51,7 @@ import "server-only";
  *
  * ── INVARIANT (added 2026-05 with #250) ────────────────────────────────────
  *
- * With service-role callers (via `/api/internal/*`), RLS does NOT backstop
+ * With service-role callers (via `/api/v1/*`), RLS does NOT backstop
  * the cross-microgrid check above — it is the SOLE defense against
  * cross-microgrid household submission. Do NOT delete on the assumption
  * that RLS will catch it; RLS only fires for user-bound clients. See PR
@@ -146,14 +146,14 @@ export type RunGenerationParams = {
   /** Resolved `auth.uid()` from the route's session. Required when
    *  mode='write' (passed to RPC as actor + entered_by_user_id for manual).
    *
-   *  For non-human callers (customerapp via `/api/internal/*`, future
+   *  For non-human callers (customerapp via `/api/v1/*`, future
    *  cron jobs, etc.) pass `null` and set `actorKind` + `actorRef`. The
    *  DB CHECK on `billing_audit_log` enforces the (kind, user_id, ref)
    *  shape (see migration 00041 / #250). */
   actorUserId: string | null;
   /** Defaults to `'human'` for backwards compatibility with all existing
    *  in-app callers (the dashboard routes). `'customerapp'` is set by
-   *  `/api/internal/*` routes; `'system'` by webhook ingestors.
+   *  `/api/v1/*` routes; `'system'` by webhook ingestors.
    *  See migration 00041 (#250). */
   actorKind?: "human" | "customerapp" | "system";
   /** Opaque caller-supplied identifier — token name for customerapp,

--- a/src/lib/internal-auth.ts
+++ b/src/lib/internal-auth.ts
@@ -1,26 +1,299 @@
 import "server-only";
+import argon2 from "argon2";
+import { randomBytes } from "node:crypto";
 import type { NextRequest } from "next/server";
-
-// NOTE (#250): the pre-#250 `CUSTOMERAPP_ACTOR_ID` constant was REMOVED.
-// It was a synthetic UUID written into `billing_audit_log.actor_user_id`
-// that did NOT exist in `auth.users`, which would trip the FK on the first
-// real `POST /api/internal/billing/generate` call. The new pattern
-// (migration 00041) writes `actor_user_id=NULL, actor_kind='customerapp',
-// actor_ref=<token name>` instead — see `/api/internal/**` routes and
-// `src/lib/billing/generate.ts` for call sites.
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase/service";
 
 /**
- * Returns true if the request carries a valid x-api-key header matching
- * INTERNAL_API_KEY. Callers must return 401 immediately when this returns false.
+ * Per-org API token auth (#255) — Authentication layer of the 4-layer
+ * trust composition for the customerapp integration (#249).
  *
- * Guards against misconfiguration: if INTERNAL_API_KEY is not set in the
- * environment, every request is rejected so the route is never silently open.
+ * Replaces the dead-code `INTERNAL_API_KEY` shared-env-var model from
+ * PR #246. The env var was never set in production; the routes have been
+ * dead code since #246 landed. As of #255 the routes use this per-org
+ * token system; the env var is removed entirely (no fallback / no
+ * deprecation window).
+ *
+ * ── Token shape ──────────────────────────────────────────────────────────
+ *
+ * Plain text:  mbe_<env>_<lookup>_<secret>
+ *   * <env>    — 2–8 chars (e.g. 'prod', 'stag', 'dev_') — env marker for
+ *                log identification + accidental-cross-env-paste detection.
+ *   * <lookup> — 8 hex chars (32 bits); NON-SECRET; indexed.
+ *   * <secret> — 43 chars base64url (32 bytes of entropy); argon2id-hashed.
+ *
+ * Total length: 61 chars. argon2id is non-deterministic (random salt per
+ * hash), so we cannot look up by hash. Industry-standard split-token
+ * pattern (Stripe / GitHub / similar): non-secret lookup column indexes
+ * the row; argon2-verify the secret remainder against the stored hash.
+ *
+ * ── Auth flow ────────────────────────────────────────────────────────────
+ *
+ *   1. Read `x-api-key` header → if missing, 401 missing_header.
+ *   2. Regex-parse with TOKEN_RE → if no match, 401 invalid_format.
+ *   3. Lookup row by token_lookup (service-role client, since this is the
+ *      auth path itself) WHERE revoked_at IS NULL. If none, 401 not_found.
+ *      Env prefix mismatch (staging token sent to prod) also hits not_found
+ *      since prod's table doesn't carry that row — no need to separately
+ *      reject by prefix.
+ *   4. argon2.verify(row.token_hash, secret) → if fails, 401 not_found
+ *      (same response for attack-surface reasons; don't leak presence).
+ *   5. If row.revoked_at IS NOT NULL (race between lookup + verify), 401
+ *      revoked. In practice the WHERE revoked_at IS NULL in step 3 catches
+ *      this, but the check inside the verify branch covers the racy
+ *      hard-cutover-regenerate window.
+ *   6. TODO (#251): check customerapp_enabled_for_org(row.org_id) — if
+ *      false, 403 customerapp_not_enabled. The DB helper does not exist
+ *      at #255's dispatch time; the check is plumbed-but-no-op here and
+ *      activates in a follow-up commit once #251 lands.
+ *   7. Update last_used_at = now() — fire-and-forget; do not await. Tiny
+ *      per-request cost; UPDATE failure is benign (we lose a tick).
+ *   8. Return { ok: true, org_id, token_id, token_name }.
  */
-export function checkInternalApiKey(request: NextRequest): boolean {
-  const envKey = process.env.INTERNAL_API_KEY;
-  if (!envKey || envKey.length < 32) {
-    return false;
+
+const TOKEN_RE =
+  /^mbe_([a-z0-9_]{2,8})_([0-9a-f]{8})_([A-Za-z0-9_-]{43})$/;
+
+// Default to 'dev_' for local dev; prod / staging deploys must set
+// MBE_TOKEN_ENV_PREFIX explicitly so the generated tokens carry the right
+// env marker.
+const ENV_PREFIX = process.env.MBE_TOKEN_ENV_PREFIX ?? "dev_";
+
+// OWASP 2024 guidance for argon2id. 19 MiB / 2 iterations / 1 thread on
+// Vercel infra ≈ 10–20 ms per verify. Acceptable latency for internal-API
+// calls; resistant to GPU/ASIC brute-force in the event of a DB leak.
+const ARGON2_OPTS = {
+  type: argon2.argon2id,
+  memoryCost: 19_456, // 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+} as const;
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export type TokenAuthOk = {
+  ok: true;
+  org_id: string;
+  token_id: string;
+  token_name: string;
+};
+
+export type TokenAuthFailReason =
+  | "missing_header"
+  | "invalid_format"
+  | "not_found"
+  | "revoked"
+  | "customerapp_not_enabled";
+
+export type TokenAuthFail = {
+  ok: false;
+  status: 401 | 403;
+  reason: TokenAuthFailReason;
+};
+
+export type TokenAuthResult = TokenAuthOk | TokenAuthFail;
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Verify the `x-api-key` header on an incoming request against the
+ * `org_api_tokens` table. Returns the resolved org_id + token_name on
+ * success; a structured failure with HTTP status on failure.
+ *
+ * Callers must respond with `NextResponse.json({error}, {status})` on
+ * failure — do not leak the internal reason code shape to the caller
+ * verbatim if you want to hide the auth-state distinction; the strings
+ * are intentionally neutral (`not_found` covers both "wrong lookup" and
+ * "wrong secret" by design).
+ */
+export async function resolveOrgFromToken(
+  request: NextRequest
+): Promise<TokenAuthResult> {
+  const headerValue = request.headers.get("x-api-key");
+  if (!headerValue) {
+    return { ok: false, status: 401, reason: "missing_header" };
   }
-  const provided = request.headers.get("x-api-key");
-  return !!provided && provided === envKey;
+
+  const match = TOKEN_RE.exec(headerValue);
+  if (!match) {
+    return { ok: false, status: 401, reason: "invalid_format" };
+  }
+
+  // match[1] is env_prefix (captured for completeness, not used at lookup
+  // time — env mismatch surfaces as not_found per the design above).
+  const lookup = match[2];
+  const secret = match[3];
+
+  const supabase = createServiceClient();
+
+  const { data: row, error } = await supabase
+    .from("org_api_tokens")
+    .select("id, org_id, name, token_hash, revoked_at")
+    .eq("token_lookup", lookup)
+    .is("revoked_at", null)
+    .maybeSingle();
+
+  if (error || !row) {
+    return { ok: false, status: 401, reason: "not_found" };
+  }
+
+  let verifyOk = false;
+  try {
+    verifyOk = await argon2.verify(row.token_hash, secret);
+  } catch {
+    // Malformed stored hash, or argon2 internal error. Treat as not_found
+    // to avoid leaking diagnostic info to unauthenticated callers.
+    verifyOk = false;
+  }
+
+  if (!verifyOk) {
+    return { ok: false, status: 401, reason: "not_found" };
+  }
+
+  // Race-window check (#255 design): a regenerate could have flipped
+  // revoked_at between our lookup and our argon2.verify. The WHERE in
+  // step 3 should have caught it, but re-check after the verify completes
+  // since verify can take ~15 ms.
+  if (row.revoked_at !== null) {
+    return { ok: false, status: 401, reason: "revoked" };
+  }
+
+  // TODO (#251): once `customerapp_enabled_for_org(_org_id UUID)` lands
+  // as a DB helper, gate auth here:
+  //
+  //   const { data: enabled } = await supabase.rpc(
+  //     "customerapp_enabled_for_org",
+  //     { _org_id: row.org_id }
+  //   );
+  //   if (!enabled) {
+  //     return { ok: false, status: 403, reason: "customerapp_not_enabled" };
+  //   }
+  //
+  // #251 was not on main at #255 dispatch time; the gate activates in a
+  // follow-up commit when #251 ships.
+
+  // Fire-and-forget last_used_at update. Failure is benign (we lose a
+  // tick); never block the request critical path on this.
+  void supabase
+    .from("org_api_tokens")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", row.id)
+    .then(({ error: updateErr }) => {
+      if (updateErr) {
+        console.warn(
+          JSON.stringify({
+            event: "internal_auth.last_used_at_update_failed",
+            token_id: row.id,
+            pg_code: (updateErr as { code?: string }).code ?? null,
+            pg_message: updateErr.message,
+            at: new Date().toISOString(),
+          })
+        );
+      }
+    });
+
+  return {
+    ok: true,
+    org_id: row.org_id,
+    token_id: row.id,
+    token_name: row.name,
+  };
+}
+
+// ── Token generation ─────────────────────────────────────────────────────
+
+export type GeneratedToken = {
+  /** Returned ONCE to the operator at creation time; never stored. */
+  plaintext: string;
+  /** 8 hex chars — written into org_api_tokens.token_lookup. */
+  lookup: string;
+  /** Env prefix used (e.g. 'prod', 'dev_') — written into env_prefix. */
+  envPrefix: string;
+  /** argon2id encoded hash — written into org_api_tokens.token_hash.
+   *  Async because argon2.hash is async (it's CPU-bound and runs in a
+   *  worker). Callers should `await hashPromise` before INSERTing the row. */
+  hashPromise: Promise<string>;
+};
+
+/**
+ * Generate a new API token. Returns the plaintext (return to operator
+ * ONCE; never store), the lookup prefix (write to DB), and a promise that
+ * resolves to the argon2id hash (write to DB).
+ *
+ * Usage (in #256 UI):
+ *
+ *   const t = generateToken();
+ *   const hash = await t.hashPromise;
+ *   await supabase.from("org_api_tokens").insert({
+ *     org_id, name, token_lookup: t.lookup, token_hash: hash,
+ *     env_prefix: t.envPrefix, created_by: userId,
+ *   });
+ *   // Return t.plaintext to the operator in the success response.
+ */
+export function generateToken(envPrefix: string = ENV_PREFIX): GeneratedToken {
+  const lookup = randomBytes(4).toString("hex"); // 8 hex chars
+  const secret = randomBytes(32).toString("base64url"); // 43 chars
+  const plaintext = `mbe_${envPrefix}_${lookup}_${secret}`;
+  return {
+    plaintext,
+    lookup,
+    envPrefix,
+    hashPromise: argon2.hash(secret, ARGON2_OPTS),
+  };
+}
+
+// ── Microgrid → org resolution (#254 / #257) ─────────────────────────────
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type MicrogridOrgOk = { ok: true; org_id: string };
+export type MicrogridOrgFail = {
+  ok: false;
+  status: 404 | 400;
+  reason: "microgrid_id_malformed" | "microgrid_not_found";
+};
+
+/**
+ * Resolve a microgrid_id → org_id via the canonical
+ * `microgrids → communities → org_id` chain.
+ *
+ * Consumed by #254 (authorization layer — does the token's org own this
+ * microgrid?) and #257 (GET endpoints scoping reads to token's org).
+ *
+ * Status-code distinction is load-bearing: malformed UUID → 400,
+ * non-existent → 404. Order matters at callsites: resolve to 404 BEFORE
+ * comparing to the token's org_id, so a non-existent UUID never reveals
+ * "exists in some other org" (UUID-enumeration defense, mirrors the
+ * 2026-04 permission-before-target-lookup learning).
+ */
+export async function resolveMicrogridOrgId(
+  supabase: SupabaseClient,
+  microgrid_id: string
+): Promise<MicrogridOrgOk | MicrogridOrgFail> {
+  if (typeof microgrid_id !== "string" || !UUID_RE.test(microgrid_id)) {
+    return { ok: false, status: 400, reason: "microgrid_id_malformed" };
+  }
+
+  const { data, error } = await supabase
+    .from("microgrids")
+    .select("id, communities!inner(org_id)")
+    .eq("id", microgrid_id)
+    .single();
+
+  if (error || !data) {
+    return { ok: false, status: 404, reason: "microgrid_not_found" };
+  }
+
+  // PostgREST returns the inner-joined relation as an object on .single().
+  // TypeScript surfaces it as an array OR object depending on inference;
+  // narrow via cast.
+  const communities = data.communities as { org_id: string } | { org_id: string }[];
+  const org_id = Array.isArray(communities) ? communities[0]?.org_id : communities?.org_id;
+  if (!org_id) {
+    return { ok: false, status: 404, reason: "microgrid_not_found" };
+  }
+
+  return { ok: true, org_id };
 }

--- a/src/lib/supabase/__tests__/audit_actor_kind.test.ts
+++ b/src/lib/supabase/__tests__/audit_actor_kind.test.ts
@@ -14,11 +14,11 @@
  *        non-human   → actor_user_id NULL,     actor_ref NOT NULL
  *
  *   3. End-to-end: `fn_record_line_item_with_audit` invoked with the
- *      widened-signature args from `/api/internal/billing/generate`
+ *      widened-signature args from `/api/v1/billing/generate`
  *      (`_actor_user_id=NULL, _actor_kind='customerapp', _actor_ref=...`)
  *      successfully inserts a billing_line_items row AND a billing_audit_log
  *      row — no FK violation. This is the PM AC "First call to
- *      `POST /api/internal/billing/generate` succeeds end-to-end".
+ *      `POST /api/v1/billing/generate` succeeds end-to-end".
  *
  *   4. Human-actor calls (the existing call-path: actor_kind defaults to
  *      `'human'`, actor_user_id non-null, actor_ref omitted) continue to

--- a/src/lib/supabase/__tests__/org_api_tokens.test.ts
+++ b/src/lib/supabase/__tests__/org_api_tokens.test.ts
@@ -1,0 +1,367 @@
+/**
+ * org_api_tokens.test.ts (#255)
+ *
+ * Failure-mode AC matrix for `resolveOrgFromToken` from the ticket body:
+ *
+ *   - Valid unrevoked token: succeeds; `last_used_at` updates (fire-and-forget).
+ *   - Token missing `mbe_` prefix → 401 (invalid_format).
+ *   - Token with wrong env prefix (staging token in prod) → 401 (not_found,
+ *     since lookup row doesn't exist in prod's table).
+ *   - Token format valid but no matching hash → 401 (not_found).
+ *   - Token format valid, hash matches, but `revoked_at IS NOT NULL` → 401
+ *     (revoked). Tested via the post-verify race-window branch since the
+ *     primary lookup WHEREs revoked_at IS NULL out.
+ *   - Hard-cutover regenerate: old token immediately 401s on next request;
+ *     new token works on first request.
+ *   - argon2id: incorrect token doesn't match a real hash (crypto sanity).
+ *   - `last_used_at` UPDATE failure doesn't block auth success.
+ *   - `generateToken` produces tokens matching the documented format regex
+ *     (env / lookup / secret split).
+ *
+ * Architecture notes:
+ *   - Tests run REAL argon2 (no mock) — at OWASP 2024 params each verify
+ *     is ~15ms, so the whole suite < 1s. Mocking argon2 would lose the
+ *     crypto-sanity coverage.
+ *   - Supabase service-role client is mocked at the module boundary; the
+ *     mock uses the `insertsByTable` / `updatesByTable` capture pattern
+ *     (PR #259 lesson — single-variable capture silently drops the
+ *     non-last write).
+ *   - `last_used_at` update is fire-and-forget (`void`) inside the
+ *     handler; the test schedules a microtask flush to assert it ran.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import argon2 from "argon2";
+
+// ── Mock controls ──────────────────────────────────────────────────────────
+//
+// The `org_api_tokens` table is touched twice per successful auth (SELECT
+// for lookup, then a fire-and-forget UPDATE for last_used_at). Capture
+// inserts AND updates per-table so we can assert independently.
+//
+// `lookupResult` is what `from('org_api_tokens').select(...).eq(...).is(...).maybeSingle()`
+// returns. Tests set it before invoking the handler.
+
+type LookupRow = {
+  id: string;
+  org_id: string;
+  name: string;
+  token_hash: string;
+  revoked_at: string | null;
+};
+
+let lookupResult: { data: LookupRow | null; error: { message: string } | null } = {
+  data: null,
+  error: null,
+};
+let updatesByTable: Record<
+  string,
+  Array<{ payload: Record<string, unknown>; eqArgs?: [string, unknown] }>
+> = {};
+let updateError: { message: string; code?: string } | null = null;
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (table: string) => ({
+      // SELECT chain — used by the lookup path.
+      select: () => ({
+        eq: () => ({
+          is: () => ({
+            maybeSingle: () => Promise.resolve(lookupResult),
+          }),
+        }),
+      }),
+      // UPDATE chain — used by the fire-and-forget last_used_at write.
+      // Returns a thenable so `void supabase.from(...).update(...).eq(...).then(...)`
+      // resolves properly.
+      update: (payload: Record<string, unknown>) => ({
+        eq: (column: string, value: unknown) => {
+          if (!updatesByTable[table]) updatesByTable[table] = [];
+          updatesByTable[table].push({ payload, eqArgs: [column, value] });
+          return {
+            then: (
+              resolve: (v: { error: { message: string; code?: string } | null }) => void
+            ) => {
+              resolve({ error: updateError });
+              return Promise.resolve({ error: updateError });
+            },
+          };
+        },
+      }),
+    }),
+  }),
+}));
+
+function makeRequest(headers: Record<string, string>): NextRequest {
+  return new NextRequest("http://localhost/api/v1/billing-periods", {
+    method: "POST",
+    headers,
+  });
+}
+
+// Real argon2 hash of a known secret — generated once, reused across tests
+// to keep the suite fast. Generated at module-load time; argon2.hash is
+// async, so we await it in a beforeAll-style helper.
+let KNOWN_SECRET: string;
+let KNOWN_HASH: string;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  lookupResult = { data: null, error: null };
+  updatesByTable = {};
+  updateError = null;
+  if (!KNOWN_HASH) {
+    // 43-char base64url string — matches the secret format from generateToken.
+    KNOWN_SECRET = "abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE";
+    KNOWN_HASH = await argon2.hash(KNOWN_SECRET, {
+      type: argon2.argon2id,
+      memoryCost: 19_456,
+      timeCost: 2,
+      parallelism: 1,
+    });
+  }
+});
+
+afterAll(() => {
+  // Restore env so a later test in the same process isn't poisoned.
+  delete process.env.MBE_TOKEN_ENV_PREFIX;
+});
+
+describe("resolveOrgFromToken (#255)", () => {
+  it("401 missing_header when x-api-key absent", async () => {
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const res = await resolveOrgFromToken(makeRequest({}));
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "missing_header" });
+  });
+
+  it("401 invalid_format when header lacks `mbe_` prefix", async () => {
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const res = await resolveOrgFromToken(
+      makeRequest({ "x-api-key": "not-an-mbe-token" })
+    );
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "invalid_format" });
+  });
+
+  it("401 invalid_format when token has wrong shape (missing secret part)", async () => {
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const res = await resolveOrgFromToken(
+      makeRequest({ "x-api-key": "mbe_dev__deadbeef_" })
+    );
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "invalid_format" });
+  });
+
+  it("401 not_found when format valid but no matching lookup row (wrong-env-prefix case lands here)", async () => {
+    lookupResult = { data: null, error: null };
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    // Format-valid token; lookup returns null (would happen for a staging
+    // token sent to prod — the row doesn't exist in prod's org_api_tokens).
+    const token =
+      "mbe_stag_12345678_abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE";
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "not_found" });
+  });
+
+  it("401 not_found when lookup matches but argon2 verify fails (wrong secret)", async () => {
+    // Lookup row exists; hash is real. Header carries a different secret —
+    // argon2.verify returns false → not_found (not invalid_format).
+    lookupResult = {
+      data: {
+        id: "token-uuid-1",
+        org_id: "org-uuid-1",
+        name: "test-token",
+        token_hash: KNOWN_HASH,
+        revoked_at: null,
+      },
+      error: null,
+    };
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    // Secret is 43 chars but doesn't match KNOWN_SECRET.
+    const wrongSecret = "WRONGwrongWRONGwrongWRONGwrongWRONGwrong123";
+    const token = `mbe_dev_12345678_${wrongSecret}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "not_found" });
+  });
+
+  it("succeeds with valid token + fires last_used_at update", async () => {
+    lookupResult = {
+      data: {
+        id: "token-uuid-1",
+        org_id: "org-uuid-1",
+        name: "customerapp-prod-2026",
+        token_hash: KNOWN_HASH,
+        revoked_at: null,
+      },
+      error: null,
+    };
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res.ok).toBe(true);
+    expect(res).toMatchObject({
+      ok: true,
+      org_id: "org-uuid-1",
+      token_id: "token-uuid-1",
+      token_name: "customerapp-prod-2026",
+    });
+
+    // Flush microtasks so the fire-and-forget UPDATE has a chance to land.
+    await new Promise((r) => setImmediate(r));
+
+    expect(updatesByTable["org_api_tokens"]).toHaveLength(1);
+    const update = updatesByTable["org_api_tokens"][0];
+    expect(update.payload).toHaveProperty("last_used_at");
+    expect(typeof update.payload.last_used_at).toBe("string");
+    expect(update.eqArgs).toEqual(["id", "token-uuid-1"]);
+  });
+
+  it("401 revoked via post-verify race-window check (revoked_at set in row despite WHERE)", async () => {
+    // Simulate a race: the lookup WHERE revoked_at IS NULL passed (the row
+    // had revoked_at=null at SELECT time), but a regenerate flipped it
+    // before the verify completed. Test by stubbing the row with
+    // revoked_at already set — exercises the in-handler race check.
+    lookupResult = {
+      data: {
+        id: "token-uuid-1",
+        org_id: "org-uuid-1",
+        name: "test-token",
+        token_hash: KNOWN_HASH,
+        revoked_at: "2026-05-26T12:00:00Z",
+      },
+      error: null,
+    };
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "revoked" });
+  });
+
+  it("auth still succeeds when last_used_at UPDATE fails (fire-and-forget benign-failure)", async () => {
+    lookupResult = {
+      data: {
+        id: "token-uuid-1",
+        org_id: "org-uuid-1",
+        name: "test-token",
+        token_hash: KNOWN_HASH,
+        revoked_at: null,
+      },
+      error: null,
+    };
+    updateError = { message: "simulated DB hiccup", code: "23505" };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res.ok).toBe(true);
+
+    // Flush microtasks so the warn fires.
+    await new Promise((r) => setImmediate(r));
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("generateToken (#255)", () => {
+  it("produces a token matching the documented format regex", async () => {
+    const { generateToken } = await import("@/lib/internal-auth");
+    const t = generateToken("prod");
+    expect(t.plaintext).toMatch(
+      /^mbe_prod_[0-9a-f]{8}_[A-Za-z0-9_-]{43}$/
+    );
+    expect(t.lookup).toMatch(/^[0-9a-f]{8}$/);
+    expect(t.envPrefix).toBe("prod");
+
+    // The hash promise resolves to a valid argon2 encoded string.
+    const hash = await t.hashPromise;
+    expect(hash).toMatch(/^\$argon2id\$/);
+  });
+
+  it("uses default env prefix when none provided", async () => {
+    delete process.env.MBE_TOKEN_ENV_PREFIX;
+    // Re-import to pick up the env default. vi.resetModules is required
+    // because the env-prefix constant is captured at module load.
+    vi.resetModules();
+    const { generateToken } = await import("@/lib/internal-auth");
+    const t = generateToken();
+    expect(t.plaintext).toMatch(/^mbe_dev__/);
+    expect(t.envPrefix).toBe("dev_");
+  });
+
+  it("generates round-trippable hash + verify", async () => {
+    // Crypto sanity check — hash a real token, verify it matches; verify
+    // a different secret against the same hash and it doesn't match.
+    const { generateToken } = await import("@/lib/internal-auth");
+    const t = generateToken("dev");
+    const hash = await t.hashPromise;
+    // Parse plaintext via the canonical token regex to extract the secret
+    // (using `.split('_')` is unsafe because env_prefix may contain `_`,
+    // e.g. the default 'dev_').
+    const match = /^mbe_([a-z0-9_]{2,8})_([0-9a-f]{8})_([A-Za-z0-9_-]{43})$/.exec(
+      t.plaintext
+    );
+    expect(match).not.toBeNull();
+    const secret = match![3];
+    expect(await argon2.verify(hash, secret)).toBe(true);
+    expect(await argon2.verify(hash, "wrong-secret-43-chars-_-aaaaaaaaaaaaa")).toBe(
+      false
+    );
+  });
+
+  it("produces unique lookup + secret per call", async () => {
+    const { generateToken } = await import("@/lib/internal-auth");
+    const a = generateToken("dev_");
+    const b = generateToken("dev_");
+    expect(a.lookup).not.toBe(b.lookup);
+    expect(a.plaintext).not.toBe(b.plaintext);
+  });
+});
+
+describe("hard-cutover regenerate behavior (#255)", () => {
+  it("old token 401s once revoked_at is set; new token works on first request", async () => {
+    // Simulates the #256 regenerate flow at the auth layer:
+    //   1. Old token: WHERE revoked_at IS NULL on lookup → no row → not_found.
+    //   2. New token: lookup returns the new row → argon2.verify → ok.
+    const { resolveOrgFromToken, generateToken } = await import(
+      "@/lib/internal-auth"
+    );
+
+    const oldToken = generateToken("dev_");
+    const newToken = generateToken("dev_");
+
+    // Old token: row excluded by WHERE revoked_at IS NULL (regenerate set it).
+    lookupResult = { data: null, error: null };
+    const resOld = await resolveOrgFromToken(
+      makeRequest({ "x-api-key": oldToken.plaintext })
+    );
+    expect(resOld.ok).toBe(false);
+    expect(resOld).toMatchObject({ status: 401, reason: "not_found" });
+
+    // New token: row exists, hash matches → ok.
+    const newHash = await newToken.hashPromise;
+    lookupResult = {
+      data: {
+        id: "new-token-uuid",
+        org_id: "org-uuid-1",
+        name: "regenerated-2026-05-26",
+        token_hash: newHash,
+        revoked_at: null,
+      },
+      error: null,
+    };
+    const resNew = await resolveOrgFromToken(
+      makeRequest({ "x-api-key": newToken.plaintext })
+    );
+    expect(resNew.ok).toBe(true);
+    expect(resNew).toMatchObject({
+      ok: true,
+      org_id: "org-uuid-1",
+      token_name: "regenerated-2026-05-26",
+    });
+  });
+});

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -705,6 +705,60 @@ export type Database = {
           },
         ]
       }
+      org_api_tokens: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          env_prefix: string
+          id: string
+          last_used_at: string | null
+          name: string
+          org_id: string
+          revoked_at: string | null
+          token_hash: string
+          token_lookup: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          env_prefix: string
+          id?: string
+          last_used_at?: string | null
+          name: string
+          org_id: string
+          revoked_at?: string | null
+          token_hash: string
+          token_lookup: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          env_prefix?: string
+          id?: string
+          last_used_at?: string | null
+          name?: string
+          org_id?: string
+          revoked_at?: string | null
+          token_hash?: string
+          token_lookup?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "org_api_tokens_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_directory"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "org_api_tokens_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       organizations: {
         Row: {
           address_city: string | null

--- a/supabase/migrations/00042_org_api_tokens.sql
+++ b/supabase/migrations/00042_org_api_tokens.sql
@@ -1,0 +1,106 @@
+-- 00042_org_api_tokens.sql
+-- #255 — per-org API tokens (replaces the dead-code INTERNAL_API_KEY model
+-- introduced by PR #246). This is the Authentication layer of the 4-layer
+-- trust composition for the customerapp integration (#249).
+--
+-- ── Why ───────────────────────────────────────────────────────────────────
+--
+-- PR #246 shipped a shared `INTERNAL_API_KEY` env-var auth model. That
+-- env var is never set in production — the route handlers are dead code
+-- until this ticket lands. #255 replaces them with a per-org token system
+-- so the credential boundary matches the RLS / multi-tenant boundary.
+--
+-- ── Token shape (Architect refinement, 2026-05-26) ────────────────────────
+--
+-- Plain text:  mbe_<env>_<lookup>_<secret>
+--   * <env>    — 4 chars (e.g. 'prod', 'stag', 'dev_') — env marker, used
+--                for log identification + accidental-cross-env-paste detection.
+--   * <lookup> — 8 hex chars (32 bits of entropy); the NON-SECRET index key.
+--   * <secret> — 43 chars base64url (32 bytes); the entropy that argon2id
+--                hashes.
+--
+-- Total length: 61 chars. Easy to copy; visually identifiable as MBE.
+--
+-- argon2id is non-deterministic (random salt per hash), so we cannot look
+-- up by hash. Industry-standard fix (Stripe / GitHub / similar): split into
+-- a non-secret indexed lookup column + secret argon2-hashed column. The
+-- secret never appears in plain text in the DB; it is only returned once at
+-- creation time and verified against the stored hash on every auth.
+--
+-- ── Schema ────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS org_api_tokens (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id        UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name          TEXT NOT NULL,
+  token_lookup  TEXT NOT NULL,
+  token_hash    TEXT NOT NULL,
+  env_prefix    TEXT NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  last_used_at  TIMESTAMPTZ,
+  revoked_at    TIMESTAMPTZ,
+  CHECK (token_lookup ~ '^[0-9a-f]{8}$'),
+  CHECK (env_prefix ~ '^[a-z0-9_]{2,8}$')
+);
+
+COMMENT ON TABLE org_api_tokens IS
+  'Per-org API tokens (#255). Replaces the shared INTERNAL_API_KEY model. Token plaintext is mbe_<env>_<lookup>_<secret>; we store token_lookup (non-secret, indexed) and token_hash (argon2id over the secret).';
+
+COMMENT ON COLUMN org_api_tokens.name IS
+  'Operator-chosen label, surfaced in audit log as actor_ref.';
+
+COMMENT ON COLUMN org_api_tokens.token_lookup IS
+  '8 hex chars; non-secret; indexed. Server resolves the row by this prefix, then argon2-verifies the secret remainder against token_hash.';
+
+COMMENT ON COLUMN org_api_tokens.token_hash IS
+  'argon2id encoded hash (~95 chars) of the secret remainder. Verified per-request; never logged or returned.';
+
+COMMENT ON COLUMN org_api_tokens.env_prefix IS
+  'Env marker (e.g. ''prod'', ''stag'', ''dev_''). Captured at creation time so logs can identify which env a token belongs to without inspecting the plaintext.';
+
+COMMENT ON COLUMN org_api_tokens.revoked_at IS
+  'Set immediately on revoke/regenerate (#256 UI). Hard cutover — no grace window. Old tokens 401 on next request.';
+
+-- Lookup uniqueness applies only to ACTIVE (not revoked) tokens. Revoked
+-- rows retain the old lookup for forensic / audit reference, and a fresh
+-- regenerate could in principle reuse the same 32-bit lookup (vanishingly
+-- unlikely but the partial index keeps the invariant honest).
+CREATE UNIQUE INDEX IF NOT EXISTS org_api_tokens_lookup_active_uq
+  ON org_api_tokens(token_lookup)
+  WHERE revoked_at IS NULL;
+
+-- Listing for the org-admin UI (#256) — most-recent-first per org, active
+-- tokens only. Revoked rows show up in a separate "history" panel that
+-- doesn't need this index.
+CREATE INDEX IF NOT EXISTS org_api_tokens_org_active_idx
+  ON org_api_tokens(org_id, created_at DESC)
+  WHERE revoked_at IS NULL;
+
+-- ── RLS ──────────────────────────────────────────────────────────────────
+--
+-- The token-auth path itself uses the service-role client (no auth.uid()
+-- yet at the moment of lookup), so RLS does NOT block the auth flow. The
+-- #256 org-admin UI for managing tokens DOES run as the human user
+-- (auth.uid() = org_manager), so we lock the table to:
+--   * super_admin: full access
+--   * org_manager scoped to the row's org_id: full access
+--
+-- This mirrors the user_roles / payment-secret pattern; consumers in the
+-- web UI use the SSR Supabase client (per-request user-bound) and thus
+-- evaluate RLS naturally. Service-role bypasses RLS by design and continues
+-- to work for the auth path.
+
+ALTER TABLE org_api_tokens ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS org_api_tokens_super_admin ON org_api_tokens;
+CREATE POLICY org_api_tokens_super_admin ON org_api_tokens
+  FOR ALL
+  USING (is_super_admin())
+  WITH CHECK (is_super_admin());
+
+DROP POLICY IF EXISTS org_api_tokens_org_manager ON org_api_tokens;
+CREATE POLICY org_api_tokens_org_manager ON org_api_tokens
+  FOR ALL
+  USING (user_can_access_org(org_id))
+  WITH CHECK (user_can_access_org(org_id));


### PR DESCRIPTION
## Summary

Wave B keystone (#255) — replaces the dead-code `INTERNAL_API_KEY` model from PR #246 with a per-org API token system. This is the Authentication layer of the 4-layer trust composition for the customerapp integration (#249). Plants the helper functions that Waves C+D depend on.

**Closes #255.**

### What ships
- **Migration 00042 `org_api_tokens`** — split-token pattern (non-secret `token_lookup` indexed + argon2id `token_hash`). Partial UNIQUE on lookup WHERE `revoked_at IS NULL`. RLS scoped to `super_admin` and `org_manager` on the row's `org_id`.
- **`argon2` dependency** at OWASP 2024 params (19MiB / 2 iterations / 1 thread, argon2id).
- **`src/lib/internal-auth.ts` full rewrite** — drops `INTERNAL_API_KEY` constant + `checkInternalApiKey`; adds `resolveOrgFromToken`, `generateToken`, `resolveMicrogridOrgId`.
- **Directory rename `src/app/api/internal/` → `src/app/api/v1/`** per the implementer-readiness clarifications on #255 (single rename atomic with the auth rewrite).
- **`POST /api/v1/billing/generate` response shape** — now returns per-line-item entity IDs (`{lineItems: [{id, householdId, ...}], errors[]}`) per the AC entity-IDs commitment (#249).
- **`actor_ref` plumbing** — both v1 routes now write the real per-org token name as `actor_ref` in the audit log, replacing the `'pre-token-system'` placeholder from #250.

## Test plan

- [x] `npm run db:types` regenerates cleanly (`org_api_tokens` row visible in `database.gen.ts`).
- [x] `npx tsc --noEmit` — 0 errors.
- [x] `npm run lint` — 0 errors, 19 pre-existing warnings (none in new code).
- [x] `SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test` — 1665 passed, 61 skipped (RLS+DEK suites as expected), 0 failed.
- [x] `npm run build` — succeeds; both `/api/v1/billing-periods` and `/api/v1/billing/generate` appear in the route manifest. argon2 native module builds cleanly under Next 16 / Turbopack.
- [x] New `src/lib/supabase/__tests__/org_api_tokens.test.ts` (13 tests) covers the full failure-mode AC matrix with real argon2 (no mock):
  - missing header → 401 `missing_header`
  - invalid format → 401 `invalid_format`
  - wrong env prefix → 401 `not_found` (lookup-row absence)
  - format valid + no row → 401 `not_found`
  - format valid + wrong secret → 401 `not_found` (attack-surface neutral)
  - format valid + revoked row → 401 `revoked` (race-window branch)
  - last_used_at UPDATE failure → still 200 (fire-and-forget benign)
  - generateToken format regex round-trip
  - hard-cutover regenerate: old token 401s, new token works on first request
- [x] Migration applies cleanly via `npx supabase db reset` against local Supabase.

## Notes for reviewers

### Biggest visual diff: directory rename
`git mv src/app/api/internal src/app/api/v1` ran cleanly — `git diff` shows the three moved files as renames (R), not as delete+add. Stale `/api/internal/*` references in comments/JSDoc inside `src/lib/billing/generate.ts`, `src/lib/billing/audit-humanize.tsx`, and `src/lib/supabase/__tests__/audit_actor_kind.test.ts` were updated to `/api/v1/*`. The two `/api/internal/*` mentions in `supabase/migrations/00041_audit_actor_kind.sql` are SQL comments in already-applied historical migration text — intentionally left as-is to avoid rewriting migration history.

`grep -rn "/api/internal" src/` after the rename returns zero. `grep -rn "INTERNAL_API_KEY" src/` returns only two documentary comment lines in `internal-auth.ts` + the v1 routes that explicitly explain the removal — no live code reads the env var.

### `argon2` native-module build on Vercel
The `npm run build` proxy succeeded locally with `argon2@^0.44.0` on Linux/WSL. argon2 is a native module; Vercel preview should mirror this if `node-gyp` headers are present in the build image. If the Vercel preview build fails on argon2's prebuild, escalate before swapping algorithms — argon2id is load-bearing.

### Composition with adjacent waves
- **Wave A (#250):** `actor_kind`/`actor_ref` columns + 4 new audit event types are consumed by this PR. The `'pre-token-system'` placeholder string from #250 is fully replaced in both v1 routes; `token_name` from `resolveOrgFromToken` flows in as `actor_ref`.
- **Wave C (#251):** `customerapp_enabled_for_org` is plumbed-but-TODO'd in `resolveOrgFromToken` with a clearly-labeled comment block. Activates in a follow-up commit once #251 lands.
- **Wave C (#254, #257):** `resolveMicrogridOrgId` planted with the signature from #254's appendix; ready for consumption by both tickets without modification.

### Env-var cleanup grep
`grep -rn "INTERNAL_API_KEY" .` (excluding node_modules) returned only the file being rewritten — no `.env.example`, no `docs/setup.md`, no `.github/workflows/*.yml`, no test fixtures. `MBE_TOKEN_ENV_PREFIX` is the only new env var introduced; defaults to `'dev_'` if unset. The repo's `.env.local.example` doesn't carry this kind of variable, so no doc churn needed beyond what's in this PR.

### Composite check / RLS for `org_api_tokens`
RLS policies match the existing pattern (`FOR ALL`, two policies: `is_super_admin()` and `user_can_access_org(org_id)`). The service-role client used by `resolveOrgFromToken` bypasses RLS by design, so the auth path is unaffected; the human-facing #256 token-management UI will run as the user-bound SSR client and evaluate RLS naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)