### PR TITLE
feat(api): add GET /api/v1/microgrids + GET /api/v1/microgrids/:id/households discovery endpoints (#257)

### DIFF
--- a/src/app/api/v1/microgrids/[microgrid_id]/households/__tests__/route.test.ts
+++ b/src/app/api/v1/microgrids/[microgrid_id]/households/__tests__/route.test.ts
@@ -1,0 +1,327 @@
+/**
+ * GET /api/v1/microgrids/:microgrid_id/households — route tests (#257).
+ *
+ * Coverage (failure-mode AC from the ticket body):
+ *   - Auth fails → 401 with reason surface.
+ *   - customerapp_enabled = FALSE → 403 (gated inside `resolveOrgFromToken`
+ *     per #251).
+ *   - Malformed `:microgrid_id` UUID → 400 (rejected inside
+ *     `resolveMicrogridOrgId`).
+ *   - Non-existent microgrid → 404 (rejected inside `resolveMicrogridOrgId`
+ *     BEFORE the org-equality check, per the UUID-enumeration defense in
+ *     `src/lib/internal-auth.ts`).
+ *   - Wrong-org microgrid → 403.
+ *   - 0 households on the microgrid → 200 with `[]` (NOT 404; the
+ *     microgrid resource exists, the collection is just empty).
+ *   - N households with various `household_devices` shapes → 200 with
+ *     `has_device` correctly computed from the embed length.
+ *   - Supabase error → 500 surfaces the message.
+ *
+ * `resolveOrgFromToken` + `resolveMicrogridOrgId` are both mocked at the
+ * module boundary (same idiom as billing-periods/route.test.ts). The
+ * supabase chain mock follows the same pattern as the sibling
+ * microgrids/route.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mock controls ──────────────────────────────────────────────────────────
+
+let mockAuthResult: {
+  ok: boolean;
+  org_id?: string;
+  token_id?: string;
+  token_name?: string;
+  status?: number;
+  reason?: string;
+} = {
+  ok: true,
+  org_id: "org-uuid-1",
+  token_id: "token-uuid-1",
+  token_name: "customerapp-prod-2026",
+};
+
+let mockResolveMgResult:
+  | { ok: true; org_id: string }
+  | { ok: false; status: 400 | 404; reason: string } = {
+  ok: true,
+  org_id: "org-uuid-1",
+};
+
+let mockSelectResult: {
+  data:
+    | Array<{
+        id: string;
+        display_name: string;
+        microgrid_id: string;
+        household_devices?: Array<{ device_id: string }> | null;
+      }>
+    | null;
+  error: { message: string } | null;
+} = { data: [], error: null };
+
+let lastQuery: {
+  table: string | null;
+  selectArg: string | null;
+  eqArgs: Array<[string, unknown]>;
+} = { table: null, selectArg: null, eqArgs: [] };
+
+vi.mock("@/lib/internal-auth", () => ({
+  resolveOrgFromToken: () => Promise.resolve(mockAuthResult),
+  resolveMicrogridOrgId: () => Promise.resolve(mockResolveMgResult),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (table: string) => {
+      lastQuery.table = table;
+      const builder = {
+        select: (arg: string) => {
+          lastQuery.selectArg = arg;
+          return builder;
+        },
+        eq: (col: string, val: unknown) => {
+          lastQuery.eqArgs.push([col, val]);
+          return builder;
+        },
+        then: (resolve: (v: typeof mockSelectResult) => unknown) =>
+          Promise.resolve(mockSelectResult).then(resolve),
+      };
+      return builder;
+    },
+  }),
+}));
+
+const MICROGRID_ID = "550e8400-e29b-41d4-a716-446655440000";
+const MALFORMED_MICROGRID_ID = "not-a-uuid";
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/microgrids/${MICROGRID_ID}/households`,
+    {
+      method: "GET",
+      headers: { "x-api-key": "stub" },
+    },
+  );
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ microgrid_id: id }) };
+}
+
+describe("GET /api/v1/microgrids/:microgrid_id/households (#257)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthResult = {
+      ok: true,
+      org_id: "org-uuid-1",
+      token_id: "token-uuid-1",
+      token_name: "customerapp-prod-2026",
+    };
+    mockResolveMgResult = { ok: true, org_id: "org-uuid-1" };
+    mockSelectResult = { data: [], error: null };
+    lastQuery = { table: null, selectArg: null, eqArgs: [] };
+  });
+
+  it("401 when x-api-key is missing", async () => {
+    mockAuthResult = { ok: false, status: 401, reason: "missing_header" };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("missing_header");
+  });
+
+  it("401 when token is unknown / revoked", async () => {
+    mockAuthResult = { ok: false, status: 401, reason: "not_found" };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when customerapp_enabled = FALSE for the token's org (#251)", async () => {
+    mockAuthResult = {
+      ok: false,
+      status: 403,
+      reason: "customerapp_not_enabled",
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("customerapp_not_enabled");
+  });
+
+  it("400 when :microgrid_id is malformed", async () => {
+    mockResolveMgResult = {
+      ok: false,
+      status: 400,
+      reason: "microgrid_id_malformed",
+    };
+    const { GET } = await import("../route");
+    const res = await GET(
+      makeGetRequest(),
+      paramsFor(MALFORMED_MICROGRID_ID),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("microgrid_id_malformed");
+  });
+
+  it("404 when :microgrid_id does not exist", async () => {
+    mockResolveMgResult = {
+      ok: false,
+      status: 404,
+      reason: "microgrid_not_found",
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("microgrid_not_found");
+  });
+
+  it("403 when :microgrid_id belongs to a DIFFERENT org than the token", async () => {
+    // 404-vs-403 ordering matters: the resolver returns ok+org_id; the
+    // route's own comparison surfaces the 403. A non-existent UUID would
+    // 404 first (above), so a 403 here genuinely means "exists, wrong org".
+    mockResolveMgResult = { ok: true, org_id: "org-uuid-OTHER" };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("microgrid_not_in_org");
+  });
+
+  it("200 with [] when the microgrid has 0 households (NOT 404)", async () => {
+    mockResolveMgResult = { ok: true, org_id: "org-uuid-1" };
+    mockSelectResult = { data: [], error: null };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+    expect(lastQuery.table).toBe("households");
+    expect(lastQuery.eqArgs).toEqual([["microgrid_id", MICROGRID_ID]]);
+  });
+
+  it("computes has_device=true when household_devices is non-empty", async () => {
+    mockSelectResult = {
+      data: [
+        {
+          id: "hh-uuid-1",
+          display_name: "Household 1",
+          microgrid_id: MICROGRID_ID,
+          household_devices: [{ device_id: "dev-uuid-1" }],
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([
+      {
+        id: "hh-uuid-1",
+        display_name: "Household 1",
+        microgrid_id: MICROGRID_ID,
+        has_device: true,
+      },
+    ]);
+  });
+
+  it("computes has_device=false when household_devices is empty array", async () => {
+    mockSelectResult = {
+      data: [
+        {
+          id: "hh-uuid-1",
+          display_name: "Household 1",
+          microgrid_id: MICROGRID_ID,
+          household_devices: [],
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json[0].has_device).toBe(false);
+  });
+
+  it("computes has_device=false when household_devices is missing/null", async () => {
+    mockSelectResult = {
+      data: [
+        {
+          id: "hh-uuid-1",
+          display_name: "Household 1",
+          microgrid_id: MICROGRID_ID,
+          household_devices: null,
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json[0].has_device).toBe(false);
+  });
+
+  it("returns mixed has_device across multiple rows", async () => {
+    mockSelectResult = {
+      data: [
+        {
+          id: "hh-uuid-1",
+          display_name: "HH1",
+          microgrid_id: MICROGRID_ID,
+          household_devices: [{ device_id: "d1" }, { device_id: "d2" }],
+        },
+        {
+          id: "hh-uuid-2",
+          display_name: "HH2",
+          microgrid_id: MICROGRID_ID,
+          household_devices: [],
+        },
+        {
+          id: "hh-uuid-3",
+          display_name: "HH3",
+          microgrid_id: MICROGRID_ID,
+          household_devices: [{ device_id: "d3" }],
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.map((r: { has_device: boolean }) => r.has_device)).toEqual([
+      true,
+      false,
+      true,
+    ]);
+  });
+
+  it("uses the customerapp-narrow column list, not select('*')", async () => {
+    mockSelectResult = { data: [], error: null };
+    const { GET } = await import("../route");
+    await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(lastQuery.selectArg).not.toMatch(/\bselect\(['"]\*/);
+    expect(lastQuery.selectArg).toContain("id, display_name, microgrid_id");
+    expect(lastQuery.selectArg).toContain("household_devices(device_id)");
+  });
+
+  it("500 when supabase errors", async () => {
+    mockSelectResult = {
+      data: null,
+      error: { message: "connection refused" },
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest(), paramsFor(MICROGRID_ID));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("connection refused");
+  });
+});

--- a/src/app/api/v1/microgrids/[microgrid_id]/households/route.ts
+++ b/src/app/api/v1/microgrids/[microgrid_id]/households/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  resolveMicrogridOrgId,
+  resolveOrgFromToken,
+} from "@/lib/internal-auth";
+import { createServiceClient } from "@/lib/supabase/service";
+import { HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP } from "@/lib/types/household-columns";
+
+/**
+ * GET /api/v1/microgrids/:microgrid_id/households — discovery endpoint (#257).
+ *
+ * Returns the households on a microgrid the per-org API token can access,
+ * so customerapp can resolve household UUIDs programmatically.
+ *
+ * Response shape:
+ *   200 OK  →  [{ id, display_name, microgrid_id, has_device }, …]
+ *              (empty array if the microgrid has zero households)
+ *   400     →  malformed `:microgrid_id` UUID
+ *   401     →  auth failure (missing / malformed / unknown / revoked token)
+ *   403     →  microgrid exists but belongs to a different org than the
+ *              token; OR `customerapp_enabled = FALSE` for the token's org
+ *              (the latter gated inside `resolveOrgFromToken` per #251).
+ *   404     →  `:microgrid_id` doesn't exist anywhere
+ *
+ * Ordering of the 403-vs-404 distinction is load-bearing: the 404 fires
+ * BEFORE the org-equality check, so a non-existent UUID never reveals
+ * "exists in some other org". `resolveMicrogridOrgId` enforces this by
+ * resolving (or 404-ing) first; the 403 is then a deliberate per-route
+ * comparison against `auth.org_id`. Matches the 2026-04 permission-before-
+ * target-lookup learning and the pattern landed by #254.
+ *
+ * `has_device` is computed in JS from a `household_devices(device_id)`
+ * embed — no `has_device` column exists on `households`. The truthy check
+ * is `row.household_devices && row.household_devices.length > 0`. A future
+ * promotion to a SECURITY DEFINER RPC (`fn_list_microgrid_households`) is
+ * tracked as a follow-up if performance characterization warrants it.
+ *
+ * Explicit column enumeration via `HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP`
+ * — never `select("*")`. Enforced by
+ * `src/lib/__tests__/no-household-star-select-customerapp.test.ts` (scoped
+ * to `src/app/api/v1/` only — operator-side `households` queries are not
+ * restricted).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ microgrid_id: string }> },
+) {
+  const auth = await resolveOrgFromToken(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status });
+  }
+
+  const { microgrid_id } = await params;
+
+  const supabase = createServiceClient();
+
+  // Resolve to 404 BEFORE comparing to the token's org (UUID-enumeration
+  // defense — see comment above).
+  const resolved = await resolveMicrogridOrgId(supabase, microgrid_id);
+  if (!resolved.ok) {
+    return NextResponse.json(
+      { error: resolved.reason },
+      { status: resolved.status },
+    );
+  }
+
+  if (resolved.org_id !== auth.org_id) {
+    return NextResponse.json(
+      { error: "microgrid_not_in_org" },
+      { status: 403 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("households")
+    .select(
+      `${HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP}, household_devices(device_id)`,
+    )
+    .eq("microgrid_id", microgrid_id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const rows = (data ?? []).map((h) => {
+    const hd = (h as { household_devices?: unknown }).household_devices;
+    const has_device = Array.isArray(hd) && hd.length > 0;
+    return {
+      id: (h as { id: string }).id,
+      display_name: (h as { display_name: string }).display_name,
+      microgrid_id: (h as { microgrid_id: string }).microgrid_id,
+      has_device,
+    };
+  });
+
+  return NextResponse.json(rows);
+}

--- a/src/app/api/v1/microgrids/__tests__/route.test.ts
+++ b/src/app/api/v1/microgrids/__tests__/route.test.ts
@@ -1,0 +1,263 @@
+/**
+ * GET /api/v1/microgrids — route tests (#257).
+ *
+ * Coverage (failure-mode AC from the ticket body):
+ *   - Auth fails (missing header / unknown token / revoked) → 401, reason
+ *     surfaces in the error body.
+ *   - customerapp_enabled = FALSE for the token's org → 403 (gated inside
+ *     `resolveOrgFromToken` per #251; this test pins the surfacing).
+ *   - Token's org has 1 microgrid → 200 with array of length 1, shape
+ *     `{ id, name, currency, community_name }`.
+ *   - Token's org has 0 microgrids → 200 with `[]` (NOT 404; the resource
+ *     exists, it's just empty).
+ *   - Token's org has 3 microgrids, another org has 2 → 200 returns only
+ *     the 3 from token's org (the `.eq("communities.org_id", …)` filter
+ *     does the work; this mocks the filtered result the supabase chain
+ *     would have returned).
+ *   - Supabase error → 500 surfaces the message.
+ *
+ * The route mocks `resolveOrgFromToken` + the supabase service client at
+ * the module boundary (same idiom as billing-periods/route.test.ts). Live-DB
+ * row visibility is verified by the higher-level integration suites; here we
+ * pin the route-layer plumbing.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mock controls ──────────────────────────────────────────────────────────
+
+let mockAuthResult: {
+  ok: boolean;
+  org_id?: string;
+  token_id?: string;
+  token_name?: string;
+  status?: number;
+  reason?: string;
+} = {
+  ok: true,
+  org_id: "org-uuid-1",
+  token_id: "token-uuid-1",
+  token_name: "customerapp-prod-2026",
+};
+
+// The `.select(...).eq(...)` chain on the supabase client returns a
+// thenable that resolves to `{ data, error }`. Tests set the resolved
+// value via `mockSelectResult`; the chain mock simply yields it on await.
+let mockSelectResult: {
+  data:
+    | Array<{
+        id: string;
+        name: string;
+        currency: string;
+        community_id?: string;
+        communities: { name: string; org_id: string } | null;
+      }>
+    | null;
+  error: { message: string } | null;
+} = { data: [], error: null };
+
+// Captured at each .from(...) call so tests can assert which table was
+// queried + which filter was applied.
+let lastQuery: {
+  table: string | null;
+  selectArg: string | null;
+  eqArgs: Array<[string, unknown]>;
+} = { table: null, selectArg: null, eqArgs: [] };
+
+vi.mock("@/lib/internal-auth", () => ({
+  resolveOrgFromToken: () => Promise.resolve(mockAuthResult),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (table: string) => {
+      lastQuery.table = table;
+      const builder = {
+        select: (arg: string) => {
+          lastQuery.selectArg = arg;
+          return builder;
+        },
+        eq: (col: string, val: unknown) => {
+          lastQuery.eqArgs.push([col, val]);
+          return builder;
+        },
+        then: (resolve: (v: typeof mockSelectResult) => unknown) =>
+          Promise.resolve(mockSelectResult).then(resolve),
+      };
+      return builder;
+    },
+  }),
+}));
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/v1/microgrids", {
+    method: "GET",
+    headers: { "x-api-key": "stub" },
+  });
+}
+
+describe("GET /api/v1/microgrids (#257)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthResult = {
+      ok: true,
+      org_id: "org-uuid-1",
+      token_id: "token-uuid-1",
+      token_name: "customerapp-prod-2026",
+    };
+    mockSelectResult = { data: [], error: null };
+    lastQuery = { table: null, selectArg: null, eqArgs: [] };
+  });
+
+  it("401 when x-api-key header is missing", async () => {
+    mockAuthResult = { ok: false, status: 401, reason: "missing_header" };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("missing_header");
+  });
+
+  it("401 when token is unknown / revoked", async () => {
+    mockAuthResult = { ok: false, status: 401, reason: "not_found" };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("not_found");
+  });
+
+  it("403 when customerapp_enabled = FALSE for the token's org (#251)", async () => {
+    mockAuthResult = {
+      ok: false,
+      status: 403,
+      reason: "customerapp_not_enabled",
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("customerapp_not_enabled");
+  });
+
+  it("200 with empty array when token's org has 0 microgrids (NOT 404)", async () => {
+    mockSelectResult = { data: [], error: null };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+    // Sanity: the filter was applied to the right org.
+    expect(lastQuery.table).toBe("microgrids");
+    expect(lastQuery.eqArgs).toEqual([["communities.org_id", "org-uuid-1"]]);
+  });
+
+  it("200 with shaped row when token's org has 1 microgrid", async () => {
+    mockSelectResult = {
+      data: [
+        {
+          id: "mg-uuid-1",
+          name: "Kasese Microgrid 1",
+          currency: "UGX",
+          community_id: "comm-uuid-1",
+          communities: { name: "Kasese", org_id: "org-uuid-1" },
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([
+      {
+        id: "mg-uuid-1",
+        name: "Kasese Microgrid 1",
+        currency: "UGX",
+        community_name: "Kasese",
+      },
+    ]);
+  });
+
+  it("200 with multiple rows when token's org has 3 microgrids", async () => {
+    mockSelectResult = {
+      data: [
+        {
+          id: "mg-uuid-1",
+          name: "MG1",
+          currency: "UGX",
+          communities: { name: "Comm1", org_id: "org-uuid-1" },
+        },
+        {
+          id: "mg-uuid-2",
+          name: "MG2",
+          currency: "UGX",
+          communities: { name: "Comm1", org_id: "org-uuid-1" },
+        },
+        {
+          id: "mg-uuid-3",
+          name: "MG3",
+          currency: "USD",
+          communities: { name: "Comm2", org_id: "org-uuid-1" },
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveLength(3);
+    expect(json.map((r: { id: string }) => r.id)).toEqual([
+      "mg-uuid-1",
+      "mg-uuid-2",
+      "mg-uuid-3",
+    ]);
+    // None of the other-org rows leak — because the supabase filter is the
+    // mechanism (here verified by the .eq arg shape).
+    expect(lastQuery.eqArgs).toEqual([["communities.org_id", "org-uuid-1"]]);
+  });
+
+  it("handles PostgREST returning communities as a 1-element array (defensive narrowing)", async () => {
+    // PostgREST sometimes returns the embedded relation as an array even
+    // for !inner; the route narrows both shapes. This pins that branch.
+    mockSelectResult = {
+      data: [
+        {
+          id: "mg-uuid-1",
+          name: "MG1",
+          currency: "UGX",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          communities: [{ name: "Kasese", org_id: "org-uuid-1" }] as any,
+        },
+      ],
+      error: null,
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json[0].community_name).toBe("Kasese");
+  });
+
+  it("uses the customerapp-narrow column list, not select('*')", async () => {
+    mockSelectResult = { data: [], error: null };
+    const { GET } = await import("../route");
+    await GET(makeGetRequest());
+    expect(lastQuery.selectArg).not.toMatch(/\bselect\(['"]\*/);
+    expect(lastQuery.selectArg).toContain("id, name, currency, community_id");
+    expect(lastQuery.selectArg).toContain("communities!inner(name, org_id)");
+  });
+
+  it("500 when supabase errors", async () => {
+    mockSelectResult = {
+      data: null,
+      error: { message: "connection refused" },
+    };
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("connection refused");
+  });
+});

--- a/src/app/api/v1/microgrids/route.ts
+++ b/src/app/api/v1/microgrids/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolveOrgFromToken } from "@/lib/internal-auth";
+import { createServiceClient } from "@/lib/supabase/service";
+import { MICROGRID_PUBLIC_COLUMNS_FOR_CUSTOMERAPP } from "@/lib/types/microgrid-columns";
+
+/**
+ * GET /api/v1/microgrids — discovery endpoint (#257).
+ *
+ * Returns the microgrids visible to the per-org API token, so the
+ * customerapp integration can resolve UUIDs programmatically instead of
+ * hardcoding them. Filtered to the token's org via the
+ * `microgrids → communities → org_id` chain (same chain used by RLS helper
+ * `user_can_access_microgrid`).
+ *
+ * Response shape:
+ *   200 OK  →  [{ id, name, currency, community_name }, …]   (empty array if zero)
+ *   401     →  auth failure (missing / malformed / unknown / revoked token)
+ *   403     →  customerapp_enabled = FALSE for the token's org (gated inside
+ *              `resolveOrgFromToken` per #251 once that helper lands; until
+ *              then the gate is no-op and this branch is unreachable).
+ *
+ * Empty array vs 404: an empty result means the org has zero microgrids,
+ * NOT that the resource is missing — return 200 with `[]`. Reserve 404 for
+ * the per-microgrid endpoint where `:id` doesn't exist.
+ *
+ * Explicit column enumeration via `MICROGRID_PUBLIC_COLUMNS_FOR_CUSTOMERAPP`
+ * — never `select("*")`. New sensitive columns added upstream do NOT leak
+ * across the customerapp boundary unless explicitly added to that constant.
+ * Enforced by `src/lib/__tests__/no-microgrid-star-select.test.ts`.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await resolveOrgFromToken(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status });
+  }
+
+  const supabase = createServiceClient();
+
+  // PostgREST `!inner` filters parent rows by joined-table predicates.
+  // `.eq("communities.org_id", auth.org_id)` resolves against the embedded
+  // relation's column, scoping the result to the token's org.
+  const { data, error } = await supabase
+    .from("microgrids")
+    .select(
+      `${MICROGRID_PUBLIC_COLUMNS_FOR_CUSTOMERAPP}, communities!inner(name, org_id)`,
+    )
+    .eq("communities.org_id", auth.org_id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Shape the embed back into the flat response contract documented above.
+  // `communities` may come back as an object (single inner-join) or an
+  // array depending on PostgREST inference; narrow defensively.
+  const rows = (data ?? []).map((m) => {
+    const communities = (m as { communities: unknown }).communities;
+    const community = Array.isArray(communities)
+      ? (communities[0] as { name: string } | undefined)
+      : (communities as { name: string } | null);
+    return {
+      id: (m as { id: string }).id,
+      name: (m as { name: string }).name,
+      currency: (m as { currency: string }).currency,
+      community_name: community?.name ?? null,
+    };
+  });
+
+  return NextResponse.json(rows);
+}

--- a/src/lib/__tests__/no-household-star-select-customerapp.test.ts
+++ b/src/lib/__tests__/no-household-star-select-customerapp.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression guard for issue #257 — defense-in-depth against `.select('*')`
+ * on the `households` table within the customerapp API boundary.
+ *
+ * The `households` table carries PII fields (`primary_phone`, `primary_email`,
+ * address columns, `account_number`, `meter_serial`) that the operator-side
+ * dashboard is welcome to read but the customerapp boundary must not.
+ * `GET /api/v1/microgrids/:id/households` MUST use
+ * `HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP` (the narrow
+ * "id, display_name, microgrid_id" projection) rather than `select("*")`.
+ *
+ * Mirrors `no-microgrid-star-select.test.ts` (the regression guard from
+ * #106) but with TWO important differences:
+ *   1. Scoped to `src/app/api/v1/` ONLY — the customerapp boundary. Operator-
+ *      side queries on `households` may use `select("*")` if convenient;
+ *      that is a different trust boundary and this test does NOT scan it.
+ *   2. The constant being enforced (`HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP`)
+ *      lives in `src/lib/types/household-columns.ts` and is intentionally
+ *      narrower than any operator-side household column list.
+ *
+ * Cheaper than a custom eslint rule; integrates with the existing Vitest setup.
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+// Scope ONLY to the customerapp API boundary. The operator-side household
+// reads in src/app/(dashboard) / src/components / src/lib are not restricted.
+const ROOTS = [path.join(REPO_ROOT, "src/app/api/v1")];
+
+// Character class on both sides covers single, double, AND backtick quotes.
+// Trailing `\*` (without a closing quote) catches both `select("*")` and the
+// embed form `select("*, household_devices(...)")`.
+const FORBIDDEN = /\.from\(["'`]households["'`]\)[\s\S]{0,200}?\.select\(["'`]\*/;
+
+const ALLOWED_FILES = new Set<string>(); // empty allowlist by design
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "__tests__" || entry === "node_modules") continue;
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walk(full, out);
+    } else if (
+      stat.isFile() &&
+      (full.endsWith(".ts") || full.endsWith(".tsx")) &&
+      // Skip co-located test files — they may reference the forbidden pattern
+      // in mocks, comments, or fixtures.
+      !full.endsWith(".test.ts") &&
+      !full.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("no .select('*') on households within /api/v1/ (issue #257)", () => {
+  it("customerapp route files do not call .from('households').select('*')", () => {
+    const offenders: string[] = [];
+    for (const root of ROOTS) {
+      for (const file of walk(root)) {
+        const rel = path.relative(REPO_ROOT, file);
+        if (ALLOWED_FILES.has(rel)) continue;
+        const text = readFileSync(file, "utf8");
+        if (FORBIDDEN.test(text)) {
+          offenders.push(rel);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `\nFound .from("households").select("*") under src/app/api/v1/:\n  ${offenders.join("\n  ")}\n` +
+        `Use HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP from src/lib/types/household-columns.ts instead.\n` +
+        `See issue #257.`,
+    ).toEqual([]);
+  });
+});

--- a/src/lib/types/household-columns.ts
+++ b/src/lib/types/household-columns.ts
@@ -1,0 +1,28 @@
+// Defense-in-depth: minimum-useful-set subset of household columns surfaced
+// to customerapp via `GET /api/v1/microgrids/:id/households` (#257).
+//
+// The `households` table carries PII fields (`primary_phone`, `primary_email`,
+// address columns, `account_number`, `meter_serial`) that an operator-side
+// dashboard query is welcome to read but the customerapp boundary must not.
+// Per the Architect's "minimum-useful set, not full CRUD" principle for the
+// customerapp API: surface only the entity ID, the human-facing display
+// name, and the microgrid grouping key. Anything else requires an explicit
+// ticket + design review and a separate constant.
+//
+// `microgrid_id` is included so a future feature could let customerapp list
+// multiple microgrids' households in one call without losing the grouping.
+// `has_device` is COMPUTED in JS (not a column) — see the route handler's
+// `household_devices(device_id)` embed.
+//
+// Enforced by `src/lib/__tests__/no-household-star-select-customerapp.test.ts`
+// — scoped to `src/app/api/v1/` only (the customerapp trust boundary).
+// Operator-side `households` queries can `.select("*")` if they need to;
+// the test does NOT scan operator-side code.
+//
+// Declared `as const` (single literal, no concatenation) so that Supabase's
+// PostgREST type machinery can narrow
+// `.select(HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP)` to a precise
+// `Pick<Household, …>` row type — generic `string` would fall through to
+// the error-shape fallback.
+export const HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP =
+  "id, display_name, microgrid_id" as const;

--- a/src/lib/types/microgrid-columns.ts
+++ b/src/lib/types/microgrid-columns.ts
@@ -16,3 +16,20 @@
 // Enforced by `src/lib/__tests__/no-microgrid-star-select.test.ts`.
 export const MICROGRID_PUBLIC_COLUMNS =
   "id, community_id, name, currency, address_line1, address_line2, address_city, address_region, address_country, address_postal_code, lat, lng, created_at, ems_type, ems_backend_url, ems_aws_region, ems_aws_access_key_id, ems_known_edge_ids, ems_last_discover_at, ems_last_discover_count, ems_last_discover_error, ems_last_discover_status" as const;
+
+// Customerapp-boundary subset (#257). The full `MICROGRID_PUBLIC_COLUMNS`
+// above is the operator-side public projection — wide enough to power the
+// dashboard UI (20+ columns). Customerapp only needs to resolve UUIDs and
+// the display name + currency for human-facing context; surfacing the wider
+// set across the per-org token API boundary breaks the "minimum useful set,
+// not full CRUD" principle and creates a future leak risk every time a new
+// sensitive column lands on `microgrids` upstream.
+//
+// Use in `.select(...)` calls on the customerapp-facing `/api/v1/microgrids`
+// endpoint. The two constants intentionally coexist — DO NOT collapse them.
+//
+// Declared `as const` so PostgREST's type machinery can narrow
+// `.select(MICROGRID_PUBLIC_COLUMNS_FOR_CUSTOMERAPP)` to a precise
+// `Pick<Microgrid, …>` row type.
+export const MICROGRID_PUBLIC_COLUMNS_FOR_CUSTOMERAPP =
+  "id, name, currency, community_id" as const;


### PR DESCRIPTION
## Summary

Closes #257. Adds two read-only `GET` endpoints under `/api/v1/` so customerapp can resolve MBE entity IDs programmatically instead of hardcoding them (the brittleness PR #246 exposed). Composed with the auth + scoping layers from #255 / #251 / #254 — purely additive (new route files + 1 new constants file + 1 added constant in an existing file + new regression-guard test).

- `GET /api/v1/microgrids` → `[{ id, name, currency, community_name }]`, filtered to the token's org via the `microgrids → communities → org_id` chain.
- `GET /api/v1/microgrids/:microgrid_id/households` → `[{ id, display_name, microgrid_id, has_device }]`. `has_device` is computed in JS from a `household_devices(device_id)` PostgREST embed (no schema column needed). 404-before-403 ordering on `resolveMicrogridOrgId` so a non-existent UUID never reveals "exists in some other org".

## Notes for reviewers

- **Minimum-useful-set principle** — two NEW narrow column constants, DO NOT collapse with the operator-side `MICROGRID_PUBLIC_COLUMNS`:
  - `MICROGRID_PUBLIC_COLUMNS_FOR_CUSTOMERAPP = "id, name, currency, community_id"` (4 fields)
  - `HOUSEHOLD_PUBLIC_COLUMNS_FOR_CUSTOMERAPP = "id, display_name, microgrid_id"` (3 fields, in new file `src/lib/types/household-columns.ts`)
  - New sensitive columns added to `microgrids` / `households` upstream do NOT leak across the customerapp boundary unless explicitly added to these constants.
- **New regression-guard test** `src/lib/__tests__/no-household-star-select-customerapp.test.ts` mirrors the #106 pattern from `no-microgrid-star-select.test.ts` but is **scoped to `src/app/api/v1/` only** — operator-side `households` queries (which read PII columns by design) are not restricted. Verified both star-select guards catch a planted `select("*")` regression.
- **Entity IDs in every response row** — by design (umbrella #249 contract).
- **Empty-array vs 404** — empty collection result returns `200 OK []` (resource exists, just empty). 404 is reserved for `:microgrid_id` not found.
- **Customerapp acceptance gate** — `customerapp_enabled = FALSE` check is layered inside `resolveOrgFromToken` per #251. Until #251 lands, that's a no-op TODO; the route tests pin the 403 surfacing so the wire-up works the moment #251 ships.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (no new errors; pre-existing warnings only)
- [x] `npm run build` succeeds; new routes `/api/v1/microgrids` and `/api/v1/microgrids/[microgrid_id]/households` listed in Next.js route manifest
- [x] Full vitest suite green: 146 files / 1688 tests pass (8 RLS/DEK suites skipped per `SKIP_RLS_TESTS=1` / `SKIP_DEK_BOOTSTRAP_TEST=1`)
- [x] Two new route test files: 9 + 13 = 22 unit tests cover full AC matrix (401 missing/unknown/revoked, 403 customerapp_not_enabled / wrong-org, 400 malformed UUID, 404 non-existent microgrid, 200+`[]` for zero results, `has_device` truthy/empty/missing/multi-row shaping)
- [x] New `no-household-star-select-customerapp.test.ts` passes; verified it catches a planted `.from("households").select("*")` violation
- [x] Existing `no-microgrid-star-select.test.ts` still passes; verified it catches a planted violation
- [ ] Reviewer: confirm column constants list is the minimum needed (architectural lens — does customerapp need any additional fields?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)