### PR TITLE
feat(api): add organizations.customerapp_enabled opt-in flag + enforce in resolveOrgFromToken (#251)

### DIFF
--- a/docs/customerapp-activation.md
+++ b/docs/customerapp-activation.md
@@ -138,4 +138,4 @@ That returns `401 not_found` on next use — separate from the
   gate; either all of an org's microgrids accept customerapp pushes or
   none of them do.
 - **Default is `FALSE`.** Every new org added to the system is opted out
-  by default. The 00043 migration sets the default at the schema level.
+  by default. The 00044 migration sets the default at the schema level.

--- a/docs/customerapp-activation.md
+++ b/docs/customerapp-activation.md
@@ -1,0 +1,141 @@
+# Customerapp activation runbook
+
+Operator-facing steps for enabling the customerapp (`/api/v1/*`) integration
+for a specific org. Required reading before flipping `customerapp_enabled =
+TRUE` against any production org.
+
+## What gets activated
+
+When an org has `organizations.customerapp_enabled = TRUE` AND a valid
+per-org API token (#255), the customerapp can call:
+
+- `POST /api/v1/billing-periods` — create a new draft billing period.
+- `POST /api/v1/billing/generate` — generate line items from manual readings.
+- (#257) `GET /api/v1/billing-periods` and related read endpoints.
+
+Without the flag set, every `/api/v1/*` call returns `403
+customerapp_not_enabled` regardless of how valid the token is.
+
+## Trust model (4-layer composition, #249)
+
+| Layer | Question it answers | Mechanism |
+|---|---|---|
+| Authentication (#255) | "You are customerapp acting as org X" | Per-org API token (argon2id-hashed). |
+| **Acceptance** (#251) | **"Org X has opted to accept customerapp pushes"** | **`organizations.customerapp_enabled` flag (this doc).** |
+| Authorization (#254) | "Payload microgrid_id ∈ token's org" | Per-request cross-check inside route handlers. |
+| Attribution (#250) | "Who acted, on whose behalf" | `actor_kind = 'customerapp'`, `actor_ref = <token name>` written into audit log. |
+
+`customerapp_enabled` is enforced once, inside `resolveOrgFromToken`
+(`src/lib/internal-auth.ts`), AFTER token validation succeeds. A new
+`/api/v1/*` route gets the gate for free by calling `resolveOrgFromToken`;
+nothing else is needed.
+
+## Activation steps
+
+### 1. Confirm the org is ready
+
+- The org has at least one community + microgrid configured.
+- The org has a rate schedule set up for the microgrid(s) the
+  customerapp will push readings for.
+- An org admin has been identified to manage tokens via the #256 UI
+  (or, pre-#256, a super_admin will mint the token via SQL).
+
+### 2. Flip the flag
+
+`super_admin` only (RLS on `organizations` blocks `org_manager` writes
+to this column):
+
+```sql
+UPDATE organizations
+SET customerapp_enabled = TRUE
+WHERE id = '<org-uuid>';
+```
+
+Or via the future MBE UI (super_admin org page → "Enable customerapp
+integration" toggle — not yet wired as of #251).
+
+### 3. Mint a per-org token (#255 / #256)
+
+Until #256 ships the UI, mint via SQL (super_admin):
+
+```sql
+-- Use the JS helper for generation; this is illustrative:
+-- import { generateToken } from "@/lib/internal-auth";
+-- const t = generateToken("prod");
+-- const hash = await t.hashPromise;
+
+INSERT INTO org_api_tokens (org_id, name, token_lookup, token_hash, env_prefix, created_by)
+VALUES (
+  '<org-uuid>',
+  'customerapp-prod-2026',  -- shows up in audit log as actor_ref
+  '<8-hex-lookup>',
+  '<argon2id-hash>',
+  'prod',
+  '<super-admin-user-id>'
+);
+```
+
+Return the plaintext (`mbe_prod_<lookup>_<secret>`, 61 chars) to the
+operator **once** — the secret is not recoverable from the DB.
+
+### 4. Wire the token into customerapp's config
+
+Customerapp reads its MBE token from its own deployment env. Update the
+secret and roll the deployment.
+
+### 5. Smoke-test
+
+From customerapp's environment:
+
+```bash
+curl -sS -X POST https://mbe.example.com/api/v1/billing-periods \
+  -H "x-api-key: $MBE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"microgrid_id":"<microgrid-uuid>","start_date":"2026-05-01","end_date":"2026-05-31"}'
+```
+
+Expected:
+- `201` with `{"id":"..."}` — activation succeeded.
+- `403 customerapp_not_enabled` — flag is still `FALSE`; re-run step 2.
+- `401 missing_header` / `invalid_format` / `not_found` — token wiring
+  is wrong; re-check step 3 / 4.
+
+## Kill-switching a misbehaving org
+
+If customerapp starts misbehaving against a single org (e.g. pushing
+clearly-wrong readings), you can disable just that org without revoking
+the token or interrupting any other org:
+
+```sql
+UPDATE organizations
+SET customerapp_enabled = FALSE
+WHERE id = '<org-uuid>';
+```
+
+Effect: the next `/api/v1/*` call from any customerapp instance using a
+token scoped to that org returns `403 customerapp_not_enabled`. The token
+itself stays valid (and `last_used_at` stays where it was — denials don't
+update the timestamp). To re-enable, flip back to `TRUE`.
+
+If the problem is the token itself (leaked, compromised), revoke at the
+token layer (#256 UI or SQL):
+
+```sql
+UPDATE org_api_tokens
+SET revoked_at = now()
+WHERE id = '<token-uuid>';
+```
+
+That returns `401 not_found` on next use — separate from the
+`customerapp_enabled` gate.
+
+## Operational caveats
+
+- **No caching.** Every `/api/v1/*` request re-evaluates the flag, so a
+  flip from `TRUE` to `FALSE` takes effect on the next call (no propagation
+  delay).
+- **Flag applies org-wide.** There is no per-microgrid or per-community
+  gate; either all of an org's microgrids accept customerapp pushes or
+  none of them do.
+- **Default is `FALSE`.** Every new org added to the system is opted out
+  by default. The 00043 migration sets the default at the schema level.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -171,6 +171,26 @@ supabase stop           # Stop all local Supabase containers
 supabase start          # Restart containers
 ```
 
+## Per-org customerapp activation (`/api/v1/*`)
+
+The customerapp integration (`/api/v1/*` routes) is gated per-org by
+`organizations.customerapp_enabled` (#251). The column defaults to `FALSE`
+on every org — a valid per-org API token (#255) is necessary but not
+sufficient. An org must be explicitly opted in before any `/api/v1/*` call
+against it succeeds; otherwise the call returns `403 customerapp_not_enabled`.
+
+Flip the flag (super_admin only — enforced by RLS on `organizations`):
+
+```sql
+UPDATE organizations
+SET customerapp_enabled = TRUE
+WHERE id = '<org-uuid>';
+```
+
+To kill-switch a misbehaving org without revoking the token, flip it back
+to `FALSE`. See `docs/customerapp-activation.md` for the full activation
+runbook.
+
 ## RLS Tests (local Supabase only)
 
 The RLS test suite (`src/lib/supabase/__tests__/rls.test.ts`) verifies that Row Level Security

--- a/src/lib/internal-auth.ts
+++ b/src/lib/internal-auth.ts
@@ -43,10 +43,10 @@ import { createServiceClient } from "@/lib/supabase/service";
  *      revoked. In practice the WHERE revoked_at IS NULL in step 3 catches
  *      this, but the check inside the verify branch covers the racy
  *      hard-cutover-regenerate window.
- *   6. TODO (#251): check customerapp_enabled_for_org(row.org_id) — if
- *      false, 403 customerapp_not_enabled. The DB helper does not exist
- *      at #255's dispatch time; the check is plumbed-but-no-op here and
- *      activates in a follow-up commit once #251 lands.
+ *   6. (#251) Acceptance gate — call customerapp_enabled_for_org(row.org_id);
+ *      if not TRUE, return 403 customerapp_not_enabled. A valid token alone
+ *      is not enough — the org has to have opted in. Single enforcement site
+ *      so a new route can't accidentally bypass.
  *   7. Update last_used_at = now() — fire-and-forget; do not await. Tiny
  *      per-request cost; UPDATE failure is benign (we lose a tick).
  *   8. Return { ok: true, org_id, token_id, token_name }.
@@ -159,19 +159,25 @@ export async function resolveOrgFromToken(
     return { ok: false, status: 401, reason: "revoked" };
   }
 
-  // TODO (#251): once `customerapp_enabled_for_org(_org_id UUID)` lands
-  // as a DB helper, gate auth here:
+  // #251 — Acceptance gate. A valid token proves the credential layer;
+  // the org also has to be opted into the customerapp integration before
+  // any `/api/v1/*` call lands. Enforcement lives here (single site) so
+  // a new route can't accidentally skip it.
   //
-  //   const { data: enabled } = await supabase.rpc(
-  //     "customerapp_enabled_for_org",
-  //     { _org_id: row.org_id }
-  //   );
-  //   if (!enabled) {
-  //     return { ok: false, status: 403, reason: "customerapp_not_enabled" };
-  //   }
-  //
-  // #251 was not on main at #255 dispatch time; the gate activates in a
-  // follow-up commit when #251 ships.
+  // `customerapp_enabled_for_org(_org_id)` returns:
+  //   * TRUE  → org has opted in; proceed.
+  //   * FALSE → org has not opted in; 403 customerapp_not_enabled.
+  //   * NULL  → org row missing (shouldn't happen given the FK on
+  //             org_api_tokens.org_id, but treat as not-enabled).
+  // The RPC `error` branch is treated as not-enabled too — we'd rather
+  // fail closed than open if the gate query itself errors.
+  const { data: enabled, error: enabledErr } = await supabase.rpc(
+    "customerapp_enabled_for_org",
+    { _org_id: row.org_id }
+  );
+  if (enabledErr || enabled !== true) {
+    return { ok: false, status: 403, reason: "customerapp_not_enabled" };
+  }
 
   // Fire-and-forget last_used_at update. Failure is benign (we lose a
   // tick); never block the request critical path on this.

--- a/src/lib/supabase/__tests__/customerapp_enabled.test.ts
+++ b/src/lib/supabase/__tests__/customerapp_enabled.test.ts
@@ -1,0 +1,320 @@
+/**
+ * customerapp_enabled.test.ts (#251)
+ *
+ * Per-org acceptance gate inside `resolveOrgFromToken`. After a token has
+ * been successfully validated (lookup row + argon2 verify), the resolver
+ * calls `customerapp_enabled_for_org(org_id)`; if the flag is FALSE the
+ * caller sees a 403 with `reason: "customerapp_not_enabled"` — regardless
+ * of how valid the token itself was.
+ *
+ * Failure-mode AC matrix (from #251 ticket body):
+ *
+ *   - Enabled org + valid token             → ok (no regression vs #255).
+ *   - Disabled org + valid token            → 403 customerapp_not_enabled.
+ *   - All-orgs-disabled default state       → 403 for every token (covered
+ *                                              by the rpc-returns-FALSE case,
+ *                                              since that's the DB default).
+ *   - RPC error (network / DB hiccup)       → fail closed → 403 (don't open
+ *                                              the gate on its own failure).
+ *   - Flag flipped TRUE→FALSE mid-flight    → next request 403s (a new
+ *                                              call always re-reads the flag;
+ *                                              no caching).
+ *   - Gate fires AFTER token validation     → an invalid token still 401s
+ *                                              (not 403); we don't expose
+ *                                              opt-in state to unauthed callers.
+ *   - Gate calls the RPC with the org_id    → resolved from the token's row,
+ *                                              not from any caller-supplied
+ *                                              payload field.
+ *
+ * Architecture notes:
+ *   - Tests run REAL argon2 (no mock) — matches the org_api_tokens.test.ts
+ *     pattern. The whole suite stays under ~1s on Vercel-class hardware.
+ *   - The Supabase service-role client is mocked at the module boundary
+ *     with both `from(...)` (for the token lookup) AND `rpc(...)` (for
+ *     the opt-in check). Tests control both via closure-captured state.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import argon2 from "argon2";
+
+// ── Mock controls ──────────────────────────────────────────────────────────
+
+type LookupRow = {
+  id: string;
+  org_id: string;
+  name: string;
+  token_hash: string;
+  revoked_at: string | null;
+};
+
+let lookupResult: { data: LookupRow | null; error: { message: string } | null } = {
+  data: null,
+  error: null,
+};
+// Captures all updates so a fire-and-forget last_used_at write doesn't
+// leak across tests.
+let updatesByTable: Record<
+  string,
+  Array<{ payload: Record<string, unknown>; eqArgs?: [string, unknown] }>
+> = {};
+let updateError: { message: string; code?: string } | null = null;
+// #251 — the acceptance-gate RPC stub. Default to opted-in so we have to
+// flip it explicitly in the rejection-path tests below.
+let customerappEnabledResult: {
+  data: boolean | null;
+  error: { message: string } | null;
+} = { data: true, error: null };
+// Captures the most-recent RPC invocation so tests can assert the gate
+// was called with the resolved org_id, not some other UUID.
+let lastRpcCall: { fn: string; args: Record<string, unknown> } | null = null;
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => ({
+          is: () => ({
+            maybeSingle: () => Promise.resolve(lookupResult),
+          }),
+        }),
+      }),
+      update: (payload: Record<string, unknown>) => ({
+        eq: (column: string, value: unknown) => {
+          if (!updatesByTable[table]) updatesByTable[table] = [];
+          updatesByTable[table].push({ payload, eqArgs: [column, value] });
+          return {
+            then: (
+              resolve: (v: { error: { message: string; code?: string } | null }) => void
+            ) => {
+              resolve({ error: updateError });
+              return Promise.resolve({ error: updateError });
+            },
+          };
+        },
+      }),
+    }),
+    rpc: (fn: string, args: Record<string, unknown>) => {
+      lastRpcCall = { fn, args };
+      return Promise.resolve(customerappEnabledResult);
+    },
+  }),
+}));
+
+function makeRequest(headers: Record<string, string>): NextRequest {
+  return new NextRequest("http://localhost/api/v1/billing-periods", {
+    method: "POST",
+    headers,
+  });
+}
+
+// Real argon2 hash — generated once, reused across tests.
+let KNOWN_SECRET: string;
+let KNOWN_HASH: string;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  lookupResult = { data: null, error: null };
+  updatesByTable = {};
+  updateError = null;
+  customerappEnabledResult = { data: true, error: null };
+  lastRpcCall = null;
+  if (!KNOWN_HASH) {
+    KNOWN_SECRET = "abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE";
+    KNOWN_HASH = await argon2.hash(KNOWN_SECRET, {
+      type: argon2.argon2id,
+      memoryCost: 19_456,
+      timeCost: 2,
+      parallelism: 1,
+    });
+  }
+});
+
+afterAll(() => {
+  delete process.env.MBE_TOKEN_ENV_PREFIX;
+});
+
+/** Convenience: stub a successful lookup so we can focus on the gate. */
+function stubValidLookup(orgId = "org-uuid-1") {
+  lookupResult = {
+    data: {
+      id: "token-uuid-1",
+      org_id: orgId,
+      name: "customerapp-prod-2026",
+      token_hash: KNOWN_HASH,
+      revoked_at: null,
+    },
+    error: null,
+  };
+}
+
+describe("customerapp_enabled acceptance gate (#251)", () => {
+  it("enabled org + valid token → ok", async () => {
+    stubValidLookup("org-uuid-enabled");
+    customerappEnabledResult = { data: true, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(true);
+    expect(res).toMatchObject({
+      ok: true,
+      org_id: "org-uuid-enabled",
+      token_name: "customerapp-prod-2026",
+    });
+  });
+
+  it("disabled org + valid token → 403 customerapp_not_enabled", async () => {
+    stubValidLookup("org-uuid-disabled");
+    customerappEnabledResult = { data: false, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 403, reason: "customerapp_not_enabled" });
+  });
+
+  it("gate is called with the resolved org_id from the token row (not from any payload)", async () => {
+    stubValidLookup("org-uuid-payload-cannot-influence-this");
+    customerappEnabledResult = { data: true, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(lastRpcCall).not.toBeNull();
+    expect(lastRpcCall!.fn).toBe("customerapp_enabled_for_org");
+    expect(lastRpcCall!.args).toEqual({
+      _org_id: "org-uuid-payload-cannot-influence-this",
+    });
+  });
+
+  it("RPC error → fail closed → 403 customerapp_not_enabled (do NOT open the gate on its own failure)", async () => {
+    stubValidLookup("org-uuid-1");
+    customerappEnabledResult = {
+      data: null,
+      error: { message: "PostgREST: unable to reach DB" },
+    };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 403, reason: "customerapp_not_enabled" });
+  });
+
+  it("RPC returns NULL (org row missing) → fail closed → 403", async () => {
+    // Shouldn't happen given the FK on org_api_tokens.org_id, but pin
+    // the defensive behavior anyway: only the literal boolean TRUE opens
+    // the gate. NULL / undefined / anything-else closes it.
+    stubValidLookup("org-uuid-1");
+    customerappEnabledResult = { data: null, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 403, reason: "customerapp_not_enabled" });
+  });
+
+  it("flag flipped TRUE → FALSE mid-flight: next request 403s (no caching across calls)", async () => {
+    stubValidLookup("org-uuid-flip");
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+
+    // Call 1: flag TRUE → ok.
+    customerappEnabledResult = { data: true, error: null };
+    const res1 = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res1.ok).toBe(true);
+
+    // Operator flips it FALSE (super_admin via SQL or future MBE UI).
+    customerappEnabledResult = { data: false, error: null };
+
+    // Call 2: same token, same org, but now the gate is closed.
+    const res2 = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+    expect(res2.ok).toBe(false);
+    expect(res2).toMatchObject({ status: 403, reason: "customerapp_not_enabled" });
+  });
+
+  it("invalid token: 401 not_found wins over 403 (gate doesn't fire if auth fails)", async () => {
+    // Lookup returns null (e.g. wrong env-prefix token sent to prod).
+    // Gate must NOT be queried — exposing customerapp_enabled state to
+    // unauthenticated callers would be a small but real info leak.
+    lookupResult = { data: null, error: null };
+    customerappEnabledResult = { data: false, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "not_found" });
+    // Gate was not called.
+    expect(lastRpcCall).toBeNull();
+  });
+
+  it("argon2-verify failure: 401 not_found wins over 403 (gate doesn't fire on wrong-secret)", async () => {
+    // Lookup row exists, but the secret in the header doesn't match
+    // the stored hash. Same reasoning as the prior test: don't reveal
+    // opt-in state to a caller who can't even prove the credential.
+    stubValidLookup("org-uuid-1");
+    customerappEnabledResult = { data: false, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const wrongSecret = "WRONGwrongWRONGwrongWRONGwrongWRONGwrong123";
+    const token = `mbe_dev_12345678_${wrongSecret}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "not_found" });
+    expect(lastRpcCall).toBeNull();
+  });
+
+  it("revoked token: 401 revoked wins over 403 (gate doesn't fire on revoked token)", async () => {
+    // Post-verify race-window check (#255 design): row was already
+    // revoked_at-set at SELECT time (or in the race window after).
+    // The gate must not fire — revoked is upstream of acceptance.
+    lookupResult = {
+      data: {
+        id: "token-uuid-1",
+        org_id: "org-uuid-1",
+        name: "test-token",
+        token_hash: KNOWN_HASH,
+        revoked_at: "2026-05-26T12:00:00Z",
+      },
+      error: null,
+    };
+    customerappEnabledResult = { data: false, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    const res = await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ status: 401, reason: "revoked" });
+    expect(lastRpcCall).toBeNull();
+  });
+
+  it("denied-by-gate: last_used_at is NOT updated (we don't leak that a token+secret pair is valid)", async () => {
+    // Defensive: if the gate rejects, don't help an attacker confirm
+    // they've got a working credential by leaving a timestamp trail.
+    stubValidLookup("org-uuid-1");
+    customerappEnabledResult = { data: false, error: null };
+
+    const { resolveOrgFromToken } = await import("@/lib/internal-auth");
+    const token = `mbe_dev_12345678_${KNOWN_SECRET}`;
+    await resolveOrgFromToken(makeRequest({ "x-api-key": token }));
+
+    // Flush microtasks just in case some stray fire-and-forget update
+    // tried to schedule.
+    await new Promise((r) => setImmediate(r));
+
+    expect(updatesByTable["org_api_tokens"]).toBeUndefined();
+  });
+});

--- a/src/lib/supabase/__tests__/org_api_tokens.test.ts
+++ b/src/lib/supabase/__tests__/org_api_tokens.test.ts
@@ -60,6 +60,15 @@ let updatesByTable: Record<
   Array<{ payload: Record<string, unknown>; eqArgs?: [string, unknown] }>
 > = {};
 let updateError: { message: string; code?: string } | null = null;
+// #251 — Acceptance-gate RPC stub. Tests set this to control whether the
+// per-org opt-in check (`customerapp_enabled_for_org`) returns TRUE / FALSE
+// or an error. Default TRUE so the existing #255 tests still exercise the
+// success path; #251-specific tests in customerapp_enabled.test.ts flip it
+// to FALSE / error to cover the gate rejection branch.
+let customerappEnabledResult: {
+  data: boolean | null;
+  error: { message: string } | null;
+} = { data: true, error: null };
 
 vi.mock("@/lib/supabase/service", () => ({
   createServiceClient: () => ({
@@ -90,6 +99,11 @@ vi.mock("@/lib/supabase/service", () => ({
         },
       }),
     }),
+    // #251 — RPC stub for customerapp_enabled_for_org. Defaults to TRUE
+    // so the existing #255 tests still exercise the success path; the
+    // dedicated customerapp_enabled.test.ts flips it to cover the gate.
+    rpc: (_fn: string, _args: Record<string, unknown>) =>
+      Promise.resolve(customerappEnabledResult),
   }),
 }));
 
@@ -111,6 +125,8 @@ beforeEach(async () => {
   lookupResult = { data: null, error: null };
   updatesByTable = {};
   updateError = null;
+  // #251 — default to opted-in so the #255 success-path tests still pass.
+  customerappEnabledResult = { data: true, error: null };
   if (!KNOWN_HASH) {
     // 43-char base64url string — matches the secret format from generateToken.
     KNOWN_SECRET = "abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE";

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -768,6 +768,7 @@ export type Database = {
           address_postal_code: string | null
           address_region: string | null
           created_at: string
+          customerapp_enabled: boolean
           id: string
           name: string
         }
@@ -779,6 +780,7 @@ export type Database = {
           address_postal_code?: string | null
           address_region?: string | null
           created_at?: string
+          customerapp_enabled?: boolean
           id?: string
           name: string
         }
@@ -790,6 +792,7 @@ export type Database = {
           address_postal_code?: string | null
           address_region?: string | null
           created_at?: string
+          customerapp_enabled?: boolean
           id?: string
           name?: string
         }
@@ -1034,6 +1037,10 @@ export type Database = {
       }
     }
     Functions: {
+      customerapp_enabled_for_org: {
+        Args: { _org_id: string }
+        Returns: boolean
+      }
       fn_apply_payment_event: {
         Args: {
           _actor_kind?: string

--- a/supabase/migrations/00043_organizations_customerapp_enabled.sql
+++ b/supabase/migrations/00043_organizations_customerapp_enabled.sql
@@ -1,0 +1,63 @@
+-- 00043_organizations_customerapp_enabled.sql
+-- #251 — Per-org acceptance gate for customerapp (`/api/v1/*`) calls.
+--
+-- ── Why ───────────────────────────────────────────────────────────────────
+--
+-- This is the **Acceptance** layer of the 4-layer trust composition for the
+-- customerapp integration (#249):
+--
+--   * Authentication (#255 per-org token)   — "You are customerapp acting as org X."
+--   * Acceptance      (THIS migration)      — "Org X has opted to accept customerapp pushes."
+--   * Authorization  (#254 microgrid_id)    — "Payload microgrid_id ∈ token's org."
+--   * Attribution    (#250 actor_kind/ref)  — "Who acted, on whose behalf."
+--
+-- A valid token alone is not enough — the org has to have opted in. This
+-- gives PM a per-org rollout control AND a kill switch independent of the
+-- credential layer. Every org defaults to FALSE — Aaron's org must be
+-- explicitly flipped TRUE before customerapp can call any `/api/v1/*` route
+-- against it.
+--
+-- Enforcement lives inside `resolveOrgFromToken` (src/lib/internal-auth.ts);
+-- routes don't reimplement the check, so the gate cannot be bypassed by
+-- forgetting it in a new endpoint.
+--
+-- ── Column add ────────────────────────────────────────────────────────────
+
+ALTER TABLE organizations
+  ADD COLUMN customerapp_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN organizations.customerapp_enabled IS
+  'Per-org opt-in for the customerapp /api/v1/* integration (#251). FALSE by default — must be flipped TRUE by a super_admin (via SQL or future MBE UI) at activation time. Acts as the per-org kill switch independent of the per-org token (#255).';
+
+-- ── Helper function ───────────────────────────────────────────────────────
+--
+-- Mirrors the existing RLS-helper pattern (`is_super_admin()`,
+-- `user_can_access_org()`, `user_can_access_microgrid()` in 00002_rls.sql):
+-- SECURITY DEFINER + STABLE + pinned search_path. Owner is `postgres`
+-- (the default for migration-applied functions), which is what the
+-- existing helpers rely on for RLS bypass when reading `user_roles`.
+--
+-- Returns NULL only if the org doesn't exist (FK on tokens prevents this
+-- in practice, but the caller treats NULL as "not enabled" via the
+-- truthiness check in `resolveOrgFromToken`).
+
+CREATE OR REPLACE FUNCTION customerapp_enabled_for_org(_org_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT customerapp_enabled FROM organizations WHERE id = _org_id;
+$$;
+
+COMMENT ON FUNCTION customerapp_enabled_for_org(UUID) IS
+  '#251 — returns organizations.customerapp_enabled for the given org_id, or NULL if the org does not exist. Called from resolveOrgFromToken (src/lib/internal-auth.ts) after token validation to enforce the per-org acceptance gate. SECURITY DEFINER so the service-role auth path can resolve it without depending on the caller`s RLS context.';
+
+-- Lock down EXECUTE: the helper exposes a row-presence signal on
+-- `organizations`, so don't expose it to anon. service_role bypasses
+-- grants by design; authenticated is allowed so the future MBE UI for
+-- toggling the flag (super_admin only — enforced by RLS on organizations)
+-- can call it to render current state.
+REVOKE EXECUTE ON FUNCTION customerapp_enabled_for_org(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION customerapp_enabled_for_org(UUID) TO authenticated, service_role;

--- a/supabase/migrations/00044_organizations_customerapp_enabled.sql
+++ b/supabase/migrations/00044_organizations_customerapp_enabled.sql
@@ -1,4 +1,4 @@
--- 00043_organizations_customerapp_enabled.sql
+-- 00044_organizations_customerapp_enabled.sql
 -- #251 — Per-org acceptance gate for customerapp (`/api/v1/*`) calls.
 --
 -- ── Why ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the **Acceptance** layer of the 4-layer trust composition for the customerapp `/api/v1/*` integration (#249). A valid per-org token (#255) is no longer sufficient — the org must also explicitly opt in by flipping `organizations.customerapp_enabled` to `TRUE`. Defaults to `FALSE` so every org is opted out at activation time.

- **Migration `00043_organizations_customerapp_enabled.sql`** — adds the `BOOLEAN NOT NULL DEFAULT FALSE` column plus a `customerapp_enabled_for_org(_org_id UUID)` `SECURITY DEFINER STABLE` helper (`search_path = public, pg_temp`), matching the existing `is_super_admin` / `user_can_access_*` pattern from `00002_rls.sql`. `EXECUTE` revoked from `PUBLIC`, granted to `authenticated` + `service_role`.
- **Single enforcement site** — `resolveOrgFromToken` in `src/lib/internal-auth.ts`. After token validation succeeds, the helper calls `supabase.rpc("customerapp_enabled_for_org", { _org_id })`; if it returns anything other than literal `TRUE`, the call resolves to `{ ok: false, status: 403, reason: "customerapp_not_enabled" }`. Fail-closed on RPC error or `NULL` return. New `/api/v1/*` routes get the gate for free.
- **Gate fires AFTER token verify** so an invalid token still 401s (opt-in state is never exposed to unauthenticated callers).
- **Docs** — `docs/setup.md` gains a "Per-org customerapp activation" section; `docs/customerapp-activation.md` is the full operator runbook (activation steps, kill-switch, trust-model recap, smoke-test curl).

Closes #251.

## Test plan

- [x] `npx supabase db reset` — migration applies cleanly against local Supabase (notice: `00043_organizations_customerapp_enabled.sql`).
- [x] `npm run db:types` — regenerates cleanly; `customerapp_enabled` lands on the `organizations` Row/Insert/Update + `customerapp_enabled_for_org` in `Functions`.
- [x] `npm run db:types:check` — passes (verified against post-reset local DB to avoid cross-worktree drift).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors (21 warnings, all pre-existing `_unused` patterns in tests).
- [x] `SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1 npm test` — 1675 passed, 61 skipped (intentional RLS/DEK skips).
- [x] New file `src/lib/supabase/__tests__/customerapp_enabled.test.ts` (10 tests) — covers the full AC matrix:
  - enabled org + valid token → ok
  - disabled org + valid token → 403 `customerapp_not_enabled`
  - gate called with token-row org_id (not payload-supplied)
  - RPC error → fail closed → 403
  - RPC returns `NULL` → fail closed → 403
  - mid-flight flip `TRUE` → `FALSE` → next request 403s (no caching)
  - invalid token: 401 `not_found` wins over 403 (gate not called)
  - argon2-verify failure: 401 wins over 403 (gate not called)
  - revoked token: 401 `revoked` wins over 403 (gate not called)
  - denied-by-gate: `last_used_at` NOT updated (don't leak credential validity)
- [x] `src/lib/supabase/__tests__/org_api_tokens.test.ts` — extended mock to stub the new `rpc` call (defaults to `TRUE` so #255 success-path tests still pass).
- [x] `npm run build` — succeeds (preview deploy will verify on PR).

## Notes for reviewers

- **`resolveOrgFromToken` control flow** — the `customerapp_enabled` check sits between the post-verify revoked-race check and the fire-and-forget `last_used_at` update. The order matters: gate doesn't fire on auth-failure paths (so we don't leak opt-in state) AND `last_used_at` isn't updated when the gate rejects (so we don't leak credential validity via timestamp delta).
- **The `customerapp_not_enabled` reason was already in `TokenAuthFailReason`** since #255 — that PR shipped the placeholder TODO that this PR replaces with the real implementation.
- **Fail-closed semantics** — `enabledErr || enabled !== true` rejects on any non-`true` return (NULL, undefined, false, error). The DB function returns `NULL` only when the org row doesn't exist; that shouldn't happen given the FK on `org_api_tokens.org_id`, but the defensive branch is covered by a dedicated test.
- **Parallel-PR mutual awareness with #252** — #252 (401 structured logging on `/api/v1/*` rejections) also touches `src/lib/internal-auth.ts`, specifically the rejection branches of `resolveOrgFromToken`. Non-overlapping changes, but same file. Recommended landing order: **this PR first, then #252 rebases mechanically** — #252's logging will then hook the new `customerapp_not_enabled` rejection branch as well.
- **Activation path** — Aaron's org is NOT enabled by default. To activate (post-merge): super_admin runs `UPDATE organizations SET customerapp_enabled = TRUE WHERE id = '<org-uuid>';`. The runbook in `docs/customerapp-activation.md` documents the full flow including kill-switch and smoke-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)