### PR TITLE
fix(middleware): add /api/v1/ to PUBLIC_PATHS — customerapp routes were unreachable behind session check (hotfix)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,12 +14,26 @@ import { NextResponse, type NextRequest } from "next/server";
 // applied downstream by the legacy /api/billing-line-items/<id>/pay route).
 // Trailing slash is intentional — avoids prefix-matching any future top-
 // level `/page` or `/profile` route.
+//
+// `/api/v1/` is the customerapp internal-API surface (#249 umbrella, Wave
+// A-D). Per-org token auth via `resolveOrgFromToken` in
+// `@/lib/internal-auth` is the authoritative auth boundary for these
+// routes — customerapp sends an `x-api-key` header, not a cookie session,
+// so `supabase.auth.getUser()` here would always return null and the
+// middleware would 401 every request before the route handler can run.
+// Each route handler calls `resolveOrgFromToken` first thing and rejects
+// with structured 401/403 codes (`missing_header`, `invalid_format`,
+// `not_found`, `revoked`, `customerapp_not_enabled`) that are deliberately
+// distinct from this middleware's "Authentication required" string.
+// Trailing slash is intentional (same reason as `/p/`).
+// Discovered 2026-05-27 during Wave A-D activation smoke test.
 const PUBLIC_PATHS = [
   "/login",
   "/accept-invite",
   "/forgot-password",
   "/reset-password",
   "/p/",
+  "/api/v1/",
 ];
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary

Hotfix discovered during Wave A-D activation smoke test (Zulip `mbe-internal > MBE APIs` msg 597990653 → 597990884): every `/api/v1/*` request returned `HTTP 401 {"error":"Authentication required"}` from `src/middleware.ts` **before** the route handler could run.

`PUBLIC_PATHS` did not include `/api/v1/`, so the Supabase-session-required check rejected every customerapp call regardless of the `x-api-key` header. The customerapp surface was unreachable in production.

## Root cause

Wave A-D inherited the gap from PR #246 — the same bug existed for `/api/internal/*` but went undetected because `INTERNAL_API_KEY` was never set in prod (the routes were dead code). The path rename from `/api/internal/` → `/api/v1/` in #260 (#255) didn't add the new prefix to `PUBLIC_PATHS` either. Route unit tests mock `next/server` + the auth helper, so they never run through the middleware layer.

## Fix

Add `"/api/v1/"` to `PUBLIC_PATHS` (trailing slash intentional — same convention as `/p/`). The route handlers' `resolveOrgFromToken` in `@/lib/internal-auth` is the authoritative auth boundary for the customerapp surface; the middleware's session check has nothing to validate against (customerapp sends `x-api-key`, not a cookie session). Code-comment block in `src/middleware.ts` documents why `/api/v1/*` belongs in `PUBLIC_PATHS` despite being `/api/*` — future contributors might assume `/api/*` should be session-enforced by default.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (one-line addition + comment)
- [x] Diff verified: only `src/middleware.ts` touched, 14 lines added (1 array entry + 13-line comment)
- [ ] Post-merge: re-run the architect-side smoke chain at `/tmp/architect-smoke-runbook.md` section C against the production Vercel deploy. Expected: `GET /api/v1/microgrids` with valid `x-api-key` returns `200 + []` (or array of microgrids) instead of `401 {"error":"Authentication required"}`. Will report results in the Zulip topic.

## Related

- Wave A-D umbrella: #249
- Smoke discovery: Zulip `mbe-internal > MBE APIs` msg 597990884 (full diagnosis)
- Architect Task #27 (closes on merge)
- Pattern this catches: the 2026-04 holistic-post-merge-review learning ("walk one happy-path query end-to-end against live Supabase after the workstream lands") — exactly the cross-layer integration bug that lesson predicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)