### PR TITLE
fix(security): REVOKE EXECUTE FROM anon on 3 SECURITY DEFINER mutators (#268)

### DIFF
--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -2015,3 +2015,80 @@ describe("RLS: Community payment provider (#115)", () => {
     });
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════
+// B1 (#268): REVOKE EXECUTE on anon-reachable SECURITY DEFINER mutators
+// ══════════════════════════════════════════════════════════════════════════
+//
+// Migration 00045 REVOKEs EXECUTE FROM PUBLIC, anon on three SECURITY DEFINER
+// functions and re-GRANTs to authenticated + service_role. The tests below
+// assert the REVOKE fires at the grant layer (PostgreSQL returns SQLSTATE
+// 42501) BEFORE the function body runs. This is structurally different from
+// the body-side defense pattern used by `fn_get_community_payment_secret`
+// (which returns NULL with no error) — these REVOKEs surface as an error.
+//
+// Authenticated happy-paths are exercised by existing tests
+// (payment_state_machine.test.ts for fn_apply_payment_event;
+// invite-user-rpc.test.ts for fn_finalize_user_invitation /
+// fn_change_user_role). If those continue to pass, the GRANT to
+// authenticated/service_role is intact.
+
+describe("B1 #268 — anon REVOKE on SECURITY DEFINER mutators", () => {
+  function expectAnonDenied(error: { code?: string; message?: string } | null): void {
+    expect(error).not.toBeNull();
+    expect(
+      error?.code === "42501" || error?.message?.toLowerCase().includes("permission denied"),
+      `Expected SQLSTATE 42501 or "permission denied" in error; got code=${error?.code} message=${error?.message}`
+    ).toBe(true);
+  }
+
+  function buildAnonClient(): SupabaseClient {
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!anonKey) throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY not set");
+    return createClient(LOCAL_SUPABASE_URL, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  it("anon RPC to fn_apply_payment_event is denied (42501)", async () => {
+    if (skipIfRequested()) return;
+    const anonClient = buildAnonClient();
+    const { error } = await anonClient.rpc("fn_apply_payment_event", {
+      _line_item_id: FIXTURE.lineItemA,
+      _to_status: "paid",
+      _source: "manual",
+      _actor_user_id: null,
+      _raw_payload: {},
+      _actor_kind: "user",
+      _actor_ref: "anon-probe",
+    });
+    expectAnonDenied(error);
+  });
+
+  it("anon RPC to fn_change_user_role is denied (42501)", async () => {
+    if (skipIfRequested()) return;
+    const anonClient = buildAnonClient();
+    // Throwaway UUIDs — REVOKE fires before any body logic / argument
+    // validation runs, so values don't need to reference real fixtures.
+    const { error } = await anonClient.rpc("fn_change_user_role", {
+      p_user_id: "00000000-0000-4000-8000-000000000001",
+      p_role: "org_manager",
+      p_scope_id: "00000000-0000-4000-8000-000000000002",
+    });
+    expectAnonDenied(error);
+  });
+
+  it("anon RPC to fn_finalize_user_invitation is denied (42501)", async () => {
+    if (skipIfRequested()) return;
+    const anonClient = buildAnonClient();
+    const { error } = await anonClient.rpc("fn_finalize_user_invitation", {
+      p_user_id: "00000000-0000-4000-8000-000000000003",
+      p_first_name: "Anon",
+      p_last_name: "Probe",
+      p_phone: "+10000000000",
+      p_role: "org_manager",
+      p_scope_id: "00000000-0000-4000-8000-000000000004",
+    });
+    expectAnonDenied(error);
+  });
+});

--- a/supabase/migrations/00045_revoke_anon_security_definer_mutators.sql
+++ b/supabase/migrations/00045_revoke_anon_security_definer_mutators.sql
@@ -1,0 +1,70 @@
+-- 00045_revoke_anon_security_definer_mutators.sql
+-- B1 (#268): Lock down the 3 anon-reachable SECURITY DEFINER mutators
+-- exposed by the Supabase linter `anon_security_definer_function_executable`.
+--
+-- Why explicit REVOKE FROM anon (not just FROM PUBLIC):
+-- 00016 line 39-44 does `ALTER DEFAULT PRIVILEGES … GRANT ALL ON ROUTINES
+-- TO anon, authenticated, service_role`. This auto-grants EXECUTE-to-anon
+-- on every function created after 00016. REVOKE FROM PUBLIC alone does NOT
+-- undo that grant (anon is a specific role, not a PUBLIC member).
+-- The root-cause fix to 00016 is #270 (B2); this ticket is the narrow,
+-- urgent surface-level lock-down for the 3 mutators with the highest blast
+-- radius (one of which — fn_apply_payment_event — has no body-side
+-- auth.uid() guard, so the anon-reachable surface is a TRUE exposure).
+--
+-- Signatures are fully-qualified because PostgreSQL function grants are
+-- keyed by (name, argument-type-list) — overloads are independent grant
+-- targets. Get these wrong and the REVOKE silently no-ops.
+
+-- 1. fn_apply_payment_event (7-arg sig from 00041)
+REVOKE EXECUTE ON FUNCTION public.fn_apply_payment_event(
+  UUID,
+  public.billing_line_item_payment_status,
+  TEXT,
+  UUID,
+  JSONB,
+  TEXT,
+  TEXT
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.fn_apply_payment_event(
+  UUID,
+  public.billing_line_item_payment_status,
+  TEXT,
+  UUID,
+  JSONB,
+  TEXT,
+  TEXT
+) TO authenticated, service_role;
+
+-- 2. fn_change_user_role (3-arg sig from 00013)
+REVOKE EXECUTE ON FUNCTION public.fn_change_user_role(
+  UUID,
+  public.user_role,
+  UUID
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.fn_change_user_role(
+  UUID,
+  public.user_role,
+  UUID
+) TO authenticated, service_role;
+
+-- 3. fn_finalize_user_invitation (6-arg sig from 00013)
+REVOKE EXECUTE ON FUNCTION public.fn_finalize_user_invitation(
+  UUID,
+  TEXT,
+  TEXT,
+  TEXT,
+  public.user_role,
+  UUID
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.fn_finalize_user_invitation(
+  UUID,
+  TEXT,
+  TEXT,
+  TEXT,
+  public.user_role,
+  UUID
+) TO authenticated, service_role;


### PR DESCRIPTION
## Summary

Closes #268 (B1 — narrow + urgent surface-level lock-down).

- Migration **00045** explicitly `REVOKE EXECUTE … FROM PUBLIC, anon` and re-`GRANT EXECUTE … TO authenticated, service_role` on the three SECURITY DEFINER mutators flagged by Supabase linter `anon_security_definer_function_executable`:
  - `fn_apply_payment_event` (7-arg sig, 00041) — **true exposure** (no body-side `auth.uid()` guard)
  - `fn_change_user_role` (3-arg sig, 00013) — defense-in-depth (body rejects anon, but anon-reachable surface remains)
  - `fn_finalize_user_invitation` (6-arg sig, 00013) — defense-in-depth (body rejects anon)
- Adds 3 regression tests in `src/lib/supabase/__tests__/rls.test.ts` under `describe("B1 #268 — anon REVOKE on SECURITY DEFINER mutators", …)`. Each asserts an anon-client `.rpc(...)` returns SQLSTATE `42501` or `"permission denied"` (REVOKE fires at the grant layer before any function body runs).
- Authenticated/service_role happy-paths preserved — existing `payment_state_machine.test.ts` (super_admin) and `invite-user-rpc.test.ts` (org_manager) suites still pass (12/12 and 8/8).

### Why explicit REVOKE FROM `anon` (not just FROM `PUBLIC`)

Migration `00016` does `ALTER DEFAULT PRIVILEGES … GRANT ALL ON ROUTINES TO anon, authenticated, service_role`, which auto-grants EXECUTE-to-anon on every function created afterward. `REVOKE FROM PUBLIC` alone does NOT undo this — `anon` is a specific role, not a member of `PUBLIC`. The 00016 root-cause fix is tracked separately as **#270 (B2)**; this ticket is the narrow lock-down for the highest blast-radius surfaces.

### Out of scope (deferred to #270 / B2)

- Patching `00016` `ALTER DEFAULT PRIVILEGES` (root cause)
- REVOKEs on the remaining ~9 SECURITY DEFINER fns
- `CLAUDE.md` convention addition ("every SECURITY DEFINER fn REVOKEs FROM PUBLIC, anon")

## Test plan

- [x] `supabase db reset` — migration 00045 applies cleanly
- [x] `npm run db:types:check` — no codegen drift (REVOKE/GRANT don't change types)
- [x] `npx tsc --noEmit` — typecheck passes
- [x] `npm run lint` — passes (warnings only, no errors)
- [x] `npm test -- rls.test.ts payment_state_machine.test.ts invite-user-rpc.test.ts` — 141/141 pass (includes 3 new B1 tests)
- [x] `npm test` — full suite: 1817/1817 pass
- [x] Commit is DCO-signed (`Signed-off-by:`) + SSH-signed (`Good "git" signature`)
- [ ] CodeQL passes on PR
- [ ] Test status check passes on PR
- [ ] Vercel preview deploys

## Verification of REVOKE shape

```
✓ B1 #268 — anon REVOKE on SECURITY DEFINER mutators > anon RPC to fn_apply_payment_event is denied (42501)
✓ B1 #268 — anon REVOKE on SECURITY DEFINER mutators > anon RPC to fn_change_user_role is denied (42501)
✓ B1 #268 — anon REVOKE on SECURITY DEFINER mutators > anon RPC to fn_finalize_user_invitation is denied (42501)
```