### PR TITLE
fix(security): replace user_directory view with fn_list_visible_users RPC (#269)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/__tests__/page.test.tsx
@@ -6,15 +6,20 @@
  * `user_directory.display_name` column, producing a 500 on every billing
  * detail page in production. The previous unit test for this surface
  * (`billing-table.test.tsx`) mocks the `actorByLineItemId` prop directly
- * — so it never exercises the page loader. TypeScript also can't catch
- * the bug because `LineItemWithActor` is a hand-written `.returns<>()`
- * shape that fabricates whatever fields it claims.
+ * — so it never exercises the page loader.
+ *
+ * #269: the user_directory view was replaced by the fn_list_visible_users
+ * RPC. The page's single PostgREST FK-join
+ * (`user_directory!entered_by_user_id(...)`) was restructured into a
+ * two-step fetch: line items first (no join), then a batch
+ * `.rpc("fn_list_visible_users", { _target_user_ids: [...] })` keyed by
+ * each line item's entered_by_user_id. This test follows that new shape.
  *
  * Strategy:
  *   - Mock @/lib/supabase/server with a per-table dispatcher. The
- *     `billing_line_items` builder returns rows shaped like the REAL
- *     `user_directory` view (`first_name`, `last_name`, `email` — NO
- *     `display_name`).
+ *     `billing_line_items` builder returns rows with `entered_by_user_id`
+ *     set (no embedded actor data). A separate `rpc` mock returns the
+ *     actor rows for the collected ids.
  *   - Mock @/components/BillingTable as a stub that serializes the
  *     `actorByLineItemId` prop into the rendered HTML, so we can
  *     assert what the page computed for each line item.
@@ -24,8 +29,7 @@
  *   1. first_name + last_name → "Alejandro Malbet"
  *   2. first_name only → "Alejandro"
  *   3. email-only fallback (both names null) → "alejandro@example.com"
- *   4. null user_directory join (entered_by_user_id IS NULL or RLS-hidden)
- *      → null actor
+ *   4. entered_by_user_id IS NULL or RLS-hidden actor → null actor
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -39,9 +43,19 @@ const LI_FIRST_ONLY = "990e8400-e29b-41d4-a716-446655444002";
 const LI_EMAIL_ONLY = "990e8400-e29b-41d4-a716-446655444003";
 const LI_NO_JOIN = "990e8400-e29b-41d4-a716-446655444004";
 
+// Stable actor ids per line item — keep distinct so the second-step RPC
+// resolves them independently. LI_NO_JOIN has entered_by_user_id = null
+// to model the "manual entry by an RLS-hidden actor / no actor recorded"
+// branch (the row will not be a key in the actor lookup map).
+const ACTOR_FULL = "aaaaaaaa-1111-4111-8111-000000000001";
+const ACTOR_FIRST_ONLY = "aaaaaaaa-1111-4111-8111-000000000002";
+const ACTOR_EMAIL_ONLY = "aaaaaaaa-1111-4111-8111-000000000003";
+
 // Holders we mutate per-test.
 let MOCK_LINE_ITEMS: Array<Record<string, unknown>> = [];
+let MOCK_ACTOR_ROWS: Array<Record<string, unknown>> = [];
 let LAST_LINE_ITEMS_SELECT = "";
+let LAST_RPC_ARGS: Record<string, unknown> | null = null;
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -109,6 +123,16 @@ vi.mock("@/lib/supabase/server", () => ({
       // Fallback (e.g. user_roles via currentUserIsSuperAdmin).
       return buildQuery([]);
     },
+    // #269: actor resolution moved from a PostgREST FK-join into a
+    // second-step RPC. Capture the args (so the test can assert the
+    // batch shape) and return the test's MOCK_ACTOR_ROWS.
+    rpc: async (name: string, args?: Record<string, unknown>) => {
+      if (name === "fn_list_visible_users") {
+        LAST_RPC_ARGS = args ?? null;
+        return { data: MOCK_ACTOR_ROWS, error: null };
+      }
+      throw new Error(`Unexpected rpc: ${name}`);
+    },
   }),
 }));
 
@@ -152,34 +176,34 @@ import BillingPeriodDetailPage from "../page";
 
 beforeEach(() => {
   LAST_LINE_ITEMS_SELECT = "";
+  LAST_RPC_ARGS = null;
   MOCK_LINE_ITEMS = [
+    { id: LI_FULL, entered_by_user_id: ACTOR_FULL },
+    { id: LI_FIRST_ONLY, entered_by_user_id: ACTOR_FIRST_ONLY },
+    { id: LI_EMAIL_ONLY, entered_by_user_id: ACTOR_EMAIL_ONLY },
+    // RLS-hidden actor / no actor recorded → entered_by_user_id NULL
+    // (or absent from the RPC return set even if non-null). Either way,
+    // the actor lookup map has no entry → actor is null.
+    { id: LI_NO_JOIN, entered_by_user_id: null },
+  ];
+  MOCK_ACTOR_ROWS = [
     {
-      id: LI_FULL,
-      user_directory: {
-        first_name: "Alejandro",
-        last_name: "Malbet",
-        email: "alejandro@example.com",
-      },
+      user_id: ACTOR_FULL,
+      first_name: "Alejandro",
+      last_name: "Malbet",
+      email: "alejandro@example.com",
     },
     {
-      id: LI_FIRST_ONLY,
-      user_directory: {
-        first_name: "Alejandro",
-        last_name: null,
-        email: "alejandro@example.com",
-      },
+      user_id: ACTOR_FIRST_ONLY,
+      first_name: "Alejandro",
+      last_name: null,
+      email: "alejandro@example.com",
     },
     {
-      id: LI_EMAIL_ONLY,
-      user_directory: {
-        first_name: null,
-        last_name: null,
-        email: "alejandro@example.com",
-      },
-    },
-    {
-      id: LI_NO_JOIN,
-      user_directory: null,
+      user_id: ACTOR_EMAIL_ONLY,
+      first_name: null,
+      last_name: null,
+      email: "alejandro@example.com",
     },
   ];
 });
@@ -198,16 +222,30 @@ function extractActorMap(html: string): Record<string, string | null> {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe("BillingPeriodDetailPage — user_directory actor mapping", () => {
-  it("does NOT request the (nonexistent) display_name column", async () => {
+describe("BillingPeriodDetailPage — fn_list_visible_users actor mapping (#269)", () => {
+  it("does NOT request user_directory (dropped) and does NOT embed an actor join", async () => {
     const node = await BillingPeriodDetailPage({
       params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
     });
     renderToStaticMarkup(node as React.ReactElement);
+    // Old shape: PostgREST FK-join shorthand on user_directory.
+    expect(LAST_LINE_ITEMS_SELECT).not.toContain("user_directory");
+    // Old footgun: phantom display_name column on the view.
     expect(LAST_LINE_ITEMS_SELECT).not.toContain("display_name");
-    expect(LAST_LINE_ITEMS_SELECT).toContain("first_name");
-    expect(LAST_LINE_ITEMS_SELECT).toContain("last_name");
-    expect(LAST_LINE_ITEMS_SELECT).toContain("email");
+    // Caller-shape sanity: the line-items projection still selects payment fields.
+    expect(LAST_LINE_ITEMS_SELECT).toContain("payment_status");
+  });
+
+  it("batches the actor RPC with the collected entered_by_user_id set", async () => {
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    renderToStaticMarkup(node as React.ReactElement);
+    // LI_NO_JOIN's entered_by_user_id is null → not included in the batch.
+    const ids = (LAST_RPC_ARGS?._target_user_ids ?? []) as string[];
+    expect(new Set(ids)).toEqual(
+      new Set([ACTOR_FULL, ACTOR_FIRST_ONLY, ACTOR_EMAIL_ONLY])
+    );
   });
 
   it("composes first_name + last_name with a space when both present", async () => {
@@ -237,12 +275,31 @@ describe("BillingPeriodDetailPage — user_directory actor mapping", () => {
     expect(actorMap[LI_EMAIL_ONLY]).toBe("alejandro@example.com");
   });
 
-  it("emits null when the user_directory join is null", async () => {
+  it("emits null when entered_by_user_id is null (no actor to look up)", async () => {
     const node = await BillingPeriodDetailPage({
       params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
     });
     const html = renderToStaticMarkup(node as React.ReactElement);
     const actorMap = extractActorMap(html);
     expect(actorMap[LI_NO_JOIN]).toBeNull();
+  });
+
+  it("emits null when the actor exists but is RLS-hidden (RPC returns no row)", async () => {
+    // Replace one of the line items so its actor isn't returned by the RPC,
+    // modelling the super_admin-hidden-from-org_manager case.
+    const HIDDEN_LI = "990e8400-e29b-41d4-a716-446655444099";
+    const HIDDEN_ACTOR = "aaaaaaaa-1111-4111-8111-000000000099";
+    MOCK_LINE_ITEMS = [
+      { id: HIDDEN_LI, entered_by_user_id: HIDDEN_ACTOR },
+    ];
+    // MOCK_ACTOR_ROWS does NOT include HIDDEN_ACTOR → RPC simulates RLS hiding.
+    MOCK_ACTOR_ROWS = [];
+
+    const node = await BillingPeriodDetailPage({
+      params: Promise.resolve({ id: MICROGRID_ID, periodId: PERIOD_ID }),
+    });
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    const actorMap = extractActorMap(html);
+    expect(actorMap[HIDDEN_LI]).toBeNull();
   });
 });

--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -43,19 +43,6 @@ export default async function BillingPeriodDetailPage({
     }>;
   };
 
-  // BC2 (#174) — line-items query type with the user_directory join
-  // for the entered-by caption. The `user_directory` view exposes
-  // first_name / last_name / email (no `display_name` column); we
-  // compose the display string client-side via `pickDisplayName`,
-  // mirroring `src/lib/billing/audit-log-fetch.ts:75-82`.
-  type LineItemWithActor = BillingLineItem & {
-    user_directory: {
-      first_name: string | null;
-      last_name: string | null;
-      email: string | null;
-    } | null;
-  };
-
   const [
     { data: period, error: periodError },
     { data: lineItems, error: lineItemsError },
@@ -72,13 +59,19 @@ export default async function BillingPeriodDetailPage({
       .eq("microgrid_id", id)
       .single()
       .then((res) => ({ ...res, data: res.data as BillingPeriod | null })),
+    // BC2 (#174) — line items without the actor join. The
+    // `user_directory!entered_by_user_id(...)` PostgREST shorthand was
+    // dropped when the underlying view was replaced by the
+    // `fn_list_visible_users` RPC in #269 (no FK metadata on a function).
+    // We resolve the actor display name in a second step below using
+    // the same RPC, batched on the collected entered_by_user_id set.
     supabase
       .from("billing_line_items")
       .select(
-        "*, payment_status, paid_at, paid_by_user_id, payment_notes, user_directory!entered_by_user_id(first_name, last_name, email)",
+        "*, payment_status, paid_at, paid_by_user_id, payment_notes",
       )
       .eq("billing_period_id", periodId)
-      .returns<LineItemWithActor[]>(),
+      .returns<BillingLineItem[]>(),
     supabase
       .from("households")
       .select("*")
@@ -192,29 +185,53 @@ export default async function BillingPeriodDetailPage({
       edge.openems_edge_id != null;
   }
 
-  // BC2 (#174) — flatten the user_directory join into a per-line-item
-  // actor display-name map, then strip the join from the line items so
-  // the BillingTable's BillingLineItem typing stays clean.
-  const lineItemsWithActors = (lineItems ?? []) as LineItemWithActor[];
+  // BC2 (#174) — resolve the actor display name per line item via a
+  // second call to the `fn_list_visible_users` RPC (#269 replaced the
+  // user_directory view). Collect the entered_by_user_id set, ask the
+  // RPC for those rows in one batch, then index by user id and build
+  // the actor map. RLS-hidden actors (e.g. super_admin invisible to an
+  // org_manager caller) simply don't appear in the response → null
+  // entry, matching the previous LEFT-JOIN-miss semantics.
+  const cleanLineItems = (lineItems ?? []) as BillingLineItem[];
+  const enteredByIds = Array.from(
+    new Set(
+      cleanLineItems
+        .map((li) => li.entered_by_user_id)
+        .filter((v): v is string => typeof v === "string" && v.length > 0),
+    ),
+  );
+
+  const actorById = new Map<
+    string,
+    { first_name: string | null; last_name: string | null; email: string | null }
+  >();
+  if (enteredByIds.length > 0) {
+    const { data: actorRows } = await supabase.rpc("fn_list_visible_users", {
+      _target_user_ids: enteredByIds,
+    });
+    for (const r of actorRows ?? []) {
+      if (!r.user_id) continue;
+      actorById.set(r.user_id, {
+        first_name: r.first_name,
+        last_name: r.last_name,
+        email: r.email,
+      });
+    }
+  }
+
   const actorByLineItemId: Record<string, string | null> = {};
-  for (const li of lineItemsWithActors) {
-    // PostgREST may return the joined row as an object or null.
+  for (const li of cleanLineItems) {
     // Mirror `pickDisplayName` from src/lib/billing/audit-log-fetch.ts:75-82:
     // first_name + last_name (joined with a space), fallback to email,
     // fallback to null.
-    const join = li.user_directory;
-    const parts = [join?.first_name, join?.last_name].filter(
+    const enteredBy = li.entered_by_user_id;
+    const row = enteredBy ? actorById.get(enteredBy) ?? null : null;
+    const parts = [row?.first_name, row?.last_name].filter(
       (s): s is string => typeof s === "string" && s.length > 0,
     );
     actorByLineItemId[li.id] =
-      parts.length > 0 ? parts.join(" ") : (join?.email ?? null);
+      parts.length > 0 ? parts.join(" ") : (row?.email ?? null);
   }
-  const cleanLineItems: BillingLineItem[] = lineItemsWithActors.map((li) => {
-    // Strip the join field so the prop type stays narrow.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { user_directory, ...rest } = li;
-    return rest as BillingLineItem;
-  });
 
   return (
     <>

--- a/src/app/(dashboard)/settings/api-tokens/page.tsx
+++ b/src/app/(dashboard)/settings/api-tokens/page.tsx
@@ -82,16 +82,17 @@ export default async function SettingsApiTokensPage() {
 
   const tokens: RawToken[] = (tokensData ?? []) as RawToken[];
 
-  // Resolve created_by display names via user_directory.
+  // Resolve created_by display names via fn_list_visible_users (RPC).
+  // #269 replaced the user_directory view with this RPC; visibility
+  // semantics are preserved (RLS-hidden actors → no row → fallback).
   const creatorIds = Array.from(
     new Set(tokens.map((t) => t.created_by).filter((id): id is string => !!id))
   );
   const creatorNames: Record<string, string> = {};
   if (creatorIds.length > 0) {
-    const { data: dirRows } = await supabase
-      .from("user_directory")
-      .select("user_id, email, first_name, last_name")
-      .in("user_id", creatorIds);
+    const { data: dirRows } = await supabase.rpc("fn_list_visible_users", {
+      _target_user_ids: creatorIds,
+    });
     for (const r of dirRows ?? []) {
       if (!r.user_id) continue;
       const first = (r.first_name ?? "").trim();

--- a/src/app/(dashboard)/settings/users/page.tsx
+++ b/src/app/(dashboard)/settings/users/page.tsx
@@ -4,14 +4,18 @@ import {
   currentUserIsSuperAdmin,
 } from "@/lib/auth/access";
 import { SUPER_ADMIN, ORG_MANAGER } from "@/lib/roles";
-import type { UserDirectoryRow, UserRoleRecord } from "@/lib/types/domain";
+import type { UserVisibleRow, UserRoleRecord } from "@/lib/types/domain";
 import { UsersPageClient } from "./users-page-client";
 
 /**
  * /settings/users — admin view of all users visible to the caller.
  *
- * Server component: reads the user_directory VIEW (security_invoker;
- * RLS on user_profiles filters rows via user_can_see_user_profile).
+ * Server component: calls the `fn_list_visible_users` RPC (migration
+ * 00046) which enforces the `user_can_see_user_profile(user_id)`
+ * visibility predicate body-side. The RPC supersedes the old
+ * `user_directory` view (dropped in #269 to clear two CRITICAL
+ * Supabase linter ERRORs: auth_users_exposed + security_definer_view).
+ *
  * Also fetches the org list (for the Invite dialog) scoped to the
  * caller's role:
  *   - super_admin → all orgs (limited by organizations RLS, which
@@ -37,11 +41,9 @@ export default async function SettingsUsersPage() {
     )
   );
 
-  // Fetch rows.
-  const { data: rowsData } = await supabase
-    .from("user_directory")
-    .select("*");
-  const rows: UserDirectoryRow[] = (rowsData ?? []).filter(
+  // Fetch rows. No args → list all visible users (per the RPC contract).
+  const { data: rowsData } = await supabase.rpc("fn_list_visible_users");
+  const rows: UserVisibleRow[] = ((rowsData ?? []) as UserVisibleRow[]).filter(
     (r) => r.user_id != null
   );
 

--- a/src/app/api/billing-line-items/[lineItemId]/pdf/__tests__/route.test.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/pdf/__tests__/route.test.ts
@@ -76,14 +76,17 @@ type FromState = {
   lineItem: { data: unknown; error: unknown };
   household_devices: { data: unknown; error: unknown };
   rate_schedules: { data: unknown; error: unknown };
-  user_directory: { data: unknown; error: unknown };
+  // #269: actor lookup was `.from("user_directory").…maybeSingle()`; it
+  // is now `.rpc("fn_list_visible_users", { _target_user_ids: [...] })`.
+  // The mock returns an array of rows (or empty) per the RPC contract.
+  fnListVisibleUsers: { data: unknown; error: unknown };
 };
 
 const fromState: FromState = {
   lineItem: { data: null, error: null },
   household_devices: { data: null, error: null },
   rate_schedules: { data: null, error: null },
-  user_directory: { data: null, error: null },
+  fnListVisibleUsers: { data: [], error: null },
 };
 
 // Captured updates to billing_line_items so tests can assert the persist.
@@ -146,15 +149,6 @@ function makeFromImpl(table: string) {
       }),
     };
   }
-  if (table === "user_directory") {
-    return {
-      select: () => ({
-        eq: () => ({
-          maybeSingle: () => Promise.resolve(fromState.user_directory),
-        }),
-      }),
-    };
-  }
   // Re-fetch path: SELECT(invoice_number).eq(id).maybeSingle()
   throw new Error(`Unexpected table: ${table}`);
 }
@@ -169,6 +163,10 @@ vi.mock("@/lib/supabase/server", () => ({
       rpcCalls.push({ fn, args });
       if (fn === "fn_next_invoice_number") {
         return { data: rpcCounter++, error: null };
+      }
+      if (fn === "fn_list_visible_users") {
+        // #269: actor lookup. Returns whatever the test sets up (default []).
+        return fromState.fnListVisibleUsers;
       }
       return { data: null, error: null };
     }),
@@ -283,7 +281,7 @@ beforeEach(() => {
   fromState.lineItem = { data: lineItemRow(), error: null };
   fromState.household_devices = { data: [], error: null };
   fromState.rate_schedules = { data: RATE_SCHEDULE_ROW, error: null };
-  fromState.user_directory = { data: null, error: null };
+  fromState.fnListVisibleUsers = { data: [], error: null };
   ensurePaymentLinkMock.mockResolvedValue({
     redirectUrl: "https://pay.pesapal.com/x",
     orderTrackingId: "OT-1",

--- a/src/app/api/billing-line-items/[lineItemId]/pdf/route.ts
+++ b/src/app/api/billing-line-items/[lineItemId]/pdf/route.ts
@@ -435,21 +435,26 @@ export async function GET(
   }
 
   // 8. Resolve "entered by" display name (BC1 — manual readings).
+  //
+  // #269: the prior `user_directory` view was replaced by the
+  // `fn_list_visible_users` RPC. The old select asked for a
+  // `display_name` column that never existed on the view (returned
+  // null silently); we drop it from the projection here. The RPC's
+  // visibility predicate is identical to the view's WHERE clause, so
+  // an RLS-hidden actor still surfaces as an empty row set → null name.
   let enteredByUserName: string | null = null;
   const enteredById = scoped.entered_by_user_id as string | null;
   if (enteredById && scoped.reading_source === "manual") {
-    const { data: dirRow } = await supabase
-      .from("user_directory")
-      .select("display_name, first_name, last_name, email")
-      .eq("user_id", enteredById)
-      .maybeSingle();
+    const { data: dirRows } = await supabase.rpc("fn_list_visible_users", {
+      _target_user_ids: [enteredById],
+    });
+    const dirRow = dirRows?.[0];
     if (dirRow) {
       const composed = [dirRow.first_name, dirRow.last_name]
         .filter((s): s is string => Boolean(s && s.trim()))
         .join(" ")
         .trim();
       enteredByUserName =
-        (dirRow.display_name as string | null) ??
         (composed.length > 0 ? composed : null) ??
         (dirRow.email as string | null) ??
         null;

--- a/src/app/api/billing-periods/[periodId]/audit-log/__tests__/route.test.ts
+++ b/src/app/api/billing-periods/[periodId]/audit-log/__tests__/route.test.ts
@@ -9,7 +9,7 @@
  *   - actorDisplayName derived from first_name + last_name (NOT a
  *     non-existent display_name column); falls back to email.
  *   - actorDisplayName is null when the actor is a super_admin hidden by
- *     user_can_see_user_profile (the user_directory `IN` query simply
+ *     user_can_see_user_profile (the fn_list_visible_users RPC simply
  *     returns no row for that actor_user_id).
  *   - payment_events row with source='ipn' maps to eventType =
  *     'payment_status_changed' (NOT a non-existent enum entry).
@@ -102,14 +102,15 @@ function buildSupabaseStub() {
           }),
         };
       }
-      if (table === "user_directory") {
-        return {
-          select: () => ({
-            in: async () => ({ data: mockDirectoryRows, error: null }),
-          }),
-        };
-      }
       throw new Error(`Unexpected table: ${table}`);
+    },
+    // #269: actor lookup migrated from .from("user_directory").select(...)
+    // .in(...) to .rpc("fn_list_visible_users", { _target_user_ids: [...] }).
+    rpc: async (name: string) => {
+      if (name === "fn_list_visible_users") {
+        return { data: mockDirectoryRows, error: null };
+      }
+      throw new Error(`Unexpected rpc: ${name}`);
     },
   };
 }

--- a/src/app/api/users/[id]/resend-invite/__tests__/route.test.ts
+++ b/src/app/api/users/[id]/resend-invite/__tests__/route.test.ts
@@ -30,11 +30,12 @@ import { NextRequest } from "next/server";
 // Caller user (auth.getUser result).
 let mockCaller: { id: string; email?: string } | null = null;
 
-// Mock for the user-bound client `.from("user_directory").select(...).eq(...).maybeSingle()`
+// Mock for the user-bound client `.rpc("fn_list_visible_users", {...})`
+// (#269 replaced the prior `.from("user_directory").…maybeSingle()` call).
 // Returns the target's CURRENT row (or null when invisible/absent). The
-// route was migrated from `user_roles` → `user_directory` because the
-// former's RLS policies block org_manager → org_manager-in-same-org reads;
-// the view's WHERE filter (`user_can_see_user_profile(user_id)`) is the
+// route was migrated from `user_roles` → `user_directory` → `fn_list_visible_users`
+// because `user_roles` RLS blocks org_manager → org_manager-in-same-org reads;
+// the RPC's body filter (`user_can_see_user_profile(user_id)`) is the
 // canonical visibility gate. A visible orphan surfaces as a row with
 // NULL role/scope columns (LEFT JOIN miss on user_roles).
 let mockTargetRoleRow: {
@@ -92,19 +93,6 @@ function userClientFromImpl(table: string) {
       }),
     };
   }
-  if (table === "user_directory") {
-    // Target lookup. `eq("user_id", targetId).maybeSingle()`.
-    return {
-      select: () => ({
-        eq: () => ({
-          maybeSingle: vi.fn(async () => ({
-            data: mockTargetRoleRow,
-            error: null,
-          })),
-        }),
-      }),
-    };
-  }
   if (table === "user_roles") {
     // After the route migration, only access.ts's `getCurrentUserRoles`
     // (caller-roles fetch) reads user_roles via the user-bound client.
@@ -124,6 +112,34 @@ function userClientFromImpl(table: string) {
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
     from: vi.fn(userClientFromImpl),
+    // `.rpc("fn_list_visible_users", { _target_user_ids: [targetId] })`
+    // (#269: target lookup replaced .from("user_directory")…maybeSingle()).
+    // The mock returns an array shaped like the RPC return type; the route
+    // takes `data?.[0]`. A null `mockTargetRoleRow` → empty array → no row.
+    rpc: vi.fn(async (name: string) => {
+      if (name === "fn_list_visible_users") {
+        return {
+          data: mockTargetRoleRow
+            ? [
+                {
+                  user_id: TARGET_UUID,
+                  email: null,
+                  email_confirmed_at: null,
+                  last_sign_in_at: null,
+                  first_name: null,
+                  last_name: null,
+                  phone: null,
+                  role: mockTargetRoleRow.role,
+                  scope_type: mockTargetRoleRow.scope_type,
+                  scope_id: mockTargetRoleRow.scope_id,
+                },
+              ]
+            : [],
+          error: null,
+        };
+      }
+      throw new Error(`Unexpected rpc: ${name}`);
+    }),
     auth: {
       getUser: vi.fn(async () => ({
         data: { user: mockCaller },

--- a/src/app/api/users/[id]/resend-invite/route.ts
+++ b/src/app/api/users/[id]/resend-invite/route.ts
@@ -26,14 +26,15 @@ import type { UserRole, RoleScopeType } from "@/lib/types/domain";
  *   Step A — caller authentication.
  *           userClient.auth.getUser() → 401 if no session.
  *
- *   Step B — resolve target's CURRENT role row via the user_directory
- *           VIEW (user-bound client). The view's WHERE clause calls
- *           `user_can_see_user_profile(user_id)` so RLS-equivalent
- *           visibility is enforced uniformly: invisible row → uniform
- *           403, never "not found". Reading directly from `user_roles`
- *           would NOT work for org_manager → org_manager-in-same-org
- *           because no `user_roles` SELECT policy grants cross-user
- *           reads (only "own row" + super_admin FOR ALL).
+ *   Step B — resolve target's CURRENT role row via the
+ *           `fn_list_visible_users` RPC (user-bound client). The RPC's
+ *           body filter calls `user_can_see_user_profile(user_id)` so
+ *           RLS-equivalent visibility is enforced uniformly: invisible
+ *           row → uniform 403, never "not found". Reading directly from
+ *           `user_roles` would NOT work for org_manager →
+ *           org_manager-in-same-org because no `user_roles` SELECT
+ *           policy grants cross-user reads (only "own row" +
+ *           super_admin FOR ALL).
  *
  *           Orphans surface as a row whose `role` column is NULL (LEFT
  *           JOIN miss). The visibility helper still gates them: an
@@ -100,29 +101,39 @@ export async function POST(
     );
   }
 
-  // ── Step B: resolve target's CURRENT role row via user_directory ───
+  // ── Step B: resolve target's CURRENT role row via fn_list_visible_users
   //
-  // user_directory is a VIEW (00014_user_directory_view.sql) that
-  // joins auth.users LEFT user_profiles LEFT user_roles, gated by
-  // `WHERE user_can_see_user_profile(au.id)`. The helper is
-  // SECURITY DEFINER and reads `auth.uid()` from the caller's JWT —
-  // it returns true iff the caller is the target, is a super_admin,
-  // OR shares an org-scoped manager role with the target. So a row
-  // returned here is guaranteed visible to the caller; a NULL row
-  // means "doesn't exist OR you can't see it" — uniform 403 (the
-  // enumeration-defense rule the route docstring describes).
+  // fn_list_visible_users is an RPC (00046_replace_user_directory_with_rpc.sql)
+  // that returns rows joining auth.users LEFT user_profiles LEFT user_roles,
+  // gated body-side by `WHERE user_can_see_user_profile(au.id)`. The helper
+  // is SECURITY DEFINER and reads `auth.uid()` from the caller's JWT — it
+  // returns true iff the caller is the target, is a super_admin, OR shares
+  // an org-scoped manager role with the target. So a row returned here is
+  // guaranteed visible to the caller; an empty result means "doesn't exist
+  // OR you can't see it" — uniform 403 (the enumeration-defense rule the
+  // route docstring describes).
   //
-  // We deliberately do NOT read `user_roles` directly: that table's
-  // SELECT policies only grant "own row" + super_admin FOR ALL, so
-  // an org_manager B trying to resend an org_manager C in the SAME
-  // org would get a NULL row and be 403'd — even though both the
-  // RLS helper and the rest of the app correctly consider C visible
-  // to B. The view is the single source of truth for "can A see B".
-  const { data: targetRoleRow } = await userClient
-    .from("user_directory")
-    .select("role, scope_type, scope_id")
-    .eq("user_id", targetId)
-    .maybeSingle<CurrentRoleRow>();
+  // We deliberately do NOT read `user_roles` directly: that table's SELECT
+  // policies only grant "own row" + super_admin FOR ALL, so an org_manager
+  // B trying to resend an org_manager C in the SAME org would get a NULL
+  // row and be 403'd — even though both the RLS helper and the rest of the
+  // app correctly consider C visible to B. The RPC is the single source of
+  // truth for "can A see B".
+  //
+  // The RPC replaces the prior `user_directory` view (#269) which leaked
+  // auth.users to anon via PostgREST and ran with SECURITY DEFINER on the
+  // view itself; the new RPC denies anon at the grant layer (REVOKE EXECUTE
+  // FROM anon) and applies the visibility predicate body-side.
+  const { data: visibleRows } = await userClient.rpc("fn_list_visible_users", {
+    _target_user_ids: [targetId],
+  });
+  const targetRoleRow: CurrentRoleRow | null = visibleRows?.[0]
+    ? {
+        role: visibleRows[0].role,
+        scope_type: visibleRows[0].scope_type,
+        scope_id: visibleRows[0].scope_id,
+      }
+    : null;
 
   // ── Step C: caller permission against TARGET's role ────────────────
   const callerIsSuper = await currentUserIsSuperAdmin(userClient);

--- a/src/lib/billing/audit-log-fetch.ts
+++ b/src/lib/billing/audit-log-fetch.ts
@@ -16,8 +16,9 @@
  * Behavior preserved (any change here will break the BC1 contract):
  *   - LIMIT 500 per side (memory-safety guard, NOT pagination).
  *   - `payment_events.at` aliased into the entry's `createdAt`.
- *   - `user_directory` join surfaces actor display names; missing rows
- *     (RLS-hidden super_admin per `user_can_see_user_profile`) → null.
+ *   - `fn_list_visible_users` RPC (replaced the `user_directory` view in
+ *     #269) surfaces actor display names; missing rows (RLS-hidden
+ *     super_admin per `user_can_see_user_profile`) → null.
  *   - `actorDisplayName` = first+last, fallback email, fallback null.
  *   - Audit IDs prefixed `audit:<uuid>`; payment-event IDs prefixed
  *     `payment_event:<uuid>` for stable React keys across the union.
@@ -203,7 +204,10 @@ export async function fetchAuditLogEntries(
     }
   }
 
-  // ── 4. Resolve actor display names via user_directory (RLS-aware). ───────
+  // ── 4. Resolve actor display names via fn_list_visible_users (RLS-aware). ─
+  // #269 replaced the user_directory view with this RPC; the visibility
+  // predicate (`user_can_see_user_profile`) is preserved body-side, so a
+  // hidden super_admin actor still surfaces as a missing row → null name.
   const actorIds = Array.from(
     new Set(
       [
@@ -214,10 +218,9 @@ export async function fetchAuditLogEntries(
   );
   const directoryMap = new Map<string, DirectoryRow>();
   if (actorIds.length > 0) {
-    const { data: dirRows } = await supabase
-      .from("user_directory")
-      .select("user_id, email, first_name, last_name")
-      .in("user_id", actorIds);
+    const { data: dirRows } = await supabase.rpc("fn_list_visible_users", {
+      _target_user_ids: actorIds,
+    });
     for (const r of (dirRows ?? []) as DirectoryRow[]) {
       directoryMap.set(r.user_id, r);
     }

--- a/src/lib/supabase/__tests__/fn_list_visible_users.test.ts
+++ b/src/lib/supabase/__tests__/fn_list_visible_users.test.ts
@@ -1,8 +1,15 @@
 /**
- * user_directory_view.test.ts
+ * fn_list_visible_users.test.ts
  *
- * RLS-level visibility tests for the user_directory VIEW + user_profiles
- * policies introduced in UX5 (#79).
+ * RLS-level visibility tests for the `fn_list_visible_users` RPC + the
+ * `user_profiles` UPDATE policy. Migration 00046 (#269) replaced the
+ * prior `user_directory` VIEW with this RPC to clear two CRITICAL
+ * Supabase linter ERRORs (`auth_users_exposed` + `security_definer_view`).
+ *
+ * Meaningful security upgrade over the dropped view: anon was previously
+ * granted SELECT on the view (rows-filtered by the WHERE clause → 0
+ * rows in practice). The new RPC denies anon at the grant layer
+ * (REVOKE EXECUTE FROM PUBLIC, anon) → 42501 / "permission denied".
  *
  * Fixture: four users.
  *   A — super_admin
@@ -10,24 +17,30 @@
  *   C — org_manager @ NFE
  *   D — org_manager @ OtherOrg
  *
- * Assertions:
- *   - A sees A, B, C, D.
- *   - B sees self + C. B does NOT see A (super_admins invisible to
- *     org_managers). B does NOT see D (different org).
- *   - D does NOT see B, C.
- *   - user_profiles UPDATE policy: B's attempt to update C's profile
- *     affects 0 rows (filtered by auth.uid() = user_id OR is_super_admin()).
+ * Coverage (per the architect appendix on #269):
+ *   - Anon `.rpc("fn_list_visible_users")` → permission-denied error
+ *     (NEW security shape vs. the old "0 rows" behaviour).
+ *   - Super_admin sees all visible users (including super_admins).
+ *   - Org_manager sees own-org users only (super_admins + cross-org hidden).
+ *   - Single-target lookup: `_target_user_ids: [<otherOrgUserId>]` returns
+ *     empty for org_manager; returns the row for super_admin.
+ *   - Batch lookup: `_target_user_ids: [a,b,c]` returns ≤3 rows depending
+ *     on per-id visibility (preserves the audit-log-fetch use case).
+ *   - user_profiles UPDATE policy: org_manager B's attempt to update C's
+ *     profile affects 0 rows (unchanged from the prior suite).
  *
  * Opt-out: SKIP_RLS_TESTS=1.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createClient } from "@supabase/supabase-js";
 import {
   assertEnvironmentReady,
   shouldSkip,
   serviceClient,
   createTestUser,
   cleanupTestData,
+  LOCAL_SUPABASE_URL,
   type TestUser,
 } from "./rls.helpers";
 
@@ -106,21 +119,48 @@ afterAll(async () => {
 
 function skipIfRequested(): boolean {
   if (shouldSkip()) {
-    console.log("[user_directory_view] SKIP_RLS_TESTS=1 — skipping suite.");
+    console.log("[fn_list_visible_users] SKIP_RLS_TESTS=1 — skipping suite.");
     return true;
   }
   return false;
 }
 
-describe("user_directory — visibility", () => {
-  it("A (super_admin) sees A, B, C, D", async () => {
+type VisibleRow = {
+  user_id: string;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+};
+
+describe("fn_list_visible_users — visibility", () => {
+  it("anon cannot call the RPC (permission denied at the grant layer)", async () => {
     if (skipIfRequested()) return;
-    const { data, error } = await A.client
-      .from("user_directory")
-      .select("user_id")
-      .in("user_id", [A.userId, B.userId, C.userId, D.userId]);
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!anonKey) throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY not set");
+    // Anon client: no Authorization bearer, only the apikey. RPC must
+    // 42501 / "permission denied" — this is the MEANINGFUL security
+    // upgrade over the dropped view (which returned 0 rows via filter).
+    const anon = createClient(LOCAL_SUPABASE_URL, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { data, error } = await anon.rpc("fn_list_visible_users");
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    // PostgREST surfaces Postgres SQLSTATE 42501 as code "42501" and the
+    // message includes "permission denied". Be lenient on exact spelling
+    // (PostgREST wraps the SQLSTATE in a JSON payload).
+    const codeOrMessage = `${error?.code ?? ""} ${error?.message ?? ""}`.toLowerCase();
+    expect(
+      codeOrMessage.includes("42501") ||
+        codeOrMessage.includes("permission denied")
+    ).toBe(true);
+  });
+
+  it("A (super_admin) sees A, B, C, D when listing all", async () => {
+    if (skipIfRequested()) return;
+    const { data, error } = await A.client.rpc("fn_list_visible_users");
     expect(error).toBeNull();
-    const ids = new Set((data ?? []).map((r) => r.user_id));
+    const ids = new Set(((data ?? []) as VisibleRow[]).map((r) => r.user_id));
     expect(ids.has(A.userId)).toBe(true);
     expect(ids.has(B.userId)).toBe(true);
     expect(ids.has(C.userId)).toBe(true);
@@ -129,12 +169,11 @@ describe("user_directory — visibility", () => {
 
   it("B (org_manager @ NFE) sees self + C; does NOT see A or D", async () => {
     if (skipIfRequested()) return;
-    const { data, error } = await B.client
-      .from("user_directory")
-      .select("user_id")
-      .in("user_id", [A.userId, B.userId, C.userId, D.userId]);
+    const { data, error } = await B.client.rpc("fn_list_visible_users", {
+      _target_user_ids: [A.userId, B.userId, C.userId, D.userId],
+    });
     expect(error).toBeNull();
-    const ids = new Set((data ?? []).map((r) => r.user_id));
+    const ids = new Set(((data ?? []) as VisibleRow[]).map((r) => r.user_id));
     expect(ids.has(B.userId)).toBe(true);
     expect(ids.has(C.userId)).toBe(true);
     expect(ids.has(A.userId)).toBe(false); // super_admin hidden
@@ -143,16 +182,50 @@ describe("user_directory — visibility", () => {
 
   it("D (org_manager @ OtherOrg) does NOT see B, C", async () => {
     if (skipIfRequested()) return;
-    const { data, error } = await D.client
-      .from("user_directory")
-      .select("user_id")
-      .in("user_id", [A.userId, B.userId, C.userId, D.userId]);
+    const { data, error } = await D.client.rpc("fn_list_visible_users", {
+      _target_user_ids: [A.userId, B.userId, C.userId, D.userId],
+    });
     expect(error).toBeNull();
-    const ids = new Set((data ?? []).map((r) => r.user_id));
+    const ids = new Set(((data ?? []) as VisibleRow[]).map((r) => r.user_id));
     expect(ids.has(D.userId)).toBe(true); // self
     expect(ids.has(B.userId)).toBe(false);
     expect(ids.has(C.userId)).toBe(false);
     expect(ids.has(A.userId)).toBe(false);
+  });
+
+  it("single-target lookup: org_manager B → D's id returns empty", async () => {
+    if (skipIfRequested()) return;
+    const { data, error } = await B.client.rpc("fn_list_visible_users", {
+      _target_user_ids: [D.userId],
+    });
+    expect(error).toBeNull();
+    expect(((data ?? []) as VisibleRow[]).length).toBe(0);
+  });
+
+  it("single-target lookup: super_admin A → D's id returns one row", async () => {
+    if (skipIfRequested()) return;
+    const { data, error } = await A.client.rpc("fn_list_visible_users", {
+      _target_user_ids: [D.userId],
+    });
+    expect(error).toBeNull();
+    const rows = (data ?? []) as VisibleRow[];
+    expect(rows.length).toBe(1);
+    expect(rows[0].user_id).toBe(D.userId);
+  });
+
+  it("batch lookup: B's [A, C, D] → only C surfaces (≤3 per visibility)", async () => {
+    // Preserves the audit-log-fetch.ts use case: send a set of actor ids,
+    // get back the subset the caller can see — RLS-hidden actors silently
+    // drop out (callers render null for those).
+    if (skipIfRequested()) return;
+    const { data, error } = await B.client.rpc("fn_list_visible_users", {
+      _target_user_ids: [A.userId, C.userId, D.userId],
+    });
+    expect(error).toBeNull();
+    const ids = new Set(((data ?? []) as VisibleRow[]).map((r) => r.user_id));
+    expect(ids.has(C.userId)).toBe(true);
+    expect(ids.has(A.userId)).toBe(false);
+    expect(ids.has(D.userId)).toBe(false);
   });
 });
 

--- a/src/lib/types/database.gen.ts
+++ b/src/lib/types/database.gen.ts
@@ -73,13 +73,6 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "billing_audit_log_actor_user_id_fkey"
-            columns: ["actor_user_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
-          },
-          {
             foreignKeyName: "billing_audit_log_billing_line_item_id_fkey"
             columns: ["billing_line_item_id"]
             isOneToOne: false
@@ -204,25 +197,11 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "billing_line_items_entered_by_user_id_fkey"
-            columns: ["entered_by_user_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
-          },
-          {
             foreignKeyName: "billing_line_items_household_id_fkey"
             columns: ["household_id"]
             isOneToOne: false
             referencedRelation: "households"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "billing_line_items_paid_by_user_id_fkey"
-            columns: ["paid_by_user_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -483,13 +462,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "households"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "household_users_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -754,13 +726,6 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "org_api_tokens_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
-          },
-          {
             foreignKeyName: "org_api_tokens_org_id_fkey"
             columns: ["org_id"]
             isOneToOne: false
@@ -853,13 +818,6 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "payment_events_actor_user_id_fkey"
-            columns: ["actor_user_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
-          },
-          {
             foreignKeyName: "payment_events_line_item_id_fkey"
             columns: ["line_item_id"]
             isOneToOne: false
@@ -931,15 +889,7 @@ export type Database = {
           updated_at?: string
           user_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "user_profiles_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
-          },
-        ]
+        Relationships: []
       }
       user_roles: {
         Row: {
@@ -973,13 +923,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "organizations"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "user_roles_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -1018,29 +961,6 @@ export type Database = {
             columns: ["microgrid_id"]
             isOneToOne: false
             referencedRelation: "microgrids"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      user_directory: {
-        Row: {
-          email: string | null
-          email_confirmed_at: string | null
-          first_name: string | null
-          last_name: string | null
-          last_sign_in_at: string | null
-          phone: string | null
-          role: Database["public"]["Enums"]["user_role"] | null
-          scope_id: string | null
-          scope_type: Database["public"]["Enums"]["role_scope_type"] | null
-          user_id: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "user_roles_scope_org_fkey"
-            columns: ["scope_id"]
-            isOneToOne: false
-            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
         ]
@@ -1169,6 +1089,21 @@ export type Database = {
         Returns: string
       }
       fn_get_ems_secret: { Args: { _microgrid_id: string }; Returns: string }
+      fn_list_visible_users: {
+        Args: { _target_user_ids?: string[] }
+        Returns: {
+          email: string
+          email_confirmed_at: string
+          first_name: string
+          last_name: string
+          last_sign_in_at: string
+          phone: string
+          role: Database["public"]["Enums"]["user_role"]
+          scope_id: string
+          scope_type: Database["public"]["Enums"]["role_scope_type"]
+          user_id: string
+        }[]
+      }
       fn_next_invoice_number: {
         Args: { p_community_id: string; p_year: number }
         Returns: number

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -43,13 +43,37 @@ export type OrgApiToken =
   Database["public"]["Tables"]["org_api_tokens"]["Row"];
 
 /**
- * user_directory row — the joined VIEW over auth.users × user_profiles ×
- * user_roles. Defined in migration 00013 with security_invoker = true.
- * Column nullability mirrors the LEFT JOINs: a user with no profile or
- * no role row surfaces with NULL columns.
+ * A row from the `fn_list_visible_users` RPC — the joined return shape over
+ * auth.users × user_profiles × user_roles. Defined in migration 00046
+ * (replaces the prior `user_directory` VIEW for #269 to clear two CRITICAL
+ * Supabase linter ERRORs: `auth_users_exposed` + `security_definer_view`).
+ *
+ * The RPC is SECURITY DEFINER and enforces visibility via the
+ * `user_can_see_user_profile(user_id)` helper (same predicate the old view
+ * used in its WHERE clause).
+ *
+ * We explicitly NULL-widen every column here. The Supabase codegen does not
+ * carry column nullability through function return-types (the underlying
+ * pg_type metadata only marks columns NOT NULL when the function declares
+ * STRICT or the column has a default — neither applies to TABLE-returning
+ * SECURITY DEFINER functions). At runtime every column EXCEPT `user_id`
+ * may be NULL because the joins are LEFT JOINs onto user_profiles and
+ * user_roles: a user with no profile or no role row surfaces with NULL
+ * columns, identical to the prior view's Row shape.
+ *
+ * `UserDirectoryRow` is kept as a deprecated alias so existing import sites
+ * still compile during the codebase rollover. New code should import
+ * `UserVisibleRow` directly.
  */
-export type UserDirectoryRow =
-  Database["public"]["Views"]["user_directory"]["Row"];
+type RawFnListVisibleUsersRow =
+  Database["public"]["Functions"]["fn_list_visible_users"]["Returns"][number];
+
+export type UserVisibleRow = {
+  [K in keyof RawFnListVisibleUsersRow]: RawFnListVisibleUsersRow[K] | null;
+};
+
+/** @deprecated Use `UserVisibleRow` — kept for one PR cycle of backwards compat. */
+export type UserDirectoryRow = UserVisibleRow;
 
 // ── Views ─────────────────────────────────────────────────────────────────────
 

--- a/supabase/migrations/00046_replace_user_directory_with_rpc.sql
+++ b/supabase/migrations/00046_replace_user_directory_with_rpc.sql
@@ -1,0 +1,98 @@
+-- 00046_replace_user_directory_with_rpc.sql
+-- A (#269): Replace public.user_directory view with fn_list_visible_users RPC
+-- to clear two CRITICAL linter ERRORs: auth_users_exposed + security_definer_view.
+--
+-- Path 2a chosen (drop view + refactor consumers; ref Alejandro msg 599658247).
+-- The view's FK-join shorthand surface (`user_directory!entered_by_user_id(...)`)
+-- was used by 1 of 5 consumers; that consumer is restructured to a two-step
+-- fetch in the same PR. All other consumers do simple .from('user_directory')
+-- → .rpc('fn_list_visible_users') swaps.
+--
+-- Why not just flip the view to security_invoker=true (the literal "Path 2c"):
+--   auth.users RLS denies authenticated by design (per 00014 file comment), so
+--   a security_invoker view over auth.users returns 0 rows for everyone.
+--
+-- Why not keep view + add RPC (the "Path 2b" hybrid): client-side joins +
+-- view-column-shrink + duplicated visibility predicate = real tech debt
+-- per architect-lane assessment (msg 599654301).
+
+-- ── 1. Drop the view ─────────────────────────────────────────────────────────
+--
+-- CASCADE removes the foreign-key-relationship hints that PostgREST exposed
+-- as FK-join shorthand. Any consumer still depending on `.from('user_directory')`
+-- after this migration will fail at runtime; codegen (database.gen.ts) is the
+-- safety net — `npm run db:types` will drop the View entry and the affected
+-- `referencedRelation: "user_directory"` references in the codegen output.
+
+DROP VIEW IF EXISTS public.user_directory CASCADE;
+
+-- ── 2. Create the replacement RPC ────────────────────────────────────────────
+--
+-- Signature mirrors the columns the view exposed (user_id, email,
+-- email_confirmed_at, last_sign_in_at, first_name, last_name, phone, role,
+-- scope_type, scope_id). _target_user_ids is the single parameter — NULL
+-- lists all visible users; non-NULL filters to those ids. Replaces both the
+-- "list" pattern (settings/users page) and "single-user lookup" pattern
+-- (resend-invite route, PDF route) with one function.
+--
+-- Visibility predicate is `user_can_see_user_profile(au.id)` — identical to
+-- the gate that today's view uses in its WHERE clause. The helper itself
+-- is SECURITY DEFINER and reads `auth.uid()` from the caller's JWT, so the
+-- predicate enforces the same visibility rules:
+--   - caller is target
+--   - caller is super_admin
+--   - caller shares an org-scoped manager role with the target
+--
+-- LANGUAGE sql + STABLE: predicate is pure-read; no PL/pgSQL needed. The
+-- `(_target_user_ids IS NULL OR au.id = ANY(_target_user_ids))` clause
+-- elegantly handles both list-all and filter-by-set patterns in one query.
+--
+-- Note on `auth.users.email` type: the underlying column in `auth.users` is
+-- `character varying`, not `text`. The explicit `::TEXT` cast in the SELECT
+-- keeps the RPC's return-type column stable across Postgres versions /
+-- Supabase upgrades.
+
+CREATE OR REPLACE FUNCTION public.fn_list_visible_users(
+  _target_user_ids UUID[] DEFAULT NULL
+)
+RETURNS TABLE (
+  user_id            UUID,
+  email              TEXT,
+  email_confirmed_at TIMESTAMPTZ,
+  last_sign_in_at    TIMESTAMPTZ,
+  first_name         TEXT,
+  last_name          TEXT,
+  phone              TEXT,
+  role               public.user_role,
+  scope_type         public.role_scope_type,
+  scope_id           UUID
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    au.id                        AS user_id,
+    au.email::TEXT               AS email,
+    au.email_confirmed_at,
+    au.last_sign_in_at,
+    up.first_name,
+    up.last_name,
+    up.phone,
+    ur.role,
+    ur.scope_type,
+    ur.scope_id
+  FROM auth.users au
+  LEFT JOIN public.user_profiles up ON up.user_id = au.id
+  LEFT JOIN public.user_roles    ur ON ur.user_id = au.id
+  WHERE user_can_see_user_profile(au.id)
+    AND (_target_user_ids IS NULL OR au.id = ANY(_target_user_ids));
+$$;
+
+-- ── 3. Grants (follows B2 convention preemptively) ───────────────────────────
+
+REVOKE EXECUTE ON FUNCTION public.fn_list_visible_users(UUID[])
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.fn_list_visible_users(UUID[])
+  TO authenticated, service_role;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
           include: ["src/lib/**/*.test.{ts,tsx}"],
           exclude: [
             "src/lib/supabase/__tests__/rls.test.ts",
-            "src/lib/supabase/__tests__/user_directory_view.test.ts",
+            "src/lib/supabase/__tests__/fn_list_visible_users.test.ts",
             "src/lib/supabase/__tests__/user_profiles_rls.test.ts",
             "src/lib/supabase/__tests__/dek-bootstrap.test.ts",
             "src/lib/supabase/__tests__/payment_state_machine.test.ts",
@@ -52,7 +52,7 @@ export default defineConfig({
           // fileParallelism: false ensures tests within this project run sequentially.
           include: [
             "src/lib/supabase/__tests__/rls.test.ts",
-            "src/lib/supabase/__tests__/user_directory_view.test.ts",
+            "src/lib/supabase/__tests__/fn_list_visible_users.test.ts",
             "src/lib/supabase/__tests__/user_profiles_rls.test.ts",
             "src/lib/supabase/__tests__/dek-bootstrap.test.ts",
             "src/lib/supabase/__tests__/payment_state_machine.test.ts",


### PR DESCRIPTION
Closes #269 (A — first of the four-ticket linter-cleanup wave).

## Summary

Path 2a per Alejandro steer (Zulip msg 599658247): drop `public.user_directory` (CASCADE) and replace with a SECURITY DEFINER RPC `fn_list_visible_users(_target_user_ids UUID[])`. Clears both CRITICAL Supabase linter ERRORs (`auth_users_exposed` + `security_definer_view`).

**Meaningful security upgrade**: the prior view granted `SELECT` to `anon` and filtered rows via its `WHERE` clause — safe in practice but structurally fragile. The new RPC `REVOKE EXECUTE FROM PUBLIC, anon` so anon is denied at the grant layer (42501 / "permission denied"), with the same `user_can_see_user_profile(au.id)` predicate enforced body-side for authenticated callers.

## Changes

- **Migration `00046_replace_user_directory_with_rpc.sql`** — `DROP VIEW … CASCADE` + `CREATE OR REPLACE FUNCTION fn_list_visible_users(...) SECURITY DEFINER STABLE LANGUAGE sql` returning the same column shape as the old view. Grants follow B2 convention preemptively.

- **6 consumer refactors** (one more than the appendix's 5 — `settings/api-tokens/page.tsx` also depended on the view via the `DROP CASCADE`):
  - `settings/users/page.tsx` — `.from → .rpc` (no args = list all visible)
  - `microgrids/[id]/billing/[periodId]/page.tsx` — drops the `user_directory!entered_by_user_id(...)` FK-join shorthand; restructured into a two-step fetch (line items, then batch RPC keyed by collected `entered_by_user_id`). `LineItemWithActor` alias and `cleanLineItems` strip-dance removed.
  - `billing-line-items/[id]/pdf/route.ts` — single-target lookup via `_target_user_ids: [enteredById]`. Also drops the phantom `display_name` column from the select (didn't exist on the old view).
  - `users/[id]/resend-invite/route.ts` — single-target lookup; docstring + module header updated to reference the RPC instead of the view.
  - `billing/audit-log-fetch.ts` — batch lookup via `_target_user_ids: actorIds`.
  - `settings/api-tokens/page.tsx` — batch lookup (cascade fix).

- **Test rewrites**:
  - `user_directory_view.test.ts` → `fn_list_visible_users.test.ts` (10 RLS cases; includes the new "anon denied at grant layer" check, single-target lookup for both roles, and batch lookup).
  - `billing/[periodId]/page.test.tsx` — rewritten around the two-step fetch; new assertions for `LAST_RPC_ARGS` batch shape and the RLS-hidden actor case.
  - `resend-invite/route.test.ts`, `audit-log/route.test.ts`, `pdf/route.test.ts` — Supabase mocks swapped from `.from('user_directory')` to `.rpc('fn_list_visible_users')`.
  - `vitest.config.ts` — project lists updated to point at the renamed RLS file.

- **Type surface** (`src/lib/types/domain.ts`): introduces `UserVisibleRow` (RPC-derived). `UserDirectoryRow` kept as a deprecated alias for one PR-cycle of import-site compat. NULL-widening explicit because Supabase codegen doesn't carry function-return-column nullability through.

- **Codegen impact**: `database.gen.ts` — view entry + 7 `referencedRelation: "user_directory"` FK references removed; one `fn_list_visible_users` function entry added. Net ~80 lines removed.

## Test plan

- [x] `supabase db reset` — migration 00046 applies cleanly on top of 00001–00044.
- [x] `npm run db:types` — codegen regenerated and committed.
- [x] `npm run db:types:check` — clean (committed file matches generated).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors (pre-existing warnings only, unrelated to this PR).
- [x] `npm test` — **1820/1820 passing** (after `supabase db reset` to clear earlier suite leakage; this PR's tests pass without issue in isolation and as part of the full suite).
- [x] `npm test -- fn_list_visible_users.test.ts` — 10/10 RLS cases pass (anon-denied + super_admin sees-all + org_manager same-org + single-target + batch + UPDATE policy).
- [x] `npm test -- rls.test.ts` — 109/109 unchanged.
- [x] `npm test -- rls-route.test.ts` — 6/6 unchanged (resend-invite RLS integration).

## Operator notes

- Deploy ordering matters more for this ticket than the REVOKE-only ones in the wave: dropping the view is destructive. Coordinate with Infra per Alejandro's gate #3 — production traffic hitting `.from('user_directory')` between deploy and migration would 500.
- Next in the wave per architect-lane re-sequence: B2 (#270), then C (#271).