### PR TITLE
fix(dashboard): make microgrid cards clickable + add keyboard focus rings

### DIFF
--- a/src/app/(dashboard)/__tests__/page.test.tsx
+++ b/src/app/(dashboard)/__tests__/page.test.tsx
@@ -1,0 +1,98 @@
+// Dashboard root page — server component tests.
+//
+// Strategy (mirrors microgrids/[id]/__tests__/page.test.tsx):
+//   - Mock @/lib/supabase/server to return fixture microgrids and household
+//     counts via a fully chainable query proxy.
+//   - Call OrgCard() directly (async server component that renders the
+//     org-panel microgrid cards) and serialize the returned JSX to HTML with
+//     renderToStaticMarkup. The root DashboardPage delegates per-org data
+//     fetching to OrgCard, so testing OrgCard exercises the card markup
+//     without the nested-async-component suspend that renderToStaticMarkup
+//     cannot await.
+//   - Assert the cards render as <a> anchors with href="/microgrids/<id>"
+//     (Support-reported P2: cards must be clickable).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ from: mockFrom }),
+}));
+
+// ── Import component under test (after mocks) ─────────────────────────────────
+
+import { OrgCard } from "../page";
+
+// ── Query builder helpers ─────────────────────────────────────────────────────
+//
+// buildQuery returns a fully chainable proxy so any call chain (select, eq,
+// returns, count/head, etc.) resolves to { data, error: null, count }.
+
+function buildQuery(data: unknown, count: number | null = null) {
+  const result = { data, error: null, count };
+  const terminal = () => Promise.resolve(result);
+
+  function makeChainable(): Record<string, unknown> {
+    return new Proxy({} as Record<string, unknown>, {
+      get(_target, prop) {
+        if (prop === "returns") return terminal;
+        if (prop === "then") {
+          return (resolve: (v: typeof result) => unknown) =>
+            Promise.resolve(result).then(resolve);
+        }
+        return () => makeChainable();
+      },
+    });
+  }
+
+  return makeChainable();
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ORG = { id: "org-1", name: "Acme Energy" };
+const MICROGRID = {
+  id: "mg-1",
+  name: "North Grid",
+  address_city: "Kampala",
+  address_country: "Uganda",
+  currency: "UGX",
+  community_id: "comm-1",
+};
+
+function wireFrom() {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "microgrids") return buildQuery([MICROGRID]);
+    if (table === "households") return buildQuery(null, 3);
+    return buildQuery([]);
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("DashboardPage org-panel microgrid cards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireFrom();
+  });
+
+  it("renders each microgrid card as an anchor linking to its detail page", async () => {
+    const tree = await OrgCard({ org: ORG as never });
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+
+    expect(html).toContain('href="/microgrids/mg-1"');
+    expect(html).toContain("North Grid");
+  });
+
+  it("renders the household count and currency inside the card", async () => {
+    const tree = await OrgCard({ org: ORG as never });
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+
+    expect(html).toContain("3 households");
+    expect(html).toContain("UGX");
+  });
+});

--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -300,7 +300,7 @@ export default async function MicrogridsPage({
             <a
               key={mg.id}
               href={`/microgrids/${mg.id}`}
-              className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted"
+              className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <h2 className="font-medium text-foreground">{mg.name}</h2>
               {locationLabel && (

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -52,7 +52,7 @@ export default async function DashboardPage() {
   );
 }
 
-async function OrgCard({ org }: { org: Organization }) {
+export async function OrgCard({ org }: { org: Organization }) {
   const supabase = await createClient();
 
   // Fetch microgrids for this org (via communities join)
@@ -94,9 +94,10 @@ async function OrgCard({ org }: { org: Organization }) {
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {microgridsWithCounts.map((mg) => (
-            <div
+            <a
               key={mg.id}
-              className="rounded-md border border-border bg-muted p-4"
+              href={`/microgrids/${mg.id}`}
+              className="block rounded-md border border-border bg-muted p-4 transition-colors hover:bg-card hover:border-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <h3 className="font-medium text-foreground">{mg.name}</h3>
               {locationLabel(mg) && (
@@ -110,7 +111,7 @@ async function OrgCard({ org }: { org: Organization }) {
                 </span>
                 <span className="text-muted-foreground">{mg.currency}</span>
               </div>
-            </div>
+            </a>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary

Support-reported **P2**: dashboard org-panel microgrid cards aren't clickable, inconsistent with the microgrids list page. No GH issue number (conversationally scoped).

Designer-approved spec (**option a**):
- Dashboard org-panel cards (`src/app/(dashboard)/page.tsx`): each card changes from a plain `<div>` to an `<a href={/microgrids/:id}>`. Keeps the `bg-muted` resting background (cards nest inside a `bg-card` org panel, so muted-at-rest preserves contrast) with a `hover:bg-card` **lighten** state, plus a `focus-visible` keyboard ring. Card sizing (`rounded-md`/`p-4`) and inner contents unchanged.
- List-page card anchor (`src/app/(dashboard)/microgrids/page.tsx`): adds **only** the `focus-visible` ring for keyboard-affordance parity. Nothing else changed (hover behavior — card→muted darken — left as-is).

The two surfaces never co-render, so the intentionally opposite hover directions (dashboard lightens, list darkens) are fine.

Frontend only — no schema change, no migration.

## Design-token compliance
Per CLAUDE.md § Design System rule #3 (token classes only). Verified `ring-ring` / `ring-offset` resolve: `--ring` is defined in `src/app/globals.css` (line 44) and exposed to Tailwind v4 as `--color-ring` (line 83). `focus-visible:ring-2` / `ring-offset-2` are Tailwind v4 core utilities. All classes used (`bg-muted`, `bg-card`, `border-border`, `ring-ring`) are semantic tokens.

## Test plan
- Added `src/app/(dashboard)/__tests__/page.test.tsx` (no existing dashboard-root test). Mirrors the established server-component test pattern (mock `@/lib/supabase/server`, render with `renderToStaticMarkup`). Tests the now-exported `OrgCard` async component directly — the root page delegates per-org fetching to `OrgCard`, and `renderToStaticMarkup` can't await nested async children. Asserts cards render as `<a href="/microgrids/:id">` and include household count + currency.
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `npm test` (full suite, SKIP_RLS/DEK) — 1775 passed, 9 files skipped (RLS/DEK, expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #283.
