### PR TITLE
fix(dashboard): align card focus rings to house convention (outline-none, no offset)

### DIFF
--- a/src/app/(dashboard)/microgrids/page.tsx
+++ b/src/app/(dashboard)/microgrids/page.tsx
@@ -300,7 +300,7 @@ export default async function MicrogridsPage({
             <a
               key={mg.id}
               href={`/microgrids/${mg.id}`}
-              className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="block rounded-lg border border-border bg-card p-6 transition-colors hover:border-border hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <h2 className="font-medium text-foreground">{mg.name}</h2>
               {locationLabel && (

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -97,7 +97,7 @@ export async function OrgCard({ org }: { org: Organization }) {
             <a
               key={mg.id}
               href={`/microgrids/${mg.id}`}
-              className="block rounded-md border border-border bg-muted p-4 transition-colors hover:bg-card hover:border-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="block rounded-md border border-border bg-muted p-4 transition-colors hover:bg-card hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <h3 className="font-medium text-foreground">{mg.name}</h3>
               {locationLabel(mg) && (


### PR DESCRIPTION
Fast-follow to #284 (cacf36c). The two new microgrid-card focus rings deviated from the repo's house focus-ring convention in two ways:

1. Omitted `focus-visible:outline-none`, so a focused card stacked the native browser outline + the custom ring (double outline).
2. Used `focus-visible:ring-offset-2` without the `ring-offset-background` token, producing an un-themed hardcoded white offset gap.

This aligns both card anchors to the canonical 48-file house pattern: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring` (NO offset). Net per anchor: add `outline-none` (kills double outline), drop untokened `ring-offset-2`; `ring-2` + `ring-ring` stay.

**Scope:** two className strings only — `src/app/(dashboard)/page.tsx` (org-panel card) and `src/app/(dashboard)/microgrids/page.tsx` (list-page card). No hover/sizing/href/content changes. `src/app/login/page.tsx` (similar pattern) is a separate pre-existing finding, deliberately out of scope.

**Priority:** P3 cosmetic.

**Lineage:** follows #283 / fast-follows #284 (cacf36c).

**Test plan:** `npx tsc --noEmit` clean; `npm run lint` 0 errors; full suite green (1775 passed). #284's anchor/href test (`src/app/(dashboard)/__tests__/page.test.tsx`) asserts anchor + href, unaffected by this class change — verified still passing.


Closes #285.
