### PR TITLE
fix(auth): use setSession/verifyOtp returned user, drop redundant getUser (#287)

### DIFF
--- a/src/app/accept-invite/__tests__/page.test.tsx
+++ b/src/app/accept-invite/__tests__/page.test.tsx
@@ -153,9 +153,8 @@ describe("AcceptInvitePage — OTP token-hash flow (query string)", () => {
 
   it("calls verifyOtp with token_hash + type:'invite' and renders the password form on success", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=invite` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
 
@@ -193,10 +192,9 @@ describe("AcceptInvitePage — OTP token-hash flow (query string)", () => {
     });
   });
 
-  it("renders error state when verifyOtp succeeds but getUser returns no user", async () => {
+  it("renders error state when verifyOtp succeeds but returns no user", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=invite` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+    verifyOtpSpy.mockResolvedValue({ data: { user: null }, error: null });
 
     const { default: AcceptInvitePage } = await import("../page");
     render(<AcceptInvitePage />);
@@ -210,9 +208,8 @@ describe("AcceptInvitePage — OTP token-hash flow (query string)", () => {
 
   it("calls updateUser with the new password and redirects to / on submit success", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=invite` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
     updateUserSpy.mockResolvedValue({ data: {}, error: null });
@@ -245,9 +242,8 @@ describe("AcceptInvitePage — OTP token-hash flow (query string)", () => {
 
   it("renders a destructive Banner when updateUser fails", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=invite` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
     updateUserSpy.mockResolvedValue({
@@ -284,9 +280,8 @@ describe("AcceptInvitePage — OTP token-hash flow (query string)", () => {
 describe("AcceptInvitePage — implicit flow (URL fragment)", () => {
   it("calls setSession with access+refresh tokens and renders form on success", async () => {
     setUrl({ hash: fragmentFor("invite") });
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    setSessionSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
 
@@ -336,10 +331,9 @@ describe("AcceptInvitePage — implicit flow (URL fragment)", () => {
     });
   });
 
-  it("renders error state when setSession ok but getUser returns no user", async () => {
+  it("renders error state when setSession ok but returns no user", async () => {
     setUrl({ hash: fragmentFor("invite") });
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+    setSessionSpy.mockResolvedValue({ data: { user: null }, error: null });
 
     const { default: AcceptInvitePage } = await import("../page");
     render(<AcceptInvitePage />);
@@ -355,9 +349,8 @@ describe("AcceptInvitePage — implicit flow (URL fragment)", () => {
       hash: "#diagnostic=foo",
       search: `?token_hash=${TOKEN_HASH}&type=invite`,
     });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc" }, session: {} },
       error: null,
     });
 
@@ -374,9 +367,8 @@ describe("AcceptInvitePage — implicit flow (URL fragment)", () => {
 
   it("submits the new password successfully via implicit-flow session", async () => {
     setUrl({ hash: fragmentFor("invite") });
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    setSessionSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
     updateUserSpy.mockResolvedValue({ data: {}, error: null });

--- a/src/app/reset-password/__tests__/page.test.tsx
+++ b/src/app/reset-password/__tests__/page.test.tsx
@@ -152,9 +152,8 @@ describe("ResetPasswordPage — OTP token-hash flow (query string)", () => {
 
   it("calls verifyOtp with token_hash + type:'recovery' and renders the password form on success", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=recovery` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
 
@@ -190,10 +189,9 @@ describe("ResetPasswordPage — OTP token-hash flow (query string)", () => {
     });
   });
 
-  it("renders error state when verifyOtp succeeds but getUser returns no user", async () => {
+  it("renders error state when verifyOtp succeeds but returns no user", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=recovery` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+    verifyOtpSpy.mockResolvedValue({ data: { user: null }, error: null });
 
     const { default: ResetPasswordPage } = await import("../page");
     render(<ResetPasswordPage />);
@@ -207,9 +205,8 @@ describe("ResetPasswordPage — OTP token-hash flow (query string)", () => {
 
   it("calls updateUser with the new password and redirects to / on submit success", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=recovery` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
     updateUserSpy.mockResolvedValue({ data: {}, error: null });
@@ -240,9 +237,8 @@ describe("ResetPasswordPage — OTP token-hash flow (query string)", () => {
 
   it("renders a destructive Banner when updateUser fails", async () => {
     setUrl({ search: `?token_hash=${TOKEN_HASH}&type=recovery` });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
     updateUserSpy.mockResolvedValue({
@@ -277,9 +273,8 @@ describe("ResetPasswordPage — OTP token-hash flow (query string)", () => {
 describe("ResetPasswordPage — implicit flow (URL fragment)", () => {
   it("calls setSession with access+refresh tokens and renders form on success", async () => {
     setUrl({ hash: fragmentFor("recovery") });
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    setSessionSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
 
@@ -327,10 +322,9 @@ describe("ResetPasswordPage — implicit flow (URL fragment)", () => {
     });
   });
 
-  it("renders error state when setSession ok but getUser returns no user", async () => {
+  it("renders error state when setSession ok but returns no user", async () => {
     setUrl({ hash: fragmentFor("recovery") });
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+    setSessionSpy.mockResolvedValue({ data: { user: null }, error: null });
 
     const { default: ResetPasswordPage } = await import("../page");
     render(<ResetPasswordPage />);
@@ -346,9 +340,8 @@ describe("ResetPasswordPage — implicit flow (URL fragment)", () => {
       hash: "#diagnostic=foo",
       search: `?token_hash=${TOKEN_HASH}&type=recovery`,
     });
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "abc" }, session: {} },
       error: null,
     });
 
@@ -365,9 +358,8 @@ describe("ResetPasswordPage — implicit flow (URL fragment)", () => {
 
   it("submits the new password successfully via implicit-flow session", async () => {
     setUrl({ hash: fragmentFor("recovery") });
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "abc", email: "u@example.com" } },
+    setSessionSpy.mockResolvedValue({
+      data: { user: { id: "abc", email: "u@example.com" }, session: {} },
       error: null,
     });
     updateUserSpy.mockResolvedValue({ data: {}, error: null });

--- a/src/lib/auth/__tests__/install-session-from-url.test.ts
+++ b/src/lib/auth/__tests__/install-session-from-url.test.ts
@@ -8,7 +8,10 @@
  *   - Detection priority: fragment with valid token wins over query.
  *   - Empty / malformed / missing-token edge cases.
  *   - Type mismatch (wrong type literal vs expectedType).
- *   - getUser failure modes after each primitive.
+ *   - no-user-returned failure modes from each primitive.
+ *   - #287 regression: helper takes the user from setSession/verifyOtp's
+ *     own server-validated return and does NOT make a redundant getUser()
+ *     call, so a failing getUser cannot break an already-installed session.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { installSessionFromUrl } from "../install-session-from-url";
@@ -18,6 +21,18 @@ type Loc = { hash: string; search: string };
 function mkLoc(over: Partial<Loc> = {}): Loc {
   return { hash: "", search: "", ...over };
 }
+
+// The user that setSession/verifyOtp return on success. The helper takes
+// the user from the primitive's own server-validated return (#287) — not
+// from a separate getUser() call.
+const FAKE_USER = { id: "u1", email: "u@example.com" };
+const FAKE_SESSION = {
+  access_token: "AT_VALID",
+  refresh_token: "RT_VALID",
+  expires_in: 3600,
+  token_type: "bearer",
+  user: FAKE_USER,
+};
 
 const FRAGMENT_INVITE = (over: Record<string, string> = {}) =>
   "#" +
@@ -82,10 +97,9 @@ beforeEach(() => {
 });
 
 describe("installSessionFromUrl — implicit flow (URL fragment)", () => {
-  it("invite: setSession + getUser succeed → ok", async () => {
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u1", email: "u@example.com" } },
+  it("invite: setSession succeeds → ok (user from setSession return, no getUser)", async () => {
+    setSessionSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
       error: null,
     });
     const result = await installSessionFromUrl({
@@ -93,21 +107,18 @@ describe("installSessionFromUrl — implicit flow (URL fragment)", () => {
       expectedType: "invite",
       location: mkLoc({ hash: FRAGMENT_INVITE() }),
     });
-    expect(result).toEqual({
-      kind: "ok",
-      user: { id: "u1", email: "u@example.com" },
-    });
+    expect(result).toEqual({ kind: "ok", user: FAKE_USER });
     expect(setSessionSpy).toHaveBeenCalledWith({
       access_token: "AT_VALID",
       refresh_token: "RT_VALID",
     });
     expect(verifyOtpSpy).not.toHaveBeenCalled();
+    expect(getUserSpy).not.toHaveBeenCalled();
   });
 
-  it("recovery: setSession + getUser succeed → ok", async () => {
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u2", email: "r@example.com" } },
+  it("recovery: setSession succeeds → ok (no redundant getUser)", async () => {
+    setSessionSpy.mockResolvedValue({
+      data: { user: { id: "u2", email: "r@example.com" }, session: FAKE_SESSION },
       error: null,
     });
     const result = await installSessionFromUrl({
@@ -117,6 +128,7 @@ describe("installSessionFromUrl — implicit flow (URL fragment)", () => {
     });
     expect(result.kind).toBe("ok");
     expect(setSessionSpy).toHaveBeenCalledOnce();
+    expect(getUserSpy).not.toHaveBeenCalled();
   });
 
   it("type mismatch (recovery fragment, expecting invite) → type_mismatch", async () => {
@@ -157,15 +169,36 @@ describe("installSessionFromUrl — implicit flow (URL fragment)", () => {
     expect(getUserSpy).not.toHaveBeenCalled();
   });
 
-  it("setSession ok but getUser returns no user → verify_error", async () => {
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+  it("setSession ok but returns no user → verify_error", async () => {
+    setSessionSpy.mockResolvedValue({ data: { user: null }, error: null });
     const result = await installSessionFromUrl({
       supabase: makeSupabase(),
       expectedType: "invite",
       location: mkLoc({ hash: FRAGMENT_INVITE() }),
     });
     expect(result.kind).toBe("verify_error");
+    expect(getUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("#287 regression: setSession returns a user → ok even if getUser would error", async () => {
+    // Proves the helper no longer depends on a separate getUser() call.
+    // setSession already installed the session AND server-validated the
+    // user; a transient getUser failure must NOT surface as verify_error.
+    setSessionSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
+      error: null,
+    });
+    getUserSpy.mockResolvedValue({
+      data: { user: null },
+      error: { message: "network" },
+    });
+    const result = await installSessionFromUrl({
+      supabase: makeSupabase(),
+      expectedType: "recovery",
+      location: mkLoc({ hash: FRAGMENT_RECOVERY() }),
+    });
+    expect(result).toEqual({ kind: "ok", user: FAKE_USER });
+    expect(getUserSpy).not.toHaveBeenCalled();
   });
 
   it("fragment present but missing access_token → falls through to query (missing if no query)", async () => {
@@ -193,9 +226,8 @@ describe("installSessionFromUrl — implicit flow (URL fragment)", () => {
   });
 
   it("fragment without auth tokens but with query token → falls through to OTP path", async () => {
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u1", email: "u@example.com" } },
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
       error: null,
     });
     const result = await installSessionFromUrl({
@@ -215,10 +247,9 @@ describe("installSessionFromUrl — implicit flow (URL fragment)", () => {
 });
 
 describe("installSessionFromUrl — OTP flow (query string)", () => {
-  it("invite: verifyOtp + getUser succeed → ok", async () => {
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u1" } },
+  it("invite: verifyOtp succeeds → ok (user from verifyOtp return, no getUser)", async () => {
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
       error: null,
     });
     const result = await installSessionFromUrl({
@@ -226,17 +257,17 @@ describe("installSessionFromUrl — OTP flow (query string)", () => {
       expectedType: "invite",
       location: mkLoc({ search: QUERY_INVITE() }),
     });
-    expect(result.kind).toBe("ok");
+    expect(result).toEqual({ kind: "ok", user: FAKE_USER });
     expect(verifyOtpSpy).toHaveBeenCalledWith({
       token_hash: "TH_VALID",
       type: "invite",
     });
+    expect(getUserSpy).not.toHaveBeenCalled();
   });
 
-  it("recovery: verifyOtp + getUser succeed → ok", async () => {
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u2" } },
+  it("recovery: verifyOtp succeeds → ok (no redundant getUser)", async () => {
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: { id: "u2" }, session: FAKE_SESSION },
       error: null,
     });
     const result = await installSessionFromUrl({
@@ -245,6 +276,7 @@ describe("installSessionFromUrl — OTP flow (query string)", () => {
       location: mkLoc({ search: QUERY_RECOVERY() }),
     });
     expect(result.kind).toBe("ok");
+    expect(getUserSpy).not.toHaveBeenCalled();
   });
 
   it("type mismatch (invite query, expecting recovery) → type_mismatch", async () => {
@@ -288,15 +320,33 @@ describe("installSessionFromUrl — OTP flow (query string)", () => {
     expect(verifyOtpSpy).not.toHaveBeenCalled();
   });
 
-  it("verifyOtp ok but getUser returns no user → verify_error", async () => {
-    verifyOtpSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({ data: { user: null }, error: null });
+  it("verifyOtp ok but returns no user → verify_error", async () => {
+    verifyOtpSpy.mockResolvedValue({ data: { user: null }, error: null });
     const result = await installSessionFromUrl({
       supabase: makeSupabase(),
       expectedType: "invite",
       location: mkLoc({ search: QUERY_INVITE() }),
     });
     expect(result.kind).toBe("verify_error");
+    expect(getUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("#287 regression: verifyOtp returns a user → ok even if getUser would error", async () => {
+    verifyOtpSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
+      error: null,
+    });
+    getUserSpy.mockResolvedValue({
+      data: { user: null },
+      error: { message: "network" },
+    });
+    const result = await installSessionFromUrl({
+      supabase: makeSupabase(),
+      expectedType: "invite",
+      location: mkLoc({ search: QUERY_INVITE() }),
+    });
+    expect(result).toEqual({ kind: "ok", user: FAKE_USER });
+    expect(getUserSpy).not.toHaveBeenCalled();
   });
 
   it("missing token_hash → missing", async () => {
@@ -340,9 +390,8 @@ describe("installSessionFromUrl — empty / edge cases", () => {
   });
 
   it("both fragment + query — fragment wins", async () => {
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u1" } },
+    setSessionSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
       error: null,
     });
     const result = await installSessionFromUrl({
@@ -459,9 +508,8 @@ describe("installSessionFromUrl — spent-token detection (#194)", () => {
     // Defensive coverage for AC1 precedence: if a malformed URL has
     // both auth tokens AND error params in the fragment, the implicit
     // happy path takes precedence (matches SDK behavior).
-    setSessionSpy.mockResolvedValue({ data: {}, error: null });
-    getUserSpy.mockResolvedValue({
-      data: { user: { id: "u1", email: "u@example.com" } },
+    setSessionSpy.mockResolvedValue({
+      data: { user: FAKE_USER, session: FAKE_SESSION },
       error: null,
     });
     const hash =

--- a/src/lib/auth/install-session-from-url.ts
+++ b/src/lib/auth/install-session-from-url.ts
@@ -93,9 +93,10 @@ export interface InstallSessionFromUrlParams {
 }
 
 /**
- * Inspect the URL for invite/recovery confirmation params, install a
- * session via the appropriate Supabase primitive, and confirm the user
- * is reachable via `getUser()`.
+ * Inspect the URL for invite/recovery confirmation params and install a
+ * session via the appropriate Supabase primitive. The installed user is
+ * taken from `setSession`/`verifyOtp`'s own server-validated return — no
+ * redundant `getUser()` round-trip (#287).
  *
  * Returns a discriminated result — callers switch on `kind`:
  *  - `ok` — session installed, `user` populated.
@@ -135,20 +136,21 @@ export async function installSessionFromUrl(
       }
       // access_token wins over fragment-level `error` params per
       // detection priority (matches SDK's implicit-flow happy path).
-      const { error: setError } = await supabase.auth.setSession({
+      const { data: setData, error: setError } = await supabase.auth.setSession({
         access_token: fragment.access_token,
         refresh_token: fragment.refresh_token,
       });
       if (setError) {
         return mapErrorToResult(setError);
       }
-      const { data: userData, error: userError } = await supabase.auth.getUser();
-      if (userError || !userData?.user) {
-        return mapErrorToResult(
-          userError ?? { message: "Session install produced no user" }
-        );
+      if (!setData?.user) {
+        // setSession resolved without error but produced no user (rare
+        // expired-refresh edge in _setSession). Treat as verify_error —
+        // but do NOT make a second network call that can fail independently
+        // after the session is already installed (#287 root cause).
+        return mapErrorToResult({ message: "Session install produced no user" });
       }
-      return { kind: "ok", user: userData.user };
+      return { kind: "ok", user: setData.user };
     }
 
     // Fragment present but missing access_token/refresh_token. Check
@@ -191,20 +193,20 @@ export async function installSessionFromUrl(
     return { kind: "type_mismatch" };
   }
 
-  const { error: verifyError } = await supabase.auth.verifyOtp({
+  const { data: verifyData, error: verifyError } = await supabase.auth.verifyOtp({
     token_hash: tokenHash,
     type: expectedType,
   });
   if (verifyError) {
     return mapErrorToResult(verifyError);
   }
-  const { data: userData, error: userError } = await supabase.auth.getUser();
-  if (userError || !userData?.user) {
-    return mapErrorToResult(
-      userError ?? { message: "verifyOtp produced no user" }
-    );
+  if (!verifyData?.user) {
+    // verifyOtp resolved without error but produced no user. Treat as
+    // verify_error — do NOT make a redundant getUser() that can fail
+    // independently after the session is already installed (#287).
+    return mapErrorToResult({ message: "verifyOtp produced no user" });
   }
-  return { kind: "ok", user: userData.user };
+  return { kind: "ok", user: verifyData.user };
 }
 
 // ── Internals ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause

`installSessionFromUrl` (the shared session installer behind `/reset-password` and `/accept-invite`) called `supabase.auth.setSession({...})` (or `verifyOtp`), **discarded its server-validated returned `user`**, then made a **separate redundant `supabase.auth.getUser()`** network call. That second call is an independent failure window: when it failed *after* `setSession` had already installed the session cookies, the helper returned `verify_error` and `/reset-password` showed "This password-reset link is invalid or expired" **over a live, already-installed session** — so the operator was magic-logged-in but never got to set a password (the sole password-set surface).

`@supabase/auth-js@2.99.0` `_setSession` already calls `_getUser(access_token)` internally and returns the server-sourced `{ user, session }`. The extra `getUser()` added failure surface without adding validation.

## Fix

In **both** success paths of `installSessionFromUrl`, use the `user` that `setSession` / `verifyOtp` already return and drop the standalone `getUser()`. A "succeeded-but-no-user → verify_error" guard is retained, now sourced from the primitive's own return (no extra network call). Error-mapping, parsers, type-mismatch / spent-token / missing branches, and the discriminated result type are unchanged.

The OTP `verifyOtp` path had the identical redundant pattern — fixed too, which also closes the same latent race in the shared accept-invite flow.

## Test plan

- `install-session-from-url.test.ts`: success mocks now put the user on `setSession`/`verifyOtp`'s own return; assert `getUser` is **not** called on success. Reworked the no-user case to come from the primitive. **Added two #287 regression tests** (implicit + OTP path): primitive returns a valid user AND a `getUser` mock that *would* error → result is `{ kind: "ok" }`, proving the helper no longer depends on `getUser`.
- Both consuming page suites updated to the new mock shape and pass: `reset-password/__tests__/page.test.tsx`, `accept-invite/__tests__/page.test.tsx`.
- Focused: 61/61 pass. Full suite: 1777 passed / 70 skipped (RLS+DEK skipped as usual), 0 failures. `tsc --noEmit` clean; `lint` 0 errors.

No migration; no codegen impact; lib + tests only.

Closes #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)