### PR TITLE
fix(payments): persist pesapal_order_id on first-time mint so IPN loo…

### DIFF
--- a/src/lib/payments/__tests__/ensure-payment-link.test.ts
+++ b/src/lib/payments/__tests__/ensure-payment-link.test.ts
@@ -104,6 +104,7 @@ function makeMockClient(opts: {
 } {
   const state = {
     persistedUrl: opts.initialRow?.pesapal_redirect_url ?? null,
+    persistedOrderId: null as string | null,
     paymentStatus: opts.initialRow?.payment_status ?? "unpaid",
     auditCalls: [] as unknown[][],
   };
@@ -169,6 +170,7 @@ function makeMockClient(opts: {
                     return { data: [], error: null };
                   }
                   state.persistedUrl = patch.pesapal_redirect_url;
+                  state.persistedOrderId = patch.pesapal_order_id ?? null;
                   return {
                     data: [
                       {
@@ -185,6 +187,7 @@ function makeMockClient(opts: {
           // force=true path: unconditional UPDATE — no .is() guard.
           select: (_cols: string) => {
             state.persistedUrl = patch.pesapal_redirect_url;
+            state.persistedOrderId = patch.pesapal_order_id ?? null;
             return Promise.resolve({
               data: [
                 {
@@ -205,6 +208,9 @@ function makeMockClient(opts: {
     state: {
       get persistedUrl() {
         return state.persistedUrl;
+      },
+      get persistedOrderId() {
+        return state.persistedOrderId;
       },
       auditCalls: state.auditCalls,
     },
@@ -521,6 +527,27 @@ describe("ensurePaymentLinkForLineItem", () => {
       .find((s) => s.includes("audit_write_failed"));
     expect(matched).toBeTruthy();
     warnSpy.mockRestore();
+  });
+
+  // ── fix/pesapal-callback regression — pesapal_order_id written on first mint ──
+  it("persists pesapal_order_id on the force=false (first-mint) path so IPN lookup can find the row", async () => {
+    // Before the fix, the force=false UPDATE only wrote pesapal_redirect_url.
+    // The IPN handler queries billing_line_items by pesapal_order_id, so any
+    // order minted without force=true would silently return unknown_order and
+    // never auto-mark as paid.
+    const { client, state } = makeMockClient({
+      initialRow: { pesapal_redirect_url: null, payment_status: "unpaid" },
+    });
+    const { ensurePaymentLinkForLineItem } = await import(
+      "../ensure-payment-link"
+    );
+
+    const r = await ensurePaymentLinkForLineItem(client as never, LINE_ITEM_ID);
+
+    expect(r.wasMinted).toBe(true);
+    // The persisted order id must match the providerReference the IPN will send
+    // back as OrderMerchantReference.
+    expect(state.persistedOrderId).toBe(GOOD_RESULT.providerReference);
   });
 
   // ── service-role client path ─────────────────────────────────────────────

--- a/src/lib/payments/__tests__/ensure-payment-link.test.ts
+++ b/src/lib/payments/__tests__/ensure-payment-link.test.ts
@@ -99,6 +99,7 @@ function makeMockClient(opts: {
   };
   state: {
     persistedUrl: string | null;
+    persistedOrderId: string | null;
     auditCalls: unknown[][];
   };
 } {

--- a/src/lib/payments/ensure-payment-link.ts
+++ b/src/lib/payments/ensure-payment-link.ts
@@ -324,7 +324,10 @@ async function mintAndPersist(
         .select("id, pesapal_redirect_url")
     : supabase
         .from("billing_line_items")
-        .update({ pesapal_redirect_url: result.redirectUrl })
+        .update({
+          pesapal_redirect_url: result.redirectUrl,
+          pesapal_order_id: result.providerReference,
+        })
         .eq("id", lineItemId)
         .is("pesapal_redirect_url", null)
         .select("id, pesapal_redirect_url");


### PR DESCRIPTION
…kup succeeds

The force=false (first-time) mint path in ensure-payment-link only wrote pesapal_redirect_url to billing_line_items, leaving pesapal_order_id NULL. The IPN handler looks up line items by pesapal_order_id, so every first-mint payment callback returned unknown_order and auto-marking never fired.

Added pesapal_order_id to the force=false UPDATE, matching the force=true path. The optimistic-concurrency IS-NULL guard is preserved.

Regression test added to ensure-payment-link.test.ts to pin that pesapal_order_id is written on first mint.

Closes #282