### PR TITLE
feat(billing): support OpenEMS-pull mode in v1 generate (optional manualReadings)

### DIFF
--- a/src/app/api/v1/billing/generate/__tests__/route.test.ts
+++ b/src/app/api/v1/billing/generate/__tests__/route.test.ts
@@ -311,4 +311,29 @@ describe("POST /api/v1/billing/generate (#254)", () => {
       actorRef: "customerapp-prod-2026",
     });
   });
+
+  it("200 + OpenEMS-pull mode: no manualReadings delegates with manualReadings:[] and householdIds undefined (every household resolved from OpenEMS)", async () => {
+    const { POST } = await import("../route");
+    const body = validBody();
+    delete (body as Record<string, unknown>).manualReadings;
+    const res = await POST(makePostRequest(body));
+    expect(res.status).toBe(200);
+    expect(runGenerationCalls).toHaveLength(1);
+    expect(runGenerationCalls[0]).toMatchObject({
+      periodId: PERIOD_ID,
+      manualReadings: [],
+      mode: "write",
+    });
+    expect(
+      (runGenerationCalls[0] as Record<string, unknown>).householdIds
+    ).toBeUndefined();
+  });
+
+  it("400 when manualReadings is present but not an array", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest(validBody({ manualReadings: "nope" })));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("manualReadings must be an array");
+    expect(runGenerationCalls).toHaveLength(0);
+  });
 });

--- a/src/app/api/v1/billing/generate/route.ts
+++ b/src/app/api/v1/billing/generate/route.ts
@@ -37,13 +37,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "microgrid_id must be a UUID" }, { status: 400 });
   }
 
-  if (!Array.isArray(rec.manualReadings) || rec.manualReadings.length === 0) {
-    return NextResponse.json(
-      { error: "manualReadings must be a non-empty array" },
-      { status: 400 }
-    );
-  }
-
+  // manualReadings is OPTIONAL. When omitted (or an empty array), every
+  // household's usage is pulled from OpenEMS over the billing period — the
+  // automated-billing path: a scheduled caller POSTs with no manualReadings and
+  // the engine resolves each household's consumption from the OpenEMS B2B API.
+  // When present, each entry overrides that household's reading; all other
+  // households still resolve from OpenEMS. householdIds is left undefined so the
+  // engine bills the period microgrid's full household set.
   const manualReadings: Array<{
     householdId: string;
     startKwh: number;
@@ -51,32 +51,40 @@ export async function POST(request: NextRequest) {
     reason?: string;
   }> = [];
 
-  for (let i = 0; i < rec.manualReadings.length; i++) {
-    const m = rec.manualReadings[i] as Record<string, unknown>;
-    if (typeof m.householdId !== "string" || !UUID_RE.test(m.householdId)) {
+  if (rec.manualReadings !== undefined) {
+    if (!Array.isArray(rec.manualReadings)) {
       return NextResponse.json(
-        { error: `manualReadings[${i}].householdId must be a UUID` },
+        { error: "manualReadings must be an array" },
         { status: 400 }
       );
     }
-    if (typeof m.startKwh !== "number" || !Number.isFinite(m.startKwh) || m.startKwh < 0) {
-      return NextResponse.json(
-        { error: `manualReadings[${i}].startKwh must be a non-negative finite number` },
-        { status: 400 }
-      );
+    for (let i = 0; i < rec.manualReadings.length; i++) {
+      const m = rec.manualReadings[i] as Record<string, unknown>;
+      if (typeof m.householdId !== "string" || !UUID_RE.test(m.householdId)) {
+        return NextResponse.json(
+          { error: `manualReadings[${i}].householdId must be a UUID` },
+          { status: 400 }
+        );
+      }
+      if (typeof m.startKwh !== "number" || !Number.isFinite(m.startKwh) || m.startKwh < 0) {
+        return NextResponse.json(
+          { error: `manualReadings[${i}].startKwh must be a non-negative finite number` },
+          { status: 400 }
+        );
+      }
+      if (typeof m.endKwh !== "number" || !Number.isFinite(m.endKwh) || m.endKwh < m.startKwh) {
+        return NextResponse.json(
+          { error: `manualReadings[${i}].endKwh must be a finite number >= startKwh` },
+          { status: 400 }
+        );
+      }
+      manualReadings.push({
+        householdId: m.householdId,
+        startKwh: m.startKwh,
+        endKwh: m.endKwh,
+        ...(typeof m.reason === "string" ? { reason: m.reason } : {}),
+      });
     }
-    if (typeof m.endKwh !== "number" || !Number.isFinite(m.endKwh) || m.endKwh < m.startKwh) {
-      return NextResponse.json(
-        { error: `manualReadings[${i}].endKwh must be a finite number >= startKwh` },
-        { status: 400 }
-      );
-    }
-    manualReadings.push({
-      householdId: m.householdId,
-      startKwh: m.startKwh,
-      endKwh: m.endKwh,
-      ...(typeof m.reason === "string" ? { reason: m.reason } : {}),
-    });
   }
 
   const supabase = createServiceClient();


### PR DESCRIPTION
## What
Make `manualReadings` optional on `POST /api/v1/billing/generate` to enable the automated OpenEMS-pull billing path.

## Why
The endpoint required a non-empty `manualReadings` array, so an automated caller (a monthly cron) could only PUSH pre-computed readings. The engine (`runGenerationFor`) already resolves every household's usage from the OpenEMS B2B API when no manual override is supplied, but the route gated it off.

## Change
- `manualReadings` is now optional. When omitted or empty, `householdIds` is left undefined, so the engine bills the period microgrid's full household set and pulls each household's consumption from OpenEMS.
- When present, entries validate exactly as before and override per household.
- Net: a scheduled caller can POST with no `manualReadings` to run fully automated billing sourced from OpenEMS (same trigger pattern as today, the readings just come from OpenEMS instead of being pushed).

## Tests
- `npx tsc --noEmit`: clean.
- `npm run lint`: 0 errors.
- Route suite: 11 passing, incl. two new cases — pull-mode (no `manualReadings` -> engine called with `manualReadings: []` and `householdIds` undefined) and the non-array guard.

## End-to-end verification
Verified the OpenEMS side independently against a self-hosted backend with the b2brest (`Backend2Backend.Rest`) bundle enabled: a Basic-auth `queryHistoricTimeseriesEnergy` (the exact call `generate.ts` makes via `edgeRpc`) returns real consumption for a live edge. So the pull path returns real data end to end.

## Maintainer note
The commit is DCO signed-off, but the SSH signature did not attach in the headless environment it was authored in, so the `required_signatures` gate will fail until re-signed (`git commit --amend -S` with the signing key loaded, then force-push). Flagging per CLAUDE.md.