### PR TITLE
hotfix(middleware): allow unauthenticated Pesapal IPN webhook (#294)

### DIFF
--- a/src/lib/__tests__/middleware.test.ts
+++ b/src/lib/__tests__/middleware.test.ts
@@ -123,4 +123,36 @@ describe("middleware PUBLIC_PATHS", () => {
     expect(res.headers.get("location")).toBeNull();
     expect(res.status).toBe(200);
   });
+
+  // #294: /api/payments/ipn is Pesapal's IPN webhook — an unauthenticated
+  // server-to-server callback with no MBE session. The middleware MUST
+  // pass it through, otherwise it 401s ("Authentication required") before
+  // the route handler runs and payments never auto-mark. Same class as the
+  // /api/v1/ hotfix (#267).
+  it("allows unauthenticated request on /api/payments/ipn (Pesapal IPN webhook — #294)", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/api/payments/ipn"));
+
+    // Pass-through (NextResponse.next), NOT the 401 JSON that API routes get
+    // when unauthenticated and non-public.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  // Path scoping: only the exact /api/payments/ipn path is public. Sibling
+  // payment routes (auth-gated payment-status mutations) must still 401 an
+  // unauthenticated API request. Guards against a broad /api/payments/
+  // prefix silently exposing them.
+  it("still 401s unauthenticated request on a sibling /api/payments/* route (#294 scoping)", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const middleware = await loadMiddleware();
+
+    const res = await middleware(makeRequest("/api/payments/status"));
+
+    // API routes return 401 JSON (not a redirect) when non-public.
+    expect(res.status).toBe(401);
+    expect(res.headers.get("location")).toBeNull();
+  });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,6 +27,19 @@ import { NextResponse, type NextRequest } from "next/server";
 // distinct from this middleware's "Authentication required" string.
 // Trailing slash is intentional (same reason as `/p/`).
 // Discovered 2026-05-27 during Wave A-D activation smoke test.
+//
+// `/api/payments/ipn` is Pesapal's IPN (Instant Payment Notification)
+// webhook — an unauthenticated server-to-server POST/GET from Pesapal
+// with no MBE session cookie, so `supabase.auth.getUser()` here always
+// returns null and the middleware would 401 every IPN before the route
+// handler runs (payments never auto-mark). Same class as the `/api/v1/`
+// entry above (#267). The route handler verifies the callback itself
+// (order-tracking-id lookup against Pesapal) — that is the auth boundary.
+// Scoped to the exact `/api/payments/ipn` path (no trailing slash, no
+// broad `/api/payments/` prefix) so sibling payment routes (e.g.
+// auth-gated payment-status mutations) stay non-public. `startsWith`
+// still matches `/api/payments/ipn` and any subpath. Discovered 2026-07
+// (#294).
 const PUBLIC_PATHS = [
   "/login",
   "/accept-invite",
@@ -34,6 +47,7 @@ const PUBLIC_PATHS = [
   "/reset-password",
   "/p/",
   "/api/v1/",
+  "/api/payments/ipn",
 ];
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## Root cause (#294)

`src/middleware.ts` runs on `/api/payments/ipn` (the matcher only excludes static assets). Pesapal's IPN (Instant Payment Notification) webhook is an **unauthenticated** server-to-server POST/GET — no MBE session cookie — so `supabase.auth.getUser()` returns `null`. Because `/api/payments/ipn` was **not** in `PUBLIC_PATHS`, the middleware returned `401 "Authentication required"` **before the route handler ever ran**. Every Pesapal IPN was blocked at the door, so payments never auto-marked (zero `payment_events` in prod, ever).

Same class of bug as the #267 hotfix, which added `/api/v1/` to `PUBLIC_PATHS` for the customerapp internal API (unauthenticated at the middleware layer, auth-gated by the handler).

## Fix

- **`src/middleware.ts`** — add `"/api/payments/ipn"` to `PUBLIC_PATHS` (one line + an explanatory comment block mirroring the existing `/api/v1/` rationale). The route handler verifies the Pesapal callback itself (order-tracking-id lookup) — that is the real auth boundary.
- **`src/lib/__tests__/middleware.test.ts`** — regression test asserting an unauthenticated request to `/api/payments/ipn` passes through (status 200, no redirect, not the 401 JSON), plus a scoping-guard test asserting a sibling `/api/payments/*` route still 401s.

## Path-scoping safety note

Scoped to the **exact** path `"/api/payments/ipn"` — **not** a broad `"/api/payments/"` prefix. Sibling payment routes (e.g. auth-gated payment-status mutations) must stay non-public. Since the check is `pathname.startsWith(p)`, `"/api/payments/ipn"` matches `/api/payments/ipn` (and any subpath) without exposing sibling routes. A dedicated test locks this in.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm test` (full suite, `SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1`) — 1782 passed, 0 failed
- Middleware suite: 9/9 pass (7 existing + 2 new)

No migration — middleware-only.

Refs #294