### PR TITLE
fix(households): surface detail-query errors instead of masking as 404 (#300)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
@@ -4,7 +4,8 @@
 //   - Mock @/lib/supabase/server so all three queries return fixture rows.
 //   - Call HouseholdDetailPage() directly (async server component) and serialize
 //     the returned JSX to HTML.
-//   - Cover 4 scenarios: populated, empty devices, empty billing, RLS-404.
+//   - Cover scenarios: populated, empty devices, empty billing, query-error
+//     surfaced (#300 throws, not 404), genuine-missing 404.
 //   - Assert chip-highlight assertion for primary_consumption_meter row.
 //
 // Environment: node (same pattern as D2 page tests).
@@ -86,13 +87,14 @@ const BILLING_PERIOD = {
 
 /**
  * Builds a mock Supabase query chain for the households table.
- * Supports `.select().eq().eq().single()` pattern.
+ * Supports `.select().eq().eq().maybeSingle()` pattern (#300: switched from
+ * .single() so 0 rows -> { data: null, error: null } instead of a PGRST116 error).
  */
 function buildHouseholdQuery(data: unknown, error: unknown = null) {
   const chain = {
     select: () => chain,
     eq: () => chain,
-    single: () => Promise.resolve({ data, error }),
+    maybeSingle: () => Promise.resolve({ data, error }),
   };
   return chain;
 }
@@ -275,14 +277,49 @@ describe("HouseholdDetailPage", () => {
     expect(html).toContain("Chint Meter 01");
   });
 
-  // (d) RLS-404: non-NFE user gets notFound()
-  it("calls notFound() when household query returns an error (RLS deny / not found)", async () => {
+  // (d) #300: a real query/embed error is SURFACED (thrown), not masked as 404.
+  // Under the pre-#300 code this fixture (data:null + PGRST error) hit notFound();
+  // now .maybeSingle() means a truthy error is a genuine failure → throw + log.
+  it("throws (surfacing the error) when the household query returns a PostgREST error", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     mockFrom.mockImplementation((table: string) => {
       if (table === "households") {
         return buildHouseholdQuery(null, {
-          message: "Row not found",
-          code: "PGRST116",
+          message: "permission denied for table devices",
+          code: "42501",
+          details: "RLS on the embedded devices/edges relationship",
+          hint: null,
         });
+      }
+      return buildFlexQuery([]);
+    });
+
+    await expect(
+      HouseholdDetailPage({
+        params: Promise.resolve({ id: "mg-1", householdId: "hh-1" }),
+      }),
+    ).rejects.toThrow(/Failed to load household hh-1/);
+
+    // The real error was surfaced, NOT swallowed into a 404.
+    expect(notFoundMock).not.toHaveBeenCalled();
+    // Structured diagnostic was logged.
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    expect(consoleErrorSpy.mock.calls[0][0]).toContain(
+      "household_detail.query_error",
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  // (e) #300: a genuinely-missing household (0 rows) still 404s. maybeSingle
+  // returns { data: null, error: null } for no match → the !household branch.
+  it("calls notFound() when the household genuinely does not exist (0 rows, no error)", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "households") {
+        return buildHouseholdQuery(null, null);
       }
       return buildFlexQuery([]);
     });

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
@@ -73,9 +73,33 @@ export default async function HouseholdDetailPage({
     )
     .eq("id", householdId)
     .eq("microgrid_id", microgridId)
-    .single<HouseholdRow>();
+    .maybeSingle<HouseholdRow>();
 
-  if (householdError || !household) {
+  if (householdError) {
+    // #300: previously a query/embed error (RLS on the devices/edges embed, or a
+    // relationship-resolution failure) was masked as a 404 by folding it into
+    // notFound(). Surface it — log structured + throw — so the real PostgREST
+    // error is visible (dev overlay / prod 500 + logs) instead of a misleading
+    // "not found." A genuinely-missing household still 404s via the !household
+    // branch below (maybeSingle returns null, not an error, for 0 rows).
+    console.error(
+      JSON.stringify({
+        event: "household_detail.query_error",
+        householdId,
+        microgridId,
+        code: householdError.code,
+        message: householdError.message,
+        details: householdError.details,
+        hint: householdError.hint,
+        at: new Date().toISOString(),
+      }),
+    );
+    throw new Error(
+      `Failed to load household ${householdId}: ${householdError.message}`,
+    );
+  }
+
+  if (!household) {
     notFound();
   }
 


### PR DESCRIPTION
## What & why

The household **detail** page 404s (via `notFound()`) for a household that IS visible in the list. Root cause is being **masked**: the detail query runs a 3-level embed (`household_devices → devices → edges`) with `.single()`, and the page folded any query **error** into the same branch as "no row":

```ts
.single<HouseholdRow>();

if (householdError || !household) {
  notFound();
}
```

`.single()` returns a **PGRST116 error** for 0 rows, so "not found" and "real error" (e.g. RLS on the embedded `devices`/`edges`, or a relationship-resolution failure) were indistinguishable — both surfaced as a misleading 404, and the real PostgREST error was swallowed server-side.

## The fix (diagnostic-enabling unmask — step 1)

1. **`.single()` → `.maybeSingle()`** — 0 rows now returns `{ data: null, error: null }`, so `householdError` is truthy **only** for real failures.
2. **Split the branch:**
   - `householdError` → log a structured `household_detail.query_error` line (code/message/details/hint) **and throw**, so the real error is visible (dev overlay / prod 500 + logs) instead of hidden.
   - `!household` → still `notFound()` (a genuinely-missing household is a real 404).

This is purely the **unmask** so the surfaced PostgREST error can name the cause. The **functional** embed/RLS fix (whether to split the embed query, adjust RLS, etc.) is **deferred to step 2** once we know whether it's RLS or schema. No migration.

## Scope

- Only the household-basics query error handling in `src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx`.
- The `.select(...)` embed shape, the other queries (portalUserCount, lineItems), and all rendering are **unchanged**.

## Tests

Updated the existing page test (`page.test.tsx`): switched the household query mock helper to `.maybeSingle()`, and replaced the old "error → notFound" case with two cases matching the new contract:
- PostgREST error → page **throws** (`Failed to load household …`), `notFound()` NOT called, structured log emitted.
- 0 rows (`{ data: null, error: null }`) → `notFound()` called.

Full suite green locally (`SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1`): 1783 passed / 70 skipped. `tsc --noEmit` clean, `lint` 0 errors.

Refs #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
