### PR TITLE
fix(households): remove phantom households.status reference breaking all detail pages (#300)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.test.tsx
@@ -66,7 +66,6 @@ const HOUSEHOLD_BASE = {
   address_line1: "Plot 14, Kisakye Ln",
   address_line2: "Block A",
   unit_label: "Unit 1",
-  status: "active",
 };
 
 const DEVICE_ROW = {

--- a/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/households/[householdId]/page.tsx
@@ -38,7 +38,6 @@ type HouseholdRow = {
   address_line1: string | null;
   address_line2: string | null;
   unit_label: string | null;
-  status: string;
   household_devices: HouseholdDeviceRow[];
 };
 
@@ -68,7 +67,7 @@ export default async function HouseholdDetailPage({
     .from("households")
     .select(
       `id, display_name, primary_phone, primary_email,
-       address_line1, address_line2, unit_label, status,
+       address_line1, address_line2, unit_label,
        household_devices(role, devices(id, name, device_type, edges(id, name)))`,
     )
     .eq("id", householdId)
@@ -174,7 +173,6 @@ export default async function HouseholdDetailPage({
           <h3 className="text-lg font-semibold text-foreground">
             {household.display_name ?? "Unnamed household"}
           </h3>
-          <StatusChip kind="household" status={household.status} />
         </div>
       </div>
 


### PR DESCRIPTION
## Root cause

The household detail page (`.../setup/households/[householdId]/page.tsx`) selected and rendered `households.status`, but that column **was never migrated in** — a half-shipped "household status" feature where the UI/type/select were added but the DB column never was. PostgREST returned `42703 "column households.status does not exist"` on **every** household detail load. After #301 unmasked the error handling (`.maybeSingle()` + throw-on-error), that surfaces as a 500 (previously it was a masked 404). Net effect: **all household detail pages were broken** for every household.

## PM decision — CUT the phantom feature

Do not add the column; remove the phantom references. If household lifecycle status is wanted later, it returns as a deliberate feature (column + semantics + UI), not a dangling half-implementation.

## The cut (4 edits, 2 files)

`page.tsx`:
1. Removed `status: string;` from the `HouseholdRow` type.
2. Removed the `status` token from the `households` `.select(...)` column list.
3. Removed the `<StatusChip kind="household" status={household.status} />` render (left the `<h3>` heading wrapper intact).

`page.test.tsx`:
4. Removed `status: "active",` from the `HOUSEHOLD_BASE` fixture.

The `StatusChip` **import was kept** — it's still used for the device-type and household-device-role chips in the linked-devices table.

## `billing_periods.status` left untouched

`billing_periods.status` is a **real, load-bearing column** on a different table. All of its references are unchanged:
- `billing_periods!inner(id, start_date, end_date, status)` in the line-items select
- `.eq("billing_periods.status", "closed")`
- `li.billing_periods?.status === "closed"`
- the `BillingLineItemRow.billing_periods.status` type field
- the `status: "closed"` billing-period test fixture

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, unrelated files)
- `npm test` (`SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1`) — 1783 passed / 70 skipped; the 6 household-detail-page tests all pass, including "renders all sections."

No migration added (by design — this is the cut, not the column).

Closes #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)