### PR TITLE
refactor(ems): move EMS secret decrypt onto the service-role client and narrow function grants

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/auth/access";
 import { HierarchyNav } from "@/components/ui/hierarchy-nav";
 import { getHierarchyLevels } from "@/lib/hierarchy";
+import { getEmsSecretForMicrogrid } from "@/lib/openems/config";
 import { deriveOpenemsBackendHealth } from "./health";
 import { OpenemsBackendShell } from "./openems-backend-shell";
 
@@ -15,8 +16,7 @@ import { OpenemsBackendShell } from "./openems-backend-shell";
 //   1. Microgrid row (name + ems_* columns)
 //   2. Draft billing-period count (mid-period guard)
 //   3. Closed billing-period count (for the type-to-confirm bypass PM copy)
-//   4. Decrypted AWS secret last-4 (super_admin only; fn_get_ems_secret returns
-//      NULL for org_manager → we render "—" in the summary)
+//   4. Decrypted AWS secret last-4 (super_admin only; org_manager renders "—")
 //   5. Permission flags: isSuperAdmin, canAccessMicrogrid
 //
 // The server component passes everything as props to a single client shell
@@ -76,15 +76,23 @@ export default async function OpenemsBackendPage({
       .eq("status", "closed"),
   ]);
 
-  // Last-4 mask of the decrypted AWS secret. fn_get_ems_secret returns NULL
-  // for non-super_admin (even on own org) per migration 00018 truth table.
+  // Last-4 mask of the decrypted AWS secret, super_admin only.
+  //
+  // `getEmsSecretForMicrogrid` re-reads the microgrid row on this same
+  // RLS-evaluated client and returns null before reaching the decrypt if the
+  // row is not visible — see the ordering note on that helper. The
+  // `isSuperAdmin` check below is the surface-level policy on top of it;
+  // neither replaces the other.
   let secretLast4: string | null = null;
   if (mg.ems_type === "cloud_aws" && isSuperAdmin) {
-    const { data: secret } = await supabase.rpc("fn_get_ems_secret", {
-      _microgrid_id: id,
-    });
-    if (typeof secret === "string" && secret.length >= 4) {
-      secretLast4 = secret.slice(-4);
+    try {
+      const secret = await getEmsSecretForMicrogrid(supabase, id);
+      if (secret && secret.length >= 4) {
+        secretLast4 = secret.slice(-4);
+      }
+    } catch {
+      // Decrypt unavailable — render "—" rather than failing the page.
+      secretLast4 = null;
     }
   }
 

--- a/src/app/api/edges/[id]/discover-devices/route.ts
+++ b/src/app/api/edges/[id]/discover-devices/route.ts
@@ -90,12 +90,17 @@ export async function GET(
   }
 
   // Resolve per-microgrid OpenEMS config.
-  // Post-#200: fn_get_ems_secret was widened to return plaintext to
-  // org_managers of the microgrid's parent org (00032), so the previous
-  // super_admin-only gate at this position has been removed. Cross-org
-  // callers are still rejected — currentUserCanAccessMicrogrid above filters
-  // them, and any residual OPENEMS_FORBIDDEN from getMicrogridEmsConfig is
-  // surfaced as 403 by the catch block below.
+  //
+  // Post-#200 (00032) org_managers are intentionally allowed here — this is
+  // the Add-Household wizard's inline discovery path, which is the surface
+  // that motivated the widening. There is no super_admin gate at this
+  // position by design.
+  //
+  // Authorization on the secret path is therefore: the `edges` RLS read
+  // above, `currentUserCanAccessMicrogrid`, and the RLS row read inside
+  // `getEmsSecretForMicrogrid` — which must run before that helper's
+  // service-role decrypt. Cross-org callers are rejected by all three. Any
+  // OPENEMS_FORBIDDEN from getMicrogridEmsConfig is surfaced as 403 below.
   let emsConfig;
   try {
     emsConfig = await getMicrogridEmsConfig(supabase, edge.microgrid_id);

--- a/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
@@ -73,6 +73,15 @@ vi.mock("@/lib/auth/access", () => ({
   currentUserIsSuperAdmin: async () => isSuperAdminReturn,
 }));
 
+// The EMS secret decrypt runs on the service-role client (migration 00049).
+// `getEmsSecretForMicrogrid` performs its own RLS row read on the user client
+// first, so the preserve-secret path now issues an EXTRA from('microgrids')
+// before this RPC — see the handler ordering in that test.
+const mockServiceRpc = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({ rpc: mockServiceRpc }),
+}));
+
 // Sequenced from() handlers — each test sets up the order of calls.
 let fromCallIndex = 0;
 const fromHandlers: Array<(table: string) => unknown> = [];
@@ -156,16 +165,14 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       return handler(table);
     });
 
-    mockRpc.mockImplementation((fnName: string) => {
-      if (fnName === "fn_get_ems_secret") {
-        return Promise.resolve({
-          data: "DECRYPTED_FAKE_SECRET",
-          error: null,
-        });
-      }
-      // fn_ems_encrypt_secret (default)
-      return Promise.resolve({ data: "\\x01020304", error: null });
-    });
+    // The user client only ever issues fn_ems_encrypt_secret now.
+    mockRpc.mockImplementation(() =>
+      Promise.resolve({ data: "\\x01020304", error: null })
+    );
+
+    mockServiceRpc.mockImplementation(() =>
+      Promise.resolve({ data: "DECRYPTED_FAKE_SECRET", error: null })
+    );
   });
 
   it("returns 400 on malformed body", async () => {
@@ -517,6 +524,9 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
       })
     );
     registerFrom(billingPeriodsHandler([]));
+    // getEmsSecretForMicrogrid's authorization read — the RLS row read that
+    // must precede the service-role decrypt.
+    registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
     registerFrom(mgUpdateHandler(null)); // persist config (WITHOUT re-encrypt)
     registerFrom(edgesSelectHandler([]));
     registerFrom(mgUpdateHandler(null)); // health
@@ -541,11 +551,14 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     const json = await res.json();
     expect(json.status).toBe("success");
 
-    // Two RPC calls expected: fn_get_ems_secret (decrypt existing) and
-    // NO fn_ems_encrypt_secret (the preserve branch skips re-encryption).
-    const rpcCalls = mockRpc.mock.calls.map((c) => c[0]);
-    expect(rpcCalls).toContain("fn_get_ems_secret");
-    expect(rpcCalls).not.toContain("fn_ems_encrypt_secret");
+    // The decrypt happens on the SERVICE-ROLE client (00049), never on the
+    // user client. The preserve branch skips re-encryption entirely.
+    const userRpcCalls = mockRpc.mock.calls.map((c) => c[0]);
+    expect(userRpcCalls).not.toContain("fn_get_ems_secret");
+    expect(userRpcCalls).not.toContain("fn_ems_encrypt_secret");
+
+    const serviceRpcCalls = mockServiceRpc.mock.calls.map((c) => c[0]);
+    expect(serviceRpcCalls).toContain("fn_get_ems_secret");
   });
 
   it("preserve-secret: blank secretAccessKey + NO existing ciphertext → 400", async () => {

--- a/src/app/api/microgrids/[id]/openems-backend/discover/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/discover/route.ts
@@ -36,10 +36,11 @@ export async function POST(
 
   const supabase = await createClient();
 
-  // Discover mutates ems_last_discover_* health fields and reads the decrypted
-  // secret (fn_get_ems_secret is SECURITY DEFINER, super_admin / service_role
-  // only). Gate here so org_managers cannot trigger a write or observe backend
-  // connectivity status indirectly through error messages.
+  // Discover mutates ems_last_discover_* health fields and resolves the
+  // decrypted secret via getMicrogridEmsConfig. Gate here so org_managers
+  // cannot trigger a write or observe backend connectivity status indirectly
+  // through error messages. This gate is in addition to the RLS row read that
+  // getEmsSecretForMicrogrid performs before its service-role decrypt.
   if (!(await currentUserIsSuperAdmin(supabase))) {
     return NextResponse.json(
       { error: "Only super admins can run OpenEMS backend discovery." },

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { currentUserCanAccessMicrogrid, currentUserIsSuperAdmin } from "@/lib/auth/access";
 import { createOpenEmsClient, OpenEmsError } from "@/lib/openems";
 import type { OpenEmsClientConfig } from "@/lib/openems";
+import { getEmsSecretForMicrogrid } from "@/lib/openems/config";
 import { scrubSecretValues } from "@/lib/logging/scrub-secrets";
 
 const UUID_RE =
@@ -271,12 +272,23 @@ export async function PUT(
   // We build the candidate OpenEmsClientConfig here (before the DB write) so
   // step 5 (edge-ID validation) can use it without a second decrypt round-trip.
   // effectiveSecret is also reused by step 7 (Discover after save).
+  //
+  // The decrypt runs on the service-role client inside
+  // `getEmsSecretForMicrogrid`, which re-reads the microgrid row on the
+  // RLS-evaluated `supabase` client first and returns null before any decrypt
+  // is reachable when that row is not visible. That read is the authorization
+  // — it must stay ahead of the decrypt (see the helper's ordering note). The
+  // route's own mgRow read + currentUserCanAccessMicrogrid + super_admin gates
+  // above have already run at this point.
   let effectiveSecret: string | undefined = secretAccessKey;
   if (type === "cloud_aws" && preserveExistingSecret) {
-    const { data: decrypted, error: decryptErr } = await supabase.rpc(
-      "fn_get_ems_secret",
-      { _microgrid_id: microgridId }
-    );
+    let decrypted: string | null = null;
+    let decryptErr: unknown = null;
+    try {
+      decrypted = await getEmsSecretForMicrogrid(supabase, microgridId);
+    } catch (err) {
+      decryptErr = err;
+    }
     if (decryptErr || !decrypted) {
       return NextResponse.json(
         {
@@ -286,7 +298,7 @@ export async function PUT(
         { status: 500 }
       );
     }
-    effectiveSecret = decrypted as string;
+    effectiveSecret = decrypted;
   }
 
   const candidateConfig: OpenEmsClientConfig =

--- a/src/lib/openems/__tests__/config.test.ts
+++ b/src/lib/openems/__tests__/config.test.ts
@@ -1,0 +1,204 @@
+/**
+ * config.test.ts — ordering invariant for the EMS secret decrypt.
+ *
+ * The decrypt runs on the service-role client, which short-circuits
+ * `fn_get_ems_secret`'s own permission gate. That makes the RLS row read on
+ * the caller's client the ONLY authorization rather than a second layer, so
+ * the assertion that matters is not "a cross-org caller gets an error" — it
+ * is "a cross-org caller never reaches the decrypt at all."
+ *
+ * These tests therefore assert on whether the service-role client was
+ * CONSTRUCTED and whether the decrypt RPC was CALLED, not on return values.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const decryptRpc = vi.fn();
+const createServiceClient = vi.fn(() => ({ rpc: decryptRpc }));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: (...args: unknown[]) =>
+    (createServiceClient as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
+import { getMicrogridEmsConfig, getEmsSecretForMicrogrid } from "../config";
+import { OpenEmsError } from "../errors";
+
+const MICROGRID_ID = "00000000-0000-4000-8000-000000000010";
+
+/**
+ * Minimal user-client stub. `row` is what the RLS-evaluated read returns:
+ * `null` models a row RLS hid from the caller (cross-org), which is exactly
+ * how PostgREST surfaces it — not as an error.
+ */
+function buildUserClient(row: Record<string, unknown> | null): {
+  client: SupabaseClient;
+  reads: string[];
+  rpc: ReturnType<typeof vi.fn>;
+} {
+  const reads: string[] = [];
+  const rpc = vi.fn();
+  const client = {
+    from(table: string) {
+      reads.push(table);
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        maybeSingle: async () => ({ data: row, error: null }),
+      };
+      return chain;
+    },
+    rpc,
+  } as unknown as SupabaseClient;
+  return { client, reads, rpc };
+}
+
+beforeEach(() => {
+  decryptRpc.mockReset();
+  createServiceClient.mockClear();
+  decryptRpc.mockResolvedValue({ data: "PLAINTEXT-SECRET", error: null });
+});
+
+describe("getEmsSecretForMicrogrid — ordering invariant", () => {
+  it("cross-org caller cannot reach the decrypt (RLS hides the row)", async () => {
+    const { client } = buildUserClient(null);
+
+    const result = await getEmsSecretForMicrogrid(client, MICROGRID_ID);
+
+    expect(result).toBeNull();
+    // The load-bearing assertions: the service-role client was never even
+    // constructed, so no decrypt could have run under it.
+    expect(createServiceClient).not.toHaveBeenCalled();
+    expect(decryptRpc).not.toHaveBeenCalled();
+  });
+
+  it("authorized caller reads the row BEFORE the decrypt is constructed", async () => {
+    const order: string[] = [];
+    const rpc = vi.fn();
+    const client = {
+      from() {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          maybeSingle: async () => {
+            order.push("rls-read");
+            return { data: { id: MICROGRID_ID }, error: null };
+          },
+        };
+        return chain;
+      },
+      rpc,
+    } as unknown as SupabaseClient;
+
+    createServiceClient.mockImplementation(() => {
+      order.push("service-client");
+      return { rpc: decryptRpc };
+    });
+    decryptRpc.mockImplementation(async () => {
+      order.push("decrypt");
+      return { data: "PLAINTEXT-SECRET", error: null };
+    });
+
+    const result = await getEmsSecretForMicrogrid(client, MICROGRID_ID);
+
+    expect(result).toBe("PLAINTEXT-SECRET");
+    expect(order).toEqual(["rls-read", "service-client", "decrypt"]);
+  });
+
+  it("never issues the decrypt RPC on the caller's own client", async () => {
+    const { client, rpc } = buildUserClient({ id: MICROGRID_ID });
+
+    await getEmsSecretForMicrogrid(client, MICROGRID_ID);
+
+    // The user client must not be the one decrypting — that is the grant we
+    // withdrew in migration 00049.
+    expect(rpc).not.toHaveBeenCalled();
+    expect(decryptRpc).toHaveBeenCalledWith("fn_get_ems_secret", {
+      _microgrid_id: MICROGRID_ID,
+    });
+  });
+
+  it("returns null when no ciphertext is stored", async () => {
+    const { client } = buildUserClient({ id: MICROGRID_ID });
+    decryptRpc.mockResolvedValue({ data: null, error: null });
+
+    expect(await getEmsSecretForMicrogrid(client, MICROGRID_ID)).toBeNull();
+  });
+
+  it("throws OpenEmsError when the decrypt RPC fails", async () => {
+    const { client } = buildUserClient({ id: MICROGRID_ID });
+    decryptRpc.mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+
+    await expect(
+      getEmsSecretForMicrogrid(client, MICROGRID_ID)
+    ).rejects.toBeInstanceOf(OpenEmsError);
+  });
+});
+
+describe("getMicrogridEmsConfig — cross-org callers stop before the decrypt", () => {
+  it("returns null and never decrypts when RLS hides the microgrid", async () => {
+    const { client } = buildUserClient(null);
+
+    expect(await getMicrogridEmsConfig(client, MICROGRID_ID)).toBeNull();
+    expect(createServiceClient).not.toHaveBeenCalled();
+    expect(decryptRpc).not.toHaveBeenCalled();
+  });
+
+  it("does not decrypt for a direct_url microgrid", async () => {
+    const { client } = buildUserClient({
+      id: MICROGRID_ID,
+      ems_type: "direct_url",
+      ems_backend_url: "https://example.invalid",
+      ems_aws_region: null,
+      ems_aws_access_key_id: null,
+    });
+
+    const cfg = await getMicrogridEmsConfig(client, MICROGRID_ID);
+
+    expect(cfg).toEqual({
+      type: "direct_url",
+      url: "https://example.invalid",
+    });
+    expect(createServiceClient).not.toHaveBeenCalled();
+    expect(decryptRpc).not.toHaveBeenCalled();
+  });
+
+  it("resolves a cloud_aws config via the service-role decrypt", async () => {
+    const { client } = buildUserClient({
+      id: MICROGRID_ID,
+      ems_type: "cloud_aws",
+      ems_backend_url: "https://example.invalid",
+      ems_aws_region: "eu-west-1",
+      ems_aws_access_key_id: "AKIAEXAMPLE",
+    });
+
+    const cfg = await getMicrogridEmsConfig(client, MICROGRID_ID);
+
+    expect(cfg).toEqual({
+      type: "cloud_aws",
+      url: "https://example.invalid",
+      region: "eu-west-1",
+      accessKeyId: "AKIAEXAMPLE",
+      secretAccessKey: "PLAINTEXT-SECRET",
+    });
+    expect(createServiceClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws OPENEMS_FORBIDDEN for cloud_aws with no retrievable secret", async () => {
+    const { client } = buildUserClient({
+      id: MICROGRID_ID,
+      ems_type: "cloud_aws",
+      ems_backend_url: "https://example.invalid",
+      ems_aws_region: "eu-west-1",
+      ems_aws_access_key_id: "AKIAEXAMPLE",
+    });
+    decryptRpc.mockResolvedValue({ data: null, error: null });
+
+    await expect(
+      getMicrogridEmsConfig(client, MICROGRID_ID)
+    ).rejects.toMatchObject({ code: "OPENEMS_FORBIDDEN", statusCode: 403 });
+  });
+});

--- a/src/lib/openems/config.ts
+++ b/src/lib/openems/config.ts
@@ -21,11 +21,9 @@ import { OpenEmsError } from "./errors";
  *   - RLS on `microgrids` filters the row via `user_can_access_microgrid(id)`.
  *     Cross-org access surfaces as `row = null` → we return `null` and the
  *     caller translates to 404.
- *   - For cloud_aws, the plaintext secret is only released to super_admin or
- *     service_role (see `fn_get_ems_secret` body in migration 00018). An
- *     org_manager of the owning org CAN see the microgrid row but CANNOT
- *     decrypt the secret → we throw 403. This is the pilot's compromise
- *     until per-microgrid secret-access roles ship.
+ *   - For cloud_aws, the decrypt runs on the service-role client via
+ *     `getEmsSecretForMicrogrid` below, which re-establishes the RLS row read
+ *     as the authorization step before any decrypt is reachable.
  *   - For direct_url, no secret retrieval is needed; org_managers are allowed
  *     to run Discover because nothing is redacted.
  */
@@ -82,7 +80,92 @@ export async function getMicrogridEmsConfig(
     );
   }
 
-  const { data: secret, error: secretErr } = await supabase.rpc(
+  const secret = await getEmsSecretForMicrogrid(supabase, microgridId);
+
+  if (!secret) {
+    // The RLS row read above already succeeded, so the caller is authorized.
+    // A null here means the authorization step inside
+    // `getEmsSecretForMicrogrid` did not resolve the row (a concurrent
+    // delete / permission change) or no ciphertext is stored for the row.
+    // Both are non-retrievable states for this caller — surface as 403 so
+    // callers keep their existing "forbidden" mapping.
+    throw new OpenEmsError(
+      "The stored secret access key for this Cloud (AWS) microgrid could not be retrieved. Re-enter the secret access key in Setup → OpenEMS Backend.",
+      "OPENEMS_FORBIDDEN",
+      403
+    );
+  }
+
+  return {
+    type: "cloud_aws",
+    url: mg.ems_backend_url,
+    region: mg.ems_aws_region,
+    accessKeyId: mg.ems_aws_access_key_id,
+    secretAccessKey: secret,
+  };
+}
+
+/**
+ * Decrypt a microgrid's stored EMS secret.
+ *
+ * ── The ordering here is load-bearing. Do not reorder. ───────────────────
+ *
+ * The decrypt runs on the **service-role** client. `fn_get_ems_secret`
+ * short-circuits its own permission gate for `service_role`, so the function
+ * contributes NO authorization on this path. The RLS row read in step 1 is
+ * therefore the ONLY authorization, not a second layer:
+ *
+ *   1. Read the `microgrids` row on the caller's own (cookie-scoped, RLS-
+ *      evaluated) client. This is the authorization step.
+ *   2. Treat "no row" as TERMINAL — return before any decrypt is reachable.
+ *      A cross-org caller is filtered by `user_can_access_microgrid` in RLS
+ *      and exits here; the service-role client is never constructed.
+ *   3. Only then decrypt on the service-role client.
+ *
+ * Written in the other order this becomes an ungated internal decrypt. Every
+ * caller that needs the plaintext MUST go through this helper rather than
+ * calling `fn_get_ems_secret` directly, so the invariant lives in one place.
+ *
+ * `authorizedClient` MUST be an RLS-evaluated client (`@/lib/supabase/server`).
+ * Passing a service-role client makes step 1 a no-op — that is only correct
+ * for machine callers that have already performed their own org check (e.g.
+ * the token-authenticated generation route, which verifies `org_id` first).
+ *
+ * Returns the plaintext, or `null` when the caller is not authorized for the
+ * row or no ciphertext is stored. Throws `OpenEmsError` on infrastructure
+ * failure (read error / decrypt RPC error).
+ */
+export async function getEmsSecretForMicrogrid(
+  authorizedClient: SupabaseClient,
+  microgridId: string
+): Promise<string | null> {
+  // ── Step 1: authorization. RLS on `microgrids` decides visibility. ──────
+  const { data: authorizedRow, error: authErr } = await authorizedClient
+    .from("microgrids")
+    .select("id")
+    .eq("id", microgridId)
+    .maybeSingle<{ id: string }>();
+
+  if (authErr) {
+    throw new OpenEmsError(
+      `Failed to authorize secret access: ${authErr.message}`,
+      "OPENEMS_INVALID_CONFIG",
+      500,
+      authErr
+    );
+  }
+
+  // ── Step 2: TERMINAL. No row → no decrypt path is reachable. ───────────
+  if (!authorizedRow) return null;
+
+  // ── Step 3: decrypt only. ──────────────────────────────────────────────
+  //
+  // Imported lazily so that SUPABASE_SERVICE_ROLE_KEY is only a hard
+  // requirement for surfaces that actually decrypt. `@/lib/supabase/service`
+  // throws at module load when the key is unset; an eager import would make
+  // every page that merely *reads* EMS config fail to boot without it.
+  const { createServiceClient } = await import("@/lib/supabase/service");
+  const { data: secret, error: secretErr } = await createServiceClient().rpc(
     "fn_get_ems_secret",
     { _microgrid_id: microgridId }
   );
@@ -96,22 +179,5 @@ export async function getMicrogridEmsConfig(
     );
   }
 
-  if (!secret) {
-    // secret is NULL — either the caller is not super_admin/service_role OR
-    // the row has no secret set (but CHECK constraint requires it for
-    // cloud_aws, so we treat the first case as the cause).
-    throw new OpenEmsError(
-      "Only super_admin may test or read meters for a Cloud (AWS) microgrid configuration. Ask a super admin to run Discover.",
-      "OPENEMS_FORBIDDEN",
-      403
-    );
-  }
-
-  return {
-    type: "cloud_aws",
-    url: mg.ems_backend_url,
-    region: mg.ems_aws_region,
-    accessKeyId: mg.ems_aws_access_key_id,
-    secretAccessKey: secret as string,
-  };
+  return typeof secret === "string" && secret.length > 0 ? secret : null;
 }

--- a/src/lib/supabase/__tests__/rls.test.ts
+++ b/src/lib/supabase/__tests__/rls.test.ts
@@ -1702,10 +1702,33 @@ describe("RLS: OpenEMS Backend (#101)", () => {
     expect(decrypted).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
   });
 
-  describe("AC-TEST-4: fn_get_ems_secret truth table", () => {
-    // Set up a microgrid with a cloud_aws config under Org A so userA is
-    // the "owner org_manager" and userB is "different org_manager."
+  describe("AC-TEST-4: fn_get_ems_secret grant surface (post-00049)", () => {
+    // Migration 00049 withdrew EXECUTE from `authenticated`. The decrypt now
+    // runs only on the service-role client, behind an RLS row read performed
+    // on the caller's own client (`getEmsSecretForMicrogrid`).
+    //
+    // The old truth table asserted per-role RETURN VALUES for authenticated
+    // callers. Those rows no longer exist as a surface: every authenticated
+    // caller — including super_admin — is now stopped at the grant layer
+    // before the body runs, so role no longer differentiates the outcome.
     const SECRET_PLAINTEXT = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    // Per CLAUDE.md § "Migration conventions", a post-hoc REVOKE on a
+    // pre-existing function surfaces as EITHER 42501 (grant layer) OR
+    // PGRST202 (PostgREST filtered it out of the schema cache). Same security
+    // outcome, different code — accept both.
+    function expectExecuteDenied(
+      error: { code?: string; message?: string } | null
+    ): void {
+      expect(error).not.toBeNull();
+      expect(
+        error?.code === "42501" ||
+          error?.code === "PGRST202" ||
+          error?.message?.toLowerCase().includes("permission denied") ||
+          error?.message?.toLowerCase().includes("could not find the function"),
+        `Expected 42501 / PGRST202 / permission-denied; got code=${error?.code} message=${error?.message}`
+      ).toBe(true);
+    }
 
     async function setupCloudAwsConfig() {
       const svc = await serviceClient();
@@ -1738,59 +1761,64 @@ describe("RLS: OpenEMS Backend (#101)", () => {
         .eq("id", FIXTURE.microgridA);
     }
 
-    it("super_admin gets plaintext when secret is set", async () => {
-      if (skipIfRequested()) return;
-      await setupCloudAwsConfig();
-      try {
-        const { data, error } = await userD.client.rpc("fn_get_ems_secret", {
-          _microgrid_id: FIXTURE.microgridA,
-        });
-        expect(error).toBeNull();
-        expect(data).toBe(SECRET_PLAINTEXT);
-      } finally {
-        await clearCloudAwsConfig();
-      }
-    });
+    // ── Every authenticated caller is denied at the grant layer ──────────
+    //
+    // These four cases previously differed by role. Post-00049 they are the
+    // same case, and that sameness is the point: role no longer decides
+    // whether the body runs, because the body is unreachable.
+    const deniedCallers: Array<[string, () => { client: SupabaseClient }]> = [
+      ["super_admin", () => userD],
+      ["org_manager (owner org)", () => userA],
+      ["org_manager (different org)", () => userB],
+      ["authenticated with no role", () => userC],
+    ];
 
-    it("super_admin gets NULL when secret is not set", async () => {
-      if (skipIfRequested()) return;
-      await clearCloudAwsConfig();
-      const { data, error } = await userD.client.rpc("fn_get_ems_secret", {
-        _microgrid_id: FIXTURE.microgridA,
+    for (const [label, getUser] of deniedCallers) {
+      it(`${label} cannot execute fn_get_ems_secret`, async () => {
+        if (skipIfRequested()) return;
+        await setupCloudAwsConfig();
+        try {
+          const { data, error } = await getUser().client.rpc(
+            "fn_get_ems_secret",
+            { _microgrid_id: FIXTURE.microgridA }
+          );
+          expectExecuteDenied(error);
+          expect(data).not.toBe(SECRET_PLAINTEXT);
+        } finally {
+          await clearCloudAwsConfig();
+        }
       });
-      expect(error).toBeNull();
-      expect(data).toBeNull();
-    });
+    }
 
-    it("org_manager (owner org) gets plaintext (post-#200 widening)", async () => {
+    it("authenticated cannot execute the underlying fn_ems_decrypt_secret either", async () => {
       if (skipIfRequested()) return;
       await setupCloudAwsConfig();
       try {
-        const { data, error } = await userA.client.rpc("fn_get_ems_secret", {
-          _microgrid_id: FIXTURE.microgridA,
-        });
-        expect(error).toBeNull();
-        expect(data).toBe(SECRET_PLAINTEXT);
+        // The ciphertext column is selectable by anyone RLS admits to the
+        // microgrid row, so withdrawing only the accessor would leave the
+        // decrypt primitive as an equivalent entry point. 00049 withdraws
+        // both. Read the ciphertext as the owner org_manager, then attempt
+        // the decrypt with it — the realistic two-step shape.
+        const { data: row } = await userA.client
+          .from("microgrids")
+          .select("ems_aws_secret_access_key_encrypted")
+          .eq("id", FIXTURE.microgridA)
+          .maybeSingle<{ ems_aws_secret_access_key_encrypted: string | null }>();
+
+        const { data, error } = await userA.client.rpc(
+          "fn_ems_decrypt_secret",
+          {
+            p_ciphertext: row?.ems_aws_secret_access_key_encrypted ?? "\\x00",
+          }
+        );
+        expectExecuteDenied(error);
+        expect(data).not.toBe(SECRET_PLAINTEXT);
       } finally {
         await clearCloudAwsConfig();
       }
     });
 
-    it("org_manager (different org) gets NULL — redacted by helper", async () => {
-      if (skipIfRequested()) return;
-      await setupCloudAwsConfig();
-      try {
-        const { data, error } = await userB.client.rpc("fn_get_ems_secret", {
-          _microgrid_id: FIXTURE.microgridA,
-        });
-        expect(error).toBeNull();
-        expect(data).toBeNull();
-      } finally {
-        await clearCloudAwsConfig();
-      }
-    });
-
-    it("service_role gets plaintext (server-side path)", async () => {
+    it("service_role still gets plaintext (the server-side decrypt path)", async () => {
       if (skipIfRequested()) return;
       await setupCloudAwsConfig();
       try {
@@ -1805,18 +1833,13 @@ describe("RLS: OpenEMS Backend (#101)", () => {
       }
     });
 
-    it("userC (no role) gets NULL", async () => {
+    it("authenticated retains fn_ems_encrypt_secret (Save flow encrypts as the user)", async () => {
       if (skipIfRequested()) return;
-      await setupCloudAwsConfig();
-      try {
-        const { data, error } = await userC.client.rpc("fn_get_ems_secret", {
-          _microgrid_id: FIXTURE.microgridA,
-        });
-        expect(error).toBeNull();
-        expect(data).toBeNull();
-      } finally {
-        await clearCloudAwsConfig();
-      }
+      const { data, error } = await userA.client.rpc("fn_ems_encrypt_secret", {
+        p_plaintext: SECRET_PLAINTEXT,
+      });
+      expect(error).toBeNull();
+      expect(data).toBeTruthy();
     });
   });
 });

--- a/supabase/migrations/00049_ems_secret_decrypt_service_role_only.sql
+++ b/supabase/migrations/00049_ems_secret_decrypt_service_role_only.sql
@@ -1,0 +1,68 @@
+-- 00049_ems_secret_decrypt_service_role_only.sql
+-- Narrow the EMS secret decrypt surface to service_role.
+--
+-- See CLAUDE.md § "Migration conventions — SECURITY DEFINER grants".
+--
+-- ── What changed in the application ──────────────────────────────────────
+--
+-- The EMS secret decrypt now runs on the service-role client
+-- (`src/lib/supabase/service.ts`) rather than the caller's cookie-scoped SSR
+-- client. Authorization is performed ahead of it, by an RLS-evaluated read of
+-- the `microgrids` row on the caller's own client — see
+-- `getEmsSecretForMicrogrid` in `src/lib/openems/config.ts`, which owns that
+-- ordering for every caller.
+--
+-- With no application path left that decrypts as `authenticated`, the
+-- `authenticated` EXECUTE grants below are no longer load-bearing and are
+-- withdrawn so the grants match the code.
+--
+-- ── Ordering invariant this migration depends on ─────────────────────────
+--
+-- `fn_get_ems_secret` short-circuits its permission gate for `service_role`,
+-- so on the service-role path the function contributes no authorization of
+-- its own. The RLS row read in `getEmsSecretForMicrogrid` step 1 is the only
+-- authorization, and "no row" is terminal — it returns before the service
+-- client is constructed. Reordering those two steps would leave the decrypt
+-- ungated. Regression coverage:
+-- `src/lib/openems/__tests__/config.test.ts` ("cross-org caller cannot reach
+-- the decrypt").
+--
+-- ── Scope ────────────────────────────────────────────────────────────────
+--
+--   fn_get_ems_secret(UUID)       — microgrid-level accessor.
+--   fn_ems_decrypt_secret(BYTEA)  — the underlying decrypt primitive.
+--
+-- Both are withdrawn together. Withdrawing only the accessor would leave the
+-- primitive as an equivalent entry point, since the ciphertext column is
+-- selectable by anyone RLS admits to the `microgrids` row. No application
+-- code calls `fn_ems_decrypt_secret` as `authenticated`: it is invoked from
+-- inside SECURITY DEFINER bodies (which execute as the function owner) and
+-- from service-role contexts.
+--
+-- `fn_ems_encrypt_secret(TEXT)` KEEPS its `authenticated` grant — the Save
+-- flow in `src/app/api/microgrids/[id]/openems-backend/route.ts` encrypts on
+-- the user-bound client, and encryption releases nothing.
+--
+-- `anon` / `PUBLIC` were already revoked in 00047; the clauses are re-issued
+-- here so this migration is self-contained and idempotent regardless of the
+-- order it is applied in.
+--
+-- ── PostgREST surface after this migration ───────────────────────────────
+--
+-- Per CLAUDE.md, a post-hoc REVOKE on a pre-existing function surfaces as
+-- either `401 / 42501` or `404 / PGRST202` depending on schema-cache state.
+-- Tests asserting denial must accept both shapes.
+
+REVOKE EXECUTE ON FUNCTION public.fn_get_ems_secret(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_get_ems_secret(UUID)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.fn_ems_decrypt_secret(BYTEA)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_ems_decrypt_secret(BYTEA)
+  TO service_role;
+
+-- Ask PostgREST to reload its schema cache so the narrowed grants take
+-- effect on the REST surface without waiting for a restart.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What

Moves the EMS secret decrypt off the caller's cookie-scoped SSR client and onto the existing service-role client (`src/lib/supabase/service.ts`), then tightens the function grants so they match how the code actually calls them.

Refs `energy-iot/mbe-docs#7`.

## Why

The decrypt and the row-level authorization previously shared one connection, which forced the decrypt function's `EXECUTE` grant to be broader than the server-side paths that actually need it. Splitting the two lets the grant narrow to `service_role`, which is the only role that now performs a decrypt.

## How

Authorization is performed explicitly, ahead of the decrypt, by an RLS-evaluated read of the `microgrids` row on the caller's own client. `getEmsSecretForMicrogrid` (`src/lib/openems/config.ts`) owns that sequence for every caller:

1. read the `microgrids` row on the user client — this is the authorization step
2. no row → **terminal** return, before any decrypt path is reachable
3. only then decrypt on the service-role client

**The ordering is load-bearing and deliberately centralised.** `fn_get_ems_secret` short-circuits its own permission gate for `service_role`, so on this path the function contributes no authorization of its own — the RLS read in step 1 is the only authorization rather than a second layer. Every caller goes through the helper rather than issuing the RPC itself, so the invariant lives in exactly one place and can't drift per-route.

### Migration `00049`

Narrows `fn_get_ems_secret(UUID)` and the underlying `fn_ems_decrypt_secret(BYTEA)` to `service_role`.

Both are narrowed together on purpose: the ciphertext column is selectable by anyone RLS admits to the `microgrids` row, so narrowing only the accessor would leave the primitive as an equivalent entry point. No application code invokes `fn_ems_decrypt_secret` as `authenticated` — it is called from inside `SECURITY DEFINER` bodies (which execute as the function owner) and from service-role contexts.

`fn_ems_encrypt_secret(TEXT)` **keeps** its `authenticated` grant: the Save flow encrypts on the user-bound client, and encryption releases nothing.

## Callers audited

| Caller | Change |
|---|---|
| `api/openems/{status,channels,energy}/route.ts` | none — via `getMicrogridEmsConfig` |
| `api/edges/[id]/discover-devices/route.ts` | none — via `getMicrogridEmsConfig`; stale gate comment refreshed |
| `api/microgrids/[id]/openems-backend/discover/route.ts` | none — via `getMicrogridEmsConfig`; stale gate comment refreshed |
| `lib/billing/generate.ts` | none — via `getMicrogridEmsConfig` |
| `microgrids/[id]/setup/openems-backend/page.tsx` | **migrated** — server component rendering the secret's last 4 |
| `api/microgrids/[id]/openems-backend/route.ts` | **migrated** — preserve-existing-secret branch |

The last two called the RPC directly and were not in the original audit list. Both already read the row under RLS and returned early before the decrypt, so the migration preserved their existing shape.

## Tests

- **`src/lib/openems/__tests__/config.test.ts`** (new) — asserts a cross-org caller **never reaches the decrypt**: that the service-role client is not even constructed, not merely that an error comes back. Also pins the read-before-decrypt call ordering, and that the decrypt is never issued on the caller's own client.
- **`rls.test.ts` AC-TEST-4** — reworked. The old per-role return-value truth table no longer describes a reachable surface: every authenticated caller is now stopped at the grant layer before the body runs, so role stops differentiating the outcome. Adds coverage for the decrypt primitive and for `fn_ems_encrypt_secret` remaining available. Denial assertions accept both `42501` and `PGRST202` per `CLAUDE.md § Migration conventions`.
- **`openems-backend/__tests__/route.test.ts`** — updated for the extra authorization read and the service-role decrypt.

## Verified, not assumed

The Add-Household wizard's inline discovery is unaffected. It reaches the secret through `GET /api/edges/[id]/discover-devices` — a server route — via `getMicrogridEmsConfig`. No client component calls the RPC; `src/lib/openems/config.ts` is `import "server-only"`, which would hard-fail any client import.

## Checks

- `npx tsc --noEmit` clean
- `npm run lint` — 0 errors (27 pre-existing warnings, untouched)
- `npm test` with `SKIP_RLS_TESTS=1 SKIP_DEK_BOOTSTRAP_TEST=1` — 154 files / 1792 tests passing, 3 consecutive green runs

The RLS and DEK-bootstrap suites are skipped here as usual — they need `supabase start` + seed + `SUPABASE_JWT_SECRET`. **The reworked AC-TEST-4 assertions therefore have not been executed against a live database and should be run once locally before merge**, since they encode the new grant surface and the 42501-vs-PGRST202 shape is environment-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzHjqbXb4YtohAhH1dduPG
