### PR TITLE
ci: run the database-backed test suites in the merge gate (#241)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,17 @@ name: Test
 # job's name below MUST stay as "Test" so the required-check context
 # resolves; do NOT add a matrix-suffix or rename.
 #
-# Skip flags (SKIP_RLS_TESTS, SKIP_DEK_BOOTSTRAP_TEST) bypass the
-# Supabase-dependent suites — running them here would require
-# `supabase start` (Docker) + seed + JWT secret. Tracked as a follow-up
-# to issue #236.
+# The database-backed suites (vitest project "rls") now run here — see
+# #241. A local Supabase is started on the runner; the suites are
+# self-fixturing and need neither the generated seed nor a repository
+# secret. Measured cold on ubuntu-latest: `supabase start` ~81-85s, the
+# 13-file rls project ~14-16s.
+#
+# SKIP_DEK_BOOTSTRAP_TEST stays set, and NOT for cost. dek-bootstrap.test.ts
+# does `ALTER DATABASE postgres SET app.allow_dev_dek`, which fails with
+# `permission denied to set parameter` because the `postgres` role is not a
+# superuser on Supabase (local or CI). It cannot pass here at any time
+# budget; that is a defect in the test, tracked separately, not a deferral.
 
 on:
   pull_request:
@@ -28,7 +35,8 @@ jobs:
   Test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Raised from 10: the Supabase start adds ~85s to the job.
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +52,21 @@ jobs:
 
       - run: npm run lint
 
-      - run: npm test
+      # Started after tsc + lint on purpose: a type or lint failure should
+      # fail in seconds rather than after paying for a database.
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - run: supabase start
+
+      - name: npm test
+        run: |
+          eval "$(supabase status -o env | grep -E '^(ANON_KEY|JWT_SECRET|SERVICE_ROLE_KEY)=')"
+          export SUPABASE_JWT_SECRET="$JWT_SECRET"
+          export NEXT_PUBLIC_SUPABASE_ANON_KEY="$ANON_KEY"
+          export SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY"
+          export NEXT_PUBLIC_SUPABASE_URL="http://localhost:54321"
+          npm test
         env:
-          SKIP_RLS_TESTS: '1'
           SKIP_DEK_BOOTSTRAP_TEST: '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,11 +62,15 @@ jobs:
 
       - name: npm test
         run: |
-          eval "$(supabase status -o env | grep -E '^(ANON_KEY|JWT_SECRET|SERVICE_ROLE_KEY)=')"
+          # These two are the only variables the suites read
+          # (rls.helpers.ts assertEnvironmentReady). The Supabase URL is NOT
+          # among them — rls.helpers hard-codes LOCAL_SUPABASE_URL, so setting
+          # NEXT_PUBLIC_SUPABASE_URL here would steer nothing while looking
+          # like it does. Service-role access is a JWT derived from the secret
+          # at runtime, not a key.
+          eval "$(supabase status -o env | grep -E '^(ANON_KEY|JWT_SECRET)=')"
           export SUPABASE_JWT_SECRET="$JWT_SECRET"
           export NEXT_PUBLIC_SUPABASE_ANON_KEY="$ANON_KEY"
-          export SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY"
-          export NEXT_PUBLIC_SUPABASE_URL="http://localhost:54321"
           npm test
         env:
           SKIP_DEK_BOOTSTRAP_TEST: '1'


### PR DESCRIPTION
Closes the `SKIP_RLS_TESTS` gap in the merge gate. #241, open since 18 May, five occurrences — it became a blocker when #322's 18 database tests turned out not to run in CI.

## What changed

- **`SKIP_RLS_TESTS: '1'` dropped.** The `rls` vitest project now runs in the gate.
- **Supabase CLI + `supabase start` added**, after `tsc` and `lint` so a type or lint failure still fails in seconds rather than after paying for a database.
- **`timeout-minutes` 10 → 15** for the added ~85s.
- **`SKIP_DEK_BOOTSTRAP_TEST: '1'` kept.**
- Job name stays exactly `Test`. It is a required context; renaming it silently un-protects `main`.

## Measured, not estimated

Three spike runs on `ubuntu-latest` (branches now deleted; numbers recorded on #241):

```
supabase_start   81s / 83s / 85s     cold, includes image pulls
rls_suite        14s / 15s / 16s     13 files
```

- **No seed needed.** `00003_seed.sql` is gitignored and generated by `./setup.sh`, so it does not exist on a runner. All three runs printed `SEED absent` and passed — the suites are self-fixturing.
- **No repository secret needed.** `supabase start` produces its own `JWT_SECRET` and `ANON_KEY`; the step reads them from `supabase status -o env`.
- **On the PR #322 head, `ems_config_access.test.ts (18 tests)` ran green** — run `30679203944`, `Tests 242 passed (242)`, 0 skipped.

## Why `SKIP_DEK_BOOTSTRAP_TEST` stays — a defect, not a deferral

`psql` **is** preinstalled on `ubuntu-latest` (16.14), so `dek-bootstrap.test.ts` does not self-skip. Run with the flag unset it fails in 2s, before reaching `supabase db reset`:

```
Error: psql ... ALTER DATABASE postgres SET app.allow_dev_dek = '1';
ERROR:  permission denied to set parameter "app.allow_dev_dek"
```

The `postgres` role is not a superuser on Supabase — `rolsuper = f` locally too, and the same statement fails there with the same error. **This file cannot pass against a non-superuser Supabase at any time budget.** Tracked separately; it is not a CI-configuration problem.

## Reviewer: two things I want your eyes on

**1. The blast radius is wider than the `rls` project.** Three files honour `SKIP_RLS_TESTS` while living in the `lib` project, so they have been self-skipping in CI and this change starts executing them:

```
src/lib/billing/__tests__/generate.test.ts
src/lib/supabase/__tests__/billing_line_items_short_slug.test.ts
src/lib/supabase/__tests__/households_phone_required.test.ts
```

The spike only ran `--project rls`; **the `Test` check on this PR is the first time these three execute in CI.** The `lib` project has file parallelism on, so they hit one database concurrently — that is the flake risk to watch, and it is why this PR exists as a measurement rather than a claim.

**2. `CLAUDE.md:224` becomes false with this merge** and I have deliberately not edited it:

> `npm test` (with `SKIP_RLS_TESTS=1` and `SKIP_DEK_BOOTSTRAP_TEST=1`) … RLS / DEK bootstrap suites stay skipped here … tracked as a follow-up to #236.

Three things wrong after this lands: the flag list, the "stay skipped" claim, and the pointer to #236 (closed). `CLAUDE.md` edits in this repo take explicit authorization, so it needs one — same route as `9707e8f`.

Also stale but self-resolving: `ems_operator.test.ts:24-25` states these assertions "do NOT execute in the gate". #322 deletes that file.

## Not included

Two `rls` project entries are illusory and neither is fixed here: `user_profiles_rls.test.ts` is listed in `vitest.config.ts` and has never existed (#323), and `dek-bootstrap.test.ts` cannot pass as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6QibNc897BzLczVMr4ThC
