### PR TITLE
test(openems): cover the #327 credential fields at the route and UI layers

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/openems-backend-shell.test.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/setup/openems-backend/__tests__/openems-backend-shell.test.tsx
@@ -33,6 +33,8 @@ import {
   fireEvent,
   act,
   within,
+  waitFor,
+  cleanup,
 } from "@testing-library/react";
 
 const mockRefresh = vi.fn();
@@ -794,5 +796,113 @@ describe("OpenemsBackendShell — Known edge IDs (#112)", () => {
     expect(container.textContent).toContain("Edge IDs");
     // The — character for empty
     expect(container.textContent).toContain("—");
+  });
+});
+
+// ── #327: HTTP Basic credential fields on the Direct URL form ─────────────
+//
+// The suite already carried `ems_basic_auth_username` and
+// `ems_has_basic_auth_password` in its fixtures, but only to satisfy the prop
+// type — nothing asserted the fields exist, render, or reach the request. A
+// fixture key is not coverage.
+describe("OpenemsBackendShell — #327 Basic credentials", () => {
+  function openDirectForm(mg: typeof BASE_MG) {
+    render(
+      <OpenemsBackendShell
+        microgrid={mg}
+        health="not_configured"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        canConfigure={true}
+        emsOperators={[]}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /direct url/i }));
+  }
+
+  it("renders username and password fields on the Direct URL form", () => {
+    openDirectForm(BASE_MG);
+    expect(screen.getByLabelText(/^username$/i)).toBeDefined();
+    expect(screen.getByLabelText(/^password$/i)).toBeDefined();
+  });
+
+  it("does NOT render them on the Cloud (AWS) form", () => {
+    render(
+      <OpenemsBackendShell
+        microgrid={BASE_MG}
+        health="not_configured"
+        draftPeriodsCount={0}
+        closedPeriodsCount={0}
+        secretLast4={null}
+        canConfigure={true}
+        emsOperators={[]}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cloud \(aws\)/i }));
+    expect(screen.queryByLabelText(/^username$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^password$/i)).toBeNull();
+  });
+
+  it("offers 'leave blank to keep' ONLY when a password is on record", () => {
+    openDirectForm(BASE_MG);
+    expect(screen.queryByText(/leave blank to keep the current password/i)).toBeNull();
+    cleanup();
+
+    openDirectForm({ ...BASE_MG, ems_has_basic_auth_password: true });
+    expect(screen.getByText(/leave blank to keep the current password/i)).toBeDefined();
+  });
+
+  it("posts the username, and omits the password when left blank", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "zero_edges", message: "No edges declared yet", edgeCount: 0, edges: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    openDirectForm({ ...BASE_MG, ems_has_basic_auth_password: true });
+    fireEvent.change(screen.getByLabelText(/backend url/i), {
+      target: { value: "https://ems.example/rest" },
+    });
+    fireEvent.change(screen.getByLabelText(/^username$/i), {
+      target: { value: "openems" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save & test|save and test|save/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+
+    expect(body.type).toBe("direct_url");
+    expect(body.basicAuthUsername).toBe("openems");
+    // Absent, not empty-string: a blank field means "keep the stored password",
+    // and sending "" would be indistinguishable from clearing it.
+    expect(body).not.toHaveProperty("basicAuthPassword");
+  });
+
+  it("sends the password when the operator types one", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "zero_edges", message: "No edges declared yet", edgeCount: 0, edges: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    openDirectForm(BASE_MG);
+    fireEvent.change(screen.getByLabelText(/backend url/i), {
+      target: { value: "https://ems.example/rest" },
+    });
+    fireEvent.change(screen.getByLabelText(/^username$/i), {
+      target: { value: "openems" },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: "s3cret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save & test|save and test|save/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.basicAuthUsername).toBe("openems");
+    expect(body.basicAuthPassword).toBe("s3cret");
   });
 });

--- a/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/__tests__/route.test.ts
@@ -104,6 +104,7 @@ function mgSelectHandler(
     name: string;
     ems_type?: "cloud_aws" | "direct_url" | null;
     ems_aws_secret_access_key_encrypted?: string | null;
+    ems_basic_auth_password_encrypted?: string | null;
   } | null
 ) {
   return () => ({
@@ -132,6 +133,24 @@ function mgUpdateHandler(error: unknown = null) {
     update: () => ({
       eq: () => Promise.resolve({ error }),
     }),
+  });
+}
+
+/**
+ * Like mgUpdateHandler, but records the payload. #327 added columns whose
+ * whole contract is what ends up in the UPDATE — "preserve" means the key is
+ * ABSENT, not null — and the discarding handler above cannot see the
+ * difference between omitted and nulled.
+ */
+function capturingUpdateHandler(
+  sink: { payload?: Record<string, unknown> },
+  error: unknown = null
+) {
+  return () => ({
+    update: (payload: Record<string, unknown>) => {
+      sink.payload = payload;
+      return { eq: () => Promise.resolve({ error }) };
+    },
   });
 }
 
@@ -745,6 +764,149 @@ describe("PUT /api/microgrids/[id]/openems-backend", () => {
     expect(saveLog.known_edge_ids_count).toBe(1);
     infoSpy.mockRestore();
   });
+
+  // ── #327: HTTP Basic credentials on direct_url ────────────────────────────
+  //
+  // The DB tests prove the columns are guarded and encrypted; the factory tests
+  // prove the client sends the header. NOTHING covered the layer between them
+  // — the save route, which is what the operator's form actually posts to.
+  // These fill that in.
+  describe("#327 direct_url Basic credentials", () => {
+    it("rejects a username with no password (400) before any write", async () => {
+      registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+
+      const { PUT } = await import("../route");
+      const res = await PUT(
+        makePutRequest({
+          type: "direct_url",
+          backendUrl: "https://ems.example/rest",
+          known_edge_ids: [],
+          basicAuthUsername: "openems",
+        }),
+        { params: Promise.resolve({ id: MG_ID }) }
+      );
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/username was provided with no password/i);
+      // Only the row read happened — no billing-period check, no UPDATE.
+      expect(fromCallIndex).toBe(1);
+    });
+
+    it("rejects a password with no username (400)", async () => {
+      registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+
+      const { PUT } = await import("../route");
+      const res = await PUT(
+        makePutRequest({
+          type: "direct_url",
+          backendUrl: "https://ems.example/rest",
+          known_edge_ids: [],
+          basicAuthPassword: "s3cret",
+        }),
+        { params: Promise.resolve({ id: MG_ID }) }
+      );
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/password was provided with no username/i);
+    });
+
+    it("persists the username and the ENCRYPTED password when both are given", async () => {
+      const sink: { payload?: Record<string, unknown> } = {};
+      registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+      registerFrom(billingPeriodsHandler([]));
+      registerFrom(capturingUpdateHandler(sink)); // persist config
+      registerFrom(mgUpdateHandler(null)); // health update
+      getEdgesStatusMock.mockResolvedValue([]);
+
+      const { PUT } = await import("../route");
+      const res = await PUT(
+        makePutRequest({
+          type: "direct_url",
+          backendUrl: "https://ems.example/rest",
+          known_edge_ids: [],
+          basicAuthUsername: "openems",
+          basicAuthPassword: "s3cret",
+        }),
+        { params: Promise.resolve({ id: MG_ID }) }
+      );
+
+      expect(res.status).toBe(200);
+      expect(sink.payload?.ems_basic_auth_username).toBe("openems");
+      // Ciphertext from fn_ems_encrypt_secret, never the plaintext.
+      expect(sink.payload?.ems_basic_auth_password_encrypted).toBe("\\x01020304");
+      expect(JSON.stringify(sink.payload)).not.toContain("s3cret");
+      expect(mockRpc).toHaveBeenCalledWith("fn_ems_encrypt_secret", {
+        p_plaintext: "s3cret",
+      });
+    });
+
+    it("OMITS the password column when blank and a ciphertext is on record (preserve)", async () => {
+      const sink: { payload?: Record<string, unknown> } = {};
+      registerFrom(
+        mgSelectHandler({
+          id: MG_ID,
+          name: MG_NAME,
+          ems_type: "direct_url",
+          ems_basic_auth_password_encrypted: "\\xDEADBEEF",
+        })
+      );
+      registerFrom(billingPeriodsHandler([]));
+      // getEmsBasicAuthPasswordForMicrogrid re-reads the row on the user client
+      // before decrypting on the service client — that read is the
+      // authorization step, and it happens AFTER the mid-period gate, when the
+      // candidate config is assembled.
+      registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+      registerFrom(capturingUpdateHandler(sink)); // persist config
+      registerFrom(mgUpdateHandler(null)); // health update
+      getEdgesStatusMock.mockResolvedValue([]);
+
+      const { PUT } = await import("../route");
+      const res = await PUT(
+        makePutRequest({
+          type: "direct_url",
+          backendUrl: "https://ems.example/rest",
+          known_edge_ids: [],
+          basicAuthUsername: "openems",
+        }),
+        { params: Promise.resolve({ id: MG_ID }) }
+      );
+
+      expect(res.status).toBe(200);
+      // ABSENT, not null. Setting it to null would wipe the stored credential —
+      // the distinction the discarding update handler could not express.
+      expect(sink.payload).not.toHaveProperty("ems_basic_auth_password_encrypted");
+      expect(sink.payload?.ems_basic_auth_username).toBe("openems");
+    });
+
+    it("nulls both credential columns when the connection type is cloud_aws", async () => {
+      const sink: { payload?: Record<string, unknown> } = {};
+      registerFrom(mgSelectHandler({ id: MG_ID, name: MG_NAME }));
+      registerFrom(billingPeriodsHandler([]));
+      registerFrom(capturingUpdateHandler(sink)); // persist config
+      registerFrom(mgUpdateHandler(null)); // health update
+      getEdgesStatusMock.mockResolvedValue([]);
+
+      const { PUT } = await import("../route");
+      const res = await PUT(
+        makePutRequest({
+          type: "cloud_aws",
+          backendUrl: "https://abc.lambda-url.us-east-1.on.aws/",
+          known_edge_ids: [],
+          region: "us-east-1",
+          accessKeyId: "AKIA",
+          secretAccessKey: "shhh",
+        }),
+        { params: Promise.resolve({ id: MG_ID }) }
+      );
+
+      expect(res.status).toBe(200);
+      // A credential left behind a form that no longer shows it is how an
+      // operator ends up unable to explain what their microgrid sends.
+      expect(sink.payload?.ems_basic_auth_username).toBeNull();
+      expect(sink.payload?.ems_basic_auth_password_encrypted).toBeNull();
+    });
+  });
+
 });
 
 // Silence `periods` unused-warning when linter is strict about top-level lets.


### PR DESCRIPTION
#329 shipped with coverage at the two ends and nothing in the middle. The DB tests prove the columns are guarded and encrypted; the factory tests prove the client emits the header. **Neither touches the save route or the form** — the layer an operator actually uses, and the layer Support asked for evidence about when nobody could produce any.

Worse than absent: the shell suite already carried `ems_basic_auth_username` and `ems_has_basic_auth_password` in its fixtures, added only to satisfy the prop type. **A fixture key reads like coverage and asserts nothing.**

## Route (5 tests)

- rejects username-without-password, and password-without-username, **before any write** (asserts the from() call count, so a future reordering that writes first fails here)
- persists the username and the **ciphertext**, never the plaintext
- **OMITS** the password column when blank with a ciphertext on record — preserve means *absent*, not null
- nulls both columns when the connection type switches to `cloud_aws`

This needed a capturing update handler. The existing `mgUpdateHandler` discards the payload, so *"the column is in the UPDATE"* and *"omitted vs nulled"* were not expressible — which is why the preserve semantics had no test rather than a weak one.

## UI (5 tests)

- fields render on the Direct URL form and **not** on the Cloud form
- "leave blank to keep the current password" appears **only** when one is on record
- the request carries `basicAuthUsername` and **omits** `basicAuthPassword` when blank
- and sends it when typed

## Every assertion was mutation-tested

Not trusted because it passed:

| mutation | result |
|---|---|
| always write the password column | preserve test fails, alone |
| remove the half-filled rejection | that test fails, alone |
| delete the credential fieldset | 4 UI tests fail |
| always send `basicAuthPassword` | the omit test fails, alone |

Each restores green.

## Scope

**Tests only — no production code changes.** 168 files, 1966 tests (1956 + 10). Nothing here changes what is deployed; it makes what is deployed checkable.

It does not replace an authenticated page load, which remains the one thing nobody has done. It does mean a regression in this behaviour now fails the gate rather than reaching an operator.

Refs #327
