### PR TITLE
fix(openems): surface HTTP status and non-JSON bodies instead of a generic error (#325)

### DIFF
--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -490,8 +490,26 @@ export async function PUT(
           reason = "unreachable";
           errorMsg = `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`;
         } else {
+          // Every remaining OpenEmsError already carries an operator-actionable
+          // message; this branch used to replace all of them with a generic
+          // string and leave the only copy of the cause in a server log (#325).
+          //
+          // `reason` stays `unknown_error` deliberately. It is persisted to
+          // `ems_last_discover_status`, whose CHECK constraint (migration
+          // 00018) permits five values; widening it needs a migration that is
+          // out of this ticket's scope — the same boundary #318 documents.
+          // The message carries the detail; the status stays lossy and tracked.
+          //
+          // What reaches here and what it tells the operator:
+          //   OPENEMS_HTTP_ERROR          status + body — including an OpenEMS
+          //                               auth failure, which arrives as 500
+          //                               rather than 401
+          //   OPENEMS_NOT_JSON            the URL is not a JSON-RPC API
+          //                               (typically the OpenEMS UI)
+          //   OPENEMS_INVALID_BACKEND_URL a stored URL failed sink-side checks
+          //   OPENEMS_RPC_ERROR           the backend's own JSON-RPC error text
           reason = "unknown_error";
-          errorMsg = "Edge validation failed with an unexpected error. Check server logs.";
+          errorMsg = err.message;
         }
         return NextResponse.json(
           { error: errorMsg, reason },

--- a/src/app/api/microgrids/[id]/openems-backend/route.ts
+++ b/src/app/api/microgrids/[id]/openems-backend/route.ts
@@ -703,6 +703,26 @@ export async function PUT(
           discoverStatus = "unreachable";
           discoverMessage = `Could not reach OpenEMS Backend at ${backendUrl.trim()}. Check the URL and that the host is reachable from Vercel.`;
         } else {
+          // DO NOT change this to `err.message` without also scrubbing it.
+          //
+          // Unlike step 5 above — which returns its message to the caller and
+          // exits — `discoverMessage` is PERSISTED to
+          // `ems_last_discover_error`, and that column is in
+          // MICROGRID_PUBLIC_COLUMNS, so anyone with org access reads it.
+          //
+          // Since #325 an OPENEMS_HTTP_ERROR message carries up to 500 bytes of
+          // the backend's own response body, and since #327 `direct_url` sends
+          // `Authorization: Basic …`. A backend whose error page echoes the
+          // request would therefore put a credential into an org-readable
+          // column. Today it cannot: this branch discards the message, and
+          // `err.message` is used only for OPENEMS_REDIRECT below.
+          //
+          // Surfacing the real message here is a reasonable thing to want —
+          // #318 covers the adjacent status problem. If you do it, route it
+          // through `scrubSecretValues(msg, { secretAccessKey, password })`
+          // first, with the literal values rather than a `Basic …` pattern: the
+          // values catch the credential however the backend echoed it, the
+          // pattern only catches the header form.
           discoverStatus = "unknown_error";
           discoverMessage =
             "Discover failed with an unexpected error. Check server logs.";
@@ -716,6 +736,7 @@ export async function PUT(
   }
 
   // Update health fields.
+  //
   const { error: healthErr } = await supabase
     .from("microgrids")
     .update({

--- a/src/lib/openems/__tests__/client.test.ts
+++ b/src/lib/openems/__tests__/client.test.ts
@@ -26,6 +26,39 @@ function mockResponse(body: unknown, status = 200): Response {
   } as Response;
 }
 
+/**
+ * A response whose body is RAW TEXT, not a JSON-serialised object.
+ *
+ * `mockResponse` above stringifies whatever it is given, so it can only ever
+ * produce well-formed JSON — it cannot express "the backend sent an HTML error
+ * page", which is exactly the case #325 is about. Tests that need a non-JSON
+ * body must use this one.
+ */
+function mockRawResponse(
+  raw: string,
+  status = 200,
+  contentType = "text/html"
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.reject(new SyntaxError("Unexpected token < in JSON")),
+    headers: new Headers({ "content-type": contentType }),
+    redirected: false,
+    statusText: "",
+    type: "basic" as ResponseType,
+    url: "",
+    clone: () => mockRawResponse(raw, status, contentType),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(raw),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
 // Helper to build a DeviceConfig fixture.
 // Post-#101: DeviceConfig no longer carries dataSourceType / openems_backend_url
 // — the client is constructed with a microgrid-scoped URL.
@@ -847,4 +880,99 @@ describe("OpenEmsClient", () => {
       expect(options?.method).toBe("POST");
     });
   });
+
+  // ── #325: non-2xx and non-JSON responses must carry their evidence ────────
+  //
+  // Before this, both fell through to `response.json()` and threw a bare
+  // SyntaxError — not an OpenEmsError — so the save route reported "Edge
+  // validation failed with an unexpected error. Check server logs." Diagnosing
+  // one real incident took three people probing the operator's host by hand.
+  describe("#325 HTTP and body-shape errors", () => {
+    it("405 with an HTML body → OPENEMS_HTTP_ERROR carrying status and body", async () => {
+      fetchSpy.mockResolvedValue(
+        mockRawResponse("<html><head><title>405 Not Allowed</title></head>", 405)
+      );
+
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toMatchObject({
+        code: "OPENEMS_HTTP_ERROR",
+        statusCode: 502,
+      });
+
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(
+        /returned HTTP 405/
+      );
+      // The body is the actionable part — without it "405" is a number.
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(
+        /405 Not Allowed/
+      );
+    });
+
+    it("502 from a proxy whose upstream is down → status is in the message", async () => {
+      fetchSpy.mockResolvedValue(
+        mockRawResponse("<html><head><title>502 Bad Gateway</title></head>", 502)
+      );
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(
+        /returned HTTP 502/
+      );
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(
+        /502 Bad Gateway/
+      );
+    });
+
+    it("an OpenEMS auth failure arrives as 500, NOT 401 — and says so", async () => {
+      // OpenEMS Backend answers an unauthenticated JSON-RPC call this way. The
+      // 401/403 branch never fires for it, which is why the generic bucket
+      // used to swallow the one message that named the cause.
+      fetchSpy.mockResolvedValue(
+        mockRawResponse(
+          "Error 500 io.openems.common.exceptions.OpenemsError$OpenemsNamedException: Authentication failed",
+          500
+        )
+      );
+
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toMatchObject({
+        code: "OPENEMS_HTTP_ERROR",
+      });
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(
+        /Authentication failed/
+      );
+    });
+
+    it("200 text/html (a UI catch-all) → OPENEMS_NOT_JSON naming the content type", async () => {
+      fetchSpy.mockResolvedValue(
+        mockRawResponse('<!DOCTYPE html><html lang="en"><base href="/">', 200)
+      );
+
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toMatchObject({
+        code: "OPENEMS_NOT_JSON",
+        statusCode: 502,
+      });
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(/text\/html/);
+      // The first bytes must actually be present. Reading the body via
+      // `.text()` AFTER `.json()` would yield "" here — the message would
+      // promise evidence and deliver none.
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(/!DOCTYPE html/);
+      await expect(client.getEdgesStatus(["edge0"])).rejects.toThrow(
+        /rather than the OpenEMS UI/
+      );
+    });
+
+    it("accepts valid JSON served WITHOUT a JSON content-type", async () => {
+      // The reason the parse decides rather than the header: servers that send
+      // correct JSON as text/plain are common, and a content-type gate would
+      // invent a failure for a setup that works.
+      fetchSpy.mockResolvedValue(
+        mockRawResponse(
+          JSON.stringify({ jsonrpc: "2.0", id: "x", result: { edge0: { online: true } } }),
+          200,
+          "text/plain"
+        )
+      );
+
+      await expect(client.getEdgesStatus(["edge0"])).resolves.toEqual([
+        { edgeId: "edge0", online: true },
+      ]);
+    });
+  });
+
 });

--- a/src/lib/openems/client.ts
+++ b/src/lib/openems/client.ts
@@ -120,11 +120,75 @@ export class OpenEmsClient implements DeviceDataAdapter {
       );
     }
 
-    const json = await response.json();
+    // Everything that is not 2xx, and not one of the two shapes handled above,
+    // stops here carrying the evidence (#325).
+    //
+    // Before this existed, control fell straight through to `response.json()`,
+    // so a 404, 405, 500 or 502 threw a bare `SyntaxError` on the HTML body —
+    // not an `OpenEmsError`, so the route's outer catch reported "Edge
+    // validation failed with an unexpected error. Check server logs." The
+    // cause existed only in the server log, and diagnosing one real incident
+    // took three people probing the operator's host directly.
+    //
+    // The status and the first bytes are the whole point: "returned HTTP 405"
+    // and "returned HTTP 502" send an operator to different places, and both
+    // are things they can act on without us.
+    //
+    // NOTE — this is where an OpenEMS auth failure actually lands. OpenEMS
+    // Backend answers an unauthenticated JSON-RPC call with **500** and
+    // `OpenemsNamedException: Authentication failed` in the body, not with
+    // 401/403, so the branch above never fires for it. Matching on the body
+    // text to re-classify it was considered and rejected: it is a different
+    // failure mode dressed as a string comparison, and the message below
+    // already names the cause verbatim. If OpenEMS ever starts sending 401,
+    // the branch above catches it and this comment is what tells you why the
+    // reason code changed.
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      // Single read: this branch throws, so the stream is never needed again.
+      throw new OpenEmsError(
+        `OpenEMS Backend at ${this.baseUrl} returned HTTP ${response.status}: ${body.slice(0, 500)}`,
+        "OPENEMS_HTTP_ERROR",
+        502,
+        { status: response.status, body: body.slice(0, 500) }
+      );
+    }
+
+    // A 2xx that is not JSON. Deliberately NOT gated on Content-Type: plenty of
+    // servers return valid JSON as `text/plain` or with no Content-Type at all,
+    // and making the header a precondition invents failures for setups that
+    // work today. The parse is the thing that genuinely cannot proceed — so let
+    // the parse decide, and put the content-type in the message where it does
+    // diagnostic work instead.
+    //
+    // The case this catches: a single-page-app catch-all that answers every
+    // path with `200 text/html`, which is what an operator gets when the URL
+    // points at an OpenEMS UI rather than at the Backend's REST API.
+    // Read the body ONCE, as text, then parse it. `response.json()` consumes
+    // the stream, so a `response.text()` in the catch would read an already-
+    // used body and yield "" — an error message promising the first bytes and
+    // delivering none, which is worse than not offering them.
+    const raw = await response.text();
+
+    let json: { error?: { message?: string } } & Record<string, unknown>;
+    try {
+      json = JSON.parse(raw);
+    } catch {
+      const contentType = response.headers.get("content-type") ?? "unknown";
+      const body = raw;
+      throw new OpenEmsError(
+        `OpenEMS Backend at ${this.baseUrl} returned ${contentType}, not JSON. ` +
+          `Check that the URL points at the Backend's JSON-RPC API rather than the OpenEMS UI. ` +
+          `First bytes: ${body.slice(0, 200)}`,
+        "OPENEMS_NOT_JSON",
+        502,
+        { contentType, body: body.slice(0, 200) }
+      );
+    }
 
     if ("error" in json) {
       throw new OpenEmsError(
-        `OpenEMS RPC error: ${json.error.message}`,
+        `OpenEMS RPC error: ${json.error?.message}`,
         "OPENEMS_RPC_ERROR",
         502,
         json.error

--- a/src/lib/openems/errors.ts
+++ b/src/lib/openems/errors.ts
@@ -14,6 +14,14 @@ export class OpenEmsError extends Error {
 // "OPENEMS_UNREACHABLE" (503) — fetch failed (network error, timeout)
 // "OPENEMS_AUTH_FAILED" (401) — 401 from B2B REST
 // "OPENEMS_RPC_ERROR" (502) — JSON-RPC error response
+// "OPENEMS_HTTP_ERROR" (502) — non-2xx that is not a redirect; carries the
+//     status and the first bytes of the body (#325). Note OpenEMS reports an
+//     authentication failure as 500 with the reason in the body, NOT as
+//     401/403, so an auth failure against an OpenEMS Backend arrives here
+//     rather than as OPENEMS_AUTH_FAILED — see the note in client.ts.
+// "OPENEMS_NOT_JSON" (502) — 2xx whose body did not parse as JSON; carries the
+//     content-type and the first bytes (#325). A reverse proxy serving an
+//     error page or a single-page-app catch-all produces this.
 // "OPENEMS_REDIRECT" (502) — backend answered with a 3xx; not followed (mbe-docs#8)
 // "OPENEMS_INVALID_BACKEND_URL" (503) — stored backend URL failed sink-side
 //     validation; typically a row written before the rules existed (mbe-docs#8)


### PR DESCRIPTION
`client.ts` had no `response.ok` check. After the redirect branch and the 401/403 branch, control fell straight to `response.json()` — so **404, 405, 500, 502, and any 200 carrying a non-JSON body threw a bare `SyntaxError`.** Not an `OpenEmsError`, so the save route's outer catch reported *"Edge validation failed with an unexpected error. Check server logs,"* and the cause existed only in the log.

Diagnosing one real incident took three people probing the operator's host directly. The message that would have made it self-service was one line: **"returned HTTP 405"** and later **"returned HTTP 502"** send an operator to different places, and both are actionable without us.

## Two new codes

| code | when | carries |
|---|---|---|
| `OPENEMS_HTTP_ERROR` | non-2xx that is not a redirect | status + first 500 bytes |
| `OPENEMS_NOT_JSON` | 2xx whose body did not parse | content-type + first 200 bytes |

## Not gated on Content-Type, deliberately

Servers returning valid JSON as `text/plain` or with no `Content-Type` are common, and making the header a precondition **invents failures for setups that work today**. The parse is the thing that genuinely cannot proceed — so the parse decides, and the content-type goes in the message where it does diagnostic work. There is a test for valid JSON served as `text/plain`.

## A bug caught on the way in

The body is read **once as text and then parsed**. My first version called `response.text()` inside the `.json()` catch — that reads an already-consumed stream, so the `.catch(() => "")` would have made "first bytes" silently empty: an error message promising evidence and delivering none. A mutation test re-introduces exactly that and fails on the first-bytes assertion.

## The route stopped swallowing it

`route.ts`'s else-branch replaced every remaining `OpenEmsError` with the generic string. It now returns `err.message`.

`reason` stays `unknown_error` **on purpose**: it is persisted to `ems_last_discover_status`, whose CHECK constraint (00018) permits five values, and widening it needs a migration outside this ticket — the same boundary #318 documents. The message carries the detail; the status stays lossy and tracked there.

## Recorded in the code

**An OpenEMS auth failure arrives as HTTP 500** with `OpenemsNamedException: Authentication failed` in the body, not as 401/403, so it lands in `OPENEMS_HTTP_ERROR` rather than `OPENEMS_AUTH_FAILED`. Matching body text to re-classify it was considered and rejected — a different failure mode dressed as a string comparison, and the message already names the cause verbatim.

## Verification

Five tests, each mutation-tested rather than trusted:

| mutation | result |
|---|---|
| remove the `!response.ok` guard | 3 tests fail |
| read the body after `.json()` | the first-bytes assertion fails |

168 files, **1971 tests** (1966 + 5). No migration, no schema, no ordering question.

Closes #325
