### PR TITLE
fix(openems): strip trailing slashes before appending /jsonrpc (#326)

### DIFF
--- a/src/lib/openems/__tests__/auth.test.ts
+++ b/src/lib/openems/__tests__/auth.test.ts
@@ -27,10 +27,26 @@ describe("BasicAuth", () => {
     );
   });
 
-  it("resolveUrl works with trailing slash", () => {
-    // Preserves exactly what the caller passes
+  // #326. This test previously asserted the double slash as CORRECT, named
+  // "works with trailing slash" and commented "Preserves exactly what the
+  // caller passes" — so the defect shipped with a green test in front of it and
+  // a reviewer scanning the suite saw trailing slashes covered.
+  it("resolveUrl strips a trailing slash before appending", () => {
     expect(auth.resolveUrl("http://localhost:8075/")).toBe(
-      "http://localhost:8075//jsonrpc"
+      "http://localhost:8075/jsonrpc"
+    );
+  });
+
+  it("resolveUrl strips repeated trailing slashes", () => {
+    expect(auth.resolveUrl("http://localhost:8075///")).toBe(
+      "http://localhost:8075/jsonrpc"
+    );
+  });
+
+  it("resolveUrl preserves a path segment while stripping its trailing slash", () => {
+    // The real shape: an operator whose backend is proxied under /rest.
+    expect(auth.resolveUrl("https://ems.example/rest/")).toBe(
+      "https://ems.example/rest/jsonrpc"
     );
   });
 

--- a/src/lib/openems/__tests__/factory.test.ts
+++ b/src/lib/openems/__tests__/factory.test.ts
@@ -139,4 +139,46 @@ describe("createOpenEmsClient(config)", () => {
     });
   });
 
+
+  // #326 — NoAuth is the direct_url path, and it had NO resolveUrl coverage at
+  // all. The trailing-slash defect existed at both append sites; only the
+  // BasicAuth one had a test, and that test asserted the bug as correct.
+  describe("NoAuth.resolveUrl (#326)", () => {
+    const noAuth = new NoAuth();
+
+    it("appends /jsonrpc", () => {
+      expect(noAuth.resolveUrl("https://ems.example/rest")).toBe(
+        "https://ems.example/rest/jsonrpc"
+      );
+    });
+
+    it("strips a trailing slash rather than producing a double slash", () => {
+      expect(noAuth.resolveUrl("https://ems.example/rest/")).toBe(
+        "https://ems.example/rest/jsonrpc"
+      );
+    });
+
+    it("strips repeated trailing slashes", () => {
+      expect(noAuth.resolveUrl("https://ems.example/rest///")).toBe(
+        "https://ems.example/rest/jsonrpc"
+      );
+    });
+  });
+
+  // SigV4 signs the root URL — the Lambda routes internally — so it must NOT
+  // acquire the strip. Pinned because "make them consistent" is the plausible
+  // wrong fix.
+  describe("SigV4Auth.resolveUrl is unaffected (#326)", () => {
+    it("returns the URL unchanged, trailing slash included", () => {
+      const auth = new SigV4Auth({
+        accessKeyId: "AKIA",
+        secretAccessKey: "s",
+        region: "us-east-1",
+      });
+      expect(auth.resolveUrl("https://abc.lambda-url.us-east-1.on.aws/")).toBe(
+        "https://abc.lambda-url.us-east-1.on.aws/"
+      );
+    });
+  });
+
 });

--- a/src/lib/openems/auth.ts
+++ b/src/lib/openems/auth.ts
@@ -1,5 +1,22 @@
 import aws4 from "aws4";
 
+/**
+ * Append the JSON-RPC path to a stored backend URL.
+ *
+ * Trailing slashes are stripped first (#326). An operator who saves
+ * `https://host/rest/` would otherwise get `https://host/rest//jsonrpc`, and
+ * whether that matters is entirely up to their server: some normalise it, some
+ * 404, some route it to a different location block than the one intended. The
+ * operator typed something that looks right and cannot see the difference from
+ * any screen we show them.
+ *
+ * Exported so `NoAuth` in ./index.ts uses the same implementation — the bug
+ * existed in two places because the append did.
+ */
+export function appendJsonRpcPath(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/jsonrpc`;
+}
+
 export interface OpenEmsAuth {
   /** Resolve the full request URL given the configured baseUrl. */
   resolveUrl(baseUrl: string): string;
@@ -22,7 +39,7 @@ export class BasicAuth implements OpenEmsAuth {
   ) {}
 
   resolveUrl(baseUrl: string): string {
-    return `${baseUrl}/jsonrpc`;
+    return appendJsonRpcPath(baseUrl);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/lib/openems/auth.ts
+++ b/src/lib/openems/auth.ts
@@ -14,7 +14,15 @@ import aws4 from "aws4";
  * existed in two places because the append did.
  */
 export function appendJsonRpcPath(baseUrl: string): string {
-  return `${baseUrl.replace(/\/+$/, "")}/jsonrpc`;
+  // Scanned as a loop rather than `replace(/\/+$/, "")` on purpose. That regex
+  // is a polynomial ReDoS on operator-supplied input (CodeQL js/polynomial-redos,
+  // high) — `+$` backtracks quadratically over a string of many slashes, and
+  // this value comes straight from a form field. The loop is linear and cannot
+  // backtrack. Do not "simplify" it back into a regex; the gate will reject it,
+  // and it would be a real slow-input path in a request handler.
+  let end = baseUrl.length;
+  while (end > 0 && baseUrl.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  return `${baseUrl.slice(0, end)}/jsonrpc`;
 }
 
 export interface OpenEmsAuth {

--- a/src/lib/openems/index.ts
+++ b/src/lib/openems/index.ts
@@ -1,6 +1,6 @@
 import { OpenEmsError } from "./errors";
 import { OpenEmsClient } from "./client";
-import { BasicAuth, SigV4Auth } from "./auth";
+import { appendJsonRpcPath, BasicAuth, SigV4Auth } from "./auth";
 
 /**
  * Configuration for constructing an OpenEMS client.
@@ -104,7 +104,7 @@ export function createOpenEmsClient(config: OpenEmsClientConfig): OpenEmsClient 
  */
 export class NoAuth {
   resolveUrl(baseUrl: string): string {
-    return `${baseUrl}/jsonrpc`;
+    return appendJsonRpcPath(baseUrl);
   }
   async apply(): Promise<Record<string, string>> {
     return { "Content-Type": "application/json" };


### PR DESCRIPTION
A backend URL saved with a trailing slash produced a double-slash request path. `https://host/rest/` became `https://host/rest//jsonrpc` — and whether that matters is entirely up to the server: some normalise it, some 404, some route it to a different location block than the operator intended. **The operator typed something that looks correct and cannot see the difference from any screen we show them.**

## The append existed twice, so did the defect

`BasicAuth.resolveUrl` and `NoAuth.resolveUrl` both had `` `${baseUrl}/jsonrpc` ``. Both now call one exported `appendJsonRpcPath`.

**`SigV4Auth` is deliberately NOT changed** — it signs the root URL because the Lambda routes internally — and there is a test pinning that, because *"make them consistent"* is the plausible wrong fix.

## The test asserted the bug as correct

```ts
it("resolveUrl works with trailing slash", () => {
  // Preserves exactly what the caller passes
  expect(auth.resolveUrl("http://localhost:8075/")).toBe(
    "http://localhost:8075//jsonrpc"   // ← asserted as correct
  );
});
```

Named *"works"*, commented as intentional. **A reviewer scanning the suite saw trailing slashes covered and moved on.** Rewritten to state the guarantee, with repeated-slash and path-segment cases added.

## NoAuth had no coverage at all

Which is the `direct_url` path — the one a self-hosted operator is on, and the one exercised in production this week. Three cases added.

## Mutation-tested, both sites

| mutation | result |
|---|---|
| revert the strip in `appendJsonRpcPath` | 3 tests fail in `auth.test.ts` |
| revert `NoAuth` alone to the inline append | the direct_url case fails |

Each restores green. The second control matters because the fix is shared: without it, "NoAuth uses the helper" would have been an assumption.

## Relationship to #325

Ruled out as the cause of that incident and recorded there as such — the host in question returned identical responses for `/jsonrpc` and `//jsonrpc`, so the double slash changed nothing. **This is the same defect without that luck.**

168 files, **1977 tests** (1971 + 6). No migration, no schema, no ordering question.

Closes #326
