### PR TITLE
fix(households): stop telling operators to check two things that are already true (#335)

### DIFF
--- a/src/components/forms/DiscoverMeterInline.tsx
+++ b/src/components/forms/DiscoverMeterInline.tsx
@@ -35,6 +35,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { DiscoveredDevice, EdgeDiscoveryResponse } from "@/lib/openems/types";
+import { humanReadable } from "@/lib/openems/device-descriptions";
 import type { AvailableMeter } from "@/components/forms/HouseholdWizard";
 
 export type DiscoverMeterInlineEdge = {
@@ -350,11 +351,47 @@ export function DiscoverMeterInline({
         </div>
       )}
 
+      {/* Two distinct states, previously collapsed into one message (#335).
+          `discovered.length === 0` is genuinely "nothing found" and the
+          original copy is correct for it. `discovered.length > 0` with no
+          candidates means devices WERE found and none classify as consumption
+          meters — and the old sentence told the operator to check that the
+          edge was online and had components configured, both of which are
+          already true in that branch (it is guarded by `edgeOnline`, and
+          discovery returned devices). That sent a pilot operator to rename his
+          meter to contain a keyword, when the device-type control has existed
+          since #151. */}
       {showResults && edgeOnline && candidates.length === 0 && (
-        <p className="rounded-md border border-border bg-muted p-3 text-sm text-muted-foreground">
-          No new consumption meters on this edge. Make sure the edge is online
-          and has components configured.
-        </p>
+        discovered.length === 0 ? (
+          <p className="rounded-md border border-border bg-muted p-3 text-sm text-muted-foreground">
+            No new consumption meters on this edge. Make sure the edge is online
+            and has components configured.
+          </p>
+        ) : (
+          <div className="rounded-md border border-border bg-muted p-3 text-sm text-muted-foreground">
+            <p className="text-foreground">
+              Found {discovered.length}{" "}
+              {discovered.length === 1 ? "device" : "devices"} on this edge, but{" "}
+              {discovered.length === 1 ? "it is not" : "none are"} classified as
+              a consumption meter, so {discovered.length === 1 ? "it" : "none"}{" "}
+              can bill a household.
+            </p>
+            <ul className="mt-2 space-y-1">
+              {discovered.map((d) => (
+                <li key={d.componentId} className="font-mono text-xs">
+                  {d.alias || d.componentId}
+                  <span className="ml-2 font-sans text-muted-foreground">
+                    — {humanReadable(d.suggestedDeviceType)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-2">
+              If one of these meters a household, open it on the edge&apos;s
+              device list and change its type to Consumption meter.
+            </p>
+          </div>
+        )
       )}
 
       {showResults && candidates.length > 0 && (

--- a/src/components/forms/HouseholdWizard.tsx
+++ b/src/components/forms/HouseholdWizard.tsx
@@ -1133,9 +1133,18 @@ function StepMeter({
               </Link>
             }
           >
-            All consumption meters on this microgrid are already assigned to a
-            household. Discover more devices on the edges setup page before
-            adding another household here, or check &ldquo;manual
+            {/* #335: this branch fires whenever no meter is AVAILABLE, which
+                has two causes — every consumption meter is already assigned,
+                or the microgrid has no device classified as a consumption
+                meter in the first place. The previous copy asserted the first
+                unconditionally, and a pilot operator whose meter had been
+                classified `other` was told his meters were all assigned when
+                he had none. Say what is true and name both causes. */}
+            No consumption meter is available to assign. Either every meter on
+            this microgrid is already linked to a household, or the devices on
+            your edges are not classified as consumption meters — a device
+            discovered as another type will not appear here until its type is
+            changed on the edges setup page. You can also check &ldquo;manual
             billing&rdquo; above to skip the meter assignment.
           </Banner>
         </div>

--- a/src/components/forms/__tests__/HouseholdWizard.test.tsx
+++ b/src/components/forms/__tests__/HouseholdWizard.test.tsx
@@ -860,6 +860,59 @@ describe("HouseholdWizard", () => {
       });
     });
 
+    /** A generic branded meter — the shape that classifies `other` (#335). */
+    function unclassifiedDevice(
+      componentId: string,
+      alias = "Workshop Meter (addr 10)"
+    ) {
+      return {
+        componentId,
+        factoryId: "Meter.Chint.DDSU666",
+        alias,
+        nature: "io.openems.edge.meter.api.ElectricityMeter",
+        openemsChannelAddress: null,
+        suggestedDeviceType: "other",
+        alreadyAdded: false,
+      };
+    }
+
+    // #335. Devices WERE found and none classify as consumption meters. The
+    // old copy told the operator to check that the edge was online and had
+    // components configured — both already true in this branch — and said
+    // nothing about the classification that removed their meter.
+    it("discovery that found only unclassified devices names them and explains why", async () => {
+      const { impl } = makeUrlDispatcher({
+        discover: [discoveryResponse([unclassifiedDevice("meter0")])],
+        devices: [],
+        household: [],
+      });
+      fetchMock.mockImplementation(impl as never);
+
+      renderWizard({
+        availableMeters: [],
+        edges: [EDGE_1],
+        edgeIdsWithoutConsumptionMeter: [EDGE_1.id],
+      });
+      fillDisplayName("HH");
+      fillPhone("+256");
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Address line 1/i)).toBeDefined()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Discover meters/i })
+      );
+
+      // Names the device the operator can see, and its classification.
+      await waitFor(() =>
+        expect(screen.getByText(/Workshop Meter \(addr 10\)/)).toBeDefined()
+      );
+      expect(screen.getByText(/not classified as a consumption meter/i)).toBeDefined();
+      // And must NOT tell them to check two things that are already true.
+      expect(screen.queryByText(/Make sure the edge is online/i)).toBeNull();
+    });
+
     it("empty discovery (no consumption meters after filter) renders the no-meters message", async () => {
       const { impl } = makeUrlDispatcher({
         discover: [discoveryResponse([])],


### PR DESCRIPTION
A pilot operator connected his backend, discovery found his meter, and the household wizard told him:

> No new consumption meters on this edge. **Make sure the edge is online and has components configured.**

**Both instructions are false in the case that matters.** The branch is guarded by `edgeOnline`, so the edge *is* online. It is only reached after discovery returned devices, so components *are* configured. Nothing mentioned the classification that removed his meter from the list, or the device-type control that fixes it — which has existed since **#151**. He renamed his meter to contain a keyword instead.

## The two states were already distinguishable

`discovered.length` and `candidates.length` are both in hand at that line.

| Condition | Meaning | Copy |
|---|---|---|
| `discovered.length === 0` | genuinely nothing found | original — kept |
| `discovered.length > 0 && candidates.length === 0` | found devices, none classified as consumption meters | **new** |

The new state **lists what was found, by name and classification**, so the operator sees their own device and the cause together, and points at the existing control.

## Same shape, second location

`HouseholdWizard`'s StepMeter banner asserted *"All consumption meters on this microgrid are already assigned to a household"* — but it fires whenever none are **available**, which is also true when the microgrid has no consumption-classified device at all. An operator with zero such meters was told all of his were assigned. It now says what is true and names both causes; **no new data was needed to stop asserting a false one.**

## Not widening the keyword list

That is the tempting third option and the one that returns once per brand whose alias convention we did not anticipate. Classification stays a default, the override already exists, and what changes is that the operator can find it.

## Verification

| mutation | result |
|---|---|
| collapse the branch to one message | the new test fails, alone |
| invert the condition | **both** tests fail, separately |

The second is the one that matters: it proves each test pins its own state rather than one message passing under both conditions.

168 files, **1978 tests** (1977 + 1). No API, no schema, no new component, no migration.

Closes #335
