### PR TITLE
feat(billing): collect the starting reading in the pre-flight panel (#339)

### DIFF
--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -37,6 +37,7 @@ export default async function BillingPeriodDetailPage({
     household_devices: Array<{
       role: string;
       devices: {
+        id: string;
         openems_component_id: string | null;
         edges: { openems_edge_id: string | null } | null;
       } | null;
@@ -85,6 +86,7 @@ export default async function BillingPeriodDetailPage({
          household_devices(
            role,
            devices(
+             id,
              openems_component_id,
              edges(openems_edge_id)
            )
@@ -172,6 +174,7 @@ export default async function BillingPeriodDetailPage({
   // available iff a primary_consumption_meter device exists AND its
   // edge.openems_edge_id AND device.openems_component_id are non-null.
   const edgeAvailableByHouseholdId: Record<string, boolean> = {};
+  const deviceIdByHouseholdId: Record<string, string> = {};
   for (const row of householdEdges ?? []) {
     const primaryHD = row.household_devices.find(
       (hd) => hd.role === "primary_consumption_meter",
@@ -183,6 +186,74 @@ export default async function BillingPeriodDetailPage({
       device.openems_component_id != null &&
       edge != null &&
       edge.openems_edge_id != null;
+    if (primaryHD?.devices) {
+      deviceIdByHouseholdId[row.id] = (primaryHD as { devices: { id?: string } })
+        .devices.id as string;
+    }
+  }
+
+  // #339 — which households need a starting reading before this period can
+  // generate.
+  //
+  // This MUST agree with `runGenerationFor`'s own condition, or the panel asks
+  // for readings generation does not want (or worse, does not ask and
+  // generation refuses). Same shape as `generate.ts`'s priorEndKwhMap: prior
+  // periods for this microgrid, line items with a non-null end_kwh, keyed by
+  // device. A device with no such row and an available edge is one whose
+  // billing history predates its OpenEMS connection.
+  const seedNeededByHouseholdId: Record<string, boolean> = {};
+  const priorHintByHouseholdId: Record<string, number | null> = {};
+  const deviceIds = Object.values(deviceIdByHouseholdId).filter(Boolean);
+
+  if (deviceIds.length > 0) {
+    const { data: priorPeriods } = await supabase
+      .from("billing_periods")
+      .select("id")
+      .eq("microgrid_id", id)
+      .lte("end_date", period.start_date)
+      .neq("id", period.id);
+
+    const priorIds = (priorPeriods ?? []).map((p) => p.id);
+    const priorEndByDevice = new Set<string>();
+
+    if (priorIds.length > 0) {
+      const { data: priorItems } = await supabase
+        .from("billing_line_items")
+        .select("device_id, end_kwh")
+        .in("billing_period_id", priorIds)
+        .in("device_id", deviceIds)
+        .not("end_kwh", "is", null);
+      for (const it of priorItems ?? []) {
+        if (it.device_id) priorEndByDevice.add(it.device_id);
+      }
+
+      // The hint line: the household's own last recorded end_kwh, including
+      // rows written before the device existed (device_id IS NULL). Shown as
+      // text and NEVER prefilled — it is a household figure, not a reading of
+      // this meter, and a prefilled plausible number is the failure mode.
+      const { data: hhPrior } = await supabase
+        .from("billing_line_items")
+        .select("household_id, end_kwh, billing_period_id")
+        .in("billing_period_id", priorIds)
+        .not("end_kwh", "is", null);
+      const order = new Map(priorIds.map((pid, i) => [pid, i]));
+      const sorted = [...(hhPrior ?? [])].sort(
+        (a, b) =>
+          (order.get(a.billing_period_id) ?? 999) -
+          (order.get(b.billing_period_id) ?? 999)
+      );
+      for (const it of sorted) {
+        if (it.household_id && !(it.household_id in priorHintByHouseholdId)) {
+          priorHintByHouseholdId[it.household_id] = Number(it.end_kwh);
+        }
+      }
+    }
+
+    for (const [hhId, devId] of Object.entries(deviceIdByHouseholdId)) {
+      seedNeededByHouseholdId[hhId] =
+        edgeAvailableByHouseholdId[hhId] === true &&
+        !priorEndByDevice.has(devId);
+    }
   }
 
   // BC2 (#174) — resolve the actor display name per line item via a
@@ -247,6 +318,9 @@ export default async function BillingPeriodDetailPage({
         isSuperAdmin={isSuperAdmin}
         communityId={communityId}
         edgeAvailableByHouseholdId={edgeAvailableByHouseholdId}
+        seedNeededByHouseholdId={seedNeededByHouseholdId}
+        priorHintByHouseholdId={priorHintByHouseholdId}
+        deviceIdByHouseholdId={deviceIdByHouseholdId}
         actorByLineItemId={actorByLineItemId}
       />
     </>

--- a/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
+++ b/src/app/(dashboard)/microgrids/[id]/billing/[periodId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { computeSeedNeeded } from "@/lib/billing/seed-detection";
 import type {
   BillingLineItem,
   BillingPeriod,
@@ -249,11 +250,14 @@ export default async function BillingPeriodDetailPage({
       }
     }
 
-    for (const [hhId, devId] of Object.entries(deviceIdByHouseholdId)) {
-      seedNeededByHouseholdId[hhId] =
-        edgeAvailableByHouseholdId[hhId] === true &&
-        !priorEndByDevice.has(devId);
-    }
+    Object.assign(
+      seedNeededByHouseholdId,
+      computeSeedNeeded({
+        deviceIdByHouseholdId,
+        edgeAvailableByHouseholdId,
+        devicesWithPriorEnd: priorEndByDevice,
+      })
+    );
   }
 
   // BC2 (#174) — resolve the actor display name per line item via a

--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -56,6 +56,9 @@ export function BillingTable({
   isSuperAdmin = false,
   communityId,
   edgeAvailableByHouseholdId,
+  seedNeededByHouseholdId,
+  priorHintByHouseholdId,
+  deviceIdByHouseholdId,
   actorByLineItemId,
 }: {
   microgridId: string;
@@ -77,6 +80,12 @@ export function BillingTable({
    * Defaults to `true` when a household id is missing from the map.
    */
   edgeAvailableByHouseholdId?: Record<string, boolean>;
+  /** #339 — households whose meter has no prior MBE reading. */
+  seedNeededByHouseholdId?: Record<string, boolean>;
+  /** #339 — the household's last recorded end_kwh, shown as a hint only. */
+  priorHintByHouseholdId?: Record<string, number | null>;
+  /** #339 — primary consumption meter per household, for the seed payload. */
+  deviceIdByHouseholdId?: Record<string, string>;
   /**
    * Map of `billing_line_items.id → actor display name` resolved via the
    * `user_directory!entered_by_user_id` join in the page loader. Drives
@@ -947,6 +956,10 @@ export function BillingTable({
           billingPeriodId={period.id}
           households={households}
           edgeAvailableByHouseholdId={edgeAvailableByHouseholdId ?? {}}
+          seedNeededByHouseholdId={seedNeededByHouseholdId ?? {}}
+          priorHintByHouseholdId={priorHintByHouseholdId ?? {}}
+          deviceIdByHouseholdId={deviceIdByHouseholdId ?? {}}
+          periodStartDate={period.start_date}
         />
       )}
 

--- a/src/components/billing/__tests__/preflight-panel.test.tsx
+++ b/src/components/billing/__tests__/preflight-panel.test.tsx
@@ -550,3 +550,145 @@ describe("PreflightPanel — Generate button label", () => {
     expect(btn?.textContent).toContain("Generate (2 households)");
   });
 });
+
+// #339 — the seed section. Shipped without tests in the first pass; these pin
+// the three things that decide whether real readings get collected or zeroes
+// get typed to clear a form.
+describe("PreflightPanel — seed readings (#339)", () => {
+  const DEVICE = "d-1";
+
+  function renderWithSeed(opts: {
+    seedNeeded?: boolean;
+    priorHint?: number | null;
+  } = {}) {
+    const households = [makeHousehold("h-1", "Nakato")];
+    return render(
+      <Wrap>
+        <PreflightPanel
+          open
+          onClose={vi.fn()}
+          billingPeriodId="p-1"
+          households={households}
+          edgeAvailableByHouseholdId={{ "h-1": true }}
+          seedNeededByHouseholdId={{ "h-1": opts.seedNeeded ?? true }}
+          priorHintByHouseholdId={{ "h-1": opts.priorHint ?? null }}
+          deviceIdByHouseholdId={{ "h-1": DEVICE }}
+          periodStartDate="2026-08-01"
+        />
+      </Wrap>,
+    );
+  }
+
+  function energyResponse(totalKwh: number) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [{ deviceId: DEVICE, totalKwh }] }),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The section must be ABSENT when nothing needs a seed. An always-present
+  // optional field is skipped, and a skipped seed is indistinguishable from a
+  // seeded zero — which is the defect being fixed.
+  it("does not render the section when no household needs a seed", () => {
+    renderWithSeed({ seedNeeded: false });
+    expect(
+      document.querySelector('[data-testid="preflight-needs-seed-section"]'),
+    ).toBeNull();
+  });
+
+  it("renders the section and blocks Generate until the reading resolves", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(214)));
+    renderWithSeed();
+
+    expect(
+      document.querySelector('[data-testid="preflight-needs-seed-section"]'),
+    ).not.toBeNull();
+
+    const btn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+
+    fireEvent.change(
+      document.querySelector(
+        '[data-testid="preflight-seed-dial-h-1"]',
+      ) as HTMLInputElement,
+      { target: { value: "4196" } },
+    );
+
+    await waitFor(() => expect(btn.disabled).toBe(false));
+  });
+
+  // The operator types one number and a different one is stored. If the
+  // derived value is wrong they must be able to see WHICH input was wrong,
+  // so the arithmetic is on screen rather than behind the field.
+  it("shows the subtraction and the derived starting reading", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(214)));
+    renderWithSeed();
+
+    fireEvent.change(
+      document.querySelector(
+        '[data-testid="preflight-seed-dial-h-1"]',
+      ) as HTMLInputElement,
+      { target: { value: "4196" } },
+    );
+
+    await waitFor(() => {
+      const math = document.querySelector(
+        '[data-testid="preflight-seed-math-h-1"]',
+      );
+      expect(math?.textContent).toContain("214");
+      // 4196 − 214
+      expect(math?.textContent).toContain("3,982");
+    });
+  });
+
+  // A derived value below zero means the dial reads under the usage already
+  // recorded this period — a mistyped digit, not a meter running backwards.
+  it("keeps Generate disabled when the derived reading is negative", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(5000)));
+    renderWithSeed();
+
+    fireEvent.change(
+      document.querySelector(
+        '[data-testid="preflight-seed-dial-h-1"]',
+      ) as HTMLInputElement,
+      { target: { value: "100" } },
+    );
+
+    const btn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-seed-math-h-1"]'),
+      ).not.toBeNull(),
+    );
+    expect(btn.disabled).toBe(true);
+  });
+
+  // The hint is the number the operator would otherwise go looking for. It is
+  // text, never a prefill: a plausible prefilled figure is confirmed by
+  // inertia, and this one is a household's number rather than this meter's.
+  it("shows the prior manual figure as a hint without prefilling the input", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(0)));
+    renderWithSeed({ priorHint: 4182 });
+
+    const input = document.querySelector(
+      '[data-testid="preflight-seed-dial-h-1"]',
+    ) as HTMLInputElement;
+    expect(input.value).toBe("");
+    expect(document.body.textContent).toContain("4,182");
+  });
+
+  it("says so when there is no prior manual bill, rather than showing nothing", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(0)));
+    renderWithSeed({ priorHint: null });
+    expect(document.body.textContent).toContain("No previous manual bill on record");
+  });
+});

--- a/src/components/billing/__tests__/preflight-panel.test.tsx
+++ b/src/components/billing/__tests__/preflight-panel.test.tsx
@@ -675,7 +675,7 @@ describe("PreflightPanel — seed readings (#339)", () => {
   // The hint is the number the operator would otherwise go looking for. It is
   // text, never a prefill: a plausible prefilled figure is confirmed by
   // inertia, and this one is a household's number rather than this meter's.
-  it("shows the prior manual figure as a hint without prefilling the input", () => {
+  it("shows the prior manual figure as a cause line without prefilling the input", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(0)));
     renderWithSeed({ priorHint: 4182 });
 
@@ -683,12 +683,64 @@ describe("PreflightPanel — seed readings (#339)", () => {
       '[data-testid="preflight-seed-dial-h-1"]',
     ) as HTMLInputElement;
     expect(input.value).toBe("");
-    expect(document.body.textContent).toContain("4,182");
+
+    const cause = document.querySelector(
+      '[data-testid="preflight-seed-cause-h-1"]',
+    );
+    expect(cause?.textContent).toContain("Billed manually until now");
+    expect(cause?.textContent).toContain("4,182");
+    // The other branch must NOT also appear.
+    expect(cause?.textContent).not.toContain("No earlier reading on record");
   });
 
-  it("says so when there is no prior manual bill, rather than showing nothing", () => {
+  it("says there is no earlier reading, and that zero is a real reading", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(0)));
     renderWithSeed({ priorHint: null });
-    expect(document.body.textContent).toContain("No previous manual bill on record");
+
+    const cause = document.querySelector(
+      '[data-testid="preflight-seed-cause-h-1"]',
+    );
+    expect(cause?.textContent).toContain("No earlier reading on record");
+    // The permission to enter zero is what makes this a question rather than
+    // a wall — without it the operator's only exit is to invent a number.
+    expect(cause?.textContent).toContain("enter zero");
+    expect(cause?.textContent).not.toContain("Billed manually until now");
+  });
+
+  // THE shape that two single-row renders cannot catch. A cause computed at
+  // section level rather than per row still looks correct in any render
+  // containing one state; only a render holding BOTH states at once
+  // distinguishes them. This is the defect the copy change exists to fix.
+  it("gives each row its own cause when two households differ", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(energyResponse(0)));
+    render(
+      <Wrap>
+        <PreflightPanel
+          open
+          onClose={vi.fn()}
+          billingPeriodId="p-1"
+          households={[makeHousehold("h-1", "Nakato"), makeHousehold("h-2", "Okello")]}
+          edgeAvailableByHouseholdId={{ "h-1": true, "h-2": true }}
+          seedNeededByHouseholdId={{ "h-1": true, "h-2": true }}
+          priorHintByHouseholdId={{ "h-1": 4182, "h-2": null }}
+          deviceIdByHouseholdId={{ "h-1": "d-1", "h-2": "d-2" }}
+          periodStartDate="2026-08-01"
+        />
+      </Wrap>,
+    );
+
+    const withHistory = document.querySelector(
+      '[data-testid="preflight-seed-cause-h-1"]',
+    );
+    const withoutHistory = document.querySelector(
+      '[data-testid="preflight-seed-cause-h-2"]',
+    );
+
+    expect(withHistory?.textContent).toContain("Billed manually until now");
+    expect(withoutHistory?.textContent).toContain("No earlier reading on record");
+    // And neither leaks the other's sentence — a section-level branch would
+    // give both rows whichever one it computed.
+    expect(withHistory?.textContent).not.toContain("No earlier reading on record");
+    expect(withoutHistory?.textContent).not.toContain("Billed manually until now");
   });
 });

--- a/src/components/billing/preflight-panel.tsx
+++ b/src/components/billing/preflight-panel.tsx
@@ -415,11 +415,16 @@ export function PreflightPanel(props: PreflightPanelProps) {
             <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
               Needs a starting reading ({needsSeed.length})
             </h4>
+            {/* One string, no branch. The CAUSE is a per-household fact and
+                belongs on the row: a microgrid with history can be adding a
+                brand-new household today, so a section-level "these were
+                billed before they were connected" is false for that row while
+                true for its neighbour. Stating an unestablished cause is
+                #335's defect, and this section would have reproduced it. */}
             <p className="mb-2 text-[12px] text-muted-foreground">
-              These meters were billed before they were connected to OpenEMS,
-              so MBE does not know what they read at the start of this period.
-              Enter the reading shown on the meter now — the starting reading
-              is worked out from it.
+              MBE has no starting reading for these meters, so it cannot work
+              out what to print as the previous reading on the invoice. Enter
+              what each meter reads now.
             </p>
             <ul className="space-y-3">
               {needsSeed.map((h) => {
@@ -457,17 +462,21 @@ export function PreflightPanel(props: PreflightPanelProps) {
                         }
                       }}
                     />
-                    {hint != null && (
-                      <p className="mt-1 text-[11px] text-muted-foreground">
-                        Last manual bill for this household ended at{" "}
-                        {hint.toLocaleString()} kWh
-                      </p>
-                    )}
-                    {hint == null && (
-                      <p className="mt-1 text-[11px] text-muted-foreground">
-                        No previous manual bill on record
-                      </p>
-                    )}
+                    {/* Per-row cause. `hint` is this household's own last
+                        recorded end_kwh, so its presence IS the per-row
+                        signal: non-null means this household has been billed
+                        here before, null means it has not — whether because
+                        the household is new or the microgrid is. Those are the
+                        same situation from the operator's side and take the
+                        same sentence. */}
+                    <p
+                      className="mt-1 text-[11px] text-muted-foreground"
+                      data-testid={`preflight-seed-cause-${h.id}`}
+                    >
+                      {hint != null
+                        ? `Billed manually until now — the last manual bill ended at ${hint.toLocaleString()} kWh.`
+                        : "No earlier reading on record. If this meter was installed for this period and started at zero, enter zero — that is a real reading, not a placeholder."}
+                    </p>
 
                     {/* The subtraction is on screen rather than behind the
                         field: the operator types one number and a different

--- a/src/components/billing/preflight-panel.tsx
+++ b/src/components/billing/preflight-panel.tsx
@@ -51,12 +51,30 @@ export interface PreflightPanelProps {
   households: Household[];
   /** Whether each household has a primary_consumption_meter on a configured edge. */
   edgeAvailableByHouseholdId: Record<string, boolean>;
+  /** #339 — households whose meter has no prior MBE reading. */
+  seedNeededByHouseholdId?: Record<string, boolean>;
+  /** #339 — the household's last recorded end_kwh. Hint text only; never
+   *  prefilled, because it is a household figure rather than a reading of
+   *  this meter and a plausible prefill is confirmed by inertia. */
+  priorHintByHouseholdId?: Record<string, number | null>;
+  /** #339 — primary consumption meter per household. */
+  deviceIdByHouseholdId?: Record<string, string>;
+  /** #339 — period start, the lower bound of the elapsed-usage query. */
+  periodStartDate?: string;
 }
 
 interface RowFormState {
   startKwh: string;
   endKwh: string;
   reason: string;
+  /** #339 — what the operator read on the dial. */
+  dialReading: string;
+  /** #339 — when they read it. Not "now": a dial read in the morning and
+   *  typed that evening is wrong by the usage in between. */
+  readAt: string;
+  /** #339 — usage from period start to readAt, fetched from OpenEMS. */
+  elapsedKwh: number | null;
+  elapsedState: "idle" | "loading" | "error";
   /** Only relevant for the override section. */
   overrideEnabled: boolean;
 }
@@ -71,6 +89,10 @@ const EMPTY_ROW: RowFormState = {
   startKwh: "",
   endKwh: "",
   reason: "",
+  dialReading: "",
+  readAt: "",
+  elapsedKwh: null,
+  elapsedState: "idle",
   overrideEnabled: false,
 };
 
@@ -92,6 +114,10 @@ export function PreflightPanel(props: PreflightPanelProps) {
     billingPeriodId,
     households,
     edgeAvailableByHouseholdId,
+    seedNeededByHouseholdId = {},
+    priorHintByHouseholdId = {},
+    deviceIdByHouseholdId = {},
+    periodStartDate,
   } = props;
   const router = useRouter();
 
@@ -137,6 +163,66 @@ export function PreflightPanel(props: PreflightPanelProps) {
     (h) => edgeAvailableByHouseholdId[h.id] !== false,
   );
 
+  // #339 — households whose meter has no prior reading. Disjoint from
+  // needsManual by construction: a seed is only meaningful for an
+  // edge-available device, and needsManual is exactly the not-available set.
+  const needsSeed = households.filter(
+    (h) => seedNeededByHouseholdId[h.id] === true,
+  );
+
+  /**
+   * The derived starting reading.
+   *
+   *     startKwh = dialReading − usage(period start → readAt)
+   *
+   * The operator is asked the answerable question ("what does the dial say?")
+   * rather than the unanswerable one ("what did it read on the 1st?"), and the
+   * subtraction is over the interval that actually elapsed rather than to now.
+   *
+   * Returns null while the elapsed usage is unknown, which is what keeps the
+   * Generate button disabled rather than letting a half-resolved row through.
+   */
+  function derivedSeed(hid: string): number | null {
+    const f = getRow(hid);
+    const dial = parseField(f.dialReading);
+    if (!dial.ok || f.elapsedKwh == null) return null;
+    const v = dial.value - f.elapsedKwh;
+    return Number.isFinite(v) ? v : null;
+  }
+
+  /** Fetch usage(period start → readAt) for this household's meter. */
+  async function loadElapsed(hid: string, readAtIso: string) {
+    const deviceId = deviceIdByHouseholdId[hid];
+    if (!deviceId || !periodStartDate) return;
+    setRow(hid, { elapsedState: "loading", elapsedKwh: null });
+    try {
+      const res = await fetch("/api/openems/energy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          deviceIds: [deviceId],
+          fromDate: periodStartDate,
+          toDate: readAtIso.slice(0, 10),
+        }),
+      });
+      if (!res.ok) {
+        setRow(hid, { elapsedState: "error", elapsedKwh: null });
+        return;
+      }
+      const body = (await res.json()) as {
+        results?: Array<{ deviceId: string; totalKwh: number | null }>;
+      };
+      const hit = (body.results ?? []).find((r) => r.deviceId === deviceId);
+      if (!hit || hit.totalKwh == null) {
+        setRow(hid, { elapsedState: "error", elapsedKwh: null });
+        return;
+      }
+      setRow(hid, { elapsedState: "idle", elapsedKwh: hit.totalKwh });
+    } catch {
+      setRow(hid, { elapsedState: "error", elapsedKwh: null });
+    }
+  }
+
   // Validation — needs-manual + override-toggled rows must all be valid.
   const overrideRows = edgeReady.filter((h) => getRow(h.id).overrideEnabled);
   const requiredRows = [...needsManual, ...overrideRows];
@@ -147,6 +233,15 @@ export function PreflightPanel(props: PreflightPanelProps) {
     if (!s.ok || !e.ok) return false;
     return e.value >= s.value;
   });
+  // #339 — every seed row must resolve to a non-negative number before
+  // Generate is offered. A negative derived value means the dial reads below
+  // the period's own usage, which is a mistyped digit rather than a meter that
+  // ran backwards.
+  const allSeedsValid = needsSeed.every((h) => {
+    const v = derivedSeed(h.id);
+    return v != null && v >= 0;
+  });
+
   const totalCount = households.length;
 
   async function handleSubmit() {
@@ -174,6 +269,22 @@ export function PreflightPanel(props: PreflightPanelProps) {
         body: JSON.stringify({
           billingPeriodId,
           manualReadings,
+          // #339. Inputs travel with the derived value: the route recomputes
+          // and rejects a mismatch, and a wrong seed stays diagnosable.
+          ...(needsSeed.length > 0
+            ? {
+                seedReadings: needsSeed.map((h) => {
+                  const f = getRow(h.id);
+                  const dial = parseField(f.dialReading);
+                  return {
+                    deviceId: deviceIdByHouseholdId[h.id],
+                    dialReadingKwh: dial.ok ? dial.value : 0,
+                    readAt: f.readAt || new Date().toISOString(),
+                    startKwh: derivedSeed(h.id) ?? 0,
+                  };
+                }),
+              }
+            : {}),
         }),
       });
       const body = (await res.json().catch(() => ({}))) as {
@@ -285,6 +396,107 @@ export function PreflightPanel(props: PreflightPanelProps) {
           )}
         </Disclosure>
 
+        {/* Section 0 (#339): meters with no prior reading. Above "Needs
+            manual entry" because it blocks the same button and is rarer.
+            Absent entirely when nothing needs a seed, which is what keeps
+            this from becoming another optional field. */}
+        {needsSeed.length > 0 && (
+          <section data-testid="preflight-needs-seed-section">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Needs a starting reading ({needsSeed.length})
+            </h4>
+            <p className="mb-2 text-[12px] text-muted-foreground">
+              These meters were billed before they were connected to OpenEMS,
+              so MBE does not know what they read at the start of this period.
+              Enter the reading shown on the meter now — the starting reading
+              is worked out from it.
+            </p>
+            <ul className="space-y-3">
+              {needsSeed.map((h) => {
+                const f = getRow(h.id);
+                const derived = derivedSeed(h.id);
+                const hint = priorHintByHouseholdId[h.id];
+                return (
+                  <li
+                    key={h.id}
+                    data-testid={`preflight-seed-row-${h.id}`}
+                    className="rounded-md border border-border p-2"
+                  >
+                    <div className="text-[12px] font-medium text-foreground">
+                      {h.display_name}
+                    </div>
+                    <label
+                      htmlFor={`seed-dial-${h.id}`}
+                      className="mt-1 block text-[11px] text-muted-foreground"
+                    >
+                      Reading on the meter (kWh)
+                    </label>
+                    <input
+                      id={`seed-dial-${h.id}`}
+                      data-testid={`preflight-seed-dial-${h.id}`}
+                      type="number"
+                      inputMode="decimal"
+                      className="w-40 rounded-md border border-border bg-card px-2 py-1 font-mono text-xs"
+                      value={f.dialReading}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setRow(h.id, { dialReading: v });
+                        const when = f.readAt || new Date().toISOString();
+                        if (f.elapsedKwh == null && f.elapsedState !== "loading") {
+                          void loadElapsed(h.id, when);
+                        }
+                      }}
+                    />
+                    {hint != null && (
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        Last manual bill for this household ended at{" "}
+                        {hint.toLocaleString()} kWh
+                      </p>
+                    )}
+                    {hint == null && (
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        No previous manual bill on record
+                      </p>
+                    )}
+
+                    {/* The subtraction is on screen rather than behind the
+                        field: the operator types one number and a different
+                        one is stored, so a wrong result has to be traceable to
+                        which input was wrong. */}
+                    <div className="mt-2 text-[11px] text-muted-foreground">
+                      {f.elapsedState === "loading" && <span>Fetching usage since period start…</span>}
+                      {f.elapsedState === "error" && (
+                        <span className="text-destructive-fg">
+                          Could not read usage since period start from OpenEMS.
+                        </span>
+                      )}
+                      {f.elapsedState === "idle" && f.elapsedKwh != null && (
+                        <span data-testid={`preflight-seed-math-${h.id}`}>
+                          Used since period start −{f.elapsedKwh.toLocaleString()} kWh
+                          {derived != null && (
+                            <>
+                              {" "}· Starting reading{" "}
+                              <strong className="text-foreground">
+                                {derived.toLocaleString()} kWh
+                              </strong>
+                            </>
+                          )}
+                        </span>
+                      )}
+                      {derived != null && derived < 0 && (
+                        <span className="ml-1 text-destructive-fg">
+                          — that is below the usage already recorded this
+                          period; check the reading.
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+
         {/* Section 2: Needs manual entry — expanded by default */}
         <section data-testid="preflight-needs-manual-section">
           <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -378,7 +590,7 @@ export function PreflightPanel(props: PreflightPanelProps) {
           type="button"
           data-testid="preflight-generate-button"
           onClick={() => void handleSubmit()}
-          disabled={!allValid || submitting}
+          disabled={!allValid || !allSeedsValid || submitting}
           title={!allValid ? "Fill in all required readings to enable Generate." : undefined}
           className={cn(
             "inline-flex h-8 items-center gap-2 rounded-md border border-primary bg-primary px-3.5 text-[13px] font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",

--- a/src/components/billing/preflight-panel.tsx
+++ b/src/components/billing/preflight-panel.tsx
@@ -245,7 +245,17 @@ export function PreflightPanel(props: PreflightPanelProps) {
   const totalCount = households.length;
 
   async function handleSubmit() {
-    if (!allValid) return;
+    // BOTH gates, not just the manual one. The button is disabled on
+    // `!allValid || !allSeedsValid`, but the button is not the only way in:
+    // any second caller reaching handleSubmit with an unresolved seed row
+    // would send `startKwh: derivedSeed() ?? 0`, and #341's route accepts it
+    // because 0 <= dialReading satisfies the ordering bound. That bills from
+    // zero — the exact invoice this panel exists to prevent, arriving through
+    // the panel built to prevent it.
+    //
+    // The `?? 0` below stays as a type-level floor; this makes it dead behind
+    // two independent checks rather than merely unreachable behind one.
+    if (!allValid || !allSeedsValid) return;
     setSubmitting(true);
     setErrorMsg(null);
 

--- a/src/lib/billing/__tests__/seed-detection.test.ts
+++ b/src/lib/billing/__tests__/seed-detection.test.ts
@@ -1,0 +1,83 @@
+/**
+ * seed-detection.test.ts — #339.
+ *
+ * The first-ever-period case is the one PM and Designer both reasoned about
+ * and neither observed, because the logic was inline in a server component
+ * and no test could reach it. That is why it is a module now.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeSeedNeeded } from "../seed-detection";
+
+const HH_A = "hh-a";
+const HH_B = "hh-b";
+const DEV_A = "dev-a";
+const DEV_B = "dev-b";
+
+describe("computeSeedNeeded (#339)", () => {
+  it("flags a meter with no prior reading", () => {
+    expect(
+      computeSeedNeeded({
+        deviceIdByHouseholdId: { [HH_A]: DEV_A },
+        edgeAvailableByHouseholdId: { [HH_A]: true },
+        devicesWithPriorEnd: new Set(),
+      })
+    ).toEqual({ [HH_A]: true });
+  });
+
+  it("does not flag a meter that already has a prior reading", () => {
+    expect(
+      computeSeedNeeded({
+        deviceIdByHouseholdId: { [HH_A]: DEV_A },
+        edgeAvailableByHouseholdId: { [HH_A]: true },
+        devicesWithPriorEnd: new Set([DEV_A]),
+      })
+    ).toEqual({ [HH_A]: false });
+  });
+
+  // A household with no usable edge goes down the manual path; asking it for a
+  // meter reading would be asking for a number nobody can read.
+  it("does not flag a household whose edge is unavailable", () => {
+    expect(
+      computeSeedNeeded({
+        deviceIdByHouseholdId: { [HH_A]: DEV_A },
+        edgeAvailableByHouseholdId: { [HH_A]: false },
+        devicesWithPriorEnd: new Set(),
+      })
+    ).toEqual({ [HH_A]: false });
+  });
+
+  // THE case that had no coverage. On a microgrid's first period there are no
+  // prior line items at all, so every edge-available household is flagged.
+  // PM ruled this correct: MBE cannot tell a new meter at zero from an
+  // existing meter at 4,182, and guessing is what produced #339.
+  it("flags EVERY edge-available household on a first-ever period", () => {
+    expect(
+      computeSeedNeeded({
+        deviceIdByHouseholdId: { [HH_A]: DEV_A, [HH_B]: DEV_B },
+        edgeAvailableByHouseholdId: { [HH_A]: true, [HH_B]: true },
+        devicesWithPriorEnd: new Set(), // no prior periods → empty
+      })
+    ).toEqual({ [HH_A]: true, [HH_B]: true });
+  });
+
+  it("is keyed by device, so two households on different meters differ", () => {
+    expect(
+      computeSeedNeeded({
+        deviceIdByHouseholdId: { [HH_A]: DEV_A, [HH_B]: DEV_B },
+        edgeAvailableByHouseholdId: { [HH_A]: true, [HH_B]: true },
+        devicesWithPriorEnd: new Set([DEV_A]),
+      })
+    ).toEqual({ [HH_A]: false, [HH_B]: true });
+  });
+
+  it("returns nothing for households with no linked meter", () => {
+    expect(
+      computeSeedNeeded({
+        deviceIdByHouseholdId: {},
+        edgeAvailableByHouseholdId: { [HH_A]: true },
+        devicesWithPriorEnd: new Set(),
+      })
+    ).toEqual({});
+  });
+});

--- a/src/lib/billing/seed-detection.ts
+++ b/src/lib/billing/seed-detection.ts
@@ -1,0 +1,58 @@
+/**
+ * seed-detection.ts — which households need a starting meter reading (#339).
+ *
+ * Extracted from the billing-period page so it can be tested directly. It was
+ * inline, and the first-ever-period case — the one both PM and Designer
+ * reasoned about and neither observed — was unreachable by any test as a
+ * result.
+ *
+ * ── This MUST agree with `runGenerationFor` ──────────────────────────────
+ *
+ * `generate.ts` refuses to bill a device that has neither a prior MBE
+ * `end_kwh` nor a seed. This decides who the panel asks. If the two disagree
+ * in one direction the operator is asked for readings generation does not
+ * want; in the other, generation refuses in front of an operator who was
+ * never given the chance to supply one. Change them together.
+ */
+
+export type SeedDetectionInput = {
+  /** Household id → its primary consumption meter's device id. */
+  deviceIdByHouseholdId: Record<string, string>;
+  /** Household id → whether an OpenEMS-backed reading is possible. */
+  edgeAvailableByHouseholdId: Record<string, boolean>;
+  /** Device ids that already have a prior MBE-recorded `end_kwh`. */
+  devicesWithPriorEnd: ReadonlySet<string>;
+};
+
+/**
+ * Returns household id → needs a starting reading.
+ *
+ * A household needs one when its meter can be read by OpenEMS but MBE has no
+ * previous reading of that meter to continue from.
+ *
+ * ── First-ever period ────────────────────────────────────────────────────
+ *
+ * On a microgrid's first period `devicesWithPriorEnd` is empty, so EVERY
+ * edge-available household is flagged. That is correct and deliberate: MBE
+ * cannot distinguish a new meter sitting at zero from an existing meter
+ * sitting at 4,182, and guessing is precisely what produced #339. The cost is
+ * one reading per meter, once, at setup, entered by someone standing where
+ * the meters are.
+ *
+ * The COPY shown for this case must not claim the meters "were billed before
+ * they were connected to OpenEMS" — on a genuinely new microgrid that is
+ * false, and asserting an unestablished cause is #335's defect.
+ */
+export function computeSeedNeeded(
+  input: SeedDetectionInput
+): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const [householdId, deviceId] of Object.entries(
+    input.deviceIdByHouseholdId
+  )) {
+    out[householdId] =
+      input.edgeAvailableByHouseholdId[householdId] === true &&
+      !input.devicesWithPriorEnd.has(deviceId);
+  }
+  return out;
+}


### PR DESCRIPTION
The generation half (#341) refuses to bill a meter whose starting reading is unknown. **This is where the operator supplies it.**

## Why the pre-flight panel, not the household wizard

`PreflightPanel` already *is* the "resolve this before the period generates" surface, and it already disables Generate until every needs-manual row is valid — **a fourth section reuses that gate exactly.**

It also fixes the timing: an operator filling in a pre-flight panel is doing meter work. An operator adding a household is at a desk, and the meter is on a wall.

## Nobody is asked who does not need it

Detection is server-side and **deliberately mirrors `generate.ts`'s own `priorEndKwhMap` query** — prior periods for the microgrid, line items with a non-null `end_kwh`, keyed by device.

**The two must agree.** A panel that asks for readings generation does not want, or fails to ask when it does, puts the refusal in front of an operator who was never given the chance. The section is **absent entirely** when nothing needs a seed, which is what keeps it from becoming another optional field that gets skipped — and a skipped seed is indistinguishable from a seeded zero, which is the defect being fixed.

## It asks the answerable question

*"What did this meter read on the 1st?"* is unanswerable three weeks in. *"What does the dial say now?"* is answerable by walking to the wall.

```
startKwh = dialReading − usage(period start → readAt)
```

via `POST /api/openems/energy`, which already accepts arbitrary date bounds. **This is immune to the open question about what populates `ActiveConsumptionEnergy`** — the first term is the physical meter and the second is a delta, which is the same number whichever end a counter started from.

## Two properties that are the whole point

**The subtraction is shown, not just applied.** The operator types one number and a different one is stored; if the derived value is wrong they must see *which input* was wrong.

**The prior manual figure is a hint line and never prefills.** It is a household's number, not a reading of this device, and a plausible prefilled value is confirmed by inertia rather than checked. Where there is no prior bill it says so — an empty space reads as a failed lookup.

## Verification

| mutation | result |
|---|---|
| drop seed rows from the Generate gate | 2 tests fail |
| prefill the input from the hint | 1 fails |
| render the section unconditionally | 1 fails |

Each restores clean, so every test pins its own behaviour.

No migration, no schema.

Closes #339
