### PR TITLE
fix(billing): collect the day a seed reading was taken (#343)

### DIFF
--- a/src/components/billing/__tests__/preflight-panel.test.tsx
+++ b/src/components/billing/__tests__/preflight-panel.test.tsx
@@ -1,6 +1,6 @@
 // PreflightPanel — component tests (jsdom environment) — BC3 #175 AC5
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { LocaleProvider } from "@/components/format/locale-context";
 import { PreflightPanel } from "../preflight-panel";
@@ -742,5 +742,217 @@ describe("PreflightPanel — seed readings (#339)", () => {
     // give both rows whichever one it computed.
     expect(withHistory?.textContent).not.toContain("No earlier reading on record");
     expect(withoutHistory?.textContent).not.toContain("Billed manually until now");
+  });
+});
+
+// #343 — the read date.
+//
+// #339 shipped a `readAt` field that no control ever wrote, so the subtraction
+// always ran to the entry date. Every test it shipped with entered the reading
+// the same day, which is the one case where that is correct — so a full green
+// suite sat on top of an over-billing defect.
+//
+// The mock below therefore answers by WINDOW: it returns a different usage
+// figure for `toDate: 2026-08-04` than for `toDate: 2026-08-10`. A test that
+// does not actually move the window gets the wrong number and fails, which is
+// what stops this file from re-acquiring the hole it is being added to close.
+describe("PreflightPanel — read date (#343)", () => {
+  const DEVICE = "d-1";
+  const TODAY = "2026-08-10";
+  const READ_DAY = "2026-08-04";
+  const USAGE_TO_READ_DAY = 214;
+  const USAGE_TO_TODAY = 980;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // shouldAdvanceTime keeps `waitFor` working — a frozen clock never
+    // resolves its polling and the suite hangs rather than fails.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-10T09:00:00"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Usage keyed by the `toDate` the panel actually asked for.
+   *
+   * `fallbackKwh` is null by default so an unexpected window yields no figure
+   * and the arithmetic tests cannot quietly pass on one.
+   *
+   * The date-validation tests MUST pass a number instead. With null, the row
+   * has no elapsed figure, `derivedSeed` returns null, and Generate is
+   * disabled for that reason — so an assertion on `btn.disabled` holds whether
+   * or not the date guard exists. Checked by mutation: removing the guard from
+   * `allSeedsValid` left all 22 tests green until this argument existed.
+   */
+  function windowedFetch(fallbackKwh: number | null = null) {
+    return vi.fn(async (_url: string, init: { body: string }) => {
+      const body = JSON.parse(init.body) as { toDate?: string };
+      const totalKwh =
+        body.toDate === READ_DAY
+          ? USAGE_TO_READ_DAY
+          : body.toDate === TODAY
+            ? USAGE_TO_TODAY
+            : fallbackKwh;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ results: [{ deviceId: DEVICE, totalKwh }] }),
+      };
+    });
+  }
+
+  function renderSeedRow() {
+    return render(
+      <Wrap>
+        <PreflightPanel
+          open
+          onClose={vi.fn()}
+          billingPeriodId="p-1"
+          households={[makeHousehold("h-1", "Nakato")]}
+          edgeAvailableByHouseholdId={{ "h-1": true }}
+          seedNeededByHouseholdId={{ "h-1": true }}
+          deviceIdByHouseholdId={{ "h-1": DEVICE }}
+          periodStartDate="2026-08-01"
+        />
+      </Wrap>,
+    );
+  }
+
+  const dateInput = () =>
+    document.querySelector(
+      '[data-testid="preflight-seed-read-date-h-1"]',
+    ) as HTMLInputElement;
+  const dialInput = () =>
+    document.querySelector(
+      '[data-testid="preflight-seed-dial-h-1"]',
+    ) as HTMLInputElement;
+
+  it("defaults to today, so same-day entry stays a single field", () => {
+    vi.stubGlobal("fetch", windowedFetch());
+    renderSeedRow();
+    expect(dateInput().value).toBe(TODAY);
+  });
+
+  // THE test. Read on the 4th, typed on the 10th: the six days in between are
+  // not the operator's consumption to bill, and before #343 they were.
+  it("uses the usage window to the READ day, not the entry day", async () => {
+    vi.stubGlobal("fetch", windowedFetch());
+    renderSeedRow();
+
+    fireEvent.change(dialInput(), { target: { value: "4196" } });
+    fireEvent.change(dateInput(), { target: { value: READ_DAY } });
+
+    await waitFor(() => {
+      const math = document.querySelector(
+        '[data-testid="preflight-seed-math-h-1"]',
+      );
+      expect(math?.textContent).toContain("214");
+      // 4196 − 214. Billing to the entry day would subtract 980 and derive
+      // 3,216, understating the start by 766 kWh — which is then billed.
+      expect(math?.textContent).toContain("3,982");
+      expect(math?.textContent).not.toContain("3,216");
+    });
+
+    // The window itself is on screen, so a wrong date is visible rather than
+    // only inferable from a number the operator cannot check.
+    expect(
+      document.querySelector('[data-testid="preflight-seed-math-h-1"]')
+        ?.textContent,
+    ).toContain(READ_DAY);
+  });
+
+  it("sends the read day in readAt and the read-day arithmetic in startKwh", async () => {
+    const fetchMock = windowedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    renderSeedRow();
+
+    fireEvent.change(dialInput(), { target: { value: "4196" } });
+    fireEvent.change(dateInput(), { target: { value: READ_DAY } });
+
+    const btn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(btn.disabled).toBe(false));
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    const generateCall = fetchMock.mock.calls.find(
+      ([url]) => url === "/api/billing/generate",
+    );
+    expect(generateCall).toBeDefined();
+    const sent = JSON.parse(
+      (generateCall![1] as { body: string }).body,
+    ) as { seedReadings: Array<{ readAt: string; startKwh: number }> };
+
+    expect(sent.seedReadings).toHaveLength(1);
+    expect(sent.seedReadings[0].startKwh).toBe(4196 - USAGE_TO_READ_DAY);
+    // Stored as an ISO timestamp, but it must be the read DAY — the audit
+    // value is what makes a wrong seed diagnosable a year later, and "now"
+    // was indistinguishable from a correct answer.
+    expect(sent.seedReadings[0].readAt.slice(0, 10)).toBe(READ_DAY);
+  });
+
+  // The control introduced two reachable wrong states that did not exist
+  // before it, so it owes both an answer. `min`/`max` are a browser hint a
+  // typed or pasted value walks straight past.
+  // `fallbackKwh: 300` is load-bearing in both of these. It resolves the
+  // arithmetic — dial 4196 − 300 = 3,896, a perfectly valid seed — so the
+  // ONLY thing left that can keep Generate disabled is the date guard.
+  it("blocks Generate on a read date before the period started", async () => {
+    vi.stubGlobal("fetch", windowedFetch(300));
+    renderSeedRow();
+
+    fireEvent.change(dialInput(), { target: { value: "4196" } });
+    fireEvent.change(dateInput(), { target: { value: "2026-07-28" } });
+
+    const btn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[data-testid="preflight-seed-date-problem-h-1"]',
+        )?.textContent,
+      ).toContain("before this period started");
+    });
+    // The seed itself resolved, so this is the guard and nothing else.
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-seed-math-h-1"]')
+          ?.textContent,
+      ).toContain("3,896"),
+    );
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("blocks Generate on a read date in the future", async () => {
+    vi.stubGlobal("fetch", windowedFetch(300));
+    renderSeedRow();
+
+    fireEvent.change(dialInput(), { target: { value: "4196" } });
+    fireEvent.change(dateInput(), { target: { value: "2026-08-11" } });
+
+    const btn = document.querySelector(
+      '[data-testid="preflight-generate-button"]',
+    ) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[data-testid="preflight-seed-date-problem-h-1"]',
+        )?.textContent,
+      ).toContain("has not happened yet");
+    });
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="preflight-seed-math-h-1"]')
+          ?.textContent,
+      ).toContain("3,896"),
+    );
+    expect(btn.disabled).toBe(true);
   });
 });

--- a/src/components/billing/preflight-panel.tsx
+++ b/src/components/billing/preflight-panel.tsx
@@ -69,10 +69,21 @@ interface RowFormState {
   reason: string;
   /** #339 — what the operator read on the dial. */
   dialReading: string;
-  /** #339 — when they read it. Not "now": a dial read in the morning and
-   *  typed that evening is wrong by the usage in between. */
-  readAt: string;
-  /** #339 — usage from period start to readAt, fetched from OpenEMS. */
+  /**
+   * #343 — the DATE the dial was read, `YYYY-MM-DD`, local to the operator.
+   *
+   * Empty means "not yet touched", and the control shows `todayLocalDate()`
+   * in that case. Read `readAtDate` only through `readDateFor()` so the
+   * default is resolved in exactly one place.
+   *
+   * #339 shipped a `readAt` field here that nothing ever wrote, so both of its
+   * consumers silently fell back to `new Date()` and the subtraction always
+   * ran to the entry date instead of the reading date (#343). A date, not a
+   * timestamp: the elapsed-usage query is day-granular, so a time input would
+   * collect precision the answer cannot use.
+   */
+  readAtDate: string;
+  /** #339 — usage from period start to the read date, fetched from OpenEMS. */
   elapsedKwh: number | null;
   elapsedState: "idle" | "loading" | "error";
   /** Only relevant for the override section. */
@@ -90,13 +101,42 @@ const EMPTY_ROW: RowFormState = {
   endKwh: "",
   reason: "",
   dialReading: "",
-  readAt: "",
+  readAtDate: "",
   elapsedKwh: null,
   elapsedState: "idle",
   overrideEnabled: false,
 };
 
 const MAX_FAILURES_INLINE = 5;
+
+/**
+ * Today, as the operator's calendar sees it (#343).
+ *
+ * Built from local getters rather than `toISOString().slice(0, 10)`, which
+ * names the UTC day: at UTC−5 an evening entry is already tomorrow in UTC, so
+ * the slice would default the control to a date the operator has not reached
+ * and query usage through it.
+ */
+function todayLocalDate(): string {
+  const d = new Date();
+  const month = `${d.getMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getDate()}`.padStart(2, "0");
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+/**
+ * The `readAt` timestamp sent to the route for a chosen read date (#343).
+ *
+ * Only the date is collected, so the two branches say what is actually known
+ * rather than inventing a time. Today: the instant is real, send it. An
+ * earlier date: the day is known and the moment is not, so send local noon —
+ * far enough from either boundary that no timezone shifts it onto an adjacent
+ * day, which midnight would.
+ */
+function readAtIsoFor(dateStr: string): string {
+  if (dateStr === todayLocalDate()) return new Date().toISOString();
+  return new Date(`${dateStr}T12:00:00`).toISOString();
+}
 
 function parseField(raw: string): { ok: true; value: number } | { ok: false } {
   const trimmed = raw.trim();
@@ -154,6 +194,18 @@ export function PreflightPanel(props: PreflightPanelProps) {
       [hid]: { ...(prev[hid] ?? EMPTY_ROW), ...partial },
     }));
   }
+  /**
+   * The read date in force for a row — the operator's choice, or today (#343).
+   *
+   * The single resolution point for the default. #339's equivalent fallback
+   * was written inline at both consumers, where nothing rendered it, so a
+   * field that was never set looked deliberate at each site. This one is
+   * resolved once and the control below displays its result, which is what
+   * makes a wrong default visible instead of inferable.
+   */
+  function readDateFor(hid: string): string {
+    return getRow(hid).readAtDate || todayLocalDate();
+  }
 
   // Partition households by edge availability.
   const needsManual = households.filter(
@@ -173,11 +225,16 @@ export function PreflightPanel(props: PreflightPanelProps) {
   /**
    * The derived starting reading.
    *
-   *     startKwh = dialReading − usage(period start → readAt)
+   *     startKwh = dialReading − usage(period start → read date)
    *
    * The operator is asked the answerable question ("what does the dial say?")
    * rather than the unanswerable one ("what did it read on the 1st?"), and the
    * subtraction is over the interval that actually elapsed rather than to now.
+   *
+   * That second clause was false from #339 until #343: the read date had no
+   * control, so it was always the entry date. It is true now because
+   * `readDateFor()` is what the visible input writes and what `loadElapsed()`
+   * queries. If the control is ever removed, delete this sentence with it.
    *
    * Returns null while the elapsed usage is unknown, which is what keeps the
    * Generate button disabled rather than letting a half-resolved row through.
@@ -190,8 +247,14 @@ export function PreflightPanel(props: PreflightPanelProps) {
     return Number.isFinite(v) ? v : null;
   }
 
-  /** Fetch usage(period start → readAt) for this household's meter. */
-  async function loadElapsed(hid: string, readAtIso: string) {
+  /**
+   * Fetch usage(period start → read date) for this household's meter.
+   *
+   * Takes the `YYYY-MM-DD` date directly (#343). It previously took an ISO
+   * timestamp and sliced the first ten characters, which names the UTC day —
+   * a west-of-UTC evening entry would have queried through tomorrow.
+   */
+  async function loadElapsed(hid: string, readDate: string) {
     const deviceId = deviceIdByHouseholdId[hid];
     if (!deviceId || !periodStartDate) return;
     setRow(hid, { elapsedState: "loading", elapsedKwh: null });
@@ -202,7 +265,7 @@ export function PreflightPanel(props: PreflightPanelProps) {
         body: JSON.stringify({
           deviceIds: [deviceId],
           fromDate: periodStartDate,
-          toDate: readAtIso.slice(0, 10),
+          toDate: readDate,
         }),
       });
       if (!res.ok) {
@@ -239,8 +302,28 @@ export function PreflightPanel(props: PreflightPanelProps) {
   // ran backwards.
   const allSeedsValid = needsSeed.every((h) => {
     const v = derivedSeed(h.id);
-    return v != null && v >= 0;
+    return v != null && v >= 0 && readDateProblem(h.id) == null;
   });
+
+  /**
+   * Why this row's read date is unusable, or null (#343).
+   *
+   * Adding the control added two states the panel could not previously reach,
+   * so it owes them both an answer. `min`/`max` on the input are a hint the
+   * browser may enforce and a typed or pasted value can bypass; this is the
+   * check that actually gates Generate.
+   */
+  function readDateProblem(hid: string): string | null {
+    const date = readDateFor(hid);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return "Enter the date as YYYY-MM-DD.";
+    // String comparison is correct for zero-padded ISO dates and avoids
+    // parsing either side into an instant, which is where timezones get in.
+    if (periodStartDate && date < periodStartDate) {
+      return "That is before this period started — the usage since then cannot be worked out from a reading taken earlier.";
+    }
+    if (date > todayLocalDate()) return "That date has not happened yet.";
+    return null;
+  }
 
   const totalCount = households.length;
 
@@ -289,7 +372,7 @@ export function PreflightPanel(props: PreflightPanelProps) {
                   return {
                     deviceId: deviceIdByHouseholdId[h.id],
                     dialReadingKwh: dial.ok ? dial.value : 0,
-                    readAt: f.readAt || new Date().toISOString(),
+                    readAt: readAtIsoFor(readDateFor(h.id)),
                     startKwh: derivedSeed(h.id) ?? 0,
                   };
                 }),
@@ -424,13 +507,15 @@ export function PreflightPanel(props: PreflightPanelProps) {
             <p className="mb-2 text-[12px] text-muted-foreground">
               MBE has no starting reading for these meters, so it cannot work
               out what to print as the previous reading on the invoice. Enter
-              what each meter reads now.
+              what each meter reads, and the day you read it.
             </p>
             <ul className="space-y-3">
               {needsSeed.map((h) => {
                 const f = getRow(h.id);
                 const derived = derivedSeed(h.id);
                 const hint = priorHintByHouseholdId[h.id];
+                const readDate = readDateFor(h.id);
+                const dateProblem = readDateProblem(h.id);
                 return (
                   <li
                     key={h.id}
@@ -456,12 +541,55 @@ export function PreflightPanel(props: PreflightPanelProps) {
                       onChange={(e) => {
                         const v = e.target.value;
                         setRow(h.id, { dialReading: v });
-                        const when = f.readAt || new Date().toISOString();
                         if (f.elapsedKwh == null && f.elapsedState !== "loading") {
-                          void loadElapsed(h.id, when);
+                          void loadElapsed(h.id, readDateFor(h.id));
                         }
                       }}
                     />
+                    {/* #343 — the date the reading was taken.
+                        Day granularity because the usage query is day-granular
+                        and because it is what the operator can answer: they
+                        remember walking the site on Tuesday, not that it was
+                        14:20. Defaults to today so same-day entry — the common
+                        path — stays a single field, and deferred entry costs
+                        one tap rather than being silently wrong. */}
+                    <label
+                      htmlFor={`seed-read-date-${h.id}`}
+                      className="mt-2 block text-[11px] text-muted-foreground"
+                    >
+                      Day this reading was taken
+                    </label>
+                    <input
+                      id={`seed-read-date-${h.id}`}
+                      data-testid={`preflight-seed-read-date-${h.id}`}
+                      type="date"
+                      className="w-40 rounded-md border border-border bg-card px-2 py-1 font-mono text-xs"
+                      value={readDate}
+                      min={periodStartDate}
+                      max={todayLocalDate()}
+                      onChange={(e) => {
+                        const date = e.target.value;
+                        setRow(h.id, { readAtDate: date });
+                        // The elapsed figure belongs to the old date, so it is
+                        // cleared rather than left on screen next to a new one.
+                        // Refetching needs a dial value to be worth showing,
+                        // but the query does not depend on it — so refetch
+                        // whenever the row has one.
+                        if (parseField(f.dialReading).ok) {
+                          void loadElapsed(h.id, date);
+                        } else {
+                          setRow(h.id, { elapsedKwh: null, elapsedState: "idle" });
+                        }
+                      }}
+                    />
+                    {dateProblem && (
+                      <p
+                        className="mt-1 text-[11px] text-destructive-fg"
+                        data-testid={`preflight-seed-date-problem-${h.id}`}
+                      >
+                        {dateProblem}
+                      </p>
+                    )}
                     {/* Per-row cause. `hint` is this household's own last
                         recorded end_kwh, so its presence IS the per-row
                         signal: non-null means this household has been billed
@@ -491,7 +619,12 @@ export function PreflightPanel(props: PreflightPanelProps) {
                       )}
                       {f.elapsedState === "idle" && f.elapsedKwh != null && (
                         <span data-testid={`preflight-seed-math-${h.id}`}>
-                          Used since period start −{f.elapsedKwh.toLocaleString()} kWh
+                          {/* #343 — the window is named, not implied. The
+                              operator can only catch a wrong read date if the
+                              interval it produced is on screen next to the
+                              number it changed. */}
+                          Used from period start to {readDate} −
+                          {f.elapsedKwh.toLocaleString()} kWh
                           {derived != null && (
                             <>
                               {" "}· Starting reading{" "}


### PR DESCRIPTION
Closes #343.

## What was wrong

#339 shipped a `readAt` field on the seed row that **no control ever wrote**. Both
consumers read it as `f.readAt || new Date().toISOString()`, so it was always the
entry time — while two docstrings said it explicitly was not:

```
preflight-panel.tsx:180  "the subtraction is over the interval that actually
                          elapsed rather than to now"
generate.ts:107          "readAt is NOT 'now'. An operator can read a dial in the
                          morning and type it that evening... days do."
```

The usage query is day-granular, so **same-day entry is correct** — and every test
#339 shipped entered the reading the same day. Read on day N, entered on day N+k,
`startKwh` is short by k days of usage, `endKwh − startKwh` is inflated, and the
household is **over-billed by exactly those days**. Walking a site and typing the
readings up later is the workflow the docstring itself describes, so the failing
path was the intended one.

## The change

- `readAtDate` (`YYYY-MM-DD`) **replaces** the dead `readAt` field rather than
  sitting beside it. One resolution point, `readDateFor()`.
- A date input per seed row defaulting to today: same-day entry stays a single
  field, deferred entry costs one tap. Day granularity because that is what the
  query uses and what an operator can actually answer — they remember walking the
  site on Tuesday, not that it was 14:20.
- `loadElapsed` takes the date directly instead of slicing an ISO timestamp, which
  named the **UTC** day — west of UTC an evening entry queried through tomorrow.
- The window is rendered beside the arithmetic (`Used from period start to
  2026-08-04 −214 kWh`), so a wrong date is visible rather than only inferable
  from a number nobody can check.
- `readDateProblem` gates Generate on the two states the control newly makes
  reachable — before the period started, and in the future. `min`/`max` are a
  browser hint that typed or pasted input walks straight past.

## Why the tests are evidence

The fetch mock **answers by window**: a different usage figure for the read day
than for today. A test that does not actually move the window gets the wrong
number and fails.

Verified by mutation, each applied to the merged code and reverted:

| Mutation | Result |
|---|---|
| `loadElapsed` always queries today | **2 failed** — arithmetic + payload |
| `readAt` reverts to `new Date()` | **1 failed** — payload |
| date guard out of `allSeedsValid` | **2 failed** — both validation tests |

**The third mutation initially passed all 22 tests.** The validation tests asserted
a disabled button that was disabled anyway: an unrecognised window returned `null`
usage, leaving the seed unresolved, so the assertion held whether or not the guard
existed — the same vacuous shape as the test I withdrew on #334. They now resolve
the arithmetic first (`fallbackKwh: 300` → a valid seed of 3,896), leaving the date
guard as the only thing that can disable the button. That argument is load-bearing
and the comment says so.

## Verification

```
full suite   171 files, 2015 tests, 0 failures   (2010 + 5 new)
tsc --noEmit clean
lint         0 errors, 0 warnings in touched files
```

Note for anyone running locally: `argon2` is declared in `package.json` but was
missing from my install, and three `src/lib/supabase/__tests__` files then fail to
*import* rather than to run — so they are silently not collected and the total
reads 35 tests lower. CI's `npm ci` installs it.

## Not in scope

Re-deriving `startKwh` server-side, and the two docstrings that still claim the
route already does — #344, deliberately held per the dispatch.

## Still open

No screen has rendered this. The control is unit-tested against mocks, like
everything else in #339 — the gap Designer recorded on `cdf281e` is unchanged and
this PR does not close it.
