### PR TITLE
fix(billing): pull-mode skips + reports un-billable households (#293)

### DIFF
--- a/src/components/BillingTable.tsx
+++ b/src/components/BillingTable.tsx
@@ -462,6 +462,25 @@ export function BillingTable({
         "Unknown household"
     );
 
+  // #293 — persistent "not billed — no meter data" indicator. Reads from
+  // PERSISTED state (households ∖ line items), not from a transient generate
+  // response, so it also reflects the unattended pull-mode cron: that path
+  // now SKIPS un-metered households with no manual reading (no zeroed
+  // placeholder row is written), so an un-metered household simply has no
+  // line item afterwards. A household counts here iff its edge is unavailable
+  // (no metered device / incomplete OpenEMS config — mirrors
+  // `runGenerationFor`'s un-metered branch) AND it has no line item in this
+  // period. Only meaningful once generation has run (some line items exist);
+  // before the first run every household is unbilled and the count would be
+  // noise, so the banner is gated on `lineItems.length > 0`.
+  const unbilledNoMeterNames = households
+    .filter(
+      (h) =>
+        (edgeAvailableByHouseholdId?.[h.id] ?? true) === false &&
+        !lineItemMap.has(h.id)
+    )
+    .map((h) => h.display_name);
+
   // Build summary rows for ClosePeriodDialog
   const closePeriodSummaryRows: ClosePeriodSummaryRow[] = [
     {
@@ -901,6 +920,32 @@ export function BillingTable({
               </li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {/* #293 — persistent "not billed — no meter data" indicator. Unlike the
+          transient generate-warnings block above (which only appears right
+          after an interactive Generate), this reads from persisted state, so
+          it surfaces households the unattended pull-mode cron skipped for
+          having no meter data and no manual reading. Gated on
+          `lineItems.length > 0` so it doesn't fire on a never-generated
+          period where every household is trivially unbilled. */}
+      {lineItems.length > 0 && unbilledNoMeterNames.length > 0 && (
+        <div data-testid="unbilled-no-meter-banner">
+          <Banner
+            tone="warn"
+            title={`${unbilledNoMeterNames.length} household${unbilledNoMeterNames.length === 1 ? "" : "s"} not billed — no meter data`}
+          >
+            <p>
+              These households have no meter and no manual reading, so no bill
+              was generated. Add a reading to bill them.
+            </p>
+            <ul className="mt-1 list-inside list-disc">
+              {unbilledNoMeterNames.map((name, i) => (
+                <li key={i}>{name}</li>
+              ))}
+            </ul>
+          </Banner>
         </div>
       )}
 

--- a/src/lib/billing/__tests__/generate-unmetered-skip.test.ts
+++ b/src/lib/billing/__tests__/generate-unmetered-skip.test.ts
@@ -1,0 +1,199 @@
+/**
+ * generate-unmetered-skip.test.ts (#293)
+ *
+ * Pull-mode (`householdIds === undefined`) guardrail: an un-metered household
+ * with no manual reading and no OpenEMS data must be SKIPPED and reported —
+ * NOT written as a silent zeroed placeholder line item.
+ *
+ * Before #293 the implicit-bulk `else` branch of runGenerationFor wrote a
+ * placeholder row (start_kwh=0, end_kwh=0, usage_kwh=0) for such a household.
+ * Pull-mode is an unattended cron, so that silently mis-billed an un-metered
+ * household as service-charge-only. The fix skips the tenant and surfaces it
+ * in the response with `code:"unmetered_no_manual"` — the same shape the
+ * explicit dashboard path already emitted.
+ *
+ * Harness: unlike the precision suite in `generate.test.ts`, this test mocks
+ * the Supabase client rather than driving a live local DB. The un-metered
+ * pull-mode path is small enough to mock cleanly (period + schedule +
+ * households + existing line items; no RPC, no OpenEMS call because the
+ * household resolves to no device), so this suite runs under
+ * `SKIP_RLS_TESTS=1` and gives executable coverage of the fix. The critical
+ * assertion — that NO write RPC fires — is verified via a spy on
+ * `supabase.rpc`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { runGenerationFor, isRunGenerationFatal } from "@/lib/billing/generate";
+
+const MICROGRID_ID = "aaaaaaaa-aaaa-4000-8000-000000000001";
+const PERIOD_ID = "aaaaaaaa-aaaa-4000-8006-000000000001";
+const HH_UNMETERED = "aaaaaaaa-aaaa-4000-8005-000000000001";
+
+/**
+ * Minimal chainable + thenable Supabase query stub. Chain methods return the
+ * same builder; the terminal `.single()` / `.maybeSingle()` and `await`
+ * (thenable) resolve to a per-table canned response.
+ */
+function makeSupabase() {
+  const rpc = vi.fn(async () => ({ data: null, error: null }));
+
+  const responses: Record<
+    string,
+    { single?: unknown; maybeSingle?: unknown; list?: unknown }
+  > = {
+    billing_periods: {
+      single: {
+        data: {
+          id: PERIOD_ID,
+          microgrid_id: MICROGRID_ID,
+          start_date: "2026-04-01",
+          end_date: "2026-04-30",
+          status: "draft",
+        },
+        error: null,
+      },
+      // Prior-period lookup is skipped for un-metered households (no device),
+      // but provide an empty list defensively.
+      list: { data: [], error: null },
+    },
+    rate_schedules: {
+      maybeSingle: {
+        data: {
+          microgrid_id: MICROGRID_ID,
+          tiers: [
+            { label: "T1", min_kwh: 0, max_kwh: null, rate_per_kwh: 100 },
+          ],
+          service_charge: 0,
+          tax_rate: 0,
+        },
+        error: null,
+      },
+    },
+    households: {
+      // One household on the microgrid with NO primary_consumption_meter
+      // device link — i.e. un-metered.
+      list: {
+        data: [
+          {
+            id: HH_UNMETERED,
+            display_name: "Unmetered Household",
+            household_devices: [],
+          },
+        ],
+        error: null,
+      },
+    },
+    billing_line_items: {
+      // No prior line items in this period.
+      list: { data: [], error: null },
+    },
+  };
+
+  function builder(table: string) {
+    const resp = responses[table] ?? { list: { data: [], error: null } };
+    const b: Record<string, unknown> = {};
+    const chain = () => b;
+    for (const m of [
+      "select",
+      "eq",
+      "neq",
+      "lte",
+      "gte",
+      "in",
+      "not",
+      "order",
+      "limit",
+    ]) {
+      b[m] = chain;
+    }
+    b.single = async () => resp.single ?? { data: null, error: null };
+    b.maybeSingle = async () =>
+      resp.maybeSingle ?? { data: null, error: null };
+    // Thenable: `await builder` resolves to the list response.
+    b.then = (
+      onFulfilled: (v: unknown) => unknown,
+      onRejected?: (e: unknown) => unknown
+    ) =>
+      Promise.resolve(resp.list ?? { data: [], error: null }).then(
+        onFulfilled,
+        onRejected
+      );
+    return b;
+  }
+
+  const supabase = {
+    from: (table: string) => builder(table),
+    rpc,
+  } as unknown as SupabaseClient;
+
+  return { supabase, rpc };
+}
+
+describe("runGenerationFor: pull-mode un-metered skip (#293)", () => {
+  it("write mode, householdIds undefined, un-metered household → skips with unmetered_no_manual and writes NO row", async () => {
+    const { supabase, rpc } = makeSupabase();
+
+    const out = await runGenerationFor({
+      supabase,
+      periodId: PERIOD_ID,
+      // Pull-mode: no householdIds, no manualReadings.
+      householdIds: undefined,
+      mode: "write",
+      actorUserId: null,
+      actorKind: "customerapp",
+      actorRef: "cron",
+    });
+
+    if (isRunGenerationFatal(out)) {
+      throw new Error(
+        `runGenerationFor returned fatal ${out.status}: ${out.body.error}`
+      );
+    }
+
+    const results = out.results;
+    expect(results.length).toBe(1);
+
+    const entry = results[0];
+    expect(entry.kind).toBe("error");
+    expect(entry.householdId).toBe(HH_UNMETERED);
+    if (entry.kind === "error") {
+      expect(entry.code).toBe("unmetered_no_manual");
+    }
+
+    // The critical regression: NO placeholder row is written. The write path
+    // is `supabase.rpc("fn_record_line_item_with_audit", …)`.
+    expect(rpc).not.toHaveBeenCalled();
+
+    // No 'written' result of any kind.
+    expect(results.some((r) => r.kind === "written")).toBe(false);
+  });
+
+  it("preview mode, householdIds undefined, un-metered household → still reports the skip (no preview row)", async () => {
+    const { supabase, rpc } = makeSupabase();
+
+    const out = await runGenerationFor({
+      supabase,
+      periodId: PERIOD_ID,
+      householdIds: undefined,
+      mode: "preview",
+      actorUserId: null,
+    });
+
+    if (isRunGenerationFatal(out)) {
+      throw new Error(
+        `runGenerationFor returned fatal ${out.status}: ${out.body.error}`
+      );
+    }
+
+    const results = out.results;
+    expect(results.length).toBe(1);
+    expect(results[0].kind).toBe("error");
+    if (results[0].kind === "error") {
+      expect(results[0].code).toBe("unmetered_no_manual");
+    }
+    // Preview never writes anyway, but assert no preview placeholder row.
+    expect(results.some((r) => r.kind === "preview")).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/billing/generate.ts
+++ b/src/lib/billing/generate.ts
@@ -701,32 +701,26 @@ export async function runGenerationFor(
       readingSource = "edge";
       deviceId = dev.deviceId;
     } else {
-      // Un-metered household with no manual override: surface as
-      // 'unmetered_no_manual'. Today's flow inserts a placeholder row
-      // (start_kwh=0, end_kwh/usage_kwh NULL); preserve that for backward
-      // compatibility — only emit the error when the caller explicitly asked
-      // for this household. For the bulk-implicit path (householdIds
-      // undefined), still insert the placeholder so the BillingTable row
-      // exists for inline manual edit.
-      if (householdIdsParam !== undefined && householdIdsParam.includes(hid)) {
-        results.push({
-          kind: "error",
-          householdId: hid,
-          householdName,
-          error:
-            "Household has no meter and no manual reading was supplied.",
-          code: "unmetered_no_manual",
-        });
-        continue;
-      }
-      // Implicit bulk path: write/preview the placeholder.
-      startKwh = 0;
-      endKwh = 0; // end_kwh is non-NULL only on UPSERT; the existing
-                  // schema permits null but the DB CHECK doesn't. We use 0
-                  // as a placeholder; the manual-edit PATCH sets actual end.
-      usageKwh = 0;
-      readingSource = "edge";
-      deviceId = null;
+      // Un-metered household with no manual override: skip and report with
+      // 'unmetered_no_manual'. This holds for BOTH the explicit dashboard
+      // path (householdIds includes this id) AND the implicit pull-mode path
+      // (householdIds === undefined) — #293.
+      //
+      // Pull-mode is an unattended cron. Writing a silent zeroed placeholder
+      // row (start_kwh=0, end_kwh=0, usage_kwh=0) there mis-bills an un-metered
+      // household as service-charge-only with no human in the loop; the only
+      // signal is the response payload. Per Alejandro's decision (2026-07-01,
+      // #293): no manual reading AND no OpenEMS data → do NOT bill; skip the
+      // tenant and report it so the cron/caller sees it. The dashboard path
+      // already emitted this same error; the two paths now agree.
+      results.push({
+        kind: "error",
+        householdId: hid,
+        householdName,
+        error: "Household has no meter and no manual reading was supplied.",
+        code: "unmetered_no_manual",
+      });
+      continue;
     }
 
     // Compute tier breakdown + total.


### PR DESCRIPTION
## Summary

Closes #293.

The automated **pull-mode** billing path (`runGenerationFor` with `householdIds === undefined`) previously wrote a **silent zeroed placeholder line item** for an un-metered household with no manual reading and no OpenEMS data. Pull-mode is an unattended cron, so this silently mis-billed such a household as service-charge-only with no human in the loop — the only signal was the response payload.

Per Alejandro's decision (2026-07-01, #293): *no manual reading AND no OpenEMS data → do NOT bill; skip the tenant and report it.*

## What changed

- **`src/lib/billing/generate.ts`** — The un-metered / no-manual `else` branch dropped the gate `if (householdIdsParam !== undefined && includes(hid))` and **deleted the implicit placeholder-write block** (`startKwh=0; endKwh=0; usageKwh=0; deviceId=null`). It now **unconditionally** skips the household and reports it via the existing `{kind:"error", code:"unmetered_no_manual"}` shape — the same the explicit dashboard path already emitted. The `continue` lands before the `mode === "preview"` block, so preview also stops emitting the zeroed row. Reuses the existing `unmetered_no_manual` code (already declared); no new code added.
- **`src/lib/billing/__tests__/generate-unmetered-skip.test.ts`** (new) — Engine-level test on `runGenerationFor` with an un-metered household + `householdIds` undefined. Mocks the Supabase client (the un-metered pull path touches only period/schedule/households/line-items — no RPC, no OpenEMS), so it runs under `SKIP_RLS_TESTS=1` and gives executable coverage. Asserts both write and preview mode skip the household with `unmetered_no_manual`, write NO row, and fire **no** `supabase.rpc` write. Mutation-robust: reaching the `unmetered_no_manual` result (length 1, correct household id) proves the else-branch executed rather than a vacuous early-bail.
- **`src/components/BillingTable.tsx`** — Persistent **"N households not billed — no meter data"** indicator (warn Banner). Derives from **persisted** state (households ∖ line items where the edge is unavailable), so it surfaces households the unattended cron skipped, not just interactive-Generate results. Gated on `lineItems.length > 0` so it stays silent on a never-generated period.

## Cross-period safety (confirmed)

The deleted placeholder set `device_id = null`, and the next-period `start_kwh` lookup (`priorEndKwhMap`) is keyed on `device_id WHERE end_kwh IS NOT NULL`. So the placeholder never fed the `start_kwh` chain; skipping writes no row → no `start_kwh` regression.

## Scope confirmations

- Explicit-`householdIds` (dashboard interactive) path: unchanged — it already skipped-and-reported; the two paths now agree.
- Metered null-reading case (`no_meter_reading`): unchanged.
- No schema/migration changes; `db:types` not run (not needed).

## Test results (env `SKIP_DEK_BOOTSTRAP_TEST=1 SKIP_RLS_TESTS=1`)

- `npx tsc --noEmit` — **pass** (clean).
- `npm run lint` — **pass** (0 errors, 27 pre-existing warnings, none in changed files).
- `npm test` — **1917 passed, 100 skipped** (RLS/DEK suites gated locally; they run in the CI `Test` gate). New suite passes (2 tests).

## Deferred

- **#299 date-convention tail** (folded into #293's comment): canonical half-open `[start, next-start)` normalization on write is **not** included here — it is a distinct change with no correctness dependency on this fix, and the issue notes no money impact on billed data. Recommend splitting to a follow-up.
- **Bundled "explicit pull-mode/source flag"** improvement: skipped — the `householdIds === undefined` signal is sufficient for the fix, and it did not fall out trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)