### PR TITLE
fix(preflight): read energyKwh from energy route, not totalKwh

### DIFF
--- a/src/components/billing/__tests__/preflight-panel.test.tsx
+++ b/src/components/billing/__tests__/preflight-panel.test.tsx
@@ -581,11 +581,15 @@ describe("PreflightPanel — seed readings (#339)", () => {
     );
   }
 
-  function energyResponse(totalKwh: number) {
+  // Mirrors the real /api/openems/energy shape (DeviceEnergyResult): the
+  // field is `energyKwh`, NOT `totalKwh` — the mismatch #367 fixed. Keep the
+  // mock on the route's real field name so a reader/route divergence fails
+  // here instead of only in production.
+  function energyResponse(energyKwh: number) {
     return {
       ok: true,
       status: 200,
-      json: async () => ({ results: [{ deviceId: DEVICE, totalKwh }] }),
+      json: async () => ({ results: [{ deviceId: DEVICE, energyKwh }] }),
     };
   }
 
@@ -624,6 +628,17 @@ describe("PreflightPanel — seed readings (#339)", () => {
     );
 
     await waitFor(() => expect(btn.disabled).toBe(false));
+
+    // #367 guard: the fetched `energyKwh` value must actually FLOW into the
+    // rendered elapsed-usage math — not merely avoid the error branch. Before
+    // the fix the reader looked up `totalKwh`, got undefined, and hit the
+    // null-guard error path, which "no crash" assertions could never catch.
+    const math = document.querySelector(
+      '[data-testid="preflight-seed-math-h-1"]',
+    );
+    expect(math?.textContent).toContain("214");
+    // 4196 − 214 — the derived seed from the concrete fetched value.
+    expect(math?.textContent).toContain("3,982");
   });
 
   // #359 — the seed anchors to the period's start, so the elapsed-usage
@@ -834,7 +849,7 @@ describe("PreflightPanel — read date (#343)", () => {
   function windowedFetch(fallbackKwh: number | null = null) {
     return vi.fn(async (_url: string, init: { body: string }) => {
       const body = JSON.parse(init.body) as { toDate?: string };
-      const totalKwh =
+      const energyKwh =
         body.toDate === READ_DAY
           ? USAGE_TO_READ_DAY
           : body.toDate === TODAY
@@ -843,7 +858,8 @@ describe("PreflightPanel — read date (#343)", () => {
       return {
         ok: true,
         status: 200,
-        json: async () => ({ results: [{ deviceId: DEVICE, totalKwh }] }),
+        // Real route field name (`energyKwh`, per DeviceEnergyResult) — #367.
+        json: async () => ({ results: [{ deviceId: DEVICE, energyKwh }] }),
       };
     });
   }

--- a/src/components/billing/preflight-panel.tsx
+++ b/src/components/billing/preflight-panel.tsx
@@ -286,14 +286,18 @@ export function PreflightPanel(props: PreflightPanelProps) {
         return;
       }
       const body = (await res.json()) as {
-        results?: Array<{ deviceId: string; totalKwh: number | null }>;
+        // DeviceEnergyResult — the route's contract names the field
+        // `energyKwh` (#367). NB: the result also carries `energyWh`;
+        // this display is in kWh, so `energyKwh` is the correct pick
+        // (`energyWh` would be a 1000x unit bug).
+        results?: Array<{ deviceId: string; energyKwh: number | null }>;
       };
       const hit = (body.results ?? []).find((r) => r.deviceId === deviceId);
-      if (!hit || hit.totalKwh == null) {
+      if (!hit || hit.energyKwh == null) {
         setRow(hid, { elapsedState: "error", elapsedKwh: null });
         return;
       }
-      setRow(hid, { elapsedState: "idle", elapsedKwh: hit.totalKwh });
+      setRow(hid, { elapsedState: "idle", elapsedKwh: hit.energyKwh });
     } catch {
       setRow(hid, { elapsedState: "error", elapsedKwh: null });
     }


### PR DESCRIPTION
Closes #367

## The mismatch

`PreflightPanel.loadElapsed` read `results[].totalKwh` from `POST /api/openems/energy`, but the route returns `DeviceEnergyResult[]` (`src/lib/openems/types.ts`), whose field is **`energyKwh`**. The live seed elapsed-usage fetch therefore always read `undefined`, tripped the `== null` guard, and rendered the error state — a broken operator-facing display on the seed/needs-seed-reading flow.

## Which side was fixed, and why

**The reader (consumer), not the route.** `DeviceEnergyResult` is the route's typed contract, produced directly by `client.getDeviceEnergy`; the preflight reader was the sole consumer diverging from it. Note the result carries both `energyWh` and `energyKwh` — the reader now explicitly picks `energyKwh` for this kWh display (commented in code; `energyWh` would be a 1000x unit bug).

## How the test now guards it

The bug was invisible because the component test mocks returned `totalKwh`, matching the buggy reader instead of the real route shape:

- Both fetch mocks (`energyResponse`, `windowedFetch`) now return the route's real field name `energyKwh`.
- The seed-section test now asserts the fetched value **flows into the rendered math** — `214` and the derived seed `3,982` appear in `preflight-seed-math-h-1` — not merely that nothing crashes. With the old `totalKwh` reader, this assertion fails (fetch resolves, guard trips, math never renders), so any future reader/route divergence fails the suite.

Scope: only #367. The `startKwh`-derivation logic (#344) is untouched; no schema change.

## Test output

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, 28 pre-existing warnings
- `SKIP_DEK_BOOTSTRAP_TEST=1 SKIP_RLS_TESTS=1 npm test` — **166 passed | 14 skipped (180 files), 1999 passed | 106 skipped (2105 tests)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)